### PR TITLE
fix: correct string escaping for Swift/Scala and add gap-filling golden tests

### DIFF
--- a/src/lang/scala.rs
+++ b/src/lang/scala.rs
@@ -194,7 +194,6 @@ impl CodeLang for Scala {
                 .replace('\t', "\\t")
                 .replace('\r', "\\r")
                 .replace('\0', "\\0")
-                .replace('$', "$$")
         )
     }
 
@@ -273,6 +272,10 @@ impl CodeLang for Scala {
 
     fn super_type_keyword(&self) -> &str {
         " extends "
+    }
+
+    fn abstract_keyword(&self) -> &str {
+        ""
     }
 
     fn super_type_subsequent_separator(&self) -> Option<&str> {
@@ -556,7 +559,7 @@ mod tests {
         assert_eq!(sc.render_string_literal("hello"), "\"hello\"");
         assert_eq!(sc.render_string_literal("it\"s"), "\"it\\\"s\"");
         assert_eq!(sc.render_string_literal("new\nline"), "\"new\\nline\"");
-        assert_eq!(sc.render_string_literal("$name"), "\"$$name\"");
+        assert_eq!(sc.render_string_literal("$name"), "\"$name\"");
     }
 
     #[test]

--- a/src/lang/swift.rs
+++ b/src/lang/swift.rs
@@ -230,8 +230,6 @@ impl CodeLang for Swift {
                 .replace('\t', "\\t")
                 .replace('\r', "\\r")
                 .replace('\0', "\\0")
-                // Escape \( to prevent accidental string interpolation.
-                .replace("\\(", "\\\\(")
         )
     }
 

--- a/test-goldens/c/annotation_attribute.c
+++ b/test-goldens/c/annotation_attribute.c
@@ -1,0 +1,5 @@
+__attribute__((packed))
+struct PackedData {
+    uint8_t flags;
+    uint32_t value;
+};

--- a/test-goldens/cpp/annotation_attribute.cpp
+++ b/test-goldens/cpp/annotation_attribute.cpp
@@ -1,0 +1,4 @@
+[[nodiscard]]
+int compute() {
+    return 42;
+}

--- a/test-goldens/dart/string_dollar_escape.dart
+++ b/test-goldens/dart/string_dollar_escape.dart
@@ -1,0 +1,5 @@
+greet(String name) {
+  final greeting = 'Hello \${name}!';
+  final template = 'Price: \$100';
+  print(greeting);
+}

--- a/test-goldens/haskell/import_grouping.hs
+++ b/test-goldens/haskell/import_grouping.hs
@@ -1,6 +1,8 @@
+import Prelude (putStrLn)
+
 import Control.Monad (when)
 import Data.Map (Map, fromList)
 
 import MyApp.Types (User)
 
--- Map fromList when User
+-- putStrLn Map fromList when User

--- a/test-goldens/kotlin/string_dollar_escape.kt
+++ b/test-goldens/kotlin/string_dollar_escape.kt
@@ -1,0 +1,5 @@
+internal fun greet(name: String) {
+    val greeting = "Hello \${name}!"
+    val template = "Price: \$100"
+    println(greeting)
+}

--- a/test-goldens/rust/control_flow.rs
+++ b/test-goldens/rust/control_flow.rs
@@ -1,9 +1,9 @@
 pub fn classify(x: i32) -> &'static str {
     if x > 0 {
-        "positive";
+        "positive"
     } else if x < 0 {
-        "negative";
+        "negative"
     } else {
-        "zero";
+        "zero"
     }
 }

--- a/test-goldens/scala/abstract_class.scala
+++ b/test-goldens/scala/abstract_class.scala
@@ -6,5 +6,5 @@ abstract class Shape {
     getClass.getSimpleName
   }
 
-  abstract def area(): Double
+  def area(): Double
 }

--- a/test-goldens/scala/string_dollar_escape.scala
+++ b/test-goldens/scala/string_dollar_escape.scala
@@ -1,0 +1,5 @@
+def greet(name: String) = {
+  val greeting = "Hello ${name}!"
+  val template = "Price: $100"
+  println(greeting)
+}

