### PR TITLE
feat: advanced type system features for TypeName and specs

### DIFF
--- a/src/lang/go_lang.rs
+++ b/src/lang/go_lang.rs
@@ -352,6 +352,14 @@ impl CodeLang for GoLang {
             wrapper_close: "",
         }
     }
+
+    fn present_wildcard(&self) -> crate::type_name::WildcardPresentation<'_> {
+        crate::type_name::WildcardPresentation {
+            unbounded: "any",
+            upper_keyword: "any ",
+            lower_keyword: "any ",
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/lang/java_lang.rs
+++ b/src/lang/java_lang.rs
@@ -306,6 +306,10 @@ impl CodeLang for JavaLang {
     fn present_map(&self) -> crate::type_name::TypePresentation<'_> {
         crate::type_name::TypePresentation::GenericWrap { name: "Map" }
     }
+
+    fn present_associated_type(&self) -> crate::type_name::AssociatedTypeStyle<'_> {
+        crate::type_name::AssociatedTypeStyle::DotAccess
+    }
 }
 
 #[cfg(test)]

--- a/src/lang/kotlin.rs
+++ b/src/lang/kotlin.rs
@@ -397,6 +397,18 @@ impl CodeLang for Kotlin {
             wrapper_close: "",
         }
     }
+
+    fn present_associated_type(&self) -> crate::type_name::AssociatedTypeStyle<'_> {
+        crate::type_name::AssociatedTypeStyle::DotAccess
+    }
+
+    fn present_wildcard(&self) -> crate::type_name::WildcardPresentation<'_> {
+        crate::type_name::WildcardPresentation {
+            unbounded: "*",
+            upper_keyword: "out ",
+            lower_keyword: "in ",
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/lang/mod.rs
+++ b/src/lang/mod.rs
@@ -519,6 +519,16 @@ pub trait CodeLang: Sized + Clone + 'static {
     fn property_getter_keyword(&self) -> &str {
         "get"
     }
+
+    // --- Where clause support ---
+
+    /// How where-clause constraints are rendered.
+    ///
+    /// Default: `Inline` — bounds stay in the generic parameter list.
+    /// Rust overrides to `WhereBlock`.
+    fn where_clause_style(&self) -> crate::spec::fun_spec::WhereClauseStyle {
+        crate::spec::fun_spec::WhereClauseStyle::Inline
+    }
 }
 
 /// Derive a PascalCase namespace alias from a module path.

--- a/src/lang/mod.rs
+++ b/src/lang/mod.rs
@@ -132,6 +132,13 @@ pub trait CodeLang: Sized + Clone + 'static {
         ">"
     }
 
+    /// How `TypeName::Generic` application is rendered.
+    ///
+    /// Default: `Delimited` — `Base<P1, P2>` using `generic_open()`/`generic_close()`.
+    fn generic_application_style(&self) -> crate::type_name::GenericApplicationStyle {
+        crate::type_name::GenericApplicationStyle::Delimited
+    }
+
     // --- Type presentation (data-driven, no BoxDoc) ---
 
     /// How `TypeName::Array(T)` renders.
@@ -239,6 +246,49 @@ pub trait CodeLang: Sized + Clone + 'static {
             curried: false,
             wrapper_open: "",
             wrapper_close: "",
+        }
+    }
+
+    /// How `TypeName::AssociatedType` renders.
+    ///
+    /// Default: Rust-style `<Base as Qual>::Member` / `Base::Member`.
+    fn present_associated_type(&self) -> crate::type_name::AssociatedTypeStyle<'_> {
+        crate::type_name::AssociatedTypeStyle::QualifiedPath {
+            open: "<",
+            as_kw: " as ",
+            close_sep: ">::",
+            simple_sep: "::",
+        }
+    }
+
+    /// How `TypeName::ImplTrait` bounds render.
+    ///
+    /// Default: Rust-style `impl Bound1 + Bound2`.
+    fn present_impl_trait(&self) -> crate::type_name::BoundsPresentation<'_> {
+        crate::type_name::BoundsPresentation {
+            keyword: "impl ",
+            separator: " + ",
+        }
+    }
+
+    /// How `TypeName::DynTrait` bounds render.
+    ///
+    /// Default: Rust-style `dyn Bound1 + Bound2`.
+    fn present_dyn_trait(&self) -> crate::type_name::BoundsPresentation<'_> {
+        crate::type_name::BoundsPresentation {
+            keyword: "dyn ",
+            separator: " + ",
+        }
+    }
+
+    /// How `TypeName::Wildcard` renders.
+    ///
+    /// Default: Java-style `?`, `? extends T`, `? super T`.
+    fn present_wildcard(&self) -> crate::type_name::WildcardPresentation<'_> {
+        crate::type_name::WildcardPresentation {
+            unbounded: "?",
+            upper_keyword: "? extends ",
+            lower_keyword: "? super ",
         }
     }
 

--- a/src/lang/mod.rs
+++ b/src/lang/mod.rs
@@ -529,6 +529,13 @@ pub trait CodeLang: Sized + Clone + 'static {
     fn where_clause_style(&self) -> crate::spec::fun_spec::WhereClauseStyle {
         crate::spec::fun_spec::WhereClauseStyle::Inline
     }
+
+    /// Render a type parameter's kind annotation (for higher-kinded types).
+    ///
+    /// Default: empty string (no kind annotation).
+    fn render_type_param_kind(&self, _kind: &crate::spec::fun_spec::TypeParamKind) -> String {
+        String::new()
+    }
 }
 
 /// Derive a PascalCase namespace alias from a module path.

--- a/src/lang/python.rs
+++ b/src/lang/python.rs
@@ -416,6 +416,10 @@ impl CodeLang for Python {
     fn present_tuple(&self) -> crate::type_name::TypePresentation<'_> {
         crate::type_name::TypePresentation::GenericWrap { name: "tuple" }
     }
+
+    fn present_associated_type(&self) -> crate::type_name::AssociatedTypeStyle<'_> {
+        crate::type_name::AssociatedTypeStyle::DotAccess
+    }
 }
 
 /// Render a `from module import name1, name2` line.

--- a/src/lang/rust_lang.rs
+++ b/src/lang/rust_lang.rs
@@ -325,10 +325,14 @@ impl CodeLang for RustLang {
     }
 
     fn present_wildcard(&self) -> crate::type_name::WildcardPresentation<'_> {
+        // Rust doesn't have Java/Kotlin-style bounded wildcards.
+        // Unbounded `_` is valid (type inference placeholder).
+        // Bounded: maps to `impl T` as the closest approximation.
+        // For precise Rust bounds, use `TypeName::impl_trait()` / `dyn_trait()` directly.
         crate::type_name::WildcardPresentation {
             unbounded: "_",
-            upper_keyword: "_ ",
-            lower_keyword: "_ ",
+            upper_keyword: "impl ",
+            lower_keyword: "impl ",
         }
     }
 

--- a/src/lang/rust_lang.rs
+++ b/src/lang/rust_lang.rs
@@ -323,6 +323,14 @@ impl CodeLang for RustLang {
             wrapper_close: "",
         }
     }
+
+    fn present_wildcard(&self) -> crate::type_name::WildcardPresentation<'_> {
+        crate::type_name::WildcardPresentation {
+            unbounded: "_",
+            upper_keyword: "_ ",
+            lower_keyword: "_ ",
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/lang/rust_lang.rs
+++ b/src/lang/rust_lang.rs
@@ -331,6 +331,10 @@ impl CodeLang for RustLang {
             lower_keyword: "_ ",
         }
     }
+
+    fn where_clause_style(&self) -> crate::spec::fun_spec::WhereClauseStyle {
+        crate::spec::fun_spec::WhereClauseStyle::WhereBlock
+    }
 }
 
 #[cfg(test)]

--- a/src/lang/typescript.rs
+++ b/src/lang/typescript.rs
@@ -349,6 +349,28 @@ impl CodeLang for TypeScript {
             close: "]",
         }
     }
