### PR TITLE
feat: modular type system — TypePresentation, Tuple, Reference, TypeAlias, Newtype

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Build structured declarations with the spec builders:
 | **ParameterSpec** | Function parameter (name + type + default + variadic) |
 | **FieldSpec** | Struct field / class property (visibility, static, readonly) |
 | **FunSpec** | Function or method (params, return type, body, async, abstract) |
-| **TypeSpec** | Class, struct, interface, trait, or enum |
+| **TypeSpec** | Class, struct, interface, trait, enum, type alias, or newtype |
 | **PropertySpec** | Computed property with getter/setter |
 | **AnnotationSpec** | `@Override`, `#[derive(...)]`, `[[nodiscard]]` |
 | **EnumVariantSpec** | Enum variant with optional value, tuple, or struct fields |

--- a/doc/src/SUMMARY.md
+++ b/doc/src/SUMMARY.md
@@ -7,4 +7,5 @@
 - [sigil_quote! Macro](sigil_quote.md)
 - [Code Templates](code_templates.md)
 - [Adding a Language](adding_a_language.md)
+- [Type Presentation](type_presentation.md)
 - [Architecture](architecture.md)

--- a/doc/src/adding_a_language.md
+++ b/doc/src/adding_a_language.md
@@ -250,3 +250,60 @@ Study these existing implementations for patterns similar to your target:
 | C | `src/lang/c_lang.rs` | Type-before-name, `#include`, `__attribute__`, struct close semicolon |
 | C++ | `src/lang/cpp_lang.rs` | `virtual` instead of `abstract`, `#include` + `using`, `[[attributes]]` |
 | Bash | `src/lang/bash.rs` | Keyword-based block closers (`fi`/`done`/`esac`), `source` imports, shell escaping |
+
+## Type Presentation
+
+When your language uses type expressions (generics, arrays, optionals, maps, etc.), you'll need to declare how each semantic type concept renders. This is done through `present_*` methods that return `TypePresentation` data — you never build `BoxDoc` directly.
+
+### How it works
+
+Each `TypeName` variant (Array, Optional, Map, etc.) asks your language for a `TypePresentation` — a small enum describing the syntactic pattern:
+
+- `GenericWrap { name }` — `name<P1, P2>` using your `generic_open()`/`generic_close()`
+- `Prefix { prefix }` — `prefix inner` (e.g., Go `[]T`, Rust `*const T`)
+- `Postfix { suffix }` — `inner suffix` (e.g., TypeScript `T[]`, Kotlin `T?`)
+- `Delimited { open, sep, close }` — `open P1 sep P2 close` (e.g., Swift `[K: V]`, Go `map[K]V`)
+- `Infix { sep }` — `P1 sep P2` (e.g., TypeScript `A | B`, Rust `A + B`)
+
+### Methods to override
+
+All `present_*` methods have defaults matching TypeScript conventions. Override only when your language differs:
+
+```rust,ignore
+impl CodeLang for YourLang {
+    // Array: default is Postfix { suffix: "[]" } (TS: T[])
+    // Override for Rust-style Vec<T>:
+    fn present_array(&self) -> TypePresentation<'_> {
+        TypePresentation::GenericWrap { name: "Vec" }
+    }
+
+    // Optional: default is Infix { sep: " | " } with "null" literal
+    // Override for Kotlin-style T?:
+    fn present_optional(&self) -> TypePresentation<'_> {
+        TypePresentation::Postfix { suffix: "?" }
+    }
+
+    // Map: default is GenericWrap { name: "Map" }
+    // Override for Go-style map[K]V:
+    fn present_map(&self) -> TypePresentation<'_> {
+        TypePresentation::Delimited { open: "map[", sep: "]", close: "" }
+    }
+
+    // Function types: default is TypeScript (A, B) => R
+    fn present_function(&self) -> FunctionPresentation<'_> {
+        FunctionPresentation {
+            keyword: "fn",
+            params_open: "(",
+            params_sep: ", ",
+            params_close: ")",
+            arrow: " -> ",
+            return_first: false,
+            curried: false,
+            wrapper_open: "",
+            wrapper_close: "",
+        }
+    }
+}
+```
+
+See [Type Presentation](type_presentation.md) for the full enum definition, all available methods, and examples for every supported language.

--- a/doc/src/adding_a_language.md
+++ b/doc/src/adding_a_language.md
@@ -1,6 +1,6 @@
 # Adding a Language
 
-sigil-stitch supports new languages by implementing the `CodeLang` trait. The trait has 45 methods: 17 required (no default implementation) and 28 with sensible defaults. You only need to override the defaults when your language diverges from the common patterns.
+sigil-stitch supports new languages by implementing the `CodeLang` trait. The trait has 63 methods: 18 required (no default implementation) and 45 with sensible defaults. You only need to override the defaults when your language diverges from the common patterns.
 
 This guide walks through the process using a hypothetical language, with references to real implementations you can study.
 
@@ -34,7 +34,7 @@ These are enough for CodeBlock-level code generation:
 
 `render_imports()` is the most complex. It receives an `ImportGroup` (deduplicated, with aliases resolved) and must emit the full import header string. Study `src/lang/typescript.rs` for ES module imports or `src/lang/rust_lang.rs` for `use` paths.
 
-### Spec Support Methods (9 required)
+### Spec Support Methods (10 required)
 
 These enable TypeSpec, FunSpec, and FieldSpec rendering:
 
@@ -60,7 +60,7 @@ This is the most important method for structural correctness. It determines whet
 
 The method takes a `TypeKind` parameter, so you can vary by type. Rust returns `true` for `TypeKind::Trait` (trait methods go inside) but `false` for `TypeKind::Struct` and `TypeKind::Enum`.
 
-### Default Methods (28 methods)
+### Default Methods (45 methods)
 
 These have defaults that work for most C-family languages. Override when your language differs.
 
@@ -102,6 +102,10 @@ These have defaults that work for most C-family languages. Override when your la
 **Property support:**
 - `property_style()` -- default `Accessor` (TS/JS: `get name()`). Swift/Kotlin: `Field` (inline get/set).
 - `property_getter_keyword()` -- default `"get"`. Kotlin: `"get()"`.
+
+**Type alias and newtype support:**
+- `type_alias_target_first()` -- default `false`. C overrides to `true` for `typedef target name;` syntax (target comes before name).
+- `render_newtype_line()` -- default emits Rust tuple struct `struct Name(Inner);`. Go overrides to `type Name Inner`, Kotlin to `value class Name(val value: Inner)`, Python to `Name = NewType("Name", Inner)`, C to `typedef Inner Name;`.
 
 ## Step-by-Step Walkthrough
 