--- a/test-goldens/swift/string_interpolation_escape.swift
+++ b/test-goldens/swift/string_interpolation_escape.swift
@@ -1,0 +1,5 @@
+func greet(name: String) {
+    let greeting = "Hello \\(name)!"
+    let escaped = "Use \\(expr) for interpolation"
+    print(greeting)
+}

--- a/tests/c/builder_edge_cases.rs
+++ b/tests/c/builder_edge_cases.rs
@@ -1,5 +1,6 @@
 use sigil_stitch::code_block::{CodeBlock, StringLitArg};
 use sigil_stitch::lang::c_lang::CLang;
+use sigil_stitch::spec::annotation_spec::AnnotationSpec;
 use sigil_stitch::spec::field_spec::FieldSpec;
 use sigil_stitch::spec::file_spec::FileSpec;
 use sigil_stitch::spec::fun_spec::FunSpec;
@@ -108,4 +109,28 @@ fn test_top_level_with_includes() {
     let output = file.render(80).unwrap();
 
     golden::assert_golden("c/top_level_with_includes.c", &output);
+}
+
+#[test]
+fn test_annotation_attribute() {
+    let mut tb = TypeSpec::<CLang>::builder("PackedData", TypeKind::Struct);
+    tb.annotate(AnnotationSpec::new("packed"));
+    tb.add_field(
+        FieldSpec::builder("flags", TypeName::primitive("uint8_t"))
+            .build()
+            .unwrap(),
+    );
+    tb.add_field(
+        FieldSpec::builder("value", TypeName::primitive("uint32_t"))
+            .build()
+            .unwrap(),
+    );
+    let ts = tb.build().unwrap();
+
+    let mut file_b = FileSpec::builder_with("packed.h", CLang::header());
+    file_b.add_type(ts);
+    let file = file_b.build().unwrap();
+    let output = file.render(80).unwrap();
+
+    golden::assert_golden("c/annotation_attribute.c", &output);
 }

--- a/tests/cpp/builder_edge_cases.rs
+++ b/tests/cpp/builder_edge_cases.rs
@@ -1,5 +1,6 @@
 use sigil_stitch::code_block::CodeBlock;
 use sigil_stitch::lang::cpp_lang::CppLang;
+use sigil_stitch::spec::annotation_spec::AnnotationSpec;
 use sigil_stitch::spec::field_spec::FieldSpec;
 use sigil_stitch::spec::file_spec::FileSpec;
 use sigil_stitch::spec::fun_spec::FunSpec;
@@ -126,4 +127,21 @@ fn test_full_header() {
     let output = file.render(80).unwrap();
 
     golden::assert_golden("cpp/full_header.cpp", &output);
+}
+
+#[test]
+fn test_annotation_attribute() {
+    let mut fb = FunSpec::<CppLang>::builder("compute");
+    fb.annotate(AnnotationSpec::new("nodiscard"));
+    fb.returns(TypeName::primitive("int"));
+    fb.body(CodeBlock::of("return 42;", ()).unwrap());
+    let fun = fb.build().unwrap();
+
+    let rendered = emit_fun(&fun);
+    let mut file_b = FileSpec::builder_with("compute.hpp", CppLang::header());
+    file_b.add_code(rendered);
+    let file = file_b.build().unwrap();
+    let output = file.render(80).unwrap();
+
+    golden::assert_golden("cpp/annotation_attribute.cpp", &output);
 }

--- a/tests/dart/builder_edge_cases.rs
+++ b/tests/dart/builder_edge_cases.rs
@@ -1,4 +1,4 @@
-use sigil_stitch::code_block::CodeBlock;
+use sigil_stitch::code_block::{CodeBlock, StringLitArg};
 use sigil_stitch::lang::dart::DartLang;
 use sigil_stitch::spec::field_spec::FieldSpec;
 use sigil_stitch::spec::file_spec::FileSpec;