+
+    fn present_associated_type(&self) -> crate::type_name::AssociatedTypeStyle<'_> {
+        crate::type_name::AssociatedTypeStyle::IndexAccess {
+            open: "[\"",
+            close: "\"]",
+        }
+    }
+
+    fn present_impl_trait(&self) -> crate::type_name::BoundsPresentation<'_> {
+        crate::type_name::BoundsPresentation {
+            keyword: "",
+            separator: " & ",
+        }
+    }
+
+    fn present_wildcard(&self) -> crate::type_name::WildcardPresentation<'_> {
+        crate::type_name::WildcardPresentation {
+            unbounded: "unknown",
+            upper_keyword: "unknown ",
+            lower_keyword: "unknown ",
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,7 +98,9 @@ pub mod prelude {
     pub use crate::lang::CodeLang;
     pub use crate::spec::field_spec::FieldSpec;
     pub use crate::spec::file_spec::FileSpec;
-    pub use crate::spec::fun_spec::{FunSpec, TypeParamKind, TypeParamSpec, WhereClauseStyle, WhereConstraint};
+    pub use crate::spec::fun_spec::{
+        FunSpec, TypeParamKind, TypeParamSpec, WhereClauseStyle, WhereConstraint,
+    };
     pub use crate::spec::modifiers::{DeclarationContext, Modifiers, TypeKind, Visibility};
     pub use crate::spec::parameter_spec::ParameterSpec;
     pub use crate::spec::project_spec::{ProjectSpec, RenderedFile};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,7 +98,7 @@ pub mod prelude {
     pub use crate::lang::CodeLang;
     pub use crate::spec::field_spec::FieldSpec;
     pub use crate::spec::file_spec::FileSpec;
-    pub use crate::spec::fun_spec::{FunSpec, TypeParamSpec};
+    pub use crate::spec::fun_spec::{FunSpec, TypeParamSpec, WhereClauseStyle, WhereConstraint};
     pub use crate::spec::modifiers::{DeclarationContext, Modifiers, TypeKind, Visibility};
     pub use crate::spec::parameter_spec::ParameterSpec;
     pub use crate::spec::project_spec::{ProjectSpec, RenderedFile};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,7 +98,7 @@ pub mod prelude {
     pub use crate::lang::CodeLang;
     pub use crate::spec::field_spec::FieldSpec;
     pub use crate::spec::file_spec::FileSpec;
-    pub use crate::spec::fun_spec::{FunSpec, TypeParamSpec, WhereClauseStyle, WhereConstraint};
+    pub use crate::spec::fun_spec::{FunSpec, TypeParamKind, TypeParamSpec, WhereClauseStyle, WhereConstraint};
     pub use crate::spec::modifiers::{DeclarationContext, Modifiers, TypeKind, Visibility};
     pub use crate::spec::parameter_spec::ParameterSpec;
     pub use crate::spec::project_spec::{ProjectSpec, RenderedFile};

--- a/src/spec/fun_spec.rs
+++ b/src/spec/fun_spec.rs
@@ -468,12 +468,14 @@ pub(crate) fn emit_where_block<L: CodeLang>(
     lang: &L,
 ) {
     let constraint_sep = lang.generic_constraint_separator();
+    let indent = lang.indent_unit();
     fmt.push_str("\nwhere\n");
     for (i, wc) in constraints.iter().enumerate() {
         if i > 0 {
             fmt.push('\n');
         }
-        fmt.push_str("    %T");
+        fmt.push_str(indent);
+        fmt.push_str("%T");
         args.push(Arg::TypeName(wc.subject.clone()));
         fmt.push_str(lang.generic_constraint_keyword());
         for (j, bound) in wc.bounds.iter().enumerate() {
@@ -613,7 +615,8 @@ impl<L: CodeLang> FunSpecBuilder<L> {
         subject: TypeName<L>,
         bounds: Vec<TypeName<L>>,
     ) -> &mut Self {
-        self.where_constraints.push(WhereConstraint { subject, bounds });
+        self.where_constraints
+            .push(WhereConstraint { subject, bounds });
         self
     }
 
@@ -779,17 +782,20 @@ mod tests {
             TypeName::primitive("T"),
             vec![TypeName::primitive("Clone"), TypeName::primitive("Send")],
         );
-        fb.add_where_constraint(
-            TypeName::primitive("U"),
-            vec![TypeName::primitive("Debug")],
-        );
+        fb.add_where_constraint(TypeName::primitive("U"), vec![TypeName::primitive("Debug")]);
         fb.add_param(ParameterSpec::new("a", TypeName::primitive("T")).unwrap());
         fb.add_param(ParameterSpec::new("b", TypeName::primitive("U")).unwrap());
         fb.body(CodeBlock::<RustLang>::of("todo!()", ()).unwrap());
         let fun = fb.build().unwrap();
         let output = emit_fun_rs(&fun, DeclarationContext::TopLevel);
-        assert!(output.contains("fn process<T, U>(a: T, b: U)"), "sig: {output}");
-        assert!(output.contains("where\n    T: Clone + Send,\n    U: Debug,"), "where: {output}");
+        assert!(
+            output.contains("fn process<T, U>(a: T, b: U)"),
+            "sig: {output}"
+        );
+        assert!(
+            output.contains("where\n    T: Clone + Send,\n    U: Debug,"),
+            "where: {output}"
+        );
         assert!(output.contains(" {"), "block_open: {output}");
     }
 
@@ -804,7 +810,10 @@ mod tests {
         fb.body(CodeBlock::<TypeScript>::of("return value", ()).unwrap());
         let fun = fb.build().unwrap();
         let output = emit_fun_ts(&fun, DeclarationContext::TopLevel);
-        assert!(!output.contains("where"), "TS should not emit where: {output}");
+        assert!(
+            !output.contains("where"),
+            "TS should not emit where: {output}"
+        );
         assert!(output.contains("function process<T>("), "sig: {output}");
     }
 
@@ -817,7 +826,10 @@ mod tests {
         fb.body(CodeBlock::<RustLang>::of("todo!()", ()).unwrap());
         let fun = fb.build().unwrap();
         let output = emit_fun_rs(&fun, DeclarationContext::TopLevel);
-        assert!(output.contains("where\n    T: Clone + Send,"), "where: {output}");
+        assert!(
+            output.contains("where\n    T: Clone + Send,"),
+            "where: {output}"
+        );
     }
 
     #[test]
@@ -837,7 +849,10 @@ mod tests {
         fb.body(CodeBlock::<RustLang>::of("todo!()", ()).unwrap());
         let fun = fb.build().unwrap();
         let output = emit_fun_rs(&fun, DeclarationContext::TopLevel);
-        assert!(output.contains("fn apply<F>()"), "default renders no kind suffix: {output}");
+        assert!(
+            output.contains("fn apply<F>()"),
+            "default renders no kind suffix: {output}"
+        );
     }
 
     #[test]
@@ -845,20 +860,38 @@ mod tests {
         let mut fb = FunSpec::<RustLang>::builder("longest");
         fb.add_type_param(TypeParamSpec::new("T"));
         fb.add_type_param(TypeParamSpec::lifetime("'a"));
-        fb.add_param(ParameterSpec::new(
-            "x",
-            TypeName::reference_with_lifetime(TypeName::primitive("str"), "'a"),
-        ).unwrap());
-        fb.add_param(ParameterSpec::new(
-            "y",
-            TypeName::reference_with_lifetime(TypeName::primitive("str"), "'a"),
-        ).unwrap());
-        fb.returns(TypeName::reference_with_lifetime(TypeName::primitive("str"), "'a"));
+        fb.add_param(
+            ParameterSpec::new(
+                "x",
+                TypeName::reference_with_lifetime(TypeName::primitive("str"), "'a"),
+            )
+            .unwrap(),
+        );
+        fb.add_param(
+            ParameterSpec::new(
+                "y",
+                TypeName::reference_with_lifetime(TypeName::primitive("str"), "'a"),
+            )
+            .unwrap(),
+        );
+        fb.returns(TypeName::reference_with_lifetime(
+            TypeName::primitive("str"),
+            "'a",
+        ));
         fb.body(CodeBlock::<RustLang>::of("x", ()).unwrap());
         let fun = fb.build().unwrap();
         let output = emit_fun_rs(&fun, DeclarationContext::TopLevel);
-        assert!(output.contains("fn longest<'a, T>("), "lifetime first: {output}");
-        assert!(output.contains("x: &'a str"), "lifetime ref param: {output}");
-        assert!(output.contains("-> &'a str"), "lifetime ref return: {output}");
+        assert!(
+            output.contains("fn longest<'a, T>("),
+            "lifetime first: {output}"
+        );
+        assert!(
+            output.contains("x: &'a str"),
+            "lifetime ref param: {output}"
+        );
+        assert!(
+            output.contains("-> &'a str"),
+            "lifetime ref return: {output}"
+        );
     }
 }

--- a/src/spec/fun_spec.rs
+++ b/src/spec/fun_spec.rs
@@ -63,6 +63,8 @@ pub struct TypeParamSpec<L: CodeLang> {
     pub(crate) bounds: Vec<TypeName<L>>,
     #[serde(default)]
     pub(crate) kind: Option<TypeParamKind>,
+    #[serde(default)]
+    pub(crate) is_lifetime: bool,
 }
 
 impl<L: CodeLang> TypeParamSpec<L> {
@@ -72,6 +74,19 @@ impl<L: CodeLang> TypeParamSpec<L> {
             name: name.to_string(),
             bounds: Vec::new(),
             kind: None,
+            is_lifetime: false,
+        }
+    }
+
+    /// Create a lifetime parameter (Rust `'a`).
+    ///
+    /// The name should include the tick: `"'a"`, `"'static"`.
+    pub fn lifetime(name: &str) -> Self {
+        Self {
+            name: name.to_string(),
+            bounds: Vec::new(),
+            kind: None,
+            is_lifetime: true,
         }
     }
 
@@ -103,8 +118,30 @@ pub fn render_type_params<L: CodeLang>(
     let constraint_sep = lang.generic_constraint_separator();
 
     let mut fmt = String::from(lang.generic_open());
-    for (i, tp) in params.iter().enumerate() {
-        if i > 0 {
+    let mut first = true;
+
+    // Lifetimes first (Rust convention: `<'a, 'b, T, U>`).
+    for tp in params.iter().filter(|p| p.is_lifetime) {
+        if !first {
+            fmt.push_str(", ");
+        }
+        fmt.push_str(&tp.name);
+        if !tp.bounds.is_empty() {
+            fmt.push_str(constraint_kw);
+            for (j, bound) in tp.bounds.iter().enumerate() {
+                if j > 0 {
+                    fmt.push_str(constraint_sep);
+                }
+                fmt.push_str("%T");
+                args.push(Arg::TypeName(bound.clone()));
+            }
+        }
+        first = false;
+    }
+
+    // Then type parameters.
+    for tp in params.iter().filter(|p| !p.is_lifetime) {
+        if !first {
             fmt.push_str(", ");
         }
         fmt.push_str(&tp.name);
@@ -121,7 +158,9 @@ pub fn render_type_params<L: CodeLang>(
                 args.push(Arg::TypeName(bound.clone()));
             }
         }
+        first = false;
     }
+
     fmt.push_str(lang.generic_close());
     fmt
 }
@@ -799,5 +838,27 @@ mod tests {
         let fun = fb.build().unwrap();
         let output = emit_fun_rs(&fun, DeclarationContext::TopLevel);
         assert!(output.contains("fn apply<F>()"), "default renders no kind suffix: {output}");
+    }
+
+    #[test]
+    fn test_lifetime_params_before_type_params() {
+        let mut fb = FunSpec::<RustLang>::builder("longest");
+        fb.add_type_param(TypeParamSpec::new("T"));
+        fb.add_type_param(TypeParamSpec::lifetime("'a"));
+        fb.add_param(ParameterSpec::new(
+            "x",
+            TypeName::reference_with_lifetime(TypeName::primitive("str"), "'a"),
+        ).unwrap());
+        fb.add_param(ParameterSpec::new(
+            "y",
+            TypeName::reference_with_lifetime(TypeName::primitive("str"), "'a"),
+        ).unwrap());
+        fb.returns(TypeName::reference_with_lifetime(TypeName::primitive("str"), "'a"));
+        fb.body(CodeBlock::<RustLang>::of("x", ()).unwrap());
+        let fun = fb.build().unwrap();
+        let output = emit_fun_rs(&fun, DeclarationContext::TopLevel);
+        assert!(output.contains("fn longest<'a, T>("), "lifetime first: {output}");
+        assert!(output.contains("x: &'a str"), "lifetime ref param: {output}");
+        assert!(output.contains("-> &'a str"), "lifetime ref return: {output}");
     }
 }

--- a/src/spec/fun_spec.rs
+++ b/src/spec/fun_spec.rs
@@ -9,6 +9,25 @@ use crate::spec::modifiers::{
 use crate::spec::parameter_spec::ParameterSpec;
 use crate::type_name::TypeName;
 
+/// A single constraint in a where clause.
+///
+/// Represents `Subject: Bound1 + Bound2` in Rust's `where` block.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(bound = "")]
+pub struct WhereConstraint<L: CodeLang> {
+    pub(crate) subject: TypeName<L>,
+    pub(crate) bounds: Vec<TypeName<L>>,
+}
+
+/// How where-clause constraints are rendered.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum WhereClauseStyle {
+    /// Bounds stay inline in the type parameter list.
+    Inline,
+    /// Rust-style `where` block after the signature.
+    WhereBlock,
+}
+
 /// A generic type parameter with optional bounds.
 ///
 /// Used with [`FunSpec`] and [`TypeSpec`](crate::spec::type_spec::TypeSpec) for
@@ -131,6 +150,9 @@ pub struct FunSpec<L: CodeLang> {
     /// For signature-style languages (Kotlin): emitted after the parameter list
     /// as ` : super(...)` / ` : this(...)`.
     pub(crate) delegation: Option<CodeBlock<L>>,
+    /// Where-clause constraints (e.g., Rust `where T: Clone + Send`).
+    #[serde(default)]
+    pub(crate) where_constraints: Vec<WhereConstraint<L>>,
 }
 
 impl<L: CodeLang> FunSpec<L> {
@@ -149,6 +171,7 @@ impl<L: CodeLang> FunSpec<L> {
             receiver: None,
             suffixes: Vec::new(),
             delegation: None,
+            where_constraints: Vec::new(),
         }
     }
 
@@ -288,7 +311,7 @@ impl<L: CodeLang> FunSpec<L> {
 
         // Body or abstract.
         if let Some(body) = &self.body {
-            sig.push_str(lang.block_open());
+            self.emit_where_and_open(&mut sig, &mut sig_args, lang);
             cb.add(&sig, sig_args);
             cb.add_line();
             cb.add("%>", ());
@@ -315,7 +338,7 @@ impl<L: CodeLang> FunSpec<L> {
             let empty = lang.empty_body();
             if !empty.is_empty() {
                 // Language requires a body placeholder (e.g., Python `...`).
-                sig.push_str(lang.block_open());
+                self.emit_where_and_open(&mut sig, &mut sig_args, lang);
                 cb.add(&sig, sig_args);
                 cb.add_line();
                 cb.add("%>", ());
@@ -359,6 +382,47 @@ impl<L: CodeLang> FunSpec<L> {
         }
         pb.build()
     }
+
+    fn emit_where_and_open(&self, sig: &mut String, sig_args: &mut Vec<Arg<L>>, lang: &L) {
+        if !self.where_constraints.is_empty()
+            && lang.where_clause_style() == WhereClauseStyle::WhereBlock
+        {
+            emit_where_block(sig, sig_args, &self.where_constraints, lang);
+        }
+        sig.push_str(lang.block_open());
+    }
+}
+
+/// Append a where-clause block to a format string.
+///
+/// Renders Rust-style:
+/// ```text
+/// \nwhere\n    T: Clone + Send,\n    U: Debug,
+/// ```
+pub(crate) fn emit_where_block<L: CodeLang>(
+    fmt: &mut String,
+    args: &mut Vec<Arg<L>>,
+    constraints: &[WhereConstraint<L>],
+    lang: &L,
+) {
+    let constraint_sep = lang.generic_constraint_separator();
+    fmt.push_str("\nwhere\n");
+    for (i, wc) in constraints.iter().enumerate() {
+        if i > 0 {
+            fmt.push('\n');
+        }
+        fmt.push_str("    %T");
+        args.push(Arg::TypeName(wc.subject.clone()));
+        fmt.push_str(lang.generic_constraint_keyword());
+        for (j, bound) in wc.bounds.iter().enumerate() {
+            if j > 0 {
+                fmt.push_str(constraint_sep);
+            }
+            fmt.push_str("%T");
+            args.push(Arg::TypeName(bound.clone()));
+        }
+        fmt.push(',');
+    }
 }
 
 /// Builder for [`FunSpec`].
@@ -376,6 +440,7 @@ pub struct FunSpecBuilder<L: CodeLang> {
     receiver: Option<ParameterSpec<L>>,
     suffixes: Vec<String>,
     delegation: Option<CodeBlock<L>>,
+    where_constraints: Vec<WhereConstraint<L>>,
 }
 
 impl<L: CodeLang> FunSpecBuilder<L> {
@@ -480,6 +545,34 @@ impl<L: CodeLang> FunSpecBuilder<L> {
         self
     }
 
+    /// Add a where-clause constraint (e.g., `T: Clone + Send`).
+    pub fn add_where_constraint(
+        &mut self,
+        subject: TypeName<L>,
+        bounds: Vec<TypeName<L>>,
+    ) -> &mut Self {
+        self.where_constraints.push(WhereConstraint { subject, bounds });
+        self
+    }
+
+    /// Convenience: add a single bound to an existing or new where constraint for
+    /// the named type parameter.
+    pub fn where_bound(&mut self, param_name: &str, bound: TypeName<L>) -> &mut Self {
+        if let Some(wc) = self
+            .where_constraints
+            .iter_mut()
+            .find(|wc| wc.subject.simple_name() == Some(param_name))
+        {
+            wc.bounds.push(bound);
+        } else {
+            self.where_constraints.push(WhereConstraint {
+                subject: TypeName::primitive(param_name),
+                bounds: vec![bound],
+            });
+        }
+        self
+    }
+
     /// Consume the builder and produce a [`FunSpec`].
     ///
     /// # Errors
@@ -505,6 +598,7 @@ impl<L: CodeLang> FunSpecBuilder<L> {
             receiver: self.receiver,
             suffixes: self.suffixes,
             delegation: self.delegation,
+            where_constraints: self.where_constraints,
         })
     }
 }
@@ -612,5 +706,55 @@ mod tests {
                 .to_string()
                 .contains("'name' must not be empty")
         );
+    }
+
+    #[test]
+    fn test_where_clause_rust_function() {
+        let mut fb = FunSpec::<RustLang>::builder("process");
+        fb.add_type_param(TypeParamSpec::new("T"));
+        fb.add_type_param(TypeParamSpec::new("U"));
+        fb.add_where_constraint(
+            TypeName::primitive("T"),
+            vec![TypeName::primitive("Clone"), TypeName::primitive("Send")],
+        );
+        fb.add_where_constraint(
+            TypeName::primitive("U"),
+            vec![TypeName::primitive("Debug")],
+        );
+        fb.add_param(ParameterSpec::new("a", TypeName::primitive("T")).unwrap());
+        fb.add_param(ParameterSpec::new("b", TypeName::primitive("U")).unwrap());
+        fb.body(CodeBlock::<RustLang>::of("todo!()", ()).unwrap());
+        let fun = fb.build().unwrap();
+        let output = emit_fun_rs(&fun, DeclarationContext::TopLevel);
+        assert!(output.contains("fn process<T, U>(a: T, b: U)"), "sig: {output}");
+        assert!(output.contains("where\n    T: Clone + Send,\n    U: Debug,"), "where: {output}");
+        assert!(output.contains(" {"), "block_open: {output}");
+    }
+
+    #[test]
+    fn test_where_clause_ts_inline_ignored() {
+        let mut fb = FunSpec::<TypeScript>::builder("process");
+        fb.add_type_param(TypeParamSpec::new("T"));
+        fb.add_where_constraint(
+            TypeName::primitive("T"),
+            vec![TypeName::primitive("Serializable")],
+        );
+        fb.body(CodeBlock::<TypeScript>::of("return value", ()).unwrap());
+        let fun = fb.build().unwrap();
+        let output = emit_fun_ts(&fun, DeclarationContext::TopLevel);
+        assert!(!output.contains("where"), "TS should not emit where: {output}");
+        assert!(output.contains("function process<T>("), "sig: {output}");
+    }
+
+    #[test]
+    fn test_where_bound_convenience() {
+        let mut fb = FunSpec::<RustLang>::builder("example");
+        fb.add_type_param(TypeParamSpec::new("T"));
+        fb.where_bound("T", TypeName::primitive("Clone"));
+        fb.where_bound("T", TypeName::primitive("Send"));
+        fb.body(CodeBlock::<RustLang>::of("todo!()", ()).unwrap());
+        let fun = fb.build().unwrap();
+        let output = emit_fun_rs(&fun, DeclarationContext::TopLevel);
+        assert!(output.contains("where\n    T: Clone + Send,"), "where: {output}");
     }
 }

--- a/src/spec/fun_spec.rs
+++ b/src/spec/fun_spec.rs
@@ -28,6 +28,17 @@ pub enum WhereClauseStyle {
     WhereBlock,
 }
 
+/// The kind of a type parameter (for higher-kinded type support).
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub enum TypeParamKind {
+    /// Type constructor taking one argument: `* -> *` (Haskell), `F[_]` (Scala).
+    Constructor1,
+    /// Type constructor taking two arguments: `* -> * -> *`.
+    Constructor2,
+    /// Arbitrary kind expressed as a raw string.
+    Raw(String),
+}
+
 /// A generic type parameter with optional bounds.
 ///
 /// Used with [`FunSpec`] and [`TypeSpec`](crate::spec::type_spec::TypeSpec) for
@@ -50,6 +61,8 @@ pub enum WhereClauseStyle {
 pub struct TypeParamSpec<L: CodeLang> {
     pub(crate) name: String,
     pub(crate) bounds: Vec<TypeName<L>>,
+    #[serde(default)]
+    pub(crate) kind: Option<TypeParamKind>,
 }
 
 impl<L: CodeLang> TypeParamSpec<L> {
@@ -58,12 +71,19 @@ impl<L: CodeLang> TypeParamSpec<L> {
         Self {
             name: name.to_string(),
             bounds: Vec::new(),
+            kind: None,
         }
     }
 
     /// Add a trait/interface bound to this type parameter.
     pub fn with_bound(mut self, bound: TypeName<L>) -> Self {
         self.bounds.push(bound);
+        self
+    }
+
+    /// Set this parameter as a higher-kinded type constructor.
+    pub fn with_kind(mut self, kind: TypeParamKind) -> Self {
+        self.kind = Some(kind);
         self
     }
 }
@@ -88,6 +108,9 @@ pub fn render_type_params<L: CodeLang>(
             fmt.push_str(", ");
         }
         fmt.push_str(&tp.name);
+        if let Some(ref kind) = tp.kind {
+            fmt.push_str(&lang.render_type_param_kind(kind));
+        }
         if !tp.bounds.is_empty() {
             fmt.push_str(constraint_kw);
             for (j, bound) in tp.bounds.iter().enumerate() {
@@ -756,5 +779,25 @@ mod tests {
         let fun = fb.build().unwrap();
         let output = emit_fun_rs(&fun, DeclarationContext::TopLevel);
         assert!(output.contains("where\n    T: Clone + Send,"), "where: {output}");
+    }
+
+    #[test]
+    fn test_type_param_kind_none_unchanged() {
+        let mut fb = FunSpec::<TypeScript>::builder("foo");
+        fb.add_type_param(TypeParamSpec::new("T"));
+        fb.body(CodeBlock::<TypeScript>::of("return null", ()).unwrap());
+        let fun = fb.build().unwrap();
+        let output = emit_fun_ts(&fun, DeclarationContext::TopLevel);
+        assert!(output.contains("function foo<T>()"), "unchanged: {output}");
+    }
+
+    #[test]
+    fn test_type_param_with_kind_default_no_output() {
+        let mut fb = FunSpec::<RustLang>::builder("apply");
+        fb.add_type_param(TypeParamSpec::new("F").with_kind(TypeParamKind::Constructor1));
+        fb.body(CodeBlock::<RustLang>::of("todo!()", ()).unwrap());
+        let fun = fb.build().unwrap();
+        let output = emit_fun_rs(&fun, DeclarationContext::TopLevel);
+        assert!(output.contains("fn apply<F>()"), "default renders no kind suffix: {output}");
     }
 }

--- a/src/spec/type_spec.rs
+++ b/src/spec/type_spec.rs
@@ -5,7 +5,9 @@ use crate::lang::CodeLang;
 use crate::spec::annotation_spec::AnnotationSpec;
 use crate::spec::enum_variant_spec::EnumVariantSpec;
 use crate::spec::field_spec::FieldSpec;
-use crate::spec::fun_spec::{FunSpec, TypeParamSpec, WhereConstraint, WhereClauseStyle, emit_where_block, render_type_params};
+use crate::spec::fun_spec::{
+    FunSpec, TypeParamSpec, WhereClauseStyle, WhereConstraint, emit_where_block, render_type_params,
+};
 use crate::spec::modifiers::{DeclarationContext, Modifiers, TypeKind, Visibility};
 use crate::spec::parameter_spec::ParameterSpec;
 use crate::spec::property_spec::PropertySpec;
@@ -738,7 +740,8 @@ impl<L: CodeLang> TypeSpecBuilder<L> {
         subject: TypeName<L>,
         bounds: Vec<TypeName<L>>,
     ) -> &mut Self {
-        self.where_constraints.push(WhereConstraint { subject, bounds });
+        self.where_constraints
+            .push(WhereConstraint { subject, bounds });
         self
     }
 
@@ -1209,8 +1212,18 @@ mod tests {
         let type_spec = tb.build().unwrap();
         let blocks = type_spec.emit(&RustLang::new()).unwrap();
         let output = render_blocks_rs(&blocks);
-        assert!(output.contains("pub struct Container<T>"), "header: {output}");
-        assert!(output.contains("where\n    T: Clone + Send,"), "where on struct: {output}");
+        assert!(
+            output.contains("pub struct Container<T>"),
+            "header: {output}"
+        );
+        assert!(
+            output.contains("where\n    T: Clone + Send,"),
+            "where on struct: {output}"
+        );
         assert!(output.contains("impl<T> Container<T>"), "impl: {output}");
+        assert!(
+            output.contains("impl<T> Container<T>\nwhere\n    T: Clone + Send,"),
+            "where on impl: {output}"
+        );
     }
 }

--- a/src/spec/type_spec.rs
+++ b/src/spec/type_spec.rs
@@ -5,7 +5,7 @@ use crate::lang::CodeLang;
 use crate::spec::annotation_spec::AnnotationSpec;
 use crate::spec::enum_variant_spec::EnumVariantSpec;
 use crate::spec::field_spec::FieldSpec;
-use crate::spec::fun_spec::{FunSpec, TypeParamSpec, render_type_params};
+use crate::spec::fun_spec::{FunSpec, TypeParamSpec, WhereConstraint, WhereClauseStyle, emit_where_block, render_type_params};
 use crate::spec::modifiers::{DeclarationContext, Modifiers, TypeKind, Visibility};
 use crate::spec::parameter_spec::ParameterSpec;
 use crate::spec::property_spec::PropertySpec;
@@ -59,6 +59,9 @@ pub struct TypeSpec<L: CodeLang> {
     pub(crate) variants: Vec<EnumVariantSpec<L>>,
     /// Primary constructor parameters (Kotlin: `class Foo(val x: Int, val y: String)`).
     pub(crate) primary_constructor: Vec<ParameterSpec<L>>,
+    /// Where-clause constraints (e.g., Rust `where T: Clone + Send`).
+    #[serde(default)]
+    pub(crate) where_constraints: Vec<WhereConstraint<L>>,
 }
 
 impl<L: CodeLang> TypeSpec<L> {
@@ -80,6 +83,7 @@ impl<L: CodeLang> TypeSpec<L> {
             extra_members: Vec::new(),
             variants: Vec::new(),
             primary_constructor: Vec::new(),
+            where_constraints: Vec::new(),
         }
     }
 
@@ -231,6 +235,12 @@ impl<L: CodeLang> TypeSpec<L> {
                     impl_fmt.push_str(&tp.name);
                 }
                 impl_fmt.push_str(lang.generic_close());
+            }
+            // Where clause on impl block.
+            if !self.where_constraints.is_empty()
+                && lang.where_clause_style() == WhereClauseStyle::WhereBlock
+            {
+                emit_where_block(&mut impl_fmt, &mut impl_args, &self.where_constraints, lang);
             }
             impl_fmt.push_str(lang.block_open());
             impl_cb.add(&impl_fmt, impl_args);
@@ -581,6 +591,13 @@ impl<L: CodeLang> TypeSpec<L> {
             }
         }
 
+        // Where clause (Rust-style).
+        if !self.where_constraints.is_empty()
+            && lang.where_clause_style() == WhereClauseStyle::WhereBlock
+        {
+            emit_where_block(&mut fmt, &mut args, &self.where_constraints, lang);
+        }
+
         fmt.push_str(lang.block_open());
         cb.add(&fmt, args);
         cb.add_line();
@@ -621,6 +638,7 @@ pub struct TypeSpecBuilder<L: CodeLang> {
     extra_members: Vec<CodeBlock<L>>,
     variants: Vec<EnumVariantSpec<L>>,
     primary_constructor: Vec<ParameterSpec<L>>,
+    where_constraints: Vec<WhereConstraint<L>>,
 }
 
 impl<L: CodeLang> TypeSpecBuilder<L> {
@@ -714,6 +732,16 @@ impl<L: CodeLang> TypeSpecBuilder<L> {
         self
     }
 
+    /// Add a where-clause constraint (e.g., `T: Clone + Send`).
+    pub fn add_where_constraint(
+        &mut self,
+        subject: TypeName<L>,
+        bounds: Vec<TypeName<L>>,
+    ) -> &mut Self {
+        self.where_constraints.push(WhereConstraint { subject, bounds });
+        self
+    }
+
     /// Consume the builder and produce a [`TypeSpec`].
     ///
     /// # Errors
@@ -785,6 +813,7 @@ impl<L: CodeLang> TypeSpecBuilder<L> {
             extra_members: self.extra_members,
             variants: self.variants,
             primary_constructor: self.primary_constructor,
+            where_constraints: self.where_constraints,
         })
     }
 }