@@ -170,9 +174,11 @@ impl CodeLang for YourLang {
     fn type_keyword(&self, kind: TypeKind) -> &str {
         match kind {
             TypeKind::Class => "class",
-            TypeKind::Interface => "interface",
+            TypeKind::Interface | TypeKind::Trait => "interface",
             TypeKind::Enum => "enum",
-            _ => "class",
+            TypeKind::Struct => "class",
+            TypeKind::TypeAlias => "type",
+            TypeKind::Newtype => "class",
         }
     }
     fn field_terminator(&self) -> &str { ";" }
@@ -262,6 +268,7 @@ Each `TypeName` variant (Array, Optional, Map, etc.) asks your language for a `T
 - `GenericWrap { name }` — `name<P1, P2>` using your `generic_open()`/`generic_close()`
 - `Prefix { prefix }` — `prefix inner` (e.g., Go `[]T`, Rust `*const T`)
 - `Postfix { suffix }` — `inner suffix` (e.g., TypeScript `T[]`, Kotlin `T?`)
+- `Surround { prefix, suffix }` — `prefix inner suffix` (e.g., C++ `const T&`, C `const T*`)
 - `Delimited { open, sep, close }` — `open P1 sep P2 close` (e.g., Swift `[K: V]`, Go `map[K]V`)
 - `Infix { sep }` — `P1 sep P2` (e.g., TypeScript `A | B`, Rust `A + B`)
 
@@ -287,6 +294,24 @@ impl CodeLang for YourLang {
     // Override for Go-style map[K]V:
     fn present_map(&self) -> TypePresentation<'_> {
         TypePresentation::Delimited { open: "map[", sep: "]", close: "" }
+    }
+
+    // Tuple: default is Delimited { open: "[", sep: ", ", close: "]" } (TS: [A, B])
+    // Override for Rust-style (A, B):
+    fn present_tuple(&self) -> TypePresentation<'_> {
+        TypePresentation::Delimited { open: "(", sep: ", ", close: ")" }
+    }
+
+    // Reference: default is Prefix { prefix: "" } (identity — for GC languages)
+    // Override for Rust-style &T:
+    fn present_reference(&self) -> TypePresentation<'_> {
+        TypePresentation::Prefix { prefix: "&" }
+    }
+
+    // Mutable reference: default is Prefix { prefix: "" } (identity)
+    // Override for C++-style T&:
+    fn present_reference_mut(&self) -> TypePresentation<'_> {
+        TypePresentation::Postfix { suffix: "&" }
     }
 
     // Function types: default is TypeScript (A, B) => R

--- a/doc/src/architecture.md
+++ b/doc/src/architecture.md
@@ -47,6 +47,15 @@ Every variant that contains other types recursively collects imports via `collec
 
 TypeName also renders to `pretty::BoxDoc` for width-aware output of complex type signatures. `BoxDoc` is used (rather than `RcDoc`) so rendered documents are `Send + Sync` and can cross thread boundaries.
 
+#### Type Presentation Layer
+
+`TypeName` variants are *semantic* — `Array(T)` means "array of T" regardless of language. Cross-language rendering is handled by a **data-driven presentation layer**:
+
+1. Each `TypeName` variant asks the language for a `TypePresentation` — a data enum describing the syntactic pattern (e.g., `GenericWrap`, `Prefix`, `Postfix`, `Delimited`, `Infix`).
+2. A single rendering engine in `type_name.rs` interprets the pattern into `BoxDoc` output.
+
+`BoxDoc` never appears in the `CodeLang` trait. Languages return pure data; the engine does all rendering. See [Type Presentation](type_presentation.md) for the full design.
+
 ### Layer 3: CodeBlock
 
 `src/code_block.rs` is the core composition primitive. A `CodeBlock<L>` stores:

--- a/doc/src/architecture.md
+++ b/doc/src/architecture.md
@@ -20,7 +20,7 @@ The library is organized in four layers, each building on the one below:
 
 ### Layer 1: CodeLang
 
-`src/lang/mod.rs` defines the `CodeLang` trait with 45 methods covering syntax, formatting, and import rendering. Each supported language implements this trait in its own module (`src/lang/typescript.rs`, etc.).
+`src/lang/mod.rs` defines the `CodeLang` trait with 63 methods covering syntax, formatting, and import rendering. Each supported language implements this trait in its own module (`src/lang/typescript.rs`, etc.).
 
 All types in the library are parameterized by `L: CodeLang`. This phantom type parameter prevents cross-language mixing at compile time. You can't accidentally pass a `TypeName<TypeScript>` to a `CodeBlock<RustLang>`.
 
@@ -36,8 +36,12 @@ The trait is `Sized + Clone + 'static` to allow language instances to be stored 
 | `Importable` | `User` from `./models` | Yes |
 | `Generic` | `Promise<User>` | Recursively |
 | `Array` | `User[]`, `Vec<User>` | Inner type tracked |
+| `ReadonlyArray` | `readonly User[]` | Inner type tracked |
 | `Optional` | `User?`, `Option<User>` | Inner type tracked |
 | `Union` | `string \| number` | All members tracked |
+| `Intersection` | `A & B`, `A + B` | All members tracked |
+| `Tuple` | `[A, B]`, `(A, B)` | All members tracked |
+| `Reference` | `&T`, `const T&` | Inner type tracked |
 | `Function` | `(x: string) => void` | Params + return tracked |
 | `Map` | `Map<string, User>` | Key + value tracked |
 | `Pointer` / `Slice` | `*const T`, `&[T]` | Inner type tracked |
@@ -51,7 +55,7 @@ TypeName also renders to `pretty::BoxDoc` for width-aware output of complex type
 
 `TypeName` variants are *semantic* — `Array(T)` means "array of T" regardless of language. Cross-language rendering is handled by a **data-driven presentation layer**:
 
-1. Each `TypeName` variant asks the language for a `TypePresentation` — a data enum describing the syntactic pattern (e.g., `GenericWrap`, `Prefix`, `Postfix`, `Delimited`, `Infix`).
+1. Each `TypeName` variant asks the language for a `TypePresentation` — a data enum describing the syntactic pattern (e.g., `GenericWrap`, `Prefix`, `Postfix`, `Surround`, `Delimited`, `Infix`).
 2. A single rendering engine in `type_name.rs` interprets the pattern into `BoxDoc` output.
 
 `BoxDoc` never appears in the `CodeLang` trait. Languages return pure data; the engine does all rendering. See [Type Presentation](type_presentation.md) for the full design.

--- a/doc/src/spec_layer.md
+++ b/doc/src/spec_layer.md
@@ -200,7 +200,7 @@ let fun = fb.build().unwrap();
 
 ## TypeSpec
 
-The largest spec. Models type declarations: struct, class, interface, trait, or enum. Takes a `TypeKind` to select the declaration form.
+The largest spec. Models type declarations: struct, class, interface, trait, enum, type alias, or newtype wrapper. Takes a `TypeKind` to select the declaration form.
 
 `.build()` returns `Err(SigilStitchError::DuplicateFieldName { type_name, field_name })` when two fields in the same type share a name.
 
@@ -291,6 +291,78 @@ let type_spec = tb.build().unwrap();
 // export class AdminService extends BaseService implements Serializable {
 // }
 ```
+
+### Type aliases
+
+`TypeKind::TypeAlias` emits a single-line type alias declaration with no body. The aliased target is set via `.extends()` (exactly one required). No fields, methods, or variants are allowed.
+
+```rust,ignore
+use sigil_stitch::prelude::*;
+use sigil_stitch::lang::typescript::TypeScript;
+use sigil_stitch::lang::rust_lang::RustLang;
+
+// TypeScript: export type UserId = string;
+let mut tb = TypeSpec::<TypeScript>::builder("UserId", TypeKind::TypeAlias);
+tb.visibility(Visibility::Public);
+tb.extends(TypeName::primitive("string"));
+let type_spec = tb.build().unwrap();
+
+// Rust: pub type Meters = f64;
+let mut tb = TypeSpec::<RustLang>::builder("Meters", TypeKind::TypeAlias);
+tb.visibility(Visibility::Public);
+tb.extends(TypeName::primitive("f64"));
+let type_spec = tb.build().unwrap();
+```
+
+Per-language rendering is controlled by `type_keyword(TypeKind::TypeAlias)`:
+- TypeScript/Rust: `type Foo = Bar;`
+- C++: `using Foo = Bar;`
+- C: `typedef Bar Foo;` (target-first, via `type_alias_target_first()`)
+- Go: `type Foo = Bar`
+- Kotlin: `typealias Foo = Bar`
+- Python: `type Foo = Bar`
+
+Type aliases support type parameters:
+
+```rust,ignore
+// Rust: pub type Result<T> = std::result::Result<T, MyError>;
+let mut tb = TypeSpec::<RustLang>::builder("Result", TypeKind::TypeAlias);
+tb.visibility(Visibility::Public);
+tb.add_type_param(TypeParamSpec::new("T"));
+tb.extends(TypeName::generic(
+    TypeName::primitive("std::result::Result"),
+    vec![TypeName::primitive("T"), TypeName::primitive("MyError")],
+));
+let type_spec = tb.build().unwrap();
+```
+
+### Newtype wrappers
+
+`TypeKind::Newtype` emits a single-line newtype wrapper. Like type aliases, the inner type is set via `.extends()` (exactly one required).
+
+```rust,ignore
+use sigil_stitch::prelude::*;
+use sigil_stitch::lang::rust_lang::RustLang;
+use sigil_stitch::lang::go_lang::GoLang;
+
+// Rust: pub struct Meters(f64);
+let mut tb = TypeSpec::<RustLang>::builder("Meters", TypeKind::Newtype);
+tb.visibility(Visibility::Public);
+tb.extends(TypeName::primitive("f64"));
+let type_spec = tb.build().unwrap();
+
+// Go: type Meters float64
+let mut tb = TypeSpec::<GoLang>::builder("Meters", TypeKind::Newtype);
+tb.extends(TypeName::primitive("float64"));
+let type_spec = tb.build().unwrap();
+```
+
+Newtype syntax varies across languages and is controlled by `render_newtype_line()`:
+- Rust: `struct Meters(f64);` (tuple struct)
+- Go: `type Meters float64` (distinct type)
+- Kotlin: `value class Meters(val value: f64)` (inline class)
+- Python: `Meters = NewType("Meters", float)` (typing.NewType)
+- C: `typedef float Meters;` (typedef)
 
 ### Enums with EnumVariantSpec
 

--- a/doc/src/type_presentation.md
+++ b/doc/src/type_presentation.md
@@ -1,0 +1,216 @@
+# Type Presentation
+
+This chapter describes how sigil-stitch renders `TypeName` variants across different languages using a data-driven presentation layer.
+
+## The Problem
+
+`TypeName` is a *semantic* type algebra — `Array(T)` means "array of T" regardless of target language. But the surface syntax varies widely:
+
+| TypeName | TypeScript | Rust | Go | Python | C++ |
+|----------|-----------|------|----|--------|-----|
+| `Array(T)` | `T[]` | `Vec<T>` | `[]T` | `list[T]` | `std::vector<T>` |
+| `Optional(T)` | `T \| null` | `Option<T>` | `*T` | `T \| None` | `std::optional<T>` |
+| `Map(K, V)` | `Record<K, V>` | `HashMap<K, V>` | `map[K]V` | `dict[K, V]` | `std::map<K, V>` |
+| `Pointer(T)` | n/a | `*const T` | `*T` | n/a | `T*` |
+
+Each variant needs language-specific rendering, but the rendering follows a small set of structural patterns. Rather than writing per-language rendering code for every variant, we identify these patterns and let languages declare which pattern to use.
+
+## Architecture
+
+```
+              ┌──────────────┐
+              │   TypeName   │  Semantic type algebra
+              │  (unchanged) │  Array, Optional, Map, ...
+              └──────┬───────┘
+                     │ to_doc_with_lang(resolve, lang)
+                     ▼
+          ┌─────────────────────┐
+          │  lang.present_*(…)  │  CodeLang returns TypePresentation (DATA)
+          └──────────┬──────────┘
+                     ▼
+          ┌─────────────────────┐
+          │  Rendering engine   │  Single function: (TypePresentation, inner docs) → BoxDoc
+          │  (one place)        │  Lives in type_name.rs, NEVER in CodeLang impls
+          └──────────┬──────────┘
+                     ▼
+                BoxDoc output
+```
+
+The key invariant: **`BoxDoc` never appears in the `CodeLang` trait.** Languages declare data (which syntactic pattern to use). The rendering engine — a single function in `type_name.rs` — interprets that data into `BoxDoc` output.
+
+This separates three concerns that were previously tangled:
+
+1. **What a type means** — `TypeName` variants (semantic, language-independent)
+2. **How a language spells it** — `TypePresentation` data (per-language, no rendering logic)
+3. **How to assemble output** — rendering engine (one place, all patterns)
+
+## TypePresentation
+
+`TypePresentation` is an enum of syntactic patterns. Each variant describes a structural template for assembling already-rendered inner type docs:
+
+```rust,ignore
+pub enum TypePresentation<'a> {
+    /// `name<P1, P2>` — uses generic_open()/generic_close().
+    /// Vec<T>, Option<T>, HashMap<K,V>, List<T>.
+    GenericWrap { name: &'a str },
+
+    /// `prefix inner` — *T, &T, []T, &mut T.
+    Prefix { prefix: &'a str },
+
+    /// `inner suffix` — T[], T?, T*.
+    Postfix { suffix: &'a str },
+
+    /// `open P1 sep P2 sep ... close` — (A, B), [T], [K: V], dict[K, V].
+    Delimited {
+        open: &'a str,
+        sep: &'a str,
+        close: &'a str,
+    },
+
+    /// `P1 sep P2 sep ... Pn` — A | B, A & B, A + B.
+    Infix { sep: &'a str },
+}
+```
+
+Five patterns cover every type rendering need across all supported languages. A language implementation never builds `BoxDoc` — it returns one of these variants with the appropriate strings filled in.
+
+## FunctionPresentation
+
+Function types are too complex for a single `TypePresentation` variant — they have parameter lists, return types, arrows, optional keywords, and wrappers that combine in language-specific ways. They get their own struct:
+
+```rust,ignore
+pub struct FunctionPresentation<'a> {
+    pub keyword: &'a str,        // "fn", "func", ""
+    pub params_open: &'a str,    // "(", "Callable[["
+    pub params_sep: &'a str,     // ", "
+    pub params_close: &'a str,   // ")", "]]"
+    pub arrow: &'a str,          // " -> ", " => ", ", "
+    pub return_first: bool,      // Dart: R Function(A, B)
+    pub curried: bool,           // Haskell: A -> B -> R
+    pub wrapper_open: &'a str,   // C++: "std::function<"
+    pub wrapper_close: &'a str,  // C++: ">"
+}
+```
+
+This declaratively covers TypeScript `(A, B) => R`, Rust `fn(A, B) -> R`, Python `Callable[[A, B], R]`, C++ `std::function<R(A, B)>`, Dart `R Function(A, B)`, and Haskell `A -> B -> R` — all from a single rendering engine interpreting the data.
+
+## CodeLang Trait Methods
+
+Languages declare their type syntax through `present_*` methods on the `CodeLang` trait. Each method returns data — never `BoxDoc`:
+
+```rust,ignore
+trait CodeLang {
+    fn present_array(&self) -> TypePresentation<'_>;
+    fn present_readonly_array(&self) -> Option<TypePresentation<'_>>;
+    fn present_optional(&self) -> TypePresentation<'_>;
+    fn optional_absent_literal(&self) -> &str;
+    fn present_map(&self) -> TypePresentation<'_>;
+    fn present_union(&self) -> TypePresentation<'_>;
+    fn present_intersection(&self) -> TypePresentation<'_>;
+    fn present_pointer(&self) -> TypePresentation<'_>;
+    fn present_slice(&self) -> TypePresentation<'_>;
+    fn present_function(&self) -> FunctionPresentation<'_>;
+}
+```
+
+Every method has a sensible default. TypeScript needs almost no overrides. Most languages override 3–5 methods with one-line data returns.
+
+## Rendering Engine
+
+A single private function in `type_name.rs` interprets presentations:
+
+```rust,ignore
+fn render_presentation(
+    pres: &TypePresentation<'_>,
+    inner_docs: Vec<BoxDoc<'static, ()>>,
+    lang: &impl CodeLang,
+) -> BoxDoc<'static, ()> {
+    match pres {
+        TypePresentation::GenericWrap { name } => {
+            // name<P1, P2> using lang.generic_open()/generic_close()
+        }
+        TypePresentation::Prefix { prefix } => {
+            // prefix inner
+        }
+        TypePresentation::Postfix { suffix } => {
+            // inner suffix
+        }
+        TypePresentation::Delimited { open, sep, close } => {
+            // open P1 sep P2 close
+        }
+        TypePresentation::Infix { sep } => {
+            // P1 sep P2 sep P3
+        }
+    }
+}
+```
+
+Each `TypeName` variant in `to_doc_with_lang` becomes a three-step process:
+
+1. Recursively render inner types to `BoxDoc`
+2. Ask the language for a `TypePresentation`
+3. Pass both to `render_presentation`
+
+```rust,ignore
+TypeName::Array(inner) => {
+    let inner_doc = inner.to_doc_with_lang(resolve, lang);
+    render_presentation(&lang.present_array(), vec![inner_doc], lang)
+}
+```
+
+## Per-Language Examples
+
+### TypeScript (mostly defaults)
+
+```rust,ignore
+fn present_map(&self) -> TypePresentation<'_> {
+    TypePresentation::GenericWrap { name: "Record" }
+}
+```
+
+Everything else uses defaults: `Array` → `Postfix { suffix: "[]" }`, `Optional` → `Infix { sep: " | " }` with `optional_absent_literal()` returning `"null"`.
+
+### Rust
+
+```rust,ignore
+fn present_array(&self) -> TypePresentation<'_> { GenericWrap { name: "Vec" } }
+fn present_optional(&self) -> TypePresentation<'_> { GenericWrap { name: "Option" } }
+fn present_map(&self) -> TypePresentation<'_> { GenericWrap { name: "HashMap" } }
+fn present_intersection(&self) -> TypePresentation<'_> { Infix { sep: " + " } }
+fn present_pointer(&self) -> TypePresentation<'_> { Prefix { prefix: "*const " } }
+fn present_slice(&self) -> TypePresentation<'_> {
+    Delimited { open: "&[", sep: "", close: "]" }
+}
+```
+
+### Go
+
+```rust,ignore
+fn present_array(&self) -> TypePresentation<'_> { Prefix { prefix: "[]" } }
+fn present_map(&self) -> TypePresentation<'_> {
+    Delimited { open: "map[", sep: "]", close: "" }
+}
+```
+
+Note that `GenericWrap` reuses `generic_open()`/`generic_close()`, so Go's `List[T]` works automatically because Go already sets `generic_open()` to `"["`.
+
+### Swift
+
+```rust,ignore
+fn present_array(&self) -> TypePresentation<'_> {
+    Delimited { open: "[", sep: "", close: "]" }
+}
+fn present_optional(&self) -> TypePresentation<'_> { Postfix { suffix: "?" } }
+fn present_map(&self) -> TypePresentation<'_> {
+    Delimited { open: "[", sep: ": ", close: "]" }
+}
+```
+
+## Design Properties
+
+1. **`BoxDoc` never appears in `CodeLang`** — languages declare data, the engine renders.
+2. **Adding a `TypeName` variant** requires one new `present_*` method returning data. No per-language render code needed.
+3. **~10 methods** replace what would otherwise be ~17+ render methods. Each is a 1-line return.
+4. **One rendering engine** in `type_name.rs` handles all patterns uniformly.
+5. **Semantic types are preserved** — `Array(T)` stays `Array(T)`. The language says "render Array as GenericWrap(Vec)" not "rewrite Array to Generic('Vec', [T])".
+6. **`GenericWrap` reuses `generic_open()`/`generic_close()`** — languages that already configure these delimiters get correct rendering automatically.

--- a/doc/src/type_presentation.md
+++ b/doc/src/type_presentation.md
@@ -12,6 +12,9 @@ This chapter describes how sigil-stitch renders `TypeName` variants across diffe
 | `Optional(T)` | `T \| null` | `Option<T>` | `*T` | `T \| None` | `std::optional<T>` |
 | `Map(K, V)` | `Record<K, V>` | `HashMap<K, V>` | `map[K]V` | `dict[K, V]` | `std::map<K, V>` |
 | `Pointer(T)` | n/a | `*const T` | `*T` | n/a | `T*` |
+| `Tuple(A, B)` | `[A, B]` | `(A, B)` | n/a | `tuple[A, B]` | `std::tuple<A, B>` |
+| `Reference(T)` | (identity) | `&T` | (identity) | (identity) | `const T&` |
+| `Reference(T, mut)` | (identity) | `&mut T` | `*T` | (identity) | `T&` |
 
 Each variant needs language-specific rendering, but the rendering follows a small set of structural patterns. Rather than writing per-language rendering code for every variant, we identify these patterns and let languages declare which pattern to use.
 
@@ -50,7 +53,7 @@ This separates three concerns that were previously tangled:
 
 ```rust,ignore
 pub enum TypePresentation<'a> {
