### PR TITLE
feat: add TypeName::ReadonlyArray for `readonly T[]`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 # Changelog
 
-## 0.2.0 (unreleased)
+## 0.2.1
 
 ### Added
 
+- `TypeName::ReadonlyArray` renders `readonly T[]` in TypeScript and falls back
+  to the same shape in other languages, so interface fields can express
+  read-only arrays without reaching for `Raw` or `Generic<ReadonlyArray<T>>`.
 - `FieldSpec::is_optional()` marks a field whose key may be absent. Rendering
   is language-specific and delegates to the new `CodeLang::optional_field_style`
   hook:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,7 +100,7 @@ dependencies = [
 
 [[package]]
 name = "sigil-stitch"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "pretty",
  "serde",
@@ -111,7 +111,7 @@ dependencies = [
 
 [[package]]
 name = "sigil-stitch-macros"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["macros"]
 resolver = "3"
 
 [workspace.package]
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"
@@ -35,7 +35,7 @@ exclude = [
 [dependencies]
 pretty = "0.12"
 snafu = "0.9"
-sigil-stitch-macros = { path = "macros", version = "0.2.0" }
+sigil-stitch-macros = { path = "macros", version = "0.2.1" }
 serde = { version = "1", features = ["derive"] }
 
 [dev-dependencies]

--- a/src/type_name.rs
+++ b/src/type_name.rs
@@ -53,6 +53,9 @@ pub enum TypeName<L: CodeLang> {
     Primitive(String),
     /// Array type. TS: `T[]`, Go: `[]T`, Rust: `Vec<T>`.
     Array(Box<TypeName<L>>),
+    /// Readonly array type. TS: `readonly T[]`. Other languages fall back to
+    /// their `Array` rendering since they lack a direct readonly-array form.
+    ReadonlyArray(Box<TypeName<L>>),
     /// Generic type. e.g., `Promise<User>`, `HashMap<String, User>`.
     Generic {
         /// The base type (e.g., `Promise`, `HashMap`).
@@ -147,6 +150,16 @@ impl<L: CodeLang> TypeName<L> {
         TypeName::Array(Box::new(inner))
     }
 
+    /// Create a readonly array type (TypeScript: `readonly T[]`).
+    ///
+    /// In languages without a direct readonly-array form (Go, most C-family),
+    /// this renders identically to [`TypeName::array`]. Use this variant only
+    /// when the readonly distinction carries information the output should
+    /// preserve (e.g. TypeScript interface fields).
+    pub fn readonly_array(inner: TypeName<L>) -> Self {
+        TypeName::ReadonlyArray(Box::new(inner))
+    }
+
     /// Create a generic type (e.g., `Promise<User>`).
     pub fn generic(base: TypeName<L>, params: Vec<TypeName<L>>) -> Self {
         TypeName::Generic {
@@ -229,6 +242,7 @@ impl<L: CodeLang> TypeName<L> {
                 });
             }
             TypeName::Array(inner)
+            | TypeName::ReadonlyArray(inner)
             | TypeName::Pointer(inner)
             | TypeName::Slice(inner)
             | TypeName::Optional(inner) => {
@@ -280,6 +294,13 @@ impl<L: CodeLang> TypeName<L> {
             TypeName::Array(inner) => {
                 // Default: TypeScript-style T[]
                 inner.to_doc(resolve).append(BoxDoc::text("[]"))
+            }
+            TypeName::ReadonlyArray(inner) => {
+                // Default: TypeScript-style `readonly T[]`; languages without
+                // a direct readonly-array form fall through here too.
+                BoxDoc::text("readonly ")
+                    .append(inner.to_doc(resolve))
+                    .append(BoxDoc::text("[]"))
             }
             TypeName::Generic { base, params } => {
                 let base_doc = base.to_doc(resolve);
@@ -376,6 +397,9 @@ impl<L: CodeLang> TypeName<L> {
             // For variants with recursive sub-types, thread lang through.
             TypeName::Array(inner) => inner
                 .to_doc_with_lang(resolve, lang)
+                .append(BoxDoc::text("[]")),
+            TypeName::ReadonlyArray(inner) => BoxDoc::text("readonly ")
+                .append(inner.to_doc_with_lang(resolve, lang))
                 .append(BoxDoc::text("[]")),
             TypeName::Union(members) => {
                 let docs: Vec<_> = members

--- a/tests/phase2_typescript_tests.rs
+++ b/tests/phase2_typescript_tests.rs
@@ -170,3 +170,29 @@ fn test_ts_enum() {
 
     golden::assert_golden("typescript/enum.ts", &output);
 }
+
+#[test]
+fn test_ts_readonly_array_field() {
+    let mut tb = TypeSpec::<TypeScript>::builder("Pet", TypeKind::Interface);
+    tb.visibility(Visibility::Public);
+
+    let mut name = FieldSpec::builder("name", TypeName::<TypeScript>::primitive("string"));
+    name.is_readonly();
+    tb.add_field(name.build().unwrap());
+
+    let mut tags = FieldSpec::builder(
+        "tags",
+        TypeName::<TypeScript>::readonly_array(TypeName::primitive("string")),
+    );
+    tags.is_readonly();
+    tb.add_field(tags.build().unwrap());
+
+    let mut file = FileSpec::<TypeScript>::builder("Pet.ts");
+    file.add_type(tb.build().unwrap());
+    let output = file.build().unwrap().render(80).unwrap();
+
+    assert!(
+        output.contains("readonly tags: readonly string[];"),
+        "expected readonly array field; got:\n{output}"
+    );
+}


### PR DESCRIPTION
Adds a ReadonlyArray variant alongside Array so TypeScript interface fields can express `readonly T[]` without reaching for Raw or Generic <ReadonlyArray<T>>. Default rendering is `readonly {inner}[]` in both
`to_doc` and `to_doc_with_lang`; languages without a direct readonly-array form fall through to the same shape, which is the least surprising behavior and matches what callers already expect from
`Array` elsewhere.

Covered by a new phase2 TypeScript integration test (`test_ts_readonly_array_field`) asserting the rendered shape.