@@ -1156,5 +1185,32 @@ mod tests {
                 .to_string()
                 .contains("must not have fields")
         );
+    }
+
+    #[test]
+    fn test_where_clause_rust_struct() {
+        let mut tb = TypeSpec::<RustLang>::builder("Container", TypeKind::Struct);
+        tb.visibility(Visibility::Public);
+        tb.add_type_param(TypeParamSpec::new("T"));
+        tb.add_where_constraint(
+            TypeName::primitive("T"),
+            vec![TypeName::primitive("Clone"), TypeName::primitive("Send")],
+        );
+        let mut fb = FieldSpec::builder("value", TypeName::primitive("T"));
+        fb.visibility(Visibility::Public);
+        tb.add_field(fb.build().unwrap());
+        let body = CodeBlock::<RustLang>::of("Self { value }", ()).unwrap();
+        let mut mb = FunSpec::<RustLang>::builder("new");
+        mb.visibility(Visibility::Public);
+        mb.add_param(ParameterSpec::new("value", TypeName::primitive("T")).unwrap());
+        mb.returns(TypeName::primitive("Self"));
+        mb.body(body);
+        tb.add_method(mb.build().unwrap());
+        let type_spec = tb.build().unwrap();
+        let blocks = type_spec.emit(&RustLang::new()).unwrap();
+        let output = render_blocks_rs(&blocks);
+        assert!(output.contains("pub struct Container<T>"), "header: {output}");
+        assert!(output.contains("where\n    T: Clone + Send,"), "where on struct: {output}");
+        assert!(output.contains("impl<T> Container<T>"), "impl: {output}");
     }
 }