-    /// `name<P1, P2>` — uses generic_open()/generic_close().
+    /// `name<P1, P2>` — delimiters from generic_open()/generic_close().
     /// Vec<T>, Option<T>, HashMap<K,V>, List<T>.
     GenericWrap { name: &'a str },
 
@@ -59,6 +62,9 @@ pub enum TypePresentation<'a> {
 
     /// `inner suffix` — T[], T?, T*.
     Postfix { suffix: &'a str },
+
+    /// `prefix inner suffix` — const T&, const T*.
+    Surround { prefix: &'a str, suffix: &'a str },
 
     /// `open P1 sep P2 sep ... close` — (A, B), [T], [K: V], dict[K, V].
     Delimited {
@@ -72,7 +78,7 @@ pub enum TypePresentation<'a> {
 }
 ```
 
-Five patterns cover every type rendering need across all supported languages. A language implementation never builds `BoxDoc` — it returns one of these variants with the appropriate strings filled in.
+Six patterns cover every type rendering need across all supported languages. A language implementation never builds `BoxDoc` — it returns one of these variants with the appropriate strings filled in.
 
 ## FunctionPresentation
 
@@ -109,6 +115,9 @@ trait CodeLang {
     fn present_intersection(&self) -> TypePresentation<'_>;
     fn present_pointer(&self) -> TypePresentation<'_>;
     fn present_slice(&self) -> TypePresentation<'_>;
+    fn present_tuple(&self) -> TypePresentation<'_>;
+    fn present_reference(&self) -> TypePresentation<'_>;
+    fn present_reference_mut(&self) -> TypePresentation<'_>;
     fn present_function(&self) -> FunctionPresentation<'_>;
 }
 ```
@@ -134,6 +143,9 @@ fn render_presentation(
         }
         TypePresentation::Postfix { suffix } => {
             // inner suffix
+        }
+        TypePresentation::Surround { prefix, suffix } => {
+            // prefix inner suffix
         }
         TypePresentation::Delimited { open, sep, close } => {
             // open P1 sep P2 close
@@ -181,7 +193,24 @@ fn present_pointer(&self) -> TypePresentation<'_> { Prefix { prefix: "*const " }
 fn present_slice(&self) -> TypePresentation<'_> {
     Delimited { open: "&[", sep: "", close: "]" }
 }
+fn present_reference(&self) -> TypePresentation<'_> { Prefix { prefix: "&" } }
+fn present_reference_mut(&self) -> TypePresentation<'_> { Prefix { prefix: "&mut " } }
 ```
+
+### C++
+
+```rust,ignore
+fn present_array(&self) -> TypePresentation<'_> { GenericWrap { name: "std::vector" } }
+fn present_optional(&self) -> TypePresentation<'_> { GenericWrap { name: "std::optional" } }
+fn present_pointer(&self) -> TypePresentation<'_> { Postfix { suffix: "*" } }
+fn present_reference(&self) -> TypePresentation<'_> {
+    Surround { prefix: "const ", suffix: "&" }
+}
+fn present_reference_mut(&self) -> TypePresentation<'_> { Postfix { suffix: "&" } }
+fn present_tuple(&self) -> TypePresentation<'_> { GenericWrap { name: "std::tuple" } }
+```
+
+The `Surround` variant was introduced specifically for C++'s `const T&` pattern, where a type needs both a prefix and a suffix. C uses it similarly for `const T*`.
 
 ### Go
 
@@ -210,7 +239,7 @@ fn present_map(&self) -> TypePresentation<'_> {
 
 1. **`BoxDoc` never appears in `CodeLang`** — languages declare data, the engine renders.
 2. **Adding a `TypeName` variant** requires one new `present_*` method returning data. No per-language render code needed.
-3. **~10 methods** replace what would otherwise be ~17+ render methods. Each is a 1-line return.
+3. **~13 methods** replace what would otherwise be ~20+ render methods. Each is a 1-line return.
 4. **One rendering engine** in `type_name.rs` handles all patterns uniformly.
 5. **Semantic types are preserved** — `Array(T)` stays `Array(T)`. The language says "render Array as GenericWrap(Vec)" not "rewrite Array to Generic('Vec', [T])".
 6. **`GenericWrap` reuses `generic_open()`/`generic_close()`** — languages that already configure these delimiters get correct rendering automatically.

--- a/src/code_block.rs
+++ b/src/code_block.rs
@@ -313,50 +313,50 @@ impl<L: CodeLang> Default for CodeBlockBuilder<L> {
 fn parse_format(format: &str) -> Result<Vec<FormatPart>, crate::error::SigilStitchError> {
     let mut parts = Vec::new();
     let mut current_literal = String::new();
-    let bytes = format.as_bytes();
-    let mut i = 0;
+    let mut chars = format.char_indices().peekable();
 
-    while i < bytes.len() {
-        if bytes[i] == b'%' && i + 1 < bytes.len() {
-            let spec = bytes[i + 1];
-            let part = match spec {
-                b'T' => Some(FormatPart::Type),
-                b'N' => Some(FormatPart::Name),
-                b'S' => Some(FormatPart::StringLit),
-                b'L' => Some(FormatPart::Literal_),
-                b'W' => Some(FormatPart::Wrap),
-                b'>' => Some(FormatPart::Indent),
-                b'<' => Some(FormatPart::Dedent),
-                b'[' => Some(FormatPart::StatementBegin),
-                b']' => Some(FormatPart::StatementEnd),
-                b'%' => {
-                    current_literal.push('%');
-                    i += 2;
-                    continue;
+    while let Some(&(_, ch)) = chars.peek() {
+        if ch == '%' {
+            chars.next();
+            if let Some(&(_, spec)) = chars.peek() {
+                chars.next();
+                let part = match spec {
+                    'T' => Some(FormatPart::Type),
+                    'N' => Some(FormatPart::Name),
+                    'S' => Some(FormatPart::StringLit),
+                    'L' => Some(FormatPart::Literal_),
+                    'W' => Some(FormatPart::Wrap),
+                    '>' => Some(FormatPart::Indent),
+                    '<' => Some(FormatPart::Dedent),
+                    '[' => Some(FormatPart::StatementBegin),
+                    ']' => Some(FormatPart::StatementEnd),
+                    '%' => {
+                        current_literal.push('%');
+                        continue;
+                    }
+                    _ => {
+                        return Err(crate::error::SigilStitchError::InvalidFormatSpecifier {
+                            format: format.to_string(),
+                            specifier: spec,
+                        });
+                    }
+                };
+                if let Some(part) = part {
+                    if !current_literal.is_empty() {
+                        parts.push(FormatPart::Literal(std::mem::take(&mut current_literal)));
+                    }
+                    parts.push(part);
                 }
-                _ => {
-                    return Err(crate::error::SigilStitchError::InvalidFormatSpecifier {
-                        format: format.to_string(),
-                        specifier: spec as char,
-                    });
-                }
-            };
-            if let Some(part) = part {
-                if !current_literal.is_empty() {
-                    parts.push(FormatPart::Literal(std::mem::take(&mut current_literal)));
-                }
-                parts.push(part);
             }
-            i += 2;
-        } else if bytes[i] == b'\n' {
+        } else if ch == '\n' {
+            chars.next();
             if !current_literal.is_empty() {
                 parts.push(FormatPart::Literal(std::mem::take(&mut current_literal)));
             }
             parts.push(FormatPart::Newline);
-            i += 1;
         } else {
-            current_literal.push(bytes[i] as char);
-            i += 1;
+            chars.next();
+            current_literal.push(ch);
         }
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -92,4 +92,15 @@ pub enum SigilStitchError {
         /// The duplicated field name.
         field_name: String,
     },
+
+    /// Invalid TypeAlias or Newtype declaration.
+    #[snafu(display("invalid {kind} {type_name:?}: {reason}"))]
+    InvalidTypeAlias {
+        /// The kind of declaration ("TypeAlias" or "Newtype").
+        kind: &'static str,
+        /// The type name.
+        type_name: String,
+        /// The reason the declaration is invalid.
+        reason: String,
+    },
 }

--- a/src/lang/c_lang.rs
+++ b/src/lang/c_lang.rs
@@ -251,6 +251,8 @@ impl CodeLang for CLang {
             TypeKind::Struct | TypeKind::Class => "struct",
             TypeKind::Enum => "enum",
             TypeKind::Interface | TypeKind::Trait => "struct",
+            TypeKind::TypeAlias => "typedef",
+            TypeKind::Newtype => "typedef",
         }
     }
 
@@ -259,8 +261,15 @@ impl CodeLang for CLang {
     }
 
     fn methods_inside_type_body(&self, _kind: TypeKind) -> bool {
-        // C structs/enums have no methods inside the body.
         false
+    }
+
+    fn type_alias_target_first(&self) -> bool {
+        true
+    }
+
+    fn render_newtype_line(&self, _vis: &str, name: &str, inner: &str) -> String {
+        format!("typedef {inner} {name};")
     }
 
     fn generic_constraint_keyword(&self) -> &str {

--- a/src/lang/c_lang.rs
+++ b/src/lang/c_lang.rs
@@ -298,6 +298,24 @@ impl CodeLang for CLang {
     fn optional_field_style(&self) -> crate::lang::config::OptionalFieldStyle {
         crate::lang::config::OptionalFieldStyle::TypePrefix("*")
     }
+
+    fn present_pointer(&self) -> crate::type_name::TypePresentation<'_> {
+        crate::type_name::TypePresentation::Postfix { suffix: "*" }
+    }
+
+    fn present_function(&self) -> crate::type_name::FunctionPresentation<'_> {
+        crate::type_name::FunctionPresentation {
+            keyword: "",
+            params_open: "(",
+            params_sep: ", ",
+            params_close: ")",
+            arrow: "",
+            return_first: true,
+            curried: false,
+            wrapper_open: "",
+            wrapper_close: "",
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/lang/c_lang.rs
+++ b/src/lang/c_lang.rs
@@ -303,6 +303,17 @@ impl CodeLang for CLang {
         crate::type_name::TypePresentation::Postfix { suffix: "*" }
     }
 
+    fn present_reference(&self) -> crate::type_name::TypePresentation<'_> {
+        crate::type_name::TypePresentation::Surround {
+            prefix: "const ",
+            suffix: "*",
+        }
+    }
+
+    fn present_reference_mut(&self) -> crate::type_name::TypePresentation<'_> {
+        crate::type_name::TypePresentation::Postfix { suffix: "*" }
+    }
+
     fn present_function(&self) -> crate::type_name::FunctionPresentation<'_> {
         crate::type_name::FunctionPresentation {
             keyword: "",

--- a/src/lang/cpp_lang.rs
+++ b/src/lang/cpp_lang.rs
@@ -257,6 +257,8 @@ impl CodeLang for CppLang {
             TypeKind::Struct => "struct",
             TypeKind::Enum => "enum class",
             TypeKind::Interface | TypeKind::Trait => "class",
+            TypeKind::TypeAlias => "using",
+            TypeKind::Newtype => "struct",
         }
     }
 
@@ -267,7 +269,7 @@ impl CodeLang for CppLang {
     fn methods_inside_type_body(&self, kind: TypeKind) -> bool {
         match kind {
             TypeKind::Class | TypeKind::Interface | TypeKind::Trait => true,
-            TypeKind::Struct | TypeKind::Enum => false,
+            TypeKind::Struct | TypeKind::Enum | TypeKind::TypeAlias | TypeKind::Newtype => false,
         }
     }
 
@@ -371,9 +373,7 @@ impl CodeLang for CppLang {
     }
 
     fn present_tuple(&self) -> crate::type_name::TypePresentation<'_> {
-        crate::type_name::TypePresentation::GenericWrap {
-            name: "std::tuple",
-        }
+        crate::type_name::TypePresentation::GenericWrap { name: "std::tuple" }
     }
 }
 

--- a/src/lang/cpp_lang.rs
+++ b/src/lang/cpp_lang.rs
@@ -318,6 +318,46 @@ impl CodeLang for CppLang {
             close: ">",
         }
     }
+
+    fn present_array(&self) -> crate::type_name::TypePresentation<'_> {
+        crate::type_name::TypePresentation::GenericWrap {
+            name: "std::vector",
+        }
+    }
+
+    fn present_readonly_array(&self) -> Option<crate::type_name::TypePresentation<'_>> {
+        Some(crate::type_name::TypePresentation::GenericWrap {
+            name: "std::vector",
+        })
+    }
+
+    fn present_optional(&self) -> crate::type_name::TypePresentation<'_> {
+        crate::type_name::TypePresentation::GenericWrap {
+            name: "std::optional",
+        }
+    }
+
+    fn present_map(&self) -> crate::type_name::TypePresentation<'_> {
+        crate::type_name::TypePresentation::GenericWrap { name: "std::map" }
+    }
+
+    fn present_pointer(&self) -> crate::type_name::TypePresentation<'_> {
+        crate::type_name::TypePresentation::Postfix { suffix: "*" }
+    }
+
+    fn present_function(&self) -> crate::type_name::FunctionPresentation<'_> {
+        crate::type_name::FunctionPresentation {
+            keyword: "",
+            params_open: "(",
+            params_sep: ", ",
+            params_close: ")",
+            arrow: "",
+            return_first: true,
+            curried: false,
+            wrapper_open: "std::function<",
+            wrapper_close: ">",
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/lang/cpp_lang.rs
+++ b/src/lang/cpp_lang.rs
@@ -358,6 +358,12 @@ impl CodeLang for CppLang {
             wrapper_close: ">",
         }
     }
+
+    fn present_tuple(&self) -> crate::type_name::TypePresentation<'_> {
+        crate::type_name::TypePresentation::GenericWrap {
+            name: "std::tuple",
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/lang/cpp_lang.rs
+++ b/src/lang/cpp_lang.rs
@@ -345,6 +345,17 @@ impl CodeLang for CppLang {
         crate::type_name::TypePresentation::Postfix { suffix: "*" }
     }
 
+    fn present_reference(&self) -> crate::type_name::TypePresentation<'_> {
+        crate::type_name::TypePresentation::Surround {
+            prefix: "const ",
+            suffix: "&",
+        }
+    }
+
+    fn present_reference_mut(&self) -> crate::type_name::TypePresentation<'_> {
+        crate::type_name::TypePresentation::Postfix { suffix: "&" }
+    }
+
     fn present_function(&self) -> crate::type_name::FunctionPresentation<'_> {
         crate::type_name::FunctionPresentation {
             keyword: "",

--- a/src/lang/dart.rs
+++ b/src/lang/dart.rs
@@ -226,6 +226,8 @@ impl CodeLang for DartLang {
             TypeKind::Class | TypeKind::Struct => "class",
             TypeKind::Interface | TypeKind::Trait => "abstract class",
             TypeKind::Enum => "enum",
+            TypeKind::TypeAlias => "typedef",
+            TypeKind::Newtype => "class",
         }
     }
 

--- a/src/lang/dart.rs
+++ b/src/lang/dart.rs
@@ -274,6 +274,36 @@ impl CodeLang for DartLang {
     fn optional_field_style(&self) -> crate::lang::config::OptionalFieldStyle {
         crate::lang::config::OptionalFieldStyle::TypeSuffix("?")
     }
+
+    fn present_array(&self) -> crate::type_name::TypePresentation<'_> {
+        crate::type_name::TypePresentation::GenericWrap { name: "List" }
+    }
+
+    fn present_readonly_array(&self) -> Option<crate::type_name::TypePresentation<'_>> {
+        Some(crate::type_name::TypePresentation::GenericWrap { name: "List" })
+    }
+
+    fn present_optional(&self) -> crate::type_name::TypePresentation<'_> {
+        crate::type_name::TypePresentation::Postfix { suffix: "?" }
+    }
+
+    fn present_map(&self) -> crate::type_name::TypePresentation<'_> {
+        crate::type_name::TypePresentation::GenericWrap { name: "Map" }
+    }
+
+    fn present_function(&self) -> crate::type_name::FunctionPresentation<'_> {
+        crate::type_name::FunctionPresentation {
+            keyword: " Function",
+            params_open: "(",
+            params_sep: ", ",
+            params_close: ")",
+            arrow: "",
+            return_first: true,
+            curried: false,
+            wrapper_open: "",
+            wrapper_close: "",
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/lang/go_lang.rs
+++ b/src/lang/go_lang.rs
@@ -300,6 +300,48 @@ impl CodeLang for GoLang {
     fn optional_field_style(&self) -> crate::lang::config::OptionalFieldStyle {
         crate::lang::config::OptionalFieldStyle::TypePrefix("*")
     }
+
+    fn present_array(&self) -> crate::type_name::TypePresentation<'_> {
+        crate::type_name::TypePresentation::Prefix { prefix: "[]" }
+    }
+
+    fn present_readonly_array(&self) -> Option<crate::type_name::TypePresentation<'_>> {
+        Some(crate::type_name::TypePresentation::Prefix { prefix: "[]" })
+    }
+
+    fn present_optional(&self) -> crate::type_name::TypePresentation<'_> {
+        crate::type_name::TypePresentation::Prefix { prefix: "*" }
+    }
+
+    fn present_map(&self) -> crate::type_name::TypePresentation<'_> {
+        crate::type_name::TypePresentation::Delimited {
+            open: "map[",
+            sep: "]",
+            close: "",
+        }
+    }
+
+    fn present_pointer(&self) -> crate::type_name::TypePresentation<'_> {
+        crate::type_name::TypePresentation::Prefix { prefix: "*" }
+    }
+
+    fn present_slice(&self) -> crate::type_name::TypePresentation<'_> {
+        crate::type_name::TypePresentation::Prefix { prefix: "[]" }
+    }
+
+    fn present_function(&self) -> crate::type_name::FunctionPresentation<'_> {
+        crate::type_name::FunctionPresentation {
+            keyword: "func",
+            params_open: "(",
+            params_sep: ", ",
+            params_close: ")",
+            arrow: " ",
+            return_first: false,
+            curried: false,
+            wrapper_open: "",
+            wrapper_close: "",
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/lang/go_lang.rs
+++ b/src/lang/go_lang.rs
@@ -243,12 +243,18 @@ impl CodeLang for GoLang {
     }
 
     fn methods_inside_type_body(&self, kind: TypeKind) -> bool {
-        // Go interfaces have method signatures in the body.
-        // Go structs do not — methods are standalone with receivers.
         match kind {
             TypeKind::Interface | TypeKind::Trait => true,
-            TypeKind::Struct | TypeKind::Class | TypeKind::Enum => false,
+            TypeKind::Struct
+            | TypeKind::Class
+            | TypeKind::Enum
+            | TypeKind::TypeAlias
+            | TypeKind::Newtype => false,
         }
+    }
+
+    fn render_newtype_line(&self, _vis: &str, name: &str, inner: &str) -> String {
+        format!("type {name} {inner}")
     }
 
     fn generic_constraint_keyword(&self) -> &str {
@@ -289,7 +295,7 @@ impl CodeLang for GoLang {
         match kind {
             TypeKind::Struct | TypeKind::Class => "struct",
             TypeKind::Interface | TypeKind::Trait => "interface",
-            TypeKind::Enum => "",
+            TypeKind::Enum | TypeKind::TypeAlias | TypeKind::Newtype => "",
         }
     }
 

--- a/src/lang/go_lang.rs
+++ b/src/lang/go_lang.rs
@@ -329,6 +329,10 @@ impl CodeLang for GoLang {
         crate::type_name::TypePresentation::Prefix { prefix: "[]" }
     }
 
+    fn present_reference_mut(&self) -> crate::type_name::TypePresentation<'_> {
+        crate::type_name::TypePresentation::Prefix { prefix: "*" }
+    }
+
     fn present_function(&self) -> crate::type_name::FunctionPresentation<'_> {
         crate::type_name::FunctionPresentation {
             keyword: "func",

--- a/src/lang/java_lang.rs
+++ b/src/lang/java_lang.rs
@@ -289,6 +289,22 @@ impl CodeLang for JavaLang {
             close: ">",
         }
     }
+
+    fn present_array(&self) -> crate::type_name::TypePresentation<'_> {
+        crate::type_name::TypePresentation::GenericWrap { name: "List" }
+    }
+
+    fn present_readonly_array(&self) -> Option<crate::type_name::TypePresentation<'_>> {
+        Some(crate::type_name::TypePresentation::GenericWrap { name: "List" })
+    }
+
+    fn present_optional(&self) -> crate::type_name::TypePresentation<'_> {
+        crate::type_name::TypePresentation::GenericWrap { name: "Optional" }
+    }
+
+    fn present_map(&self) -> crate::type_name::TypePresentation<'_> {
+        crate::type_name::TypePresentation::GenericWrap { name: "Map" }
+    }
 }
 
 #[cfg(test)]

--- a/src/lang/java_lang.rs
+++ b/src/lang/java_lang.rs
@@ -236,6 +236,7 @@ impl CodeLang for JavaLang {
             TypeKind::Class | TypeKind::Struct => "class",
             TypeKind::Interface | TypeKind::Trait => "interface",
             TypeKind::Enum => "enum",
+            TypeKind::TypeAlias | TypeKind::Newtype => "class",
         }
     }
 

--- a/src/lang/javascript.rs
+++ b/src/lang/javascript.rs
@@ -250,10 +250,9 @@ impl CodeLang for JavaScript {
     fn type_keyword(&self, kind: TypeKind) -> &str {
         match kind {
             TypeKind::Class | TypeKind::Struct => "class",
-            // JS has no interface/trait — map to class for fallback.
             TypeKind::Interface | TypeKind::Trait => "class",
-            // JS has no native enum — map to class for fallback.
             TypeKind::Enum => "class",
+            TypeKind::TypeAlias | TypeKind::Newtype => "class",
         }
     }
 

--- a/src/lang/javascript.rs
+++ b/src/lang/javascript.rs
@@ -291,6 +291,14 @@ impl CodeLang for JavaScript {
     fn enum_variant_trailing_separator(&self) -> bool {
         true
     }
+
+    fn present_tuple(&self) -> crate::type_name::TypePresentation<'_> {
+        crate::type_name::TypePresentation::Delimited {
+            open: "[",
+            sep: ", ",
+            close: "]",
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/lang/kotlin.rs
+++ b/src/lang/kotlin.rs
@@ -361,6 +361,36 @@ impl CodeLang for Kotlin {
     fn optional_field_style(&self) -> crate::lang::config::OptionalFieldStyle {
         crate::lang::config::OptionalFieldStyle::TypeSuffix("?")
     }
+
+    fn present_array(&self) -> crate::type_name::TypePresentation<'_> {
+        crate::type_name::TypePresentation::GenericWrap { name: "List" }
+    }
+
+    fn present_readonly_array(&self) -> Option<crate::type_name::TypePresentation<'_>> {
+        Some(crate::type_name::TypePresentation::GenericWrap { name: "List" })
+    }
+
+    fn present_optional(&self) -> crate::type_name::TypePresentation<'_> {
+        crate::type_name::TypePresentation::Postfix { suffix: "?" }
+    }
+
+    fn present_map(&self) -> crate::type_name::TypePresentation<'_> {
+        crate::type_name::TypePresentation::GenericWrap { name: "Map" }
+    }
+
+    fn present_function(&self) -> crate::type_name::FunctionPresentation<'_> {
+        crate::type_name::FunctionPresentation {
+            keyword: "",
+            params_open: "(",
+            params_sep: ", ",
+            params_close: ")",
+            arrow: " -> ",
+            return_first: false,
+            curried: false,
+            wrapper_open: "",
+            wrapper_close: "",
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/lang/kotlin.rs
+++ b/src/lang/kotlin.rs
@@ -297,6 +297,8 @@ impl CodeLang for Kotlin {
             TypeKind::Struct => "data class",
             TypeKind::Interface | TypeKind::Trait => "interface",
             TypeKind::Enum => "enum class",
+            TypeKind::TypeAlias => "typealias",
+            TypeKind::Newtype => "value class",
         }
     }
 
@@ -306,6 +308,10 @@ impl CodeLang for Kotlin {
 
     fn methods_inside_type_body(&self, _kind: TypeKind) -> bool {
         true
+    }
+
+    fn render_newtype_line(&self, vis: &str, name: &str, inner: &str) -> String {
+        format!("{vis}value class {name}(val value: {inner})")
     }
 
     fn generic_constraint_keyword(&self) -> &str {

--- a/src/lang/mod.rs
+++ b/src/lang/mod.rs
@@ -257,6 +257,20 @@ pub trait CodeLang: Sized + Clone + 'static {
         ""
     }
 
+    /// Whether type alias uses reversed order (`typedef target name;` in C).
+    ///
+    /// Default: `false` (most languages: `type name = target`).
+    fn type_alias_target_first(&self) -> bool {
+        false
+    }
+
+    /// Render a newtype declaration line from pre-rendered components.
+    ///
+    /// Default: Rust tuple-struct `{vis}struct {name}({inner});`.
+    fn render_newtype_line(&self, vis: &str, name: &str, inner: &str) -> String {
+        format!("{vis}struct {name}({inner});")
+    }
+
     /// Opening block delimiter appended after a function signature or type header.
     ///
     /// Default: `" {"` (brace languages). Python overrides to `":"`.

--- a/src/lang/mod.rs
+++ b/src/lang/mod.rs
@@ -132,6 +132,91 @@ pub trait CodeLang: Sized + Clone + 'static {
         ">"
     }
 
+    // --- Type presentation (data-driven, no BoxDoc) ---
+
+    /// How `TypeName::Array(T)` renders.
+    ///
+    /// Default: `Postfix { suffix: "[]" }` (TypeScript `T[]`).
+    fn present_array(&self) -> crate::type_name::TypePresentation<'_> {
+        crate::type_name::TypePresentation::Postfix { suffix: "[]" }
+    }
+
+    /// How `TypeName::ReadonlyArray(T)` renders.
+    ///
+    /// Default: `None` — renders as `readonly ` + the array presentation.
+    /// Override to return `Some(...)` for languages with distinct readonly array syntax.
+    fn present_readonly_array(&self) -> Option<crate::type_name::TypePresentation<'_>> {
+        None
+    }
+
+    /// How `TypeName::Optional(T)` renders.
+    ///
+    /// Default: `Infix { sep: " | " }` — renders `T | null` (TypeScript style).
+    /// When using `Infix`, the absent literal from `optional_absent_literal()` is
+    /// automatically appended as the second member.
+    fn present_optional(&self) -> crate::type_name::TypePresentation<'_> {
+        crate::type_name::TypePresentation::Infix { sep: " | " }
+    }
+
+    /// The literal used for the "absent" case in Optional when using `Infix` presentation.
+    ///
+    /// Default: `"null"`. Python: `"None"`.
+    fn optional_absent_literal(&self) -> &str {
+        "null"
+    }
+
+    /// How `TypeName::Map { K, V }` renders.
+    ///
+    /// Default: `GenericWrap { name: "Map" }`.
+    fn present_map(&self) -> crate::type_name::TypePresentation<'_> {
+        crate::type_name::TypePresentation::GenericWrap { name: "Map" }
+    }
+
+    /// How `TypeName::Union(members)` renders.
+    ///
+    /// Default: `Infix { sep: " | " }`.
+    fn present_union(&self) -> crate::type_name::TypePresentation<'_> {
+        crate::type_name::TypePresentation::Infix { sep: " | " }
+    }
+
+    /// How `TypeName::Intersection(members)` renders.
+    ///
+    /// Default: `Infix { sep: " & " }`.
+    fn present_intersection(&self) -> crate::type_name::TypePresentation<'_> {
+        crate::type_name::TypePresentation::Infix { sep: " & " }
+    }
+
+    /// How `TypeName::Pointer(T)` renders.
+    ///
+    /// Default: `Prefix { prefix: "*" }`.
+    fn present_pointer(&self) -> crate::type_name::TypePresentation<'_> {
+        crate::type_name::TypePresentation::Prefix { prefix: "*" }
+    }
+
+    /// How `TypeName::Slice(T)` renders.
+    ///
+    /// Default: `Prefix { prefix: "[]" }`.
+    fn present_slice(&self) -> crate::type_name::TypePresentation<'_> {
+        crate::type_name::TypePresentation::Prefix { prefix: "[]" }
+    }
+
+    /// How `TypeName::Function { params, return_type }` renders.
+    ///
+    /// Default: TypeScript `(A, B) => R`.
+    fn present_function(&self) -> crate::type_name::FunctionPresentation<'_> {
+        crate::type_name::FunctionPresentation {
+            keyword: "",
+            params_open: "(",
+            params_sep: ", ",
+            params_close: ")",
+            arrow: " => ",
+            return_first: false,
+            curried: false,
+            wrapper_open: "",
+            wrapper_close: "",
+        }
+    }
+
     /// Qualify an import name for rendering in code.
     ///
     /// Default: return the resolved name as-is (TS/Rust import individual symbols).
@@ -167,6 +252,14 @@ pub trait CodeLang: Sized + Clone + 'static {
     /// Default: `false`. Python overrides to `true` (docstrings go inside the body).
     fn doc_comment_inside_body(&self) -> bool {
         false
+    }
+
+    /// Whether doc comments should be emitted before annotations/attributes.
+    ///
+    /// Default: `true`. Most languages (Rust, Go, TypeScript) put doc comments
+    /// above annotations. Java overrides to `false` (`@Override` before Javadoc).
+    fn doc_before_annotations(&self) -> bool {
+        true
     }
 
     /// Closing delimiter for base class / implements list.

--- a/src/lang/mod.rs
+++ b/src/lang/mod.rs
@@ -211,6 +211,20 @@ pub trait CodeLang: Sized + Clone + 'static {
         }
     }
 
+    /// How `TypeName::Reference { mutable: false }` renders.
+    ///
+    /// Default: `Prefix { prefix: "" }` — GC languages render as bare inner type.
+    fn present_reference(&self) -> crate::type_name::TypePresentation<'_> {
+        crate::type_name::TypePresentation::Prefix { prefix: "" }
+    }
+
+    /// How `TypeName::Reference { mutable: true }` renders.
+    ///
+    /// Default: `Prefix { prefix: "" }` — GC languages render as bare inner type.
+    fn present_reference_mut(&self) -> crate::type_name::TypePresentation<'_> {
+        crate::type_name::TypePresentation::Prefix { prefix: "" }
+    }
+
     /// How `TypeName::Function { params, return_type }` renders.
     ///
     /// Default: TypeScript `(A, B) => R`.

--- a/src/lang/mod.rs
+++ b/src/lang/mod.rs
@@ -200,6 +200,17 @@ pub trait CodeLang: Sized + Clone + 'static {
         crate::type_name::TypePresentation::Prefix { prefix: "[]" }
     }
 
+    /// How `TypeName::Tuple(elements)` renders.
+    ///
+    /// Default: `Delimited { open: "(", sep: ", ", close: ")" }` (Rust/Swift `(A, B, C)`).
+    fn present_tuple(&self) -> crate::type_name::TypePresentation<'_> {
+        crate::type_name::TypePresentation::Delimited {
+            open: "(",
+            sep: ", ",
+            close: ")",
+        }
+    }
+
     /// How `TypeName::Function { params, return_type }` renders.
     ///
     /// Default: TypeScript `(A, B) => R`.

--- a/src/lang/python.rs
+++ b/src/lang/python.rs
@@ -371,6 +371,40 @@ impl CodeLang for Python {
     fn optional_field_style(&self) -> crate::lang::config::OptionalFieldStyle {
         crate::lang::config::OptionalFieldStyle::UnionWithNone(" | ")
     }
+
+    fn present_array(&self) -> crate::type_name::TypePresentation<'_> {
+        crate::type_name::TypePresentation::GenericWrap { name: "list" }
+    }
+
+    fn present_readonly_array(&self) -> Option<crate::type_name::TypePresentation<'_>> {
+        Some(crate::type_name::TypePresentation::GenericWrap { name: "list" })
+    }
+
+    fn optional_absent_literal(&self) -> &str {
+        "None"
+    }
+
+    fn present_map(&self) -> crate::type_name::TypePresentation<'_> {
+        crate::type_name::TypePresentation::Delimited {
+            open: "dict[",
+            sep: ", ",
+            close: "]",
+        }
+    }
+
+    fn present_function(&self) -> crate::type_name::FunctionPresentation<'_> {
+        crate::type_name::FunctionPresentation {
+            keyword: "",
+            params_open: "Callable[[",
+            params_sep: ", ",
+            params_close: "]",
+            arrow: ", ",
+            return_first: false,
+            curried: false,
+            wrapper_open: "",
+            wrapper_close: "]",
+        }
+    }
 }
 
 /// Render a `from module import name1, name2` line.

--- a/src/lang/python.rs
+++ b/src/lang/python.rs
@@ -300,8 +300,12 @@ impl CodeLang for Python {
         " -> "
     }
 
-    fn type_keyword(&self, _kind: TypeKind) -> &str {
-        "class"
+    fn type_keyword(&self, kind: TypeKind) -> &str {
+        match kind {
+            TypeKind::TypeAlias => "type",
+            TypeKind::Newtype => "class",
+            _ => "class",
+        }
     }
 
     fn field_terminator(&self) -> &str {
@@ -309,8 +313,11 @@ impl CodeLang for Python {
     }
 
     fn methods_inside_type_body(&self, _kind: TypeKind) -> bool {
-        // Python always has methods inside the class body.
         true
+    }
+
+    fn render_newtype_line(&self, _vis: &str, name: &str, inner: &str) -> String {
+        format!("{name} = NewType(\"{name}\", {inner})")
     }
 
     fn generic_constraint_keyword(&self) -> &str {

--- a/src/lang/python.rs
+++ b/src/lang/python.rs
@@ -405,6 +405,10 @@ impl CodeLang for Python {
             wrapper_close: "]",
         }
     }
+
+    fn present_tuple(&self) -> crate::type_name::TypePresentation<'_> {
+        crate::type_name::TypePresentation::GenericWrap { name: "tuple" }
+    }
 }
 
 /// Render a `from module import name1, name2` line.

--- a/src/lang/rust_lang.rs
+++ b/src/lang/rust_lang.rs
@@ -215,6 +215,8 @@ impl CodeLang for RustLang {
             TypeKind::Struct | TypeKind::Class => "struct",
             TypeKind::Trait | TypeKind::Interface => "trait",
             TypeKind::Enum => "enum",
+            TypeKind::TypeAlias => "type",
+            TypeKind::Newtype => "struct",
         }
     }
 
@@ -225,7 +227,11 @@ impl CodeLang for RustLang {
     fn methods_inside_type_body(&self, kind: TypeKind) -> bool {
         match kind {
             TypeKind::Trait | TypeKind::Interface => true,
-            TypeKind::Struct | TypeKind::Class | TypeKind::Enum => false,
+            TypeKind::Struct
+            | TypeKind::Class
+            | TypeKind::Enum
+            | TypeKind::TypeAlias
+            | TypeKind::Newtype => false,
         }
     }
 

--- a/src/lang/rust_lang.rs
+++ b/src/lang/rust_lang.rs
@@ -263,6 +263,52 @@ impl CodeLang for RustLang {
             close: ">",
         }
     }
+
+    fn present_array(&self) -> crate::type_name::TypePresentation<'_> {
+        crate::type_name::TypePresentation::GenericWrap { name: "Vec" }
+    }
+
+    fn present_readonly_array(&self) -> Option<crate::type_name::TypePresentation<'_>> {
+        Some(crate::type_name::TypePresentation::GenericWrap { name: "Vec" })
+    }
+
+    fn present_optional(&self) -> crate::type_name::TypePresentation<'_> {
+        crate::type_name::TypePresentation::GenericWrap { name: "Option" }
+    }
+
+    fn present_map(&self) -> crate::type_name::TypePresentation<'_> {
+        crate::type_name::TypePresentation::GenericWrap { name: "HashMap" }
+    }
+
+    fn present_intersection(&self) -> crate::type_name::TypePresentation<'_> {
+        crate::type_name::TypePresentation::Infix { sep: " + " }
+    }
+
+    fn present_pointer(&self) -> crate::type_name::TypePresentation<'_> {
+        crate::type_name::TypePresentation::Prefix { prefix: "*const " }
+    }
+
+    fn present_slice(&self) -> crate::type_name::TypePresentation<'_> {
+        crate::type_name::TypePresentation::Delimited {
+            open: "&[",
+            sep: "",
+            close: "]",
+        }
+    }
+
+    fn present_function(&self) -> crate::type_name::FunctionPresentation<'_> {
+        crate::type_name::FunctionPresentation {
+            keyword: "fn",
+            params_open: "(",
+            params_sep: ", ",
+            params_close: ")",
+            arrow: " -> ",
+            return_first: false,
+            curried: false,
+            wrapper_open: "",
+            wrapper_close: "",
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/lang/rust_lang.rs
+++ b/src/lang/rust_lang.rs
@@ -296,6 +296,14 @@ impl CodeLang for RustLang {
         }
     }
 
+    fn present_reference(&self) -> crate::type_name::TypePresentation<'_> {
+        crate::type_name::TypePresentation::Prefix { prefix: "&" }
+    }
+
+    fn present_reference_mut(&self) -> crate::type_name::TypePresentation<'_> {
+        crate::type_name::TypePresentation::Prefix { prefix: "&mut " }
+    }
+
     fn present_function(&self) -> crate::type_name::FunctionPresentation<'_> {
         crate::type_name::FunctionPresentation {
             keyword: "fn",

--- a/src/lang/swift.rs
+++ b/src/lang/swift.rs
@@ -289,6 +289,7 @@ impl CodeLang for Swift {
             TypeKind::Struct => "struct",
             TypeKind::Interface | TypeKind::Trait => "protocol",
             TypeKind::Enum => "enum",
+            TypeKind::TypeAlias | TypeKind::Newtype => "typealias",
         }
     }
 

--- a/src/lang/swift.rs
+++ b/src/lang/swift.rs
@@ -346,6 +346,34 @@ impl CodeLang for Swift {
     fn optional_field_style(&self) -> crate::lang::config::OptionalFieldStyle {
         crate::lang::config::OptionalFieldStyle::TypeSuffix("?")
     }
+
+    fn present_array(&self) -> crate::type_name::TypePresentation<'_> {
+        crate::type_name::TypePresentation::Delimited {
+            open: "[",
+            sep: "",
+            close: "]",
+        }
+    }
+
+    fn present_readonly_array(&self) -> Option<crate::type_name::TypePresentation<'_>> {
+        Some(crate::type_name::TypePresentation::Delimited {
+            open: "[",
+            sep: "",
+            close: "]",
+        })
+    }
+
+    fn present_optional(&self) -> crate::type_name::TypePresentation<'_> {
+        crate::type_name::TypePresentation::Postfix { suffix: "?" }
+    }
+
+    fn present_map(&self) -> crate::type_name::TypePresentation<'_> {
+        crate::type_name::TypePresentation::Delimited {
+            open: "[",
+            sep: ": ",
+            close: "]",
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/lang/typescript.rs
+++ b/src/lang/typescript.rs
@@ -336,6 +336,10 @@ impl CodeLang for TypeScript {
     fn optional_field_style(&self) -> crate::lang::config::OptionalFieldStyle {
         crate::lang::config::OptionalFieldStyle::NameSuffix("?")
     }
+
+    fn present_map(&self) -> crate::type_name::TypePresentation<'_> {
+        crate::type_name::TypePresentation::GenericWrap { name: "Record" }
+    }
 }
 
 #[cfg(test)]

--- a/src/lang/typescript.rs
+++ b/src/lang/typescript.rs
@@ -298,6 +298,7 @@ impl CodeLang for TypeScript {
             TypeKind::Class | TypeKind::Struct => "class",
             TypeKind::Interface | TypeKind::Trait => "interface",
             TypeKind::Enum => "enum",
+            TypeKind::TypeAlias | TypeKind::Newtype => "type",
         }
     }
 

--- a/src/lang/typescript.rs
+++ b/src/lang/typescript.rs
@@ -340,6 +340,14 @@ impl CodeLang for TypeScript {
     fn present_map(&self) -> crate::type_name::TypePresentation<'_> {
         crate::type_name::TypePresentation::GenericWrap { name: "Record" }
     }
+
+    fn present_tuple(&self) -> crate::type_name::TypePresentation<'_> {
+        crate::type_name::TypePresentation::Delimited {
+            open: "[",
+            sep: ", ",
+            close: "]",
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/spec/field_spec.rs
+++ b/src/spec/field_spec.rs
@@ -82,7 +82,21 @@ impl<L: CodeLang> FieldSpec<L> {
     ) -> Result<CodeBlock<L>, crate::error::SigilStitchError> {
         let mut cb = CodeBlock::<L>::builder();
 
-        // Annotations (structured specs first, then raw CodeBlocks).
+        let emit_doc = || -> Option<String> {
+            if self.doc.is_empty() {
+                return None;
+            }
+            let doc_lines: Vec<&str> = self.doc.iter().map(|s| s.as_str()).collect();
+            Some(lang.render_doc_comment(&doc_lines))
+        };
+
+        if lang.doc_before_annotations()
+            && let Some(doc_str) = emit_doc()
+        {
+            cb.add("%L", doc_str);
+            cb.add_line();
+        }
+
         for spec in &self.annotation_specs {
             cb.add_code(spec.emit(lang)?);
             cb.add_line();
@@ -92,10 +106,9 @@ impl<L: CodeLang> FieldSpec<L> {
             cb.add_line();
         }
 
-        // Doc comment.
-        if !self.doc.is_empty() {
-            let doc_lines: Vec<&str> = self.doc.iter().map(|s| s.as_str()).collect();
-            let doc_str = lang.render_doc_comment(&doc_lines);
+        if !lang.doc_before_annotations()
+            && let Some(doc_str) = emit_doc()
+        {
             cb.add("%L", doc_str);
             cb.add_line();
         }

--- a/src/spec/fun_spec.rs
+++ b/src/spec/fun_spec.rs
@@ -165,7 +165,21 @@ impl<L: CodeLang> FunSpec<L> {
     ) -> Result<CodeBlock<L>, crate::error::SigilStitchError> {
         let mut cb = CodeBlock::<L>::builder();
 
-        // Annotations (structured specs first, then raw CodeBlocks).
+        let emit_doc = || -> Option<String> {
+            if self.doc.is_empty() || lang.doc_comment_inside_body() {
+                return None;
+            }
+            let doc_lines: Vec<&str> = self.doc.iter().map(|s| s.as_str()).collect();
+            Some(lang.render_doc_comment(&doc_lines))
+        };
+
+        if lang.doc_before_annotations()
+            && let Some(doc_str) = emit_doc()
+        {
+            cb.add("%L", doc_str);
+            cb.add_line();
+        }
+
         for spec in &self.annotation_specs {
             cb.add_code(spec.emit(lang)?);
             cb.add_line();
@@ -175,11 +189,9 @@ impl<L: CodeLang> FunSpec<L> {
             cb.add_line();
         }
 
-        // Doc comment (above the declaration, unless lang puts it inside the body).
-        let doc_inside = lang.doc_comment_inside_body();
-        if !self.doc.is_empty() && !doc_inside {
-            let doc_lines: Vec<&str> = self.doc.iter().map(|s| s.as_str()).collect();
-            let doc_str = lang.render_doc_comment(&doc_lines);
+        if !lang.doc_before_annotations()
+            && let Some(doc_str) = emit_doc()
+        {
             cb.add("%L", doc_str);
             cb.add_line();
         }
@@ -281,7 +293,7 @@ impl<L: CodeLang> FunSpec<L> {
             cb.add_line();
             cb.add("%>", ());
             // Docstring inside body (Python).
-            if !self.doc.is_empty() && doc_inside {
+            if !self.doc.is_empty() && lang.doc_comment_inside_body() {
                 let doc_lines: Vec<&str> = self.doc.iter().map(|s| s.as_str()).collect();
                 let doc_str = lang.render_doc_comment(&doc_lines);
                 cb.add("%L", doc_str);
@@ -308,7 +320,7 @@ impl<L: CodeLang> FunSpec<L> {
                 cb.add_line();
                 cb.add("%>", ());
                 // Docstring inside body (Python).
-                if !self.doc.is_empty() && doc_inside {
+                if !self.doc.is_empty() && lang.doc_comment_inside_body() {
                     let doc_lines: Vec<&str> = self.doc.iter().map(|s| s.as_str()).collect();
                     let doc_str = lang.render_doc_comment(&doc_lines);
                     cb.add("%L", doc_str);

--- a/src/spec/modifiers.rs
+++ b/src/spec/modifiers.rs
@@ -40,6 +40,10 @@ pub enum TypeKind {
     Trait,
     /// Both languages: `enum`.
     Enum,
+    /// Type alias: `type Foo = Bar;` (TS/Rust), `typedef Bar Foo;` (C), `using Foo = Bar;` (C++).
+    TypeAlias,
+    /// Newtype wrapper: Rust `struct Foo(Bar);`, Go `type Foo Bar`, Kotlin `value class Foo(val value: Bar)`.
+    Newtype,
 }
 
 /// How a `PropertySpec` renders: accessor methods or inline field body.

--- a/src/spec/property_spec.rs
+++ b/src/spec/property_spec.rs
@@ -274,6 +274,21 @@ impl<L: CodeLang> PropertySpec<L> {
         cb: &mut crate::code_block::CodeBlockBuilder<L>,
         lang: &L,
     ) -> Result<(), crate::error::SigilStitchError> {
+        let emit_doc = || -> Option<String> {
+            if self.doc.is_empty() || lang.doc_comment_inside_body() {
+                return None;
+            }
+            let doc_lines: Vec<&str> = self.doc.iter().map(|s| s.as_str()).collect();
+            Some(lang.render_doc_comment(&doc_lines))
+        };
+
+        if lang.doc_before_annotations()
+            && let Some(doc_str) = emit_doc()
+        {
+            cb.add("%L", doc_str);
+            cb.add_line();
+        }
+
         for spec in &self.annotation_specs {
             cb.add_code(spec.emit(lang)?);
             cb.add_line();
@@ -282,12 +297,14 @@ impl<L: CodeLang> PropertySpec<L> {
             cb.add_code(ann.clone());
             cb.add_line();
         }
-        if !self.doc.is_empty() {
-            let doc_lines: Vec<&str> = self.doc.iter().map(|s| s.as_str()).collect();
-            let doc_str = lang.render_doc_comment(&doc_lines);
+
+        if !lang.doc_before_annotations()
+            && let Some(doc_str) = emit_doc()
+        {
             cb.add("%L", doc_str);
             cb.add_line();
         }
+
         Ok(())
     }
 }

--- a/src/spec/type_spec.rs
+++ b/src/spec/type_spec.rs
@@ -98,6 +98,11 @@ impl<L: CodeLang> TypeSpec<L> {
     /// Returns a `Vec` because Rust struct + impl = two separate blocks,
     /// while TypeScript class = one block.
     pub fn emit(&self, lang: &L) -> Result<Vec<CodeBlock<L>>, crate::error::SigilStitchError> {
+        match self.kind {
+            TypeKind::TypeAlias => return Ok(vec![self.emit_type_alias(lang)?]),
+            TypeKind::Newtype => return Ok(vec![self.emit_newtype(lang)?]),
+            _ => {}
+        }
         if lang.methods_inside_type_body(self.kind) {
             Ok(vec![self.emit_inline(lang)?])
         } else {
@@ -261,6 +266,73 @@ impl<L: CodeLang> TypeSpec<L> {
         }
 
         Ok(blocks)
+    }
+
+    /// Emit a type alias declaration: `type Name = Target;`.
+    fn emit_type_alias(&self, lang: &L) -> Result<CodeBlock<L>, crate::error::SigilStitchError> {
+        let mut cb = CodeBlock::<L>::builder();
+        let mut args: Vec<Arg<L>> = Vec::new();
+
+        self.emit_preamble(&mut cb, lang)?;
+
+        let vis = lang.render_visibility(self.modifiers.visibility, DeclarationContext::TopLevel);
+        let kw = lang.type_keyword(self.kind);
+        let tp_str = render_type_params(&self.type_params, lang, &mut args);
+
+        let target = self
+            .super_types
+            .first()
+            .cloned()
+            .unwrap_or_else(|| TypeName::primitive(""));
+
+        let semi = if lang.uses_semicolons() { ";" } else { "" };
+
+        let fmt = if lang.type_alias_target_first() {
+            // C typedef: `typedef target name;`
+            args.push(Arg::TypeName(target));
+            format!("{kw} %T {}{tp_str}{semi}", self.name)
+        } else {
+            // Normal: `{vis}type name<params> = target;`
+            args.push(Arg::TypeName(target));
+            format!("{vis}{kw} {}{tp_str} = %T{semi}", self.name)
+        };
+
+        cb.add(&fmt, args);
+        cb.add_line();
+        cb.build()
+    }
+
+    /// Emit a newtype wrapper declaration.
+    fn emit_newtype(&self, lang: &L) -> Result<CodeBlock<L>, crate::error::SigilStitchError> {
+        let mut cb = CodeBlock::<L>::builder();
+
+        self.emit_preamble(&mut cb, lang)?;
+
+        let vis = lang.render_visibility(self.modifiers.visibility, DeclarationContext::TopLevel);
+        let target = self
+            .super_types
+            .first()
+            .cloned()
+            .unwrap_or_else(|| TypeName::primitive(""));
+
+        let resolve = |_module: &str, name: &str| name.to_string();
+        let inner_str = target.render(80, &resolve).unwrap_or_default();
+
+        let mut tp_args: Vec<Arg<L>> = Vec::new();
+        let tp_str = render_type_params(&self.type_params, lang, &mut tp_args);
+        let name_with_params = format!("{}{tp_str}", self.name);
+
+        let line = lang.render_newtype_line(vis, &name_with_params, &inner_str);
+
+        // Build format string: the line is literal, but type param bounds need %T resolution.
+        if tp_args.is_empty() {
+            cb.add("%L", line);
+        } else {
+            // The line contains type param bound placeholders — pass args through.
+            cb.add(&line, tp_args);
+        }
+        cb.add_line();
+        cb.build()
     }
 
     /// Emit enum variants with language-aware separators.
@@ -667,6 +739,36 @@ impl<L: CodeLang> TypeSpecBuilder<L> {
             }
         }
 
+        // Validate TypeAlias / Newtype constraints.
+        if matches!(self.kind, TypeKind::TypeAlias | TypeKind::Newtype) {
+            let kind_str = if self.kind == TypeKind::TypeAlias {
+                "TypeAlias"
+            } else {
+                "Newtype"
+            };
+            if self.super_types.len() != 1 {
+                return Err(crate::error::SigilStitchError::InvalidTypeAlias {
+                    kind: kind_str,
+                    type_name: self.name.clone(),
+                    reason: format!(
+                        "expected exactly 1 super_type (the target type), got {}",
+                        self.super_types.len()
+                    ),
+                });
+            }
+            if !self.fields.is_empty()
+                || !self.methods.is_empty()
+                || !self.variants.is_empty()
+                || !self.properties.is_empty()
+            {
+                return Err(crate::error::SigilStitchError::InvalidTypeAlias {
+                    kind: kind_str,
+                    type_name: self.name.clone(),
+                    reason: "must not have fields, methods, variants, or properties".to_string(),
+                });
+            }
+        }
+
         Ok(TypeSpec {
             name: self.name,
             kind: self.kind,
@@ -862,5 +964,197 @@ mod tests {
         );
         let result = tb.build();
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_type_alias_rust() {
+        let mut tb = TypeSpec::<RustLang>::builder("Meters", TypeKind::TypeAlias);
+        tb.extends(TypeName::primitive("f64"));
+        let spec = tb.build().unwrap();
+        let lang = RustLang::new();
+        let blocks = spec.emit(&lang).unwrap();
+        let output = render_blocks_rs(&blocks);
+        assert_eq!(output.trim(), "type Meters = f64;");
+    }
+
+    #[test]
+    fn test_type_alias_rust_pub() {
+        let mut tb = TypeSpec::<RustLang>::builder("Meters", TypeKind::TypeAlias);
+        tb.visibility(Visibility::Public);
+        tb.extends(TypeName::primitive("f64"));
+        let spec = tb.build().unwrap();
+        let lang = RustLang::new();
+        let blocks = spec.emit(&lang).unwrap();
+        let output = render_blocks_rs(&blocks);
+        assert_eq!(output.trim(), "pub type Meters = f64;");
+    }
+
+    #[test]
+    fn test_type_alias_ts() {
+        let mut tb = TypeSpec::<TypeScript>::builder("UserId", TypeKind::TypeAlias);
+        tb.visibility(Visibility::Public);
+        tb.extends(TypeName::primitive("string"));
+        let spec = tb.build().unwrap();
+        let blocks = spec.emit(&TypeScript::new()).unwrap();
+        let output = render_blocks_ts(&blocks);
+        assert_eq!(output.trim(), "export type UserId = string;");
+    }
+
+    #[test]
+    fn test_type_alias_cpp() {
+        use crate::lang::cpp_lang::CppLang;
+        let mut tb = TypeSpec::<CppLang>::builder("Meters", TypeKind::TypeAlias);
+        tb.extends(TypeName::primitive("double"));
+        let spec = tb.build().unwrap();
+        let lang = CppLang::new();
+        let imports = crate::import::ImportGroup::new();
+        let blocks = spec.emit(&lang).unwrap();
+        let mut renderer = crate::code_renderer::CodeRenderer::new(&lang, &imports, 80);
+        let output = renderer.render(&blocks[0]).unwrap();
+        assert_eq!(output.trim(), "using Meters = double;");
+    }
+
+    #[test]
+    fn test_type_alias_c() {
+        use crate::lang::c_lang::CLang;
+        let mut tb = TypeSpec::<CLang>::builder("Meters", TypeKind::TypeAlias);
+        tb.extends(TypeName::primitive("double"));
+        let spec = tb.build().unwrap();
+        let lang = CLang::new();
+        let imports = crate::import::ImportGroup::new();
+        let blocks = spec.emit(&lang).unwrap();
+        let mut renderer = crate::code_renderer::CodeRenderer::new(&lang, &imports, 80);
+        let output = renderer.render(&blocks[0]).unwrap();
+        assert_eq!(output.trim(), "typedef double Meters;");
+    }
+
+    #[test]
+    fn test_type_alias_go() {
+        use crate::lang::go_lang::GoLang;
+        let mut tb = TypeSpec::<GoLang>::builder("Meters", TypeKind::TypeAlias);
+        tb.extends(TypeName::primitive("float64"));
+        let spec = tb.build().unwrap();
+        let lang = GoLang::new();
+        let imports = crate::import::ImportGroup::new();
+        let blocks = spec.emit(&lang).unwrap();
+        let mut renderer = crate::code_renderer::CodeRenderer::new(&lang, &imports, 80);
+        let output = renderer.render(&blocks[0]).unwrap();
+        assert_eq!(output.trim(), "type Meters = float64");
+    }
+
+    #[test]
+    fn test_type_alias_python() {
+        use crate::lang::python::Python;
+        let mut tb = TypeSpec::<Python>::builder("UserId", TypeKind::TypeAlias);
+        tb.extends(TypeName::primitive("str"));
+        let spec = tb.build().unwrap();
+        let lang = Python::new();
+        let imports = crate::import::ImportGroup::new();
+        let blocks = spec.emit(&lang).unwrap();
+        let mut renderer = crate::code_renderer::CodeRenderer::new(&lang, &imports, 80);
+        let output = renderer.render(&blocks[0]).unwrap();
+        assert_eq!(output.trim(), "type UserId = str");
+    }
+
+    #[test]
+    fn test_type_alias_kotlin() {
+        use crate::lang::kotlin::Kotlin;
+        let mut tb = TypeSpec::<Kotlin>::builder("Name", TypeKind::TypeAlias);
+        tb.visibility(Visibility::Public);
+        tb.extends(TypeName::primitive("String"));
+        let spec = tb.build().unwrap();
+        let lang = Kotlin::new();
+        let imports = crate::import::ImportGroup::new();
+        let blocks = spec.emit(&lang).unwrap();
+        let mut renderer = crate::code_renderer::CodeRenderer::new(&lang, &imports, 80);
+        let output = renderer.render(&blocks[0]).unwrap();
+        assert_eq!(output.trim(), "typealias Name = String");
+    }
+
+    #[test]
+    fn test_newtype_rust() {
+        let mut tb = TypeSpec::<RustLang>::builder("Meters", TypeKind::Newtype);
+        tb.visibility(Visibility::Public);
+        tb.extends(TypeName::primitive("f64"));
+        let spec = tb.build().unwrap();
+        let lang = RustLang::new();
+        let blocks = spec.emit(&lang).unwrap();
+        let output = render_blocks_rs(&blocks);
+        assert_eq!(output.trim(), "pub struct Meters(f64);");
+    }
+
+    #[test]
+    fn test_newtype_go() {
+        use crate::lang::go_lang::GoLang;
+        let mut tb = TypeSpec::<GoLang>::builder("Meters", TypeKind::Newtype);
+        tb.extends(TypeName::primitive("float64"));
+        let spec = tb.build().unwrap();
+        let lang = GoLang::new();
+        let imports = crate::import::ImportGroup::new();
+        let blocks = spec.emit(&lang).unwrap();
+        let mut renderer = crate::code_renderer::CodeRenderer::new(&lang, &imports, 80);
+        let output = renderer.render(&blocks[0]).unwrap();
+        assert_eq!(output.trim(), "type Meters float64");
+    }
+
+    #[test]
+    fn test_newtype_kotlin() {
+        use crate::lang::kotlin::Kotlin;
+        let mut tb = TypeSpec::<Kotlin>::builder("Meters", TypeKind::Newtype);
+        tb.visibility(Visibility::Public);
+        tb.extends(TypeName::primitive("Double"));
+        let spec = tb.build().unwrap();
+        let lang = Kotlin::new();
+        let imports = crate::import::ImportGroup::new();
+        let blocks = spec.emit(&lang).unwrap();
+        let mut renderer = crate::code_renderer::CodeRenderer::new(&lang, &imports, 80);
+        let output = renderer.render(&blocks[0]).unwrap();
+        assert_eq!(output.trim(), "value class Meters(val value: Double)");
+    }
+
+    #[test]
+    fn test_newtype_python() {
+        use crate::lang::python::Python;
+        let mut tb = TypeSpec::<Python>::builder("UserId", TypeKind::Newtype);
+        tb.extends(TypeName::primitive("str"));
+        let spec = tb.build().unwrap();
+        let lang = Python::new();
+        let imports = crate::import::ImportGroup::new();
+        let blocks = spec.emit(&lang).unwrap();
+        let mut renderer = crate::code_renderer::CodeRenderer::new(&lang, &imports, 80);
+        let output = renderer.render(&blocks[0]).unwrap();
+        assert_eq!(output.trim(), "UserId = NewType(\"UserId\", str)");
+    }
+
+    #[test]
+    fn test_type_alias_validation_no_super_type() {
+        let tb = TypeSpec::<TypeScript>::builder("Foo", TypeKind::TypeAlias);
+        let result = tb.build();
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("expected exactly 1 super_type")
+        );
+    }
+
+    #[test]
+    fn test_type_alias_validation_has_fields() {
+        let mut tb = TypeSpec::<TypeScript>::builder("Foo", TypeKind::TypeAlias);
+        tb.extends(TypeName::primitive("string"));
+        tb.add_field(
+            FieldSpec::builder("x", TypeName::primitive("number"))
+                .build()
+                .unwrap(),
+        );
+        let result = tb.build();
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("must not have fields")
+        );
     }
 }

--- a/src/spec/type_spec.rs
+++ b/src/spec/type_spec.rs
@@ -277,6 +277,21 @@ impl<L: CodeLang> TypeSpec<L> {
         for (i, variant) in self.variants.iter().enumerate() {
             // Emit variant parts directly here rather than calling variant.emit(),
             // because we need to append the separator before the trailing newline.
+            let emit_variant_doc = || -> Option<String> {
+                if variant.doc.is_empty() || lang.doc_comment_inside_body() {
+                    return None;
+                }
+                let doc_lines: Vec<&str> = variant.doc.iter().map(|s| s.as_str()).collect();
+                Some(lang.render_doc_comment(&doc_lines))
+            };
+
+            if lang.doc_before_annotations()
+                && let Some(doc_str) = emit_variant_doc()
+            {
+                cb.add("%L", doc_str);
+                cb.add_line();
+            }
+
             for spec in &variant.annotation_specs {
                 cb.add_code(spec.emit(lang)?);
                 cb.add_line();
@@ -285,9 +300,10 @@ impl<L: CodeLang> TypeSpec<L> {
                 cb.add_code(ann.clone());
                 cb.add_line();
             }
-            if !variant.doc.is_empty() && !lang.doc_comment_inside_body() {
-                let doc_lines: Vec<&str> = variant.doc.iter().map(|s| s.as_str()).collect();
-                let doc_str = lang.render_doc_comment(&doc_lines);
+
+            if !lang.doc_before_annotations()
+                && let Some(doc_str) = emit_variant_doc()
+            {
                 cb.add("%L", doc_str);
                 cb.add_line();
             }
@@ -380,6 +396,21 @@ impl<L: CodeLang> TypeSpec<L> {
         cb: &mut CodeBlockBuilder<L>,
         lang: &L,
     ) -> Result<(), crate::error::SigilStitchError> {
+        let emit_doc = || -> Option<String> {
+            if self.doc.is_empty() || lang.doc_comment_inside_body() {
+                return None;
+            }
+            let doc_lines: Vec<&str> = self.doc.iter().map(|s| s.as_str()).collect();
+            Some(lang.render_doc_comment(&doc_lines))
+        };
+
+        if lang.doc_before_annotations()
+            && let Some(doc_str) = emit_doc()
+        {
+            cb.add("%L", doc_str);
+            cb.add_line();
+        }
+
         for spec in &self.annotation_specs {
             cb.add_code(spec.emit(lang)?);
             cb.add_line();
@@ -388,12 +419,14 @@ impl<L: CodeLang> TypeSpec<L> {
             cb.add_code(ann.clone());
             cb.add_line();
         }
-        if !self.doc.is_empty() && !lang.doc_comment_inside_body() {
-            let doc_lines: Vec<&str> = self.doc.iter().map(|s| s.as_str()).collect();
-            let doc_str = lang.render_doc_comment(&doc_lines);
+
+        if !lang.doc_before_annotations()
+            && let Some(doc_str) = emit_doc()
+        {
             cb.add("%L", doc_str);
             cb.add_line();
         }
+
         Ok(())
     }
 

--- a/src/type_name.rs
+++ b/src/type_name.rs
@@ -245,9 +245,7 @@ fn render_function_presentation(
 
     let signature = if pres.return_first {
         // C++/Dart: R keyword(A, B)
-        return_doc
-            .append(keyword_doc)
-            .append(params_block)
+        return_doc.append(keyword_doc).append(params_block)
     } else {
         // TS/Rust/Go: keyword(A, B) -> R
         keyword_doc
@@ -656,8 +654,7 @@ impl<L: CodeLang> TypeName<L> {
                 let pres = lang.present_optional();
                 match &pres {
                     TypePresentation::Infix { .. } => {
-                        let null_doc =
-                            BoxDoc::text(lang.optional_absent_literal().to_string());
+                        let null_doc = BoxDoc::text(lang.optional_absent_literal().to_string());
                         render_presentation(&pres, vec![inner_doc, null_doc], lang)
                     }
                     _ => render_presentation(&pres, vec![inner_doc], lang),
@@ -957,10 +954,8 @@ mod tests {
     fn test_tuple_with_lang_python() {
         use crate::lang::python::Python;
         let lang = Python::new();
-        let t = TypeName::<Python>::tuple(vec![
-            TypeName::primitive("str"),
-            TypeName::primitive("int"),
-        ]);
+        let t =
+            TypeName::<Python>::tuple(vec![TypeName::primitive("str"), TypeName::primitive("int")]);
         let doc = t.to_doc_with_lang(&identity_resolve, &lang);
         let mut buf = Vec::new();
         doc.render(80, &mut buf).unwrap();

--- a/src/type_name.rs
+++ b/src/type_name.rs
@@ -3,6 +3,67 @@ use pretty::BoxDoc;
 use crate::import::ImportRef;
 use crate::lang::CodeLang;
 
+/// Syntactic pattern for rendering a compound type construct.
+///
+/// Each variant describes a structural pattern for assembling already-rendered
+/// inner type docs into the output. The rendering engine in `type_name.rs`
+/// interprets these patterns — language implementations never build `BoxDoc`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TypePresentation<'a> {
+    /// `name<P1, P2>` — delimiters from `generic_open()`/`generic_close()`.
+    GenericWrap {
+        /// The wrapper type name (e.g., `"Vec"`, `"Option"`, `"HashMap"`).
+        name: &'a str,
+    },
+    /// `prefix inner` — `*T`, `&T`, `[]T`, `&mut T`.
+    Prefix {
+        /// The prefix string (e.g., `"*"`, `"[]"`, `"*const "`).
+        prefix: &'a str,
+    },
+    /// `inner suffix` — `T[]`, `T?`, `T*`.
+    Postfix {
+        /// The suffix string (e.g., `"[]"`, `"?"`).
+        suffix: &'a str,
+    },
+    /// `open P1 sep P2 sep ... close` — `(A, B)`, `[T]`, `[K: V]`, `dict[K, V]`.
+    Delimited {
+        /// Opening delimiter.
+        open: &'a str,
+        /// Separator between elements.
+        sep: &'a str,
+        /// Closing delimiter.
+        close: &'a str,
+    },
+    /// `P1 sep P2 sep ... Pn` — `A | B`, `A & B`, `A + B`.
+    Infix {
+        /// Separator between elements (e.g., `" | "`, `" & "`).
+        sep: &'a str,
+    },
+}
+
+/// Syntactic pattern for rendering a function type expression.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FunctionPresentation<'a> {
+    /// Keyword before the param list (e.g., `"fn"`, `"func"`, `""`).
+    pub keyword: &'a str,
+    /// Opening delimiter for the param list (e.g., `"("`, `"Callable[["`).
+    pub params_open: &'a str,
+    /// Separator between params (e.g., `", "`).
+    pub params_sep: &'a str,
+    /// Closing delimiter for the param list (e.g., `")"`, `"]]"`).
+    pub params_close: &'a str,
+    /// Arrow/separator between params and return type (e.g., `" -> "`, `" => "`).
+    pub arrow: &'a str,
+    /// Whether the return type comes before the params (Dart: `R Function(A, B)`).
+    pub return_first: bool,
+    /// Whether to render curried (Haskell: `A -> B -> R` instead of `(A, B) -> R`).
+    pub curried: bool,
+    /// Outer wrapper opening (e.g., C++ `"std::function<"`).
+    pub wrapper_open: &'a str,
+    /// Outer wrapper closing (e.g., C++ `">"`).
+    pub wrapper_close: &'a str,
+}
+
 /// A type name reference in generated code.
 ///
 /// `TypeName` represents a type as it should appear in the output. The
@@ -93,6 +154,92 @@ pub enum TypeName<L: CodeLang> {
     /// Phantom data to carry L without requiring it in all variants.
     #[doc(hidden)]
     _Phantom(std::marker::PhantomData<L>),
+}
+
+fn render_presentation(
+    pres: &TypePresentation<'_>,
+    inner_docs: Vec<BoxDoc<'static, ()>>,
+    lang: &impl CodeLang,
+) -> BoxDoc<'static, ()> {
+    match pres {
+        TypePresentation::GenericWrap { name } => {
+            let sep = BoxDoc::text(",").append(BoxDoc::softline());
+            let params = BoxDoc::intersperse(inner_docs, sep);
+            BoxDoc::text(name.to_string())
+                .append(BoxDoc::text(lang.generic_open().to_string()))
+                .append(params.nest(2).group())
+                .append(BoxDoc::text(lang.generic_close().to_string()))
+        }
+        TypePresentation::Prefix { prefix } => {
+            debug_assert_eq!(inner_docs.len(), 1);
+            let inner = inner_docs.into_iter().next().unwrap_or_else(BoxDoc::nil);
+            BoxDoc::text(prefix.to_string()).append(inner)
+        }
+        TypePresentation::Postfix { suffix } => {
+            debug_assert_eq!(inner_docs.len(), 1);
+            let inner = inner_docs.into_iter().next().unwrap_or_else(BoxDoc::nil);
+            inner.append(BoxDoc::text(suffix.to_string()))
+        }
+        TypePresentation::Delimited { open, sep, close } => {
+            let separator = BoxDoc::text(sep.to_string());
+            let body = BoxDoc::intersperse(inner_docs, separator);
+            BoxDoc::text(open.to_string())
+                .append(body.nest(2).group())
+                .append(BoxDoc::text(close.to_string()))
+        }
+        TypePresentation::Infix { sep } => {
+            let sep_trimmed = sep.trim_start();
+            let separator = BoxDoc::softline().append(BoxDoc::text(sep_trimmed.to_string()));
+            BoxDoc::intersperse(inner_docs, separator).group()
+        }
+    }
+}
+
+fn render_function_presentation(
+    pres: &FunctionPresentation<'_>,
+    param_docs: Vec<BoxDoc<'static, ()>>,
+    return_doc: BoxDoc<'static, ()>,
+) -> BoxDoc<'static, ()> {
+    if pres.curried {
+        // Haskell style: A -> B -> R
+        let mut all = param_docs;
+        all.push(return_doc);
+        let sep = BoxDoc::text(pres.arrow.to_string());
+        return BoxDoc::intersperse(all, sep);
+    }
+
+    let sep = BoxDoc::text(pres.params_sep.to_string());
+    let params_doc = BoxDoc::intersperse(param_docs, sep);
+    let params_block = BoxDoc::text(pres.params_open.to_string())
+        .append(params_doc.nest(2).group())
+        .append(BoxDoc::text(pres.params_close.to_string()));
+
+    let keyword_doc = if pres.keyword.is_empty() {
+        BoxDoc::nil()
+    } else {
+        BoxDoc::text(pres.keyword.to_string())
+    };
+
+    let signature = if pres.return_first {
+        // C++/Dart: R keyword(A, B)
+        return_doc
+            .append(keyword_doc)
+            .append(params_block)
+    } else {
+        // TS/Rust/Go: keyword(A, B) -> R
+        keyword_doc
+            .append(params_block)
+            .append(BoxDoc::text(pres.arrow.to_string()))
+            .append(return_doc)
+    };
+
+    if pres.wrapper_open.is_empty() {
+        signature
+    } else {
+        BoxDoc::text(pres.wrapper_open.to_string())
+            .append(signature)
+            .append(BoxDoc::text(pres.wrapper_close.to_string()))
+    }
 }
 
 impl<L: CodeLang> TypeName<L> {
@@ -394,60 +541,70 @@ impl<L: CodeLang> TypeName<L> {
                     .append(params_doc.nest(2).group())
                     .append(BoxDoc::text(lang.generic_close().to_string()))
             }
-            // For variants with recursive sub-types, thread lang through.
-            TypeName::Array(inner) => inner
-                .to_doc_with_lang(resolve, lang)
-                .append(BoxDoc::text("[]")),
-            TypeName::ReadonlyArray(inner) => BoxDoc::text("readonly ")
-                .append(inner.to_doc_with_lang(resolve, lang))
-                .append(BoxDoc::text("[]")),
+            TypeName::Array(inner) => {
+                let inner_doc = inner.to_doc_with_lang(resolve, lang);
+                render_presentation(&lang.present_array(), vec![inner_doc], lang)
+            }
+            TypeName::ReadonlyArray(inner) => {
+                let inner_doc = inner.to_doc_with_lang(resolve, lang);
+                if let Some(pres) = lang.present_readonly_array() {
+                    render_presentation(&pres, vec![inner_doc], lang)
+                } else {
+                    // Default: "readonly " + array rendering
+                    let array_doc =
+                        render_presentation(&lang.present_array(), vec![inner_doc], lang);
+                    BoxDoc::text("readonly ").append(array_doc)
+                }
+            }
             TypeName::Union(members) => {
                 let docs: Vec<_> = members
                     .iter()
                     .map(|m| m.to_doc_with_lang(resolve, lang))
                     .collect();
-                let sep = BoxDoc::softline().append(BoxDoc::text("| "));
-                BoxDoc::intersperse(docs, sep).group()
+                render_presentation(&lang.present_union(), docs, lang)
             }
             TypeName::Intersection(members) => {
                 let docs: Vec<_> = members
                     .iter()
                     .map(|m| m.to_doc_with_lang(resolve, lang))
                     .collect();
-                let sep = BoxDoc::softline().append(BoxDoc::text("& "));
-                BoxDoc::intersperse(docs, sep).group()
+                render_presentation(&lang.present_intersection(), docs, lang)
             }
             TypeName::Pointer(inner) => {
-                BoxDoc::text("*").append(inner.to_doc_with_lang(resolve, lang))
+                let inner_doc = inner.to_doc_with_lang(resolve, lang);
+                render_presentation(&lang.present_pointer(), vec![inner_doc], lang)
             }
             TypeName::Slice(inner) => {
-                BoxDoc::text("[]").append(inner.to_doc_with_lang(resolve, lang))
+                let inner_doc = inner.to_doc_with_lang(resolve, lang);
+                render_presentation(&lang.present_slice(), vec![inner_doc], lang)
             }
-            TypeName::Map { key, value } => BoxDoc::text("map[")
-                .append(key.to_doc_with_lang(resolve, lang))
-                .append(BoxDoc::text("]"))
-                .append(value.to_doc_with_lang(resolve, lang)),
+            TypeName::Map { key, value } => {
+                let key_doc = key.to_doc_with_lang(resolve, lang);
+                let value_doc = value.to_doc_with_lang(resolve, lang);
+                render_presentation(&lang.present_map(), vec![key_doc, value_doc], lang)
+            }
             TypeName::Optional(inner) => {
                 let inner_doc = inner.to_doc_with_lang(resolve, lang);
-                inner_doc
-                    .append(BoxDoc::softline())
-                    .append(BoxDoc::text("| null"))
-                    .group()
+                let pres = lang.present_optional();
+                match &pres {
+                    TypePresentation::Infix { .. } => {
+                        let null_doc =
+                            BoxDoc::text(lang.optional_absent_literal().to_string());
+                        render_presentation(&pres, vec![inner_doc, null_doc], lang)
+                    }
+                    _ => render_presentation(&pres, vec![inner_doc], lang),
+                }
             }
             TypeName::Function {
                 params,
                 return_type,
             } => {
-                let params_docs: Vec<_> = params
+                let param_docs: Vec<_> = params
                     .iter()
                     .map(|p| p.to_doc_with_lang(resolve, lang))
                     .collect();
-                let sep = BoxDoc::text(",").append(BoxDoc::softline());
-                let params_doc = BoxDoc::intersperse(params_docs, sep);
-                BoxDoc::text("(")
-                    .append(params_doc.nest(2).group())
-                    .append(BoxDoc::text(") => "))
-                    .append(return_type.to_doc_with_lang(resolve, lang))
+                let return_doc = return_type.to_doc_with_lang(resolve, lang);
+                render_function_presentation(&lang.present_function(), param_docs, return_doc)
             }
             // Leaf variants delegate to to_doc (no recursion needed).
             _ => self.to_doc(resolve),

--- a/src/type_name.rs
+++ b/src/type_name.rs
@@ -141,6 +141,8 @@ pub enum TypeName<L: CodeLang> {
     },
     /// Optional type. TS: `T | null`, Rust: `Option<T>`.
     Optional(Box<TypeName<L>>),
+    /// Tuple type. Rust: `(A, B)`, TS: `[A, B]`, Python: `tuple[A, B]`.
+    Tuple(Vec<TypeName<L>>),
     /// Function type. TS: `(a: A, b: B) => R`.
     Function {
         /// The parameter types.
@@ -348,6 +350,16 @@ impl<L: CodeLang> TypeName<L> {
         TypeName::Optional(Box::new(inner))
     }
 
+    /// Create a tuple type (e.g., Rust `(A, B)`, TS `[A, B]`).
+    pub fn tuple(elements: Vec<TypeName<L>>) -> Self {
+        TypeName::Tuple(elements)
+    }
+
+    /// Create a unit type (empty tuple: Rust `()`).
+    pub fn unit() -> Self {
+        TypeName::Tuple(Vec::new())
+    }
+
     /// Create a function type.
     pub fn function(params: Vec<TypeName<L>>, return_type: TypeName<L>) -> Self {
         TypeName::Function {
@@ -401,7 +413,9 @@ impl<L: CodeLang> TypeName<L> {
                     p.collect_imports(out);
                 }
             }
-            TypeName::Union(members) | TypeName::Intersection(members) => {
+            TypeName::Union(members)
+            | TypeName::Intersection(members)
+            | TypeName::Tuple(members) => {
                 for m in members {
                     m.collect_imports(out);
                 }
@@ -482,6 +496,16 @@ impl<L: CodeLang> TypeName<L> {
                     .append(BoxDoc::softline())
                     .append(BoxDoc::text("| null"))
                     .group()
+            }
+            TypeName::Tuple(elements) => {
+                let docs: Vec<_> = elements.iter().map(|e| e.to_doc(resolve)).collect();
+                if docs.is_empty() {
+                    return BoxDoc::text("()");
+                }
+                let sep = BoxDoc::text(",").append(BoxDoc::softline());
+                BoxDoc::text("(")
+                    .append(BoxDoc::intersperse(docs, sep).nest(2).group())
+                    .append(BoxDoc::text(")"))
             }
             TypeName::Function {
                 params,
@@ -594,6 +618,13 @@ impl<L: CodeLang> TypeName<L> {
                     }
                     _ => render_presentation(&pres, vec![inner_doc], lang),
                 }
+            }
+            TypeName::Tuple(elements) => {
+                let docs: Vec<_> = elements
+                    .iter()
+                    .map(|e| e.to_doc_with_lang(resolve, lang))
+                    .collect();
+                render_presentation(&lang.present_tuple(), docs, lang)
             }
             TypeName::Function {
                 params,
@@ -812,5 +843,102 @@ mod tests {
         // The resolve function should map to the alias.
         let resolve = |_module: &str, _name: &str| "MyUser".to_string();
         assert_eq!(t.render(80, &resolve).unwrap(), "MyUser");
+    }
+
+    #[test]
+    fn test_tuple() {
+        let t = TypeName::<TypeScript>::tuple(vec![
+            TypeName::primitive("string"),
+            TypeName::primitive("number"),
+        ]);
+        assert_eq!(t.render(80, &identity_resolve).unwrap(), "(string, number)");
+    }
+
+    #[test]
+    fn test_unit_tuple() {
+        let t = TypeName::<TypeScript>::unit();
+        assert_eq!(t.render(80, &identity_resolve).unwrap(), "()");
+    }
+
+    #[test]
+    fn test_tuple_collect_imports() {
+        let t = TypeName::<TypeScript>::tuple(vec![
+            TypeName::importable("./models", "User"),
+            TypeName::importable("./models", "Tag"),
+        ]);
+        let mut imports = Vec::new();
+        t.collect_imports(&mut imports);
+        assert_eq!(imports.len(), 2);
+        assert_eq!(imports[0].name, "User");
+        assert_eq!(imports[1].name, "Tag");
+    }
+
+    #[test]
+    fn test_tuple_with_lang_ts() {
+        let lang = TypeScript::new();
+        let t = TypeName::<TypeScript>::tuple(vec![
+            TypeName::primitive("string"),
+            TypeName::primitive("number"),
+        ]);
+        let doc = t.to_doc_with_lang(&identity_resolve, &lang);
+        let mut buf = Vec::new();
+        doc.render(80, &mut buf).unwrap();
+        assert_eq!(String::from_utf8(buf).unwrap(), "[string, number]");
+    }
+
+    #[test]
+    fn test_tuple_with_lang_rust() {
+        use crate::lang::rust_lang::RustLang;
+        let lang = RustLang::new();
+        let t = TypeName::<RustLang>::tuple(vec![
+            TypeName::primitive("String"),
+            TypeName::primitive("i32"),
+        ]);
+        let doc = t.to_doc_with_lang(&identity_resolve, &lang);
+        let mut buf = Vec::new();
+        doc.render(80, &mut buf).unwrap();
+        assert_eq!(String::from_utf8(buf).unwrap(), "(String, i32)");
+    }
+
+    #[test]
+    fn test_tuple_with_lang_python() {
+        use crate::lang::python::Python;
+        let lang = Python::new();
+        let t = TypeName::<Python>::tuple(vec![
+            TypeName::primitive("str"),
+            TypeName::primitive("int"),
+        ]);
+        let doc = t.to_doc_with_lang(&identity_resolve, &lang);
+        let mut buf = Vec::new();
+        doc.render(80, &mut buf).unwrap();
+        assert_eq!(String::from_utf8(buf).unwrap(), "tuple[str, int]");
+    }
+
+    #[test]
+    fn test_tuple_with_lang_cpp() {
+        use crate::lang::cpp_lang::CppLang;
+        let lang = CppLang::new();
+        let t = TypeName::<CppLang>::tuple(vec![
+            TypeName::primitive("int"),
+            TypeName::primitive("std::string"),
+        ]);
+        let doc = t.to_doc_with_lang(&identity_resolve, &lang);
+        let mut buf = Vec::new();
+        doc.render(80, &mut buf).unwrap();
+        assert_eq!(
+            String::from_utf8(buf).unwrap(),
+            "std::tuple<int, std::string>"
+        );
+    }
+
+    #[test]
+    fn test_unit_tuple_with_lang_rust() {
+        use crate::lang::rust_lang::RustLang;
+        let lang = RustLang::new();
+        let t = TypeName::<RustLang>::unit();
+        let doc = t.to_doc_with_lang(&identity_resolve, &lang);
+        let mut buf = Vec::new();
+        doc.render(80, &mut buf).unwrap();
+        assert_eq!(String::from_utf8(buf).unwrap(), "()");
     }
 }

--- a/src/type_name.rs
+++ b/src/type_name.rs
@@ -1080,4 +1080,37 @@ mod tests {
         doc.render(80, &mut buf).unwrap();
         assert_eq!(String::from_utf8(buf).unwrap(), "*int");
     }
+
+    #[test]
+    fn test_reference_with_lang_go() {
+        use crate::lang::go_lang::GoLang;
+        let lang = GoLang::new();
+        let t = TypeName::<GoLang>::reference(TypeName::primitive("int"));
+        let doc = t.to_doc_with_lang(&identity_resolve, &lang);
+        let mut buf = Vec::new();
+        doc.render(80, &mut buf).unwrap();
+        assert_eq!(String::from_utf8(buf).unwrap(), "int");
+    }
+
+    #[test]
+    fn test_reference_with_lang_c() {
+        use crate::lang::c_lang::CLang;
+        let lang = CLang::new();
+        let t = TypeName::<CLang>::reference(TypeName::primitive("int"));
+        let doc = t.to_doc_with_lang(&identity_resolve, &lang);
+        let mut buf = Vec::new();
+        doc.render(80, &mut buf).unwrap();
+        assert_eq!(String::from_utf8(buf).unwrap(), "const int*");
+    }
+
+    #[test]
+    fn test_reference_mut_with_lang_c() {
+        use crate::lang::c_lang::CLang;
+        let lang = CLang::new();
+        let t = TypeName::<CLang>::reference_mut(TypeName::primitive("int"));
+        let doc = t.to_doc_with_lang(&identity_resolve, &lang);
+        let mut buf = Vec::new();
+        doc.render(80, &mut buf).unwrap();
+        assert_eq!(String::from_utf8(buf).unwrap(), "int*");
+    }
 }

--- a/src/type_name.rs
+++ b/src/type_name.rs
@@ -25,6 +25,13 @@ pub enum TypePresentation<'a> {
         /// The suffix string (e.g., `"[]"`, `"?"`).
         suffix: &'a str,
     },
+    /// `prefix inner suffix` — `const T&`, `const T*`.
+    Surround {
+        /// The prefix string (e.g., `"const "`).
+        prefix: &'a str,
+        /// The suffix string (e.g., `"&"`, `"*"`).
+        suffix: &'a str,
+    },
     /// `open P1 sep P2 sep ... close` — `(A, B)`, `[T]`, `[K: V]`, `dict[K, V]`.
     Delimited {
         /// Opening delimiter.
@@ -143,6 +150,13 @@ pub enum TypeName<L: CodeLang> {
     Optional(Box<TypeName<L>>),
     /// Tuple type. Rust: `(A, B)`, TS: `[A, B]`, Python: `tuple[A, B]`.
     Tuple(Vec<TypeName<L>>),
+    /// Reference type. Rust: `&T` / `&mut T`, C++: `const T&` / `T&`.
+    Reference {
+        /// The referenced type.
+        inner: Box<TypeName<L>>,
+        /// Whether the reference is mutable.
+        mutable: bool,
+    },
     /// Function type. TS: `(a: A, b: B) => R`.
     Function {
         /// The parameter types.
@@ -181,6 +195,13 @@ fn render_presentation(
             debug_assert_eq!(inner_docs.len(), 1);
             let inner = inner_docs.into_iter().next().unwrap_or_else(BoxDoc::nil);
             inner.append(BoxDoc::text(suffix.to_string()))
+        }
+        TypePresentation::Surround { prefix, suffix } => {
+            debug_assert_eq!(inner_docs.len(), 1);
+            let inner = inner_docs.into_iter().next().unwrap_or_else(BoxDoc::nil);
+            BoxDoc::text(prefix.to_string())
+                .append(inner)
+                .append(BoxDoc::text(suffix.to_string()))
         }
         TypePresentation::Delimited { open, sep, close } => {
             let separator = BoxDoc::text(sep.to_string());
@@ -360,6 +381,22 @@ impl<L: CodeLang> TypeName<L> {
         TypeName::Tuple(Vec::new())
     }
 
+    /// Create a shared reference type (Rust `&T`, C++ `const T&`).
+    pub fn reference(inner: TypeName<L>) -> Self {
+        TypeName::Reference {
+            inner: Box::new(inner),
+            mutable: false,
+        }
+    }
+
+    /// Create a mutable reference type (Rust `&mut T`, C++ `T&`).
+    pub fn reference_mut(inner: TypeName<L>) -> Self {
+        TypeName::Reference {
+            inner: Box::new(inner),
+            mutable: true,
+        }
+    }
+
     /// Create a function type.
     pub fn function(params: Vec<TypeName<L>>, return_type: TypeName<L>) -> Self {
         TypeName::Function {
@@ -405,6 +442,9 @@ impl<L: CodeLang> TypeName<L> {
             | TypeName::Pointer(inner)
             | TypeName::Slice(inner)
             | TypeName::Optional(inner) => {
+                inner.collect_imports(out);
+            }
+            TypeName::Reference { inner, .. } => {
                 inner.collect_imports(out);
             }
             TypeName::Generic { base, params } => {
@@ -506,6 +546,10 @@ impl<L: CodeLang> TypeName<L> {
                 BoxDoc::text("(")
                     .append(BoxDoc::intersperse(docs, sep).nest(2).group())
                     .append(BoxDoc::text(")"))
+            }
+            TypeName::Reference { inner, mutable } => {
+                let prefix = if *mutable { "&mut " } else { "&" };
+                BoxDoc::text(prefix).append(inner.to_doc(resolve))
             }
             TypeName::Function {
                 params,
@@ -625,6 +669,15 @@ impl<L: CodeLang> TypeName<L> {
                     .map(|e| e.to_doc_with_lang(resolve, lang))
                     .collect();
                 render_presentation(&lang.present_tuple(), docs, lang)
+            }
+            TypeName::Reference { inner, mutable } => {
+                let inner_doc = inner.to_doc_with_lang(resolve, lang);
+                let pres = if *mutable {
+                    lang.present_reference_mut()
+                } else {
+                    lang.present_reference()
+                };
+                render_presentation(&pres, vec![inner_doc], lang)
             }
             TypeName::Function {
                 params,
@@ -940,5 +993,91 @@ mod tests {
         let mut buf = Vec::new();
         doc.render(80, &mut buf).unwrap();
         assert_eq!(String::from_utf8(buf).unwrap(), "()");
+    }
+
+    #[test]
+    fn test_reference() {
+        let t = TypeName::<TypeScript>::reference(TypeName::primitive("str"));
+        assert_eq!(t.render(80, &identity_resolve).unwrap(), "&str");
+    }
+
+    #[test]
+    fn test_reference_mut() {
+        let t = TypeName::<TypeScript>::reference_mut(TypeName::primitive("Vec<i32>"));
+        assert_eq!(t.render(80, &identity_resolve).unwrap(), "&mut Vec<i32>");
+    }
+
+    #[test]
+    fn test_reference_collect_imports() {
+        let t = TypeName::<TypeScript>::reference(TypeName::importable("./models", "User"));
+        let mut imports = Vec::new();
+        t.collect_imports(&mut imports);
+        assert_eq!(imports.len(), 1);
+        assert_eq!(imports[0].name, "User");
+    }
+
+    #[test]
+    fn test_reference_with_lang_rust() {
+        use crate::lang::rust_lang::RustLang;
+        let lang = RustLang::new();
+        let t = TypeName::<RustLang>::reference(TypeName::primitive("String"));
+        let doc = t.to_doc_with_lang(&identity_resolve, &lang);
+        let mut buf = Vec::new();
+        doc.render(80, &mut buf).unwrap();
+        assert_eq!(String::from_utf8(buf).unwrap(), "&String");
+    }
+
+    #[test]
+    fn test_reference_mut_with_lang_rust() {
+        use crate::lang::rust_lang::RustLang;
+        let lang = RustLang::new();
+        let t = TypeName::<RustLang>::reference_mut(TypeName::primitive("String"));
+        let doc = t.to_doc_with_lang(&identity_resolve, &lang);
+        let mut buf = Vec::new();
+        doc.render(80, &mut buf).unwrap();
+        assert_eq!(String::from_utf8(buf).unwrap(), "&mut String");
+    }
+
+    #[test]
+    fn test_reference_with_lang_cpp() {
+        use crate::lang::cpp_lang::CppLang;
+        let lang = CppLang::new();
+        let t = TypeName::<CppLang>::reference(TypeName::primitive("std::string"));
+        let doc = t.to_doc_with_lang(&identity_resolve, &lang);
+        let mut buf = Vec::new();
+        doc.render(80, &mut buf).unwrap();
+        assert_eq!(String::from_utf8(buf).unwrap(), "const std::string&");
+    }
+
+    #[test]
+    fn test_reference_mut_with_lang_cpp() {
+        use crate::lang::cpp_lang::CppLang;
+        let lang = CppLang::new();
+        let t = TypeName::<CppLang>::reference_mut(TypeName::primitive("std::string"));
+        let doc = t.to_doc_with_lang(&identity_resolve, &lang);
+        let mut buf = Vec::new();
+        doc.render(80, &mut buf).unwrap();
+        assert_eq!(String::from_utf8(buf).unwrap(), "std::string&");
+    }
+
+    #[test]
+    fn test_reference_with_lang_ts() {
+        let lang = TypeScript::new();
+        let t = TypeName::<TypeScript>::reference(TypeName::primitive("string"));
+        let doc = t.to_doc_with_lang(&identity_resolve, &lang);
+        let mut buf = Vec::new();
+        doc.render(80, &mut buf).unwrap();
+        assert_eq!(String::from_utf8(buf).unwrap(), "string");
+    }
+
+    #[test]
+    fn test_reference_mut_with_lang_go() {
+        use crate::lang::go_lang::GoLang;
+        let lang = GoLang::new();
+        let t = TypeName::<GoLang>::reference_mut(TypeName::primitive("int"));
+        let doc = t.to_doc_with_lang(&identity_resolve, &lang);
+        let mut buf = Vec::new();
+        doc.render(80, &mut buf).unwrap();
+        assert_eq!(String::from_utf8(buf).unwrap(), "*int");
     }
 }

--- a/tests/golden/cpp/template_class.cpp
+++ b/tests/golden/cpp/template_class.cpp
@@ -1,7 +1,7 @@
 #pragma once
 
-template<typename T>
 /// A simple stack container.
+template<typename T>
 class Stack {
 private:
     std::vector<T> data_;

--- a/tests/golden/rust/struct_with_impl.rs
+++ b/tests/golden/rust/struct_with_impl.rs
@@ -2,8 +2,8 @@ use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize)]
 /// Application configuration.
+#[derive(Serialize, Deserialize)]
 pub struct Config {
     pub name: String,
     pub values: HashMap<String, i64>,


### PR DESCRIPTION
## Summary

- **TypePresentation layer**: Data-driven rendering for compound types — languages return a `TypePresentation` enum variant (GenericWrap, Prefix, Postfix, Surround, Delimited, Infix) and a single engine renders all patterns. `BoxDoc` never appears in `CodeLang`.
- **TypeName::Tuple**: `(A, B)` (Rust), `[A, B]` (TS), `tuple[A, B]` (Python), `std::tuple<A, B>` (C++), with `present_tuple()` on CodeLang.
- **TypeName::Reference**: `&T` / `&mut T` (Rust), `const T&` / `T&` (C++), `const T*` / `T*` (C), identity for GC languages. Introduces `TypePresentation::Surround { prefix, suffix }` for the C++ `const T&` pattern.
- **TypeKind::TypeAlias / Newtype**: Single-line declarations (`type Foo = Bar`, `struct Foo(Bar)`, `typedef Bar Foo`, etc.) with per-language rendering via `type_alias_target_first()` and `render_newtype_line()`. Builder validation ensures exactly one super_type and no fields/methods/variants.
- **Bug fixes**: `char_indices` fix for multi-byte format strings, unified doc-comment emission across all spec emitters.
- **Docs**: Updated mdbook (type_presentation, architecture, spec_layer, adding_a_language) and README to reflect all new features and correct CodeLang method counts (63 total).

## Test plan

- [x] `cargo test --workspace` passes (all existing + ~50 new tests)
- [x] Golden files updated for affected languages
- [x] Cross-language coverage: TypePresentation tested for all 13 languages, TypeAlias/Newtype tested for 7 languages (Rust, TS, C++, C, Go, Python, Kotlin)