@@ -86,4 +86,27 @@ fn test_full_module() {
     let output = file.render(80).unwrap();
 
     golden::assert_golden("dart/full_module.dart", &output);
+}
+
+#[test]
+fn test_string_dollar_escape() {
+    let body = CodeBlock::<DartLang>::of(
+        "final greeting = %S;\nfinal template = %S;\nprint(greeting);",
+        (
+            StringLitArg("Hello ${name}!".into()),
+            StringLitArg("Price: $100".into()),
+        ),
+    )
+    .unwrap();
+    let mut fb = FunSpec::<DartLang>::builder("greet");
+    fb.add_param(ParameterSpec::new("name", TypeName::primitive("String")).unwrap());
+    fb.body(body);
+    let fun = fb.build().unwrap();
+
+    let mut file_b = FileSpec::builder_with("greet.dart", DartLang::new());
+    file_b.add_function(fun);
+    let file = file_b.build().unwrap();
+    let output = file.render(80).unwrap();
+
+    golden::assert_golden("dart/string_dollar_escape.dart", &output);
 }

--- a/tests/haskell/builder_imports.rs
+++ b/tests/haskell/builder_imports.rs
@@ -27,13 +27,17 @@ fn test_function_with_imports() {
 
 #[test]
 fn test_import_grouping() {
+    let put_str_ln = TypeName::<Haskell>::importable("Prelude", "putStrLn");
     let map_type = TypeName::<Haskell>::importable("Data.Map", "Map");
     let from_list = TypeName::<Haskell>::importable("Data.Map", "fromList");
     let when_fn = TypeName::<Haskell>::importable("Control.Monad", "when");
     let user = TypeName::<Haskell>::importable("MyApp.Types", "User");
 
     let mut b = CodeBlock::<Haskell>::builder();
-    b.add("-- %T %T %T %T", (map_type, from_list, when_fn, user));
+    b.add(
+        "-- %T %T %T %T %T",
+        (put_str_ln, map_type, from_list, when_fn, user),
+    );
     b.add_line();
     let block = b.build().unwrap();
 

--- a/tests/kotlin/builder_edge_cases.rs
+++ b/tests/kotlin/builder_edge_cases.rs
@@ -1,4 +1,4 @@
-use sigil_stitch::code_block::CodeBlock;
+use sigil_stitch::code_block::{CodeBlock, StringLitArg};
 use sigil_stitch::lang::kotlin::Kotlin;
 use sigil_stitch::spec::field_spec::FieldSpec;
 use sigil_stitch::spec::file_spec::FileSpec;
@@ -77,4 +77,27 @@ fn test_full_module() {
     let output = file.render(80).unwrap();
 
     golden::assert_golden("kotlin/full_module.kt", &output);
+}
+
+#[test]
+fn test_string_dollar_escape() {
+    let body = CodeBlock::<Kotlin>::of(
+        "val greeting = %S\nval template = %S\nprintln(greeting)",
+        (
+            StringLitArg("Hello ${name}!".into()),
+            StringLitArg("Price: $100".into()),
+        ),
+    )
+    .unwrap();
+    let mut fb = FunSpec::<Kotlin>::builder("greet");
+    fb.add_param(ParameterSpec::new("name", TypeName::primitive("String")).unwrap());
+    fb.body(body);
+    let fun = fb.build().unwrap();
+
+    let mut file_b = FileSpec::builder_with("greet.kt", Kotlin::new());
+    file_b.add_function(fun);
+    let file = file_b.build().unwrap();
+    let output = file.render(80).unwrap();
+
+    golden::assert_golden("kotlin/string_dollar_escape.kt", &output);
 }

--- a/tests/rust/builder_control_flow.rs
+++ b/tests/rust/builder_control_flow.rs
@@ -11,11 +11,14 @@ fn test_control_flow() {
     b.add_line();
     b.add("%>", ());
     b.begin_control_flow("if x > 0", ());
-    b.add_statement("\"positive\"", ());
+    b.add("\"positive\"", ());
+    b.add_line();
     b.next_control_flow("else if x < 0", ());
-    b.add_statement("\"negative\"", ());
+    b.add("\"negative\"", ());
+    b.add_line();
     b.next_control_flow("else", ());
-    b.add_statement("\"zero\"", ());
+    b.add("\"zero\"", ());
+    b.add_line();
     b.end_control_flow();
     b.add("%<", ());
     b.add("}", ());

--- a/tests/scala/builder_edge_cases.rs
+++ b/tests/scala/builder_edge_cases.rs
@@ -1,0 +1,31 @@
+use sigil_stitch::code_block::{CodeBlock, StringLitArg};
+use sigil_stitch::lang::scala::Scala;
+use sigil_stitch::spec::file_spec::FileSpec;
+use sigil_stitch::spec::fun_spec::FunSpec;
+use sigil_stitch::spec::parameter_spec::ParameterSpec;
+use sigil_stitch::type_name::TypeName;
+
+use super::golden;
+
+#[test]
+fn test_string_dollar_escape() {
+    let body = CodeBlock::<Scala>::of(
+        "val greeting = %S\nval template = %S\nprintln(greeting)",
+        (
+            StringLitArg("Hello ${name}!".into()),
+            StringLitArg("Price: $100".into()),
+        ),
+    )
+    .unwrap();
+    let mut fb = FunSpec::<Scala>::builder("greet");
+    fb.add_param(ParameterSpec::new("name", TypeName::primitive("String")).unwrap());
+    fb.body(body);
+    let fun = fb.build().unwrap();
+
+    let mut file_b = FileSpec::builder_with("greet.scala", Scala::new());
+    file_b.add_function(fun);
+    let file = file_b.build().unwrap();
+    let output = file.render(80).unwrap();
+
+    golden::assert_golden("scala/string_dollar_escape.scala", &output);
+}

--- a/tests/scala/main.rs
+++ b/tests/scala/main.rs
@@ -2,6 +2,7 @@
 mod golden;
 
 mod builder_control_flow;
+mod builder_edge_cases;
 mod builder_functions;
 mod builder_imports;
 mod builder_types;

--- a/tests/swift/builder_edge_cases.rs
+++ b/tests/swift/builder_edge_cases.rs
@@ -1,4 +1,4 @@
-use sigil_stitch::code_block::CodeBlock;
+use sigil_stitch::code_block::{CodeBlock, StringLitArg};
 use sigil_stitch::lang::swift::Swift;
 use sigil_stitch::spec::field_spec::FieldSpec;
 use sigil_stitch::spec::file_spec::FileSpec;
@@ -82,4 +82,27 @@ fn test_full_module() {
     let output = file.render(80).unwrap();
 
     golden::assert_golden("swift/full_module.swift", &output);
+}
+
+#[test]
+fn test_string_interpolation_escape() {
+    let body = CodeBlock::<Swift>::of(
+        "let greeting = %S\nlet escaped = %S\nprint(greeting)",
+        (
+            StringLitArg("Hello \\(name)!".into()),
+            StringLitArg("Use \\(expr) for interpolation".into()),
+        ),
+    )
+    .unwrap();
+    let mut fb = FunSpec::<Swift>::builder("greet");
+    fb.add_param(ParameterSpec::new("name", TypeName::primitive("String")).unwrap());
+    fb.body(body);
+    let fun = fb.build().unwrap();
+
+    let mut file_b = FileSpec::builder_with("greet.swift", Swift::new());
+    file_b.add_function(fun);
+    let file = file_b.build().unwrap();
+    let output = file.render(80).unwrap();
+
+    golden::assert_golden("swift/string_interpolation_escape.swift", &output);
 }


### PR DESCRIPTION
## Summary

- **Swift**: Remove double-escaping of `\(` in `render_string_literal` that produced `\\\(` (triggering string interpolation instead of escaping it)
- **Scala**: Remove incorrect `$` → `$$` escaping (only valid in interpolated strings, not plain `"..."` strings), and override `abstract_keyword()` to `""` since Scala doesn't use `abstract` on individual methods
- **Rust golden**: Fix `control_flow.rs` to use expressions without trailing semicolons so the generated function actually returns a value
- **New golden tests**: string escaping (Kotlin `\$`, Scala `$`, Swift `\\(`, Dart `\$`), Haskell import grouping with all 3 groups, C++ `[[nodiscard]]` and C `__attribute__((packed))` annotation rendering

## Test plan

- [x] `cargo test --workspace` — 957 tests pass, 0 failures
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Verified corrected golden outputs are valid in their target languages