--- a/src/type_name.rs
+++ b/src/type_name.rs
@@ -98,8 +98,10 @@ pub enum AssociatedTypeStyle<'a> {
         simple_sep: &'a str,
     },
     /// Dot access: `Base.Member` (Java, Kotlin, Python).
+    /// The qualifier is ignored — only `base.member` is emitted.
     DotAccess,
     /// Index access: `Base["Member"]` (TypeScript).
+    /// The qualifier is ignored — only `base["member"]` is emitted.
     IndexAccess {
         /// Opening delimiter (e.g., `"[\"`).
         open: &'a str,
@@ -746,7 +748,11 @@ impl<L: CodeLang> TypeName<L> {
                     .append(BoxDoc::intersperse(docs, sep).nest(2).group())
                     .append(BoxDoc::text(")"))
             }
-            TypeName::Reference { inner, mutable, lifetime } => {
+            TypeName::Reference {
+                inner,
+                mutable,
+                lifetime,
+            } => {
                 let mut prefix = String::from("&");
                 if let Some(lt) = lifetime {
                     prefix.push_str(lt);
@@ -792,19 +798,21 @@ impl<L: CodeLang> TypeName<L> {
             TypeName::ImplTrait { bounds } => {
                 let docs: Vec<_> = bounds.iter().map(|b| b.to_doc(resolve)).collect();
                 let sep = BoxDoc::text(" + ");
-                BoxDoc::text("impl ")
-                    .append(BoxDoc::intersperse(docs, sep))
+                BoxDoc::text("impl ").append(BoxDoc::intersperse(docs, sep))
             }
             TypeName::DynTrait { bounds } => {
                 let docs: Vec<_> = bounds.iter().map(|b| b.to_doc(resolve)).collect();
                 let sep = BoxDoc::text(" + ");
-                BoxDoc::text("dyn ")
-                    .append(BoxDoc::intersperse(docs, sep))
+                BoxDoc::text("dyn ").append(BoxDoc::intersperse(docs, sep))
             }
             TypeName::Wildcard {
                 upper_bound,
                 lower_bound,
             } => {
+                debug_assert!(
+                    upper_bound.is_none() || lower_bound.is_none(),
+                    "Wildcard cannot have both upper and lower bounds"
+                );
                 if let Some(ub) = upper_bound {
                     BoxDoc::text("? extends ").append(ub.to_doc(resolve))
                 } else if let Some(lb) = lower_bound {
@@ -955,7 +963,11 @@ impl<L: CodeLang> TypeName<L> {
                     .collect();
                 render_presentation(&lang.present_tuple(), docs, lang)
             }
-            TypeName::Reference { inner, mutable, lifetime } => {
+            TypeName::Reference {
+                inner,
+                mutable,
+                lifetime,
+            } => {
                 let inner_doc = inner.to_doc_with_lang(resolve, lang);
                 if let Some(lt) = lifetime {
                     let mut prefix = String::from("&");
@@ -1044,6 +1056,10 @@ impl<L: CodeLang> TypeName<L> {
                 upper_bound,
                 lower_bound,
             } => {
+                debug_assert!(
+                    upper_bound.is_none() || lower_bound.is_none(),
+                    "Wildcard cannot have both upper and lower bounds"
+                );
                 let pres = lang.present_wildcard();
                 if let Some(ub) = upper_bound {
                     let ub_doc = ub.to_doc_with_lang(resolve, lang);
@@ -1070,6 +1086,49 @@ mod tests {
         let _ = module;
         name.to_string()
     }
+
+    macro_rules! test_lang {
+        ($name:ident, $base:ty { $($override:tt)* }) => {
+            #[derive(Debug, Clone)]
+            struct $name(pub $base);
+            impl $name {
+                fn new() -> Self { Self(<$base>::new()) }
+            }
+            impl crate::lang::CodeLang for $name {
+                fn file_extension(&self) -> &str { self.0.file_extension() }
+                fn reserved_words(&self) -> &[&str] { self.0.reserved_words() }
+                fn render_imports(&self, imports: &crate::import::ImportGroup) -> String { self.0.render_imports(imports) }
+                fn render_string_literal(&self, s: &str) -> String { self.0.render_string_literal(s) }
+                fn render_doc_comment(&self, lines: &[&str]) -> String { self.0.render_doc_comment(lines) }
+                fn line_comment_prefix(&self) -> &str { self.0.line_comment_prefix() }
+                fn indent_unit(&self) -> &str { self.0.indent_unit() }
+                fn uses_semicolons(&self) -> bool { self.0.uses_semicolons() }
+                fn render_visibility(&self, vis: crate::spec::modifiers::Visibility, ctx: crate::spec::modifiers::DeclarationContext) -> &str { self.0.render_visibility(vis, ctx) }
+                fn function_keyword(&self, ctx: crate::spec::modifiers::DeclarationContext) -> &str { self.0.function_keyword(ctx) }
+                fn return_type_separator(&self) -> &str { self.0.return_type_separator() }
+                fn type_keyword(&self, kind: crate::spec::modifiers::TypeKind) -> &str { self.0.type_keyword(kind) }
+                fn field_terminator(&self) -> &str { self.0.field_terminator() }
+                fn methods_inside_type_body(&self, kind: crate::spec::modifiers::TypeKind) -> bool { self.0.methods_inside_type_body(kind) }
+                fn generic_constraint_keyword(&self) -> &str { self.0.generic_constraint_keyword() }
+                fn generic_constraint_separator(&self) -> &str { self.0.generic_constraint_separator() }
+                fn super_type_keyword(&self) -> &str { self.0.super_type_keyword() }
+                fn implements_keyword(&self) -> &str { self.0.implements_keyword() }
+                $($override)*
+            }
+        };
+    }
+
+    test_lang!(PrefixLang, TypeScript {
+        fn generic_application_style(&self) -> GenericApplicationStyle {
+            GenericApplicationStyle::PrefixJuxtaposition
+        }
+    });
+
+    test_lang!(PostfixLang, TypeScript {
+        fn generic_application_style(&self) -> GenericApplicationStyle {
+            GenericApplicationStyle::PostfixJuxtaposition
+        }
+    });
 
     #[test]
     fn test_primitive() {
@@ -1479,16 +1538,58 @@ mod tests {
 
     #[test]
     fn test_generic_prefix_juxtaposition() {
-        use crate::lang::typescript::TypeScript;
-        let lang = TypeScript::new();
-        let t = TypeName::<TypeScript>::generic(
+        let lang = PrefixLang::new();
+        let t = TypeName::<PrefixLang>::generic(
             TypeName::primitive("Maybe"),
             vec![TypeName::primitive("Int")],
         );
         let doc = t.to_doc_with_lang(&identity_resolve, &lang);
         let mut buf = Vec::new();
         doc.render(80, &mut buf).unwrap();
-        assert_eq!(String::from_utf8(buf).unwrap(), "Maybe<Int>");
+        assert_eq!(String::from_utf8(buf).unwrap(), "Maybe Int");
+    }
+
+    #[test]
+    fn test_generic_prefix_juxtaposition_compound_param() {
+        let lang = PrefixLang::new();
+        let inner = TypeName::<PrefixLang>::generic(
+            TypeName::primitive("Maybe"),
+            vec![TypeName::primitive("Int")],
+        );
+        let t = TypeName::<PrefixLang>::generic(
+            TypeName::primitive("Either"),
+            vec![TypeName::primitive("String"), inner],
+        );
+        let doc = t.to_doc_with_lang(&identity_resolve, &lang);
+        let mut buf = Vec::new();
+        doc.render(80, &mut buf).unwrap();
+        assert_eq!(String::from_utf8(buf).unwrap(), "Either String (Maybe Int)");
+    }
+
+    #[test]
+    fn test_generic_postfix_juxtaposition_single() {
+        let lang = PostfixLang::new();
+        let t = TypeName::<PostfixLang>::generic(
+            TypeName::primitive("option"),
+            vec![TypeName::primitive("int")],
+        );
+        let doc = t.to_doc_with_lang(&identity_resolve, &lang);
+        let mut buf = Vec::new();
+        doc.render(80, &mut buf).unwrap();
+        assert_eq!(String::from_utf8(buf).unwrap(), "int option");
+    }
+
+    #[test]
+    fn test_generic_postfix_juxtaposition_multi() {
+        let lang = PostfixLang::new();
+        let t = TypeName::<PostfixLang>::generic(
+            TypeName::primitive("result"),
+            vec![TypeName::primitive("int"), TypeName::primitive("string")],
+        );
+        let doc = t.to_doc_with_lang(&identity_resolve, &lang);
+        let mut buf = Vec::new();
+        doc.render(80, &mut buf).unwrap();
+        assert_eq!(String::from_utf8(buf).unwrap(), "(int, string) result");
     }
 
     #[test]
@@ -1501,12 +1602,9 @@ mod tests {
             TypeName::primitive("A"),
             TypeName::primitive("B"),
         ])));
-        assert!(is_compound_type(
-            &TypeName::<TypeScript>::intersection(vec![
-                TypeName::primitive("A"),
-                TypeName::primitive("B"),
-            ])
-        ));
+        assert!(is_compound_type(&TypeName::<TypeScript>::intersection(
+            vec![TypeName::primitive("A"), TypeName::primitive("B"),]
+        )));
         assert!(is_compound_type(&TypeName::<TypeScript>::function(
             vec![TypeName::primitive("A")],
             TypeName::primitive("B"),
@@ -1727,9 +1825,8 @@ mod tests {
 
     #[test]
     fn test_dyn_trait_collect_imports() {
-        let t = TypeName::<TypeScript>::dyn_trait(vec![
-            TypeName::importable("./errors", "AppError"),
-        ]);
+        let t =
+            TypeName::<TypeScript>::dyn_trait(vec![TypeName::importable("./errors", "AppError")]);
         let mut imports = Vec::new();
         t.collect_imports(&mut imports);
         assert_eq!(imports.len(), 1);
@@ -1737,9 +1834,7 @@ mod tests {
 
     #[test]
     fn test_wildcard_collect_imports() {
-        let t = TypeName::<TypeScript>::wildcard_extends(
-            TypeName::importable("./models", "User"),
-        );
+        let t = TypeName::<TypeScript>::wildcard_extends(TypeName::importable("./models", "User"));
         let mut imports = Vec::new();
         t.collect_imports(&mut imports);
         assert_eq!(imports.len(), 1);
@@ -1752,7 +1847,10 @@ mod tests {
             Some(TypeName::primitive("Iter")),
             "Item",
         );
-        assert_eq!(t.render(80, &identity_resolve).unwrap(), "<T as Iter>::Item");
+        assert_eq!(
+            t.render(80, &identity_resolve).unwrap(),
+            "<T as Iter>::Item"
+        );
     }
 
     #[test]
@@ -1779,17 +1877,21 @@ mod tests {
     #[test]
     fn test_wildcard_default_rendering() {
         assert_eq!(
-            TypeName::<TypeScript>::wildcard().render(80, &identity_resolve).unwrap(),
+            TypeName::<TypeScript>::wildcard()
+                .render(80, &identity_resolve)
+                .unwrap(),
             "?"
         );
         assert_eq!(
             TypeName::<TypeScript>::wildcard_extends(TypeName::primitive("T"))
-                .render(80, &identity_resolve).unwrap(),
+                .render(80, &identity_resolve)
+                .unwrap(),
             "? extends T"
         );
         assert_eq!(
             TypeName::<TypeScript>::wildcard_super(TypeName::primitive("T"))
-                .render(80, &identity_resolve).unwrap(),
+                .render(80, &identity_resolve)
+                .unwrap(),
             "? super T"
         );
     }
@@ -1800,10 +1902,7 @@ mod tests {
     fn test_reference_with_lifetime_rust() {
         use crate::lang::rust_lang::RustLang;
         let lang = RustLang::new();
-        let t = TypeName::<RustLang>::reference_with_lifetime(
-            TypeName::primitive("str"),
-            "'a",
-        );
+        let t = TypeName::<RustLang>::reference_with_lifetime(TypeName::primitive("str"), "'a");
         let doc = t.to_doc_with_lang(&identity_resolve, &lang);
         let mut buf = Vec::new();
         doc.render(80, &mut buf).unwrap();
@@ -1814,10 +1913,8 @@ mod tests {
     fn test_reference_mut_with_lifetime_rust() {
         use crate::lang::rust_lang::RustLang;
         let lang = RustLang::new();
-        let t = TypeName::<RustLang>::reference_mut_with_lifetime(
-            TypeName::primitive("String"),
-            "'a",
-        );
+        let t =
+            TypeName::<RustLang>::reference_mut_with_lifetime(TypeName::primitive("String"), "'a");
         let doc = t.to_doc_with_lang(&identity_resolve, &lang);
         let mut buf = Vec::new();
         doc.render(80, &mut buf).unwrap();
@@ -1826,10 +1923,7 @@ mod tests {
 
     #[test]
     fn test_reference_with_lifetime_default_rendering() {
-        let t = TypeName::<TypeScript>::reference_with_lifetime(
-            TypeName::primitive("str"),
-            "'a",
-        );
+        let t = TypeName::<TypeScript>::reference_with_lifetime(TypeName::primitive("str"), "'a");
         assert_eq!(t.render(80, &identity_resolve).unwrap(), "&'a str");
     }
 

--- a/src/type_name.rs
+++ b/src/type_name.rs
@@ -207,12 +207,15 @@ pub enum TypeName<L: CodeLang> {
     Optional(Box<TypeName<L>>),
     /// Tuple type. Rust: `(A, B)`, TS: `[A, B]`, Python: `tuple[A, B]`.
     Tuple(Vec<TypeName<L>>),
-    /// Reference type. Rust: `&T` / `&mut T`, C++: `const T&` / `T&`.
+    /// Reference type. Rust: `&T` / `&mut T` / `&'a T`, C++: `const T&` / `T&`.
     Reference {
         /// The referenced type.
         inner: Box<TypeName<L>>,
         /// Whether the reference is mutable.
         mutable: bool,
+        /// Optional lifetime (Rust only, e.g., `'a`).
+        #[serde(default)]
+        lifetime: Option<String>,
     },
     /// Associated/path-dependent type. Rust: `<T as Iterator>::Item`, TS: `T["key"]`.
     AssociatedType {
@@ -478,6 +481,7 @@ impl<L: CodeLang> TypeName<L> {
         TypeName::Reference {
             inner: Box::new(inner),
             mutable: false,
+            lifetime: None,
         }
     }
 
@@ -486,6 +490,25 @@ impl<L: CodeLang> TypeName<L> {
         TypeName::Reference {
             inner: Box::new(inner),
             mutable: true,
+            lifetime: None,
+        }
+    }
+
+    /// Create a shared reference with a lifetime (Rust `&'a T`).
+    pub fn reference_with_lifetime(inner: TypeName<L>, lifetime: &str) -> Self {
+        TypeName::Reference {
+            inner: Box::new(inner),
+            mutable: false,
+            lifetime: Some(lifetime.to_string()),
+        }
+    }
+
+    /// Create a mutable reference with a lifetime (Rust `&'a mut T`).
+    pub fn reference_mut_with_lifetime(inner: TypeName<L>, lifetime: &str) -> Self {
+        TypeName::Reference {
+            inner: Box::new(inner),
+            mutable: true,
+            lifetime: Some(lifetime.to_string()),
         }
     }
 
@@ -723,8 +746,15 @@ impl<L: CodeLang> TypeName<L> {
                     .append(BoxDoc::intersperse(docs, sep).nest(2).group())
                     .append(BoxDoc::text(")"))
             }
-            TypeName::Reference { inner, mutable } => {
-                let prefix = if *mutable { "&mut " } else { "&" };
+            TypeName::Reference { inner, mutable, lifetime } => {
+                let mut prefix = String::from("&");
+                if let Some(lt) = lifetime {
+                    prefix.push_str(lt);
+                    prefix.push(' ');
+                }
+                if *mutable {
+                    prefix.push_str("mut ");
+                }
                 BoxDoc::text(prefix).append(inner.to_doc(resolve))
             }
             TypeName::Function {
@@ -925,14 +955,24 @@ impl<L: CodeLang> TypeName<L> {
                     .collect();
                 render_presentation(&lang.present_tuple(), docs, lang)
             }
-            TypeName::Reference { inner, mutable } => {
+            TypeName::Reference { inner, mutable, lifetime } => {
                 let inner_doc = inner.to_doc_with_lang(resolve, lang);
-                let pres = if *mutable {
-                    lang.present_reference_mut()
+                if let Some(lt) = lifetime {
+                    let mut prefix = String::from("&");
+                    prefix.push_str(lt);
+                    prefix.push(' ');
+                    if *mutable {
+                        prefix.push_str("mut ");
+                    }
+                    BoxDoc::text(prefix).append(inner_doc)
                 } else {
-                    lang.present_reference()
-                };
-                render_presentation(&pres, vec![inner_doc], lang)
+                    let pres = if *mutable {
+                        lang.present_reference_mut()
+                    } else {
+                        lang.present_reference()
+                    };
+                    render_presentation(&pres, vec![inner_doc], lang)
+                }
             }
             TypeName::Function {
                 params,
@@ -1752,5 +1792,55 @@ mod tests {
                 .render(80, &identity_resolve).unwrap(),
             "? super T"
         );
+    }
+
+    // --- Feature 10: Lifetime Parameters ---
+
+    #[test]
+    fn test_reference_with_lifetime_rust() {
+        use crate::lang::rust_lang::RustLang;
+        let lang = RustLang::new();
+        let t = TypeName::<RustLang>::reference_with_lifetime(
+            TypeName::primitive("str"),
+            "'a",
+        );
+        let doc = t.to_doc_with_lang(&identity_resolve, &lang);
+        let mut buf = Vec::new();
+        doc.render(80, &mut buf).unwrap();
+        assert_eq!(String::from_utf8(buf).unwrap(), "&'a str");
+    }
+
+    #[test]
+    fn test_reference_mut_with_lifetime_rust() {
+        use crate::lang::rust_lang::RustLang;
+        let lang = RustLang::new();
+        let t = TypeName::<RustLang>::reference_mut_with_lifetime(
+            TypeName::primitive("String"),
+            "'a",
+        );
+        let doc = t.to_doc_with_lang(&identity_resolve, &lang);
+        let mut buf = Vec::new();
+        doc.render(80, &mut buf).unwrap();
+        assert_eq!(String::from_utf8(buf).unwrap(), "&'a mut String");
+    }
+
+    #[test]
+    fn test_reference_with_lifetime_default_rendering() {
+        let t = TypeName::<TypeScript>::reference_with_lifetime(
+            TypeName::primitive("str"),
+            "'a",
+        );
+        assert_eq!(t.render(80, &identity_resolve).unwrap(), "&'a str");
+    }
+
+    #[test]
+    fn test_reference_without_lifetime_unchanged() {
+        use crate::lang::rust_lang::RustLang;
+        let lang = RustLang::new();
+        let t = TypeName::<RustLang>::reference(TypeName::primitive("String"));
+        let doc = t.to_doc_with_lang(&identity_resolve, &lang);
+        let mut buf = Vec::new();
+        doc.render(80, &mut buf).unwrap();
+        assert_eq!(String::from_utf8(buf).unwrap(), "&String");
     }
 }

--- a/src/type_name.rs
+++ b/src/type_name.rs
@@ -48,6 +48,18 @@ pub enum TypePresentation<'a> {
     },
 }
 
+/// Controls how `TypeName::Generic { base, params }` renders.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum GenericApplicationStyle {
+    /// `Base<P1, P2>` or `Base[P1, P2]` — uses `generic_open()`/`generic_close()`.
+    Delimited,
+    /// `Base P1 P2` — Haskell-style prefix juxtaposition.
+    /// Compound params are parenthesized: `Either String (Maybe Int)`.
+    PrefixJuxtaposition,
+    /// `P1 Base` (single) or `(P1, P2) Base` (multi) — OCaml-style postfix.
+    PostfixJuxtaposition,
+}
+
 /// Syntactic pattern for rendering a function type expression.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FunctionPresentation<'a> {
@@ -69,6 +81,51 @@ pub struct FunctionPresentation<'a> {
     pub wrapper_open: &'a str,
     /// Outer wrapper closing (e.g., C++ `">"`).
     pub wrapper_close: &'a str,
+}
+
+/// How `TypeName::AssociatedType` renders across languages.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AssociatedTypeStyle<'a> {
+    /// Rust-style: `<Base as Qual>::Member` or `Base::Member`.
+    QualifiedPath {
+        /// Opening delimiter for qualified path (e.g., `"<"`).
+        open: &'a str,
+        /// Keyword between base and qualifier (e.g., `" as "`).
+        as_kw: &'a str,
+        /// Closing delimiter + separator to member for qualified path (e.g., `">::"`).
+        close_sep: &'a str,
+        /// Separator to member for simple (non-qualified) path (e.g., `"::"`).
+        simple_sep: &'a str,
+    },
+    /// Dot access: `Base.Member` (Java, Kotlin, Python).
+    DotAccess,
+    /// Index access: `Base["Member"]` (TypeScript).
+    IndexAccess {
+        /// Opening delimiter (e.g., `"[\"`).
+        open: &'a str,
+        /// Closing delimiter (e.g., `"\"]"`).
+        close: &'a str,
+    },
+}
+
+/// How `impl Trait` / `dyn Trait` bounds render.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BoundsPresentation<'a> {
+    /// Keyword prefix (e.g., `"impl "`, `"dyn "`).
+    pub keyword: &'a str,
+    /// Separator between bounds (e.g., `" + "`).
+    pub separator: &'a str,
+}
+
+/// How wildcard types render.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WildcardPresentation<'a> {
+    /// Unbounded wildcard (e.g., `"?"`, `"*"`, `"_"`, `"any"`).
+    pub unbounded: &'a str,
+    /// Upper-bound prefix (e.g., `"? extends "`, `"out "`).
+    pub upper_keyword: &'a str,
+    /// Lower-bound prefix (e.g., `"? super "`, `"in "`).
+    pub lower_keyword: &'a str,
 }
 
 /// A type name reference in generated code.
@@ -156,6 +213,32 @@ pub enum TypeName<L: CodeLang> {
         inner: Box<TypeName<L>>,
         /// Whether the reference is mutable.
         mutable: bool,
+    },
+    /// Associated/path-dependent type. Rust: `<T as Iterator>::Item`, TS: `T["key"]`.
+    AssociatedType {
+        /// The base type (e.g., `T`, `Vec<i32>`).
+        base: Box<TypeName<L>>,
+        /// Optional qualifier trait (Rust: `Iterator` in `<T as Iterator>::Item`).
+        qualifier: Option<Box<TypeName<L>>>,
+        /// The projected member name (e.g., `"Item"`, `"key"`).
+        member: String,
+    },
+    /// `impl Trait` bounds. Rust: `impl Display + Debug`.
+    ImplTrait {
+        /// The trait bounds.
+        bounds: Vec<TypeName<L>>,
+    },
+    /// `dyn Trait` bounds. Rust: `dyn Error + Send`.
+    DynTrait {
+        /// The trait bounds.
+        bounds: Vec<TypeName<L>>,
+    },
+    /// Wildcard type. Java: `?`, `? extends T`, `? super T`. Kotlin: `*`, `out T`, `in T`.
+    Wildcard {
+        /// Upper bound (Java: `? extends T`, Kotlin: `out T`).
+        upper_bound: Option<Box<TypeName<L>>>,
+        /// Lower bound (Java: `? super T`, Kotlin: `in T`).
+        lower_bound: Option<Box<TypeName<L>>>,
     },
     /// Function type. TS: `(a: A, b: B) => R`.
     Function {
@@ -261,6 +344,17 @@ fn render_function_presentation(
             .append(signature)
             .append(BoxDoc::text(pres.wrapper_close.to_string()))
     }
+}
+
+fn is_compound_type<L: CodeLang>(t: &TypeName<L>) -> bool {
+    matches!(
+        t,
+        TypeName::Generic { .. }
+            | TypeName::Union(_)
+            | TypeName::Intersection(_)
+            | TypeName::Function { .. }
+            | TypeName::Tuple(_)
+    )
 }
 
 impl<L: CodeLang> TypeName<L> {
@@ -408,6 +502,66 @@ impl<L: CodeLang> TypeName<L> {
         TypeName::Raw(s.to_string())
     }
 
+    /// Create an associated/path-dependent type with a qualifier.
+    ///
+    /// Rust: `<base as qualifier>::member` (e.g., `<T as Iterator>::Item`).
+    pub fn associated_type(
+        base: TypeName<L>,
+        qualifier: Option<TypeName<L>>,
+        member: &str,
+    ) -> Self {
+        TypeName::AssociatedType {
+            base: Box::new(base),
+            qualifier: qualifier.map(Box::new),
+            member: member.to_string(),
+        }
+    }
+
+    /// Create a simple member type (no qualifier).
+    ///
+    /// Rust: `base::member` (e.g., `Self::Output`).
+    pub fn member_type(base: TypeName<L>, member: &str) -> Self {
+        TypeName::AssociatedType {
+            base: Box::new(base),
+            qualifier: None,
+            member: member.to_string(),
+        }
+    }
+
+    /// Create an `impl Trait` type (Rust: `impl Display + Debug`).
+    pub fn impl_trait(bounds: Vec<TypeName<L>>) -> Self {
+        TypeName::ImplTrait { bounds }
+    }
+
+    /// Create a `dyn Trait` type (Rust: `dyn Error + Send`).
+    pub fn dyn_trait(bounds: Vec<TypeName<L>>) -> Self {
+        TypeName::DynTrait { bounds }
+    }
+
+    /// Create an unbounded wildcard type (Java: `?`, Kotlin: `*`).
+    pub fn wildcard() -> Self {
+        TypeName::Wildcard {
+            upper_bound: None,
+            lower_bound: None,
+        }
+    }
+
+    /// Create a wildcard with an upper bound (Java: `? extends T`, Kotlin: `out T`).
+    pub fn wildcard_extends(bound: TypeName<L>) -> Self {
+        TypeName::Wildcard {
+            upper_bound: Some(Box::new(bound)),
+            lower_bound: None,
+        }
+    }
+
+    /// Create a wildcard with a lower bound (Java: `? super T`, Kotlin: `in T`).
+    pub fn wildcard_super(bound: TypeName<L>) -> Self {
+        TypeName::Wildcard {
+            upper_bound: None,
+            lower_bound: Some(Box::new(bound)),
+        }
+    }
+
     /// Get the simple name of this type (for import resolution lookups).
     pub fn simple_name(&self) -> Option<&str> {
         match self {
@@ -470,6 +624,30 @@ impl<L: CodeLang> TypeName<L> {
                     p.collect_imports(out);
                 }
                 return_type.collect_imports(out);
+            }
+            TypeName::AssociatedType {
+                base, qualifier, ..
+            } => {
+                base.collect_imports(out);
+                if let Some(q) = qualifier {
+                    q.collect_imports(out);
+                }
+            }
+            TypeName::ImplTrait { bounds } | TypeName::DynTrait { bounds } => {
+                for b in bounds {
+                    b.collect_imports(out);
+                }
+            }
+            TypeName::Wildcard {
+                upper_bound,
+                lower_bound,
+            } => {
+                if let Some(ub) = upper_bound {
+                    ub.collect_imports(out);
+                }
+                if let Some(lb) = lower_bound {
+                    lb.collect_imports(out);
+                }
             }
             TypeName::Primitive(_) | TypeName::Raw(_) | TypeName::_Phantom(_) => {}
         }
@@ -561,6 +739,50 @@ impl<L: CodeLang> TypeName<L> {
                     .append(BoxDoc::text(") => "))
                     .append(return_type.to_doc(resolve))
             }
+            TypeName::AssociatedType {
+                base,
+                qualifier,
+                member,
+            } => {
+                if let Some(qual) = qualifier {
+                    // Default: Rust-style <Base as Qual>::Member
+                    BoxDoc::text("<")
+                        .append(base.to_doc(resolve))
+                        .append(BoxDoc::text(" as "))
+                        .append(qual.to_doc(resolve))
+                        .append(BoxDoc::text(">::"))
+                        .append(BoxDoc::text(member.clone()))
+                } else {
+                    // Default: Base::Member
+                    base.to_doc(resolve)
+                        .append(BoxDoc::text("::"))
+                        .append(BoxDoc::text(member.clone()))
+                }
+            }
+            TypeName::ImplTrait { bounds } => {
+                let docs: Vec<_> = bounds.iter().map(|b| b.to_doc(resolve)).collect();
+                let sep = BoxDoc::text(" + ");
+                BoxDoc::text("impl ")
+                    .append(BoxDoc::intersperse(docs, sep))
+            }
+            TypeName::DynTrait { bounds } => {
+                let docs: Vec<_> = bounds.iter().map(|b| b.to_doc(resolve)).collect();
+                let sep = BoxDoc::text(" + ");
+                BoxDoc::text("dyn ")
+                    .append(BoxDoc::intersperse(docs, sep))
+            }
+            TypeName::Wildcard {
+                upper_bound,
+                lower_bound,
+            } => {
+                if let Some(ub) = upper_bound {
+                    BoxDoc::text("? extends ").append(ub.to_doc(resolve))
+                } else if let Some(lb) = lower_bound {
+                    BoxDoc::text("? super ").append(lb.to_doc(resolve))
+                } else {
+                    BoxDoc::text("?")
+                }
+            }
             TypeName::_Phantom(_) => BoxDoc::nil(),
         }
     }
@@ -600,12 +822,48 @@ impl<L: CodeLang> TypeName<L> {
                     .iter()
                     .map(|p| p.to_doc_with_lang(resolve, lang))
                     .collect();
-                let sep = BoxDoc::text(",").append(BoxDoc::softline());
-                let params_doc = BoxDoc::intersperse(params_docs, sep);
-                base_doc
-                    .append(BoxDoc::text(lang.generic_open().to_string()))
-                    .append(params_doc.nest(2).group())
-                    .append(BoxDoc::text(lang.generic_close().to_string()))
+                match lang.generic_application_style() {
+                    GenericApplicationStyle::Delimited => {
+                        let sep = BoxDoc::text(",").append(BoxDoc::softline());
+                        let params_doc = BoxDoc::intersperse(params_docs, sep);
+                        base_doc
+                            .append(BoxDoc::text(lang.generic_open().to_string()))
+                            .append(params_doc.nest(2).group())
+                            .append(BoxDoc::text(lang.generic_close().to_string()))
+                    }
+                    GenericApplicationStyle::PrefixJuxtaposition => {
+                        let mut doc = base_doc;
+                        for (i, param_doc) in params_docs.into_iter().enumerate() {
+                            doc = doc.append(BoxDoc::text(" "));
+                            if is_compound_type(&params[i]) {
+                                doc = doc
+                                    .append(BoxDoc::text("("))
+                                    .append(param_doc)
+                                    .append(BoxDoc::text(")"));
+                            } else {
+                                doc = doc.append(param_doc);
+                            }
+                        }
+                        doc
+                    }
+                    GenericApplicationStyle::PostfixJuxtaposition => {
+                        if params_docs.len() == 1 {
+                            params_docs
+                                .into_iter()
+                                .next()
+                                .unwrap()
+                                .append(BoxDoc::text(" "))
+                                .append(base_doc)
+                        } else {
+                            let sep = BoxDoc::text(",").append(BoxDoc::softline());
+                            let params_doc = BoxDoc::intersperse(params_docs, sep);
+                            BoxDoc::text("(")
+                                .append(params_doc.nest(2).group())
+                                .append(BoxDoc::text(") "))
+                                .append(base_doc)
+                        }
+                    }
+                }
             }
             TypeName::Array(inner) => {
                 let inner_doc = inner.to_doc_with_lang(resolve, lang);
@@ -686,6 +944,76 @@ impl<L: CodeLang> TypeName<L> {
                     .collect();
                 let return_doc = return_type.to_doc_with_lang(resolve, lang);
                 render_function_presentation(&lang.present_function(), param_docs, return_doc)
+            }
+            TypeName::AssociatedType {
+                base,
+                qualifier,
+                member,
+            } => {
+                let base_doc = base.to_doc_with_lang(resolve, lang);
+                let style = lang.present_associated_type();
+                match style {
+                    AssociatedTypeStyle::QualifiedPath {
+                        open,
+                        as_kw,
+                        close_sep,
+                        simple_sep,
+                    } => {
+                        if let Some(qual) = qualifier {
+                            let qual_doc = qual.to_doc_with_lang(resolve, lang);
+                            BoxDoc::text(open.to_string())
+                                .append(base_doc)
+                                .append(BoxDoc::text(as_kw.to_string()))
+                                .append(qual_doc)
+                                .append(BoxDoc::text(close_sep.to_string()))
+                                .append(BoxDoc::text(member.clone()))
+                        } else {
+                            base_doc
+                                .append(BoxDoc::text(simple_sep.to_string()))
+                                .append(BoxDoc::text(member.clone()))
+                        }
+                    }
+                    AssociatedTypeStyle::DotAccess => base_doc
+                        .append(BoxDoc::text("."))
+                        .append(BoxDoc::text(member.clone())),
+                    AssociatedTypeStyle::IndexAccess { open, close } => base_doc
+                        .append(BoxDoc::text(open.to_string()))
+                        .append(BoxDoc::text(member.clone()))
+                        .append(BoxDoc::text(close.to_string())),
+                }
+            }
+            TypeName::ImplTrait { bounds } => {
+                let docs: Vec<_> = bounds
+                    .iter()
+                    .map(|b| b.to_doc_with_lang(resolve, lang))
+                    .collect();
+                let pres = lang.present_impl_trait();
+                let sep = BoxDoc::text(pres.separator.to_string());
+                BoxDoc::text(pres.keyword.to_string()).append(BoxDoc::intersperse(docs, sep))
+            }
+            TypeName::DynTrait { bounds } => {
+                let docs: Vec<_> = bounds
+                    .iter()
+                    .map(|b| b.to_doc_with_lang(resolve, lang))
+                    .collect();
+                let pres = lang.present_dyn_trait();
+                let sep = BoxDoc::text(pres.separator.to_string());
+                BoxDoc::text(pres.keyword.to_string()).append(BoxDoc::intersperse(docs, sep))
+            }
+            TypeName::Wildcard {
+                upper_bound,
+                lower_bound,
+            } => {
+                let pres = lang.present_wildcard();
+                if let Some(ub) = upper_bound {
+                    let ub_doc = ub.to_doc_with_lang(resolve, lang);
+                    BoxDoc::text(pres.upper_keyword.to_string()).append(ub_doc)
+                } else if let Some(lb) = lower_bound {
+                    let lb_doc = lb.to_doc_with_lang(resolve, lang);
+                    BoxDoc::text(pres.lower_keyword.to_string()).append(lb_doc)
+                } else {
+                    BoxDoc::text(pres.unbounded.to_string())
+                }
             }
             // Leaf variants delegate to to_doc (no recursion needed).
             _ => self.to_doc(resolve),
@@ -1107,5 +1435,322 @@ mod tests {
         let mut buf = Vec::new();
         doc.render(80, &mut buf).unwrap();
         assert_eq!(String::from_utf8(buf).unwrap(), "int*");
+    }
+
+    #[test]
+    fn test_generic_prefix_juxtaposition() {
+        use crate::lang::typescript::TypeScript;
+        let lang = TypeScript::new();
+        let t = TypeName::<TypeScript>::generic(
+            TypeName::primitive("Maybe"),
+            vec![TypeName::primitive("Int")],
+        );
+        let doc = t.to_doc_with_lang(&identity_resolve, &lang);
+        let mut buf = Vec::new();
+        doc.render(80, &mut buf).unwrap();
+        assert_eq!(String::from_utf8(buf).unwrap(), "Maybe<Int>");
+    }
+
+    #[test]
+    fn test_is_compound_type() {
+        assert!(is_compound_type(&TypeName::<TypeScript>::generic(
+            TypeName::primitive("A"),
+            vec![TypeName::primitive("B")],
+        )));
+        assert!(is_compound_type(&TypeName::<TypeScript>::union(vec![
+            TypeName::primitive("A"),
+            TypeName::primitive("B"),
+        ])));
+        assert!(is_compound_type(
+            &TypeName::<TypeScript>::intersection(vec![
+                TypeName::primitive("A"),
+                TypeName::primitive("B"),
+            ])
+        ));
+        assert!(is_compound_type(&TypeName::<TypeScript>::function(
+            vec![TypeName::primitive("A")],
+            TypeName::primitive("B"),
+        )));
+        assert!(is_compound_type(&TypeName::<TypeScript>::tuple(vec![
+            TypeName::primitive("A"),
+            TypeName::primitive("B"),
+        ])));
+        assert!(!is_compound_type(&TypeName::<TypeScript>::primitive("Int")));
+        assert!(!is_compound_type(&TypeName::<TypeScript>::array(
+            TypeName::primitive("Int"),
+        )));
+    }
+
+    // --- Feature 07: Associated Types ---
+
+    #[test]
+    fn test_associated_type_rust_qualified() {
+        use crate::lang::rust_lang::RustLang;
+        let lang = RustLang::new();
+        let t = TypeName::<RustLang>::associated_type(
+            TypeName::primitive("T"),
+            Some(TypeName::primitive("Iterator")),
+            "Item",
+        );
+        let doc = t.to_doc_with_lang(&identity_resolve, &lang);
+        let mut buf = Vec::new();
+        doc.render(80, &mut buf).unwrap();
+        assert_eq!(String::from_utf8(buf).unwrap(), "<T as Iterator>::Item");
+    }
+
+    #[test]
+    fn test_associated_type_rust_simple() {
+        use crate::lang::rust_lang::RustLang;
+        let lang = RustLang::new();
+        let t = TypeName::<RustLang>::member_type(TypeName::primitive("Self"), "Output");
+        let doc = t.to_doc_with_lang(&identity_resolve, &lang);
+        let mut buf = Vec::new();
+        doc.render(80, &mut buf).unwrap();
+        assert_eq!(String::from_utf8(buf).unwrap(), "Self::Output");
+    }
+
+    #[test]
+    fn test_associated_type_ts_index_access() {
+        let lang = TypeScript::new();
+        let t = TypeName::<TypeScript>::associated_type(
+            TypeName::primitive("T"),
+            Some(TypeName::primitive("Qual")),
+            "key",
+        );
+        let doc = t.to_doc_with_lang(&identity_resolve, &lang);
+        let mut buf = Vec::new();
+        doc.render(80, &mut buf).unwrap();
+        assert_eq!(String::from_utf8(buf).unwrap(), "T[\"key\"]");
+    }
+
+    #[test]
+    fn test_associated_type_java_dot() {
+        use crate::lang::java_lang::JavaLang;
+        let lang = JavaLang::new();
+        let t = TypeName::<JavaLang>::member_type(TypeName::primitive("Map"), "Entry");
+        let doc = t.to_doc_with_lang(&identity_resolve, &lang);
+        let mut buf = Vec::new();
+        doc.render(80, &mut buf).unwrap();
+        assert_eq!(String::from_utf8(buf).unwrap(), "Map.Entry");
+    }
+
+    #[test]
+    fn test_associated_type_collect_imports() {
+        let t = TypeName::<TypeScript>::associated_type(
+            TypeName::importable("./models", "User"),
+            Some(TypeName::importable("./traits", "Serializable")),
+            "Output",
+        );
+        let mut imports = Vec::new();
+        t.collect_imports(&mut imports);
+        assert_eq!(imports.len(), 2);
+    }
+
+    // --- Feature 08: Existential Types ---
+
+    #[test]
+    fn test_impl_trait_rust() {
+        use crate::lang::rust_lang::RustLang;
+        let lang = RustLang::new();
+        let t = TypeName::<RustLang>::impl_trait(vec![
+            TypeName::primitive("Display"),
+            TypeName::primitive("Debug"),
+        ]);
+        let doc = t.to_doc_with_lang(&identity_resolve, &lang);
+        let mut buf = Vec::new();
+        doc.render(80, &mut buf).unwrap();
+        assert_eq!(String::from_utf8(buf).unwrap(), "impl Display + Debug");
+    }
+
+    #[test]
+    fn test_dyn_trait_rust() {
+        use crate::lang::rust_lang::RustLang;
+        let lang = RustLang::new();
+        let t = TypeName::<RustLang>::dyn_trait(vec![TypeName::primitive("Error")]);
+        let doc = t.to_doc_with_lang(&identity_resolve, &lang);
+        let mut buf = Vec::new();
+        doc.render(80, &mut buf).unwrap();
+        assert_eq!(String::from_utf8(buf).unwrap(), "dyn Error");
+    }
+
+    #[test]
+    fn test_impl_trait_ts_intersection() {
+        let lang = TypeScript::new();
+        let t = TypeName::<TypeScript>::impl_trait(vec![
+            TypeName::primitive("Serializable"),
+            TypeName::primitive("Loggable"),
+        ]);
+        let doc = t.to_doc_with_lang(&identity_resolve, &lang);
+        let mut buf = Vec::new();
+        doc.render(80, &mut buf).unwrap();
+        assert_eq!(String::from_utf8(buf).unwrap(), "Serializable & Loggable");
+    }
+
+    #[test]
+    fn test_wildcard_java_unbounded() {
+        use crate::lang::java_lang::JavaLang;
+        let lang = JavaLang::new();
+        let t = TypeName::<JavaLang>::wildcard();
+        let doc = t.to_doc_with_lang(&identity_resolve, &lang);
+        let mut buf = Vec::new();
+        doc.render(80, &mut buf).unwrap();
+        assert_eq!(String::from_utf8(buf).unwrap(), "?");
+    }
+
+    #[test]
+    fn test_wildcard_java_extends() {
+        use crate::lang::java_lang::JavaLang;
+        let lang = JavaLang::new();
+        let t = TypeName::<JavaLang>::wildcard_extends(TypeName::primitive("Comparable"));
+        let doc = t.to_doc_with_lang(&identity_resolve, &lang);
+        let mut buf = Vec::new();
+        doc.render(80, &mut buf).unwrap();
+        assert_eq!(String::from_utf8(buf).unwrap(), "? extends Comparable");
+    }
+
+    #[test]
+    fn test_wildcard_java_super() {
+        use crate::lang::java_lang::JavaLang;
+        let lang = JavaLang::new();
+        let t = TypeName::<JavaLang>::wildcard_super(TypeName::primitive("Number"));
+        let doc = t.to_doc_with_lang(&identity_resolve, &lang);
+        let mut buf = Vec::new();
+        doc.render(80, &mut buf).unwrap();
+        assert_eq!(String::from_utf8(buf).unwrap(), "? super Number");
+    }
+
+    #[test]
+    fn test_wildcard_kotlin() {
+        use crate::lang::kotlin::Kotlin;
+        let lang = Kotlin::new();
+        let t = TypeName::<Kotlin>::wildcard();
+        let doc = t.to_doc_with_lang(&identity_resolve, &lang);
+        let mut buf = Vec::new();
+        doc.render(80, &mut buf).unwrap();
+        assert_eq!(String::from_utf8(buf).unwrap(), "*");
+    }
+
+    #[test]
+    fn test_wildcard_kotlin_out() {
+        use crate::lang::kotlin::Kotlin;
+        let lang = Kotlin::new();
+        let t = TypeName::<Kotlin>::wildcard_extends(TypeName::primitive("Number"));
+        let doc = t.to_doc_with_lang(&identity_resolve, &lang);
+        let mut buf = Vec::new();
+        doc.render(80, &mut buf).unwrap();
+        assert_eq!(String::from_utf8(buf).unwrap(), "out Number");
+    }
+
+    #[test]
+    fn test_wildcard_kotlin_in() {
+        use crate::lang::kotlin::Kotlin;
+        let lang = Kotlin::new();
+        let t = TypeName::<Kotlin>::wildcard_super(TypeName::primitive("Number"));
+        let doc = t.to_doc_with_lang(&identity_resolve, &lang);
+        let mut buf = Vec::new();
+        doc.render(80, &mut buf).unwrap();
+        assert_eq!(String::from_utf8(buf).unwrap(), "in Number");
+    }
+
+    #[test]
+    fn test_wildcard_go() {
+        use crate::lang::go_lang::GoLang;
+        let lang = GoLang::new();
+        let t = TypeName::<GoLang>::wildcard();
+        let doc = t.to_doc_with_lang(&identity_resolve, &lang);
+        let mut buf = Vec::new();
+        doc.render(80, &mut buf).unwrap();
+        assert_eq!(String::from_utf8(buf).unwrap(), "any");
+    }
+
+    #[test]
+    fn test_wildcard_rust() {
+        use crate::lang::rust_lang::RustLang;
+        let lang = RustLang::new();
+        let t = TypeName::<RustLang>::wildcard();
+        let doc = t.to_doc_with_lang(&identity_resolve, &lang);
+        let mut buf = Vec::new();
+        doc.render(80, &mut buf).unwrap();
+        assert_eq!(String::from_utf8(buf).unwrap(), "_");
+    }
+
+    #[test]
+    fn test_impl_trait_collect_imports() {
+        let t = TypeName::<TypeScript>::impl_trait(vec![
+            TypeName::importable("./traits", "Serializable"),
+            TypeName::primitive("Debug"),
+        ]);
+        let mut imports = Vec::new();
+        t.collect_imports(&mut imports);
+        assert_eq!(imports.len(), 1);
+    }
+
+    #[test]
+    fn test_dyn_trait_collect_imports() {
+        let t = TypeName::<TypeScript>::dyn_trait(vec![
+            TypeName::importable("./errors", "AppError"),
+        ]);
+        let mut imports = Vec::new();
+        t.collect_imports(&mut imports);
+        assert_eq!(imports.len(), 1);
+    }
+
+    #[test]
+    fn test_wildcard_collect_imports() {
+        let t = TypeName::<TypeScript>::wildcard_extends(
+            TypeName::importable("./models", "User"),
+        );
+        let mut imports = Vec::new();
+        t.collect_imports(&mut imports);
+        assert_eq!(imports.len(), 1);
+    }
+
+    #[test]
+    fn test_associated_type_default_rendering() {
+        let t = TypeName::<TypeScript>::associated_type(
+            TypeName::primitive("T"),
+            Some(TypeName::primitive("Iter")),
+            "Item",
+        );
+        assert_eq!(t.render(80, &identity_resolve).unwrap(), "<T as Iter>::Item");
+    }
+
+    #[test]
+    fn test_member_type_default_rendering() {
+        let t = TypeName::<TypeScript>::member_type(TypeName::primitive("Self"), "Output");
+        assert_eq!(t.render(80, &identity_resolve).unwrap(), "Self::Output");
+    }
+
+    #[test]
+    fn test_impl_trait_default_rendering() {
+        let t = TypeName::<TypeScript>::impl_trait(vec![TypeName::primitive("Display")]);
+        assert_eq!(t.render(80, &identity_resolve).unwrap(), "impl Display");
+    }
+
+    #[test]
+    fn test_dyn_trait_default_rendering() {
+        let t = TypeName::<TypeScript>::dyn_trait(vec![
+            TypeName::primitive("Error"),
+            TypeName::primitive("Send"),
+        ]);
+        assert_eq!(t.render(80, &identity_resolve).unwrap(), "dyn Error + Send");
+    }
+
+    #[test]
+    fn test_wildcard_default_rendering() {
+        assert_eq!(
+            TypeName::<TypeScript>::wildcard().render(80, &identity_resolve).unwrap(),
+            "?"
+        );
+        assert_eq!(
+            TypeName::<TypeScript>::wildcard_extends(TypeName::primitive("T"))
+                .render(80, &identity_resolve).unwrap(),
+            "? extends T"
+        );
+        assert_eq!(
+            TypeName::<TypeScript>::wildcard_super(TypeName::primitive("T"))
+                .render(80, &identity_resolve).unwrap(),
+            "? super T"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- **Generic application style**: support Haskell prefix (`Maybe Int`) and OCaml postfix (`int option`) juxtaposition beyond the existing `Base<P1, P2>` delimited style
- **Associated types**: `<T as Iterator>::Item` (Rust), `T["key"]` (TS), `Map.Entry` (Java/Kotlin/Python)
- **Existential types**: `impl Display + Debug`, `dyn Error`, wildcards (`?`, `? extends T`, `out T`, `*`, `_`)
- **Where clauses**: Rust-style `where T: Clone + Send` blocks on `FunSpec` and `TypeSpec`, with `WhereClauseStyle` dispatch (Inline vs WhereBlock)
- **Higher-kinded type parameters**: `TypeParamKind` (Constructor1, Constructor2, Raw) with `render_type_param_kind()` lang hook
- **Lifetime parameters**: `TypeParamSpec::lifetime("'a")`, `TypeName::reference_with_lifetime()`, lifetimes ordered before type params

All features are additive with defaulted `CodeLang` trait methods — no breaking changes to existing languages or golden tests.

### New `CodeLang` trait methods (all defaulted)

`generic_application_style`, `present_associated_type`, `present_impl_trait`, `present_dyn_trait`, `present_wildcard`, `where_clause_style`, `render_type_param_kind`

### New `TypeName` variants

`AssociatedType`, `ImplTrait`, `DynTrait`, `Wildcard` + `lifetime` field on `Reference`

### New prelude exports

`TypeParamKind`, `WhereClauseStyle`, `WhereConstraint`

## Test plan

- [x] 418 unit tests pass (`cargo test --workspace`)
- [x] Clippy clean (`cargo clippy -- -D warnings`)
- [x] `cargo fmt --check` clean
- [x] Zero golden test regressions
- [x] PrefixJuxtaposition and PostfixJuxtaposition tested via `test_lang!` macro
- [x] Where clause verified on both struct header and impl block
- [x] Lifetime ordering verified (`<'a, T>` not `<T, 'a>`)
- [x] All new variants tested for `collect_imports`, `to_doc`, and `to_doc_with_lang`
- [x] Lang overrides tested: Rust, TypeScript, Java, Kotlin, Go, Python