### PR TITLE
refactor: v2.0 architecture — erase generic, config structs, CodeNode IR

### DIFF
--- a/examples/c_codegen.rs
+++ b/examples/c_codegen.rs
@@ -22,14 +22,14 @@ use sigil_stitch::type_name::TypeName;
 
 fn main() {
     // --- Types that trigger #include ---
-    let printf = TypeName::<CLang>::importable("stdio.h", "printf");
-    let malloc = TypeName::<CLang>::importable("stdlib.h", "malloc");
-    let free = TypeName::<CLang>::importable("stdlib.h", "free");
+    let printf = TypeName::importable("stdio.h", "printf");
+    let malloc = TypeName::importable("stdlib.h", "malloc");
+    let free = TypeName::importable("stdlib.h", "free");
 
     // --- Enum: LogLevel ---
-    let mut enum_b = TypeSpec::<CLang>::builder("LogLevel", TypeKind::Enum);
-    enum_b.doc("Severity levels for the logging system.");
-    let mut members = CodeBlock::<CLang>::builder();
+    let enum_b = TypeSpec::builder("LogLevel", TypeKind::Enum);
+    let enum_b = enum_b.doc("Severity levels for the logging system.");
+    let mut members = CodeBlock::builder();
     members.add("LOG_DEBUG,", ());
     members.add_line();
     members.add("LOG_INFO,", ());
@@ -38,36 +38,37 @@ fn main() {
     members.add_line();
     members.add("LOG_ERROR", ());
     members.add_line();
-    enum_b.extra_member(members.build().unwrap());
+    let enum_b = enum_b.extra_member(members.build().unwrap());
     let log_level = enum_b.build().unwrap();
 
     // --- Struct: Config ---
-    let mut struct_b = TypeSpec::<CLang>::builder("Config", TypeKind::Struct);
-    struct_b.doc("Application configuration.");
-    struct_b.add_field(
-        FieldSpec::builder("host", TypeName::primitive("const char*"))
-            .build()
-            .unwrap(),
-    );
-    struct_b.add_field(
-        FieldSpec::builder("port", TypeName::primitive("int"))
-            .build()
-            .unwrap(),
-    );
-    struct_b.add_field(
-        FieldSpec::builder("log_level", TypeName::primitive("enum LogLevel"))
-            .build()
-            .unwrap(),
-    );
-    struct_b.add_field(
-        FieldSpec::builder("max_connections", TypeName::primitive("int"))
-            .build()
-            .unwrap(),
-    );
-    let config = struct_b.build().unwrap();
+    let config = TypeSpec::builder("Config", TypeKind::Struct)
+        .doc("Application configuration.")
+        .add_field(
+            FieldSpec::builder("host", TypeName::primitive("const char*"))
+                .build()
+                .unwrap(),
+        )
+        .add_field(
+            FieldSpec::builder("port", TypeName::primitive("int"))
+                .build()
+                .unwrap(),
+        )
+        .add_field(
+            FieldSpec::builder("log_level", TypeName::primitive("enum LogLevel"))
+                .build()
+                .unwrap(),
+        )
+        .add_field(
+            FieldSpec::builder("max_connections", TypeName::primitive("int"))
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
 
     // --- Function: config_create ---
-    let mut create_body_b = CodeBlock::<CLang>::builder();
+    let mut create_body_b = CodeBlock::builder();
     create_body_b.add(
         "struct Config* cfg = (struct Config*)%T(sizeof(struct Config));",
         (malloc,),
@@ -84,23 +85,25 @@ fn main() {
     create_body_b.add("return cfg;", ());
     let create_body = create_body_b.build().unwrap();
 
-    let mut create_fn = FunSpec::<CLang>::builder("config_create");
-    create_fn.add_param(ParameterSpec::new("host", TypeName::primitive("const char*")).unwrap());
-    create_fn.add_param(ParameterSpec::new("port", TypeName::primitive("int")).unwrap());
-    create_fn.returns(TypeName::primitive("struct Config*"));
-    create_fn.body(create_body);
-    let config_create = create_fn.build().unwrap();
+    let config_create = FunSpec::builder("config_create")
+        .add_param(ParameterSpec::new("host", TypeName::primitive("const char*")).unwrap())
+        .add_param(ParameterSpec::new("port", TypeName::primitive("int")).unwrap())
+        .returns(TypeName::primitive("struct Config*"))
+        .body(create_body)
+        .build()
+        .unwrap();
 
     // --- Function: config_destroy ---
-    let destroy_body = CodeBlock::<CLang>::of("%T(cfg);", (free,)).unwrap();
-    let mut destroy_fn = FunSpec::<CLang>::builder("config_destroy");
-    destroy_fn.add_param(ParameterSpec::new("cfg", TypeName::primitive("struct Config*")).unwrap());
-    destroy_fn.returns(TypeName::primitive("void"));
-    destroy_fn.body(destroy_body);
-    let config_destroy = destroy_fn.build().unwrap();
+    let destroy_body = CodeBlock::of("%T(cfg);", (free,)).unwrap();
+    let config_destroy = FunSpec::builder("config_destroy")
+        .add_param(ParameterSpec::new("cfg", TypeName::primitive("struct Config*")).unwrap())
+        .returns(TypeName::primitive("void"))
+        .body(destroy_body)
+        .build()
+        .unwrap();
 
     // --- Function: config_print ---
-    let print_body = CodeBlock::<CLang>::of(
+    let print_body = CodeBlock::of(
         "%T(%S, cfg->host, cfg->port, cfg->log_level);",
         (
             printf,
@@ -108,23 +111,22 @@ fn main() {
         ),
     )
     .unwrap();
-    let mut print_fn = FunSpec::<CLang>::builder("config_print");
-    print_fn
-        .add_param(ParameterSpec::new("cfg", TypeName::primitive("const struct Config*")).unwrap());
-    print_fn.returns(TypeName::primitive("void"));
-    print_fn.body(print_body);
+    let print_fn = FunSpec::builder("config_print")
+        .add_param(ParameterSpec::new("cfg", TypeName::primitive("const struct Config*")).unwrap())
+        .returns(TypeName::primitive("void"))
+        .body(print_body);
     let config_print = print_fn.build().unwrap();
 
     // --- Assemble file ---
-    let mut fb = FileSpec::builder_with("config.h", CLang::header());
-    fb.header(CodeBlock::<CLang>::of("#pragma once", ()).unwrap());
-    fb.add_type(log_level);
-    fb.add_type(config);
-    fb.add_function(config_create);
-    fb.add_function(config_destroy);
-    fb.add_function(config_print);
-
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("config.h", CLang::header())
+        .header(CodeBlock::of("#pragma once", ()).unwrap())
+        .add_type(log_level)
+        .add_type(config)
+        .add_function(config_create)
+        .add_function(config_destroy)
+        .add_function(config_print)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
     print!("{output}");
 }

--- a/examples/cpp_codegen.rs
+++ b/examples/cpp_codegen.rs
@@ -24,27 +24,27 @@ use sigil_stitch::spec::type_spec::TypeSpec;
 use sigil_stitch::type_name::TypeName;
 
 /// Helper: emit a FunSpec as a CodeBlock for embedding in extra_member.
-fn emit_fun(fun: &FunSpec<CppLang>) -> CodeBlock<CppLang> {
+fn emit_fun(fun: &FunSpec) -> CodeBlock {
     let lang = CppLang::new();
     fun.emit(&lang, DeclarationContext::Member).unwrap()
 }
 
 /// Helper: emit a FieldSpec as a CodeBlock for embedding in extra_member.
-fn emit_field(field: &FieldSpec<CppLang>) -> CodeBlock<CppLang> {
+fn emit_field(field: &FieldSpec) -> CodeBlock {
     let lang = CppLang::new();
     field.emit(&lang, DeclarationContext::Member).unwrap()
 }
 
 fn main() {
     // --- Imports ---
-    let iostream = TypeName::<CppLang>::importable("iostream", "std::cout");
-    let string_h = TypeName::<CppLang>::importable("string", "std::string");
-    let vector_h = TypeName::<CppLang>::importable("vector", "std::vector");
+    let iostream = TypeName::importable("iostream", "std::cout");
+    let string_h = TypeName::importable("string", "std::string");
+    let vector_h = TypeName::importable("vector", "std::vector");
 
     // --- Enum class: LogLevel ---
-    let mut enum_b = TypeSpec::<CppLang>::builder("LogLevel", TypeKind::Enum);
-    enum_b.doc("Severity levels for the logging system.");
-    let mut members = CodeBlock::<CppLang>::builder();
+    let enum_b = TypeSpec::builder("LogLevel", TypeKind::Enum);
+    let enum_b = enum_b.doc("Severity levels for the logging system.");
+    let mut members = CodeBlock::builder();
     members.add("Debug,", ());
     members.add_line();
     members.add("Info,", ());
@@ -53,53 +53,62 @@ fn main() {
     members.add_line();
     members.add("Error", ());
     members.add_line();
-    enum_b.extra_member(members.build().unwrap());
+    let enum_b = enum_b.extra_member(members.build().unwrap());
     let log_level = enum_b.build().unwrap();
 
     // --- Abstract base class: Logger ---
-    let mut logger_b = TypeSpec::<CppLang>::builder("Logger", TypeKind::Class);
-    logger_b.doc("Abstract base class for loggers.");
+    let logger_b = TypeSpec::builder("Logger", TypeKind::Class);
+    let logger_b = logger_b.doc("Abstract base class for loggers.");
 
-    let mut pub_section = CodeBlock::<CppLang>::builder();
+    let mut pub_section = CodeBlock::builder();
     pub_section.add("%<", ());
     pub_section.add("public:", ());
     pub_section.add_line();
     pub_section.add("%>", ());
 
     // Pure virtual: virtual void log(const char* msg) = 0;
-    let mut log_fn = FunSpec::<CppLang>::builder("log");
-    log_fn.is_abstract();
-    log_fn.add_param(ParameterSpec::new("msg", TypeName::primitive("const char*")).unwrap());
-    log_fn.returns(TypeName::primitive("void"));
-    log_fn.suffix("= 0");
-    pub_section.add_code(emit_fun(&log_fn.build().unwrap()));
+    pub_section.add_code(emit_fun(
+        &FunSpec::builder("log")
+            .is_abstract()
+            .add_param(ParameterSpec::new("msg", TypeName::primitive("const char*")).unwrap())
+            .returns(TypeName::primitive("void"))
+            .suffix("= 0")
+            .build()
+            .unwrap(),
+    ));
 
     // Pure virtual: virtual LogLevel level() const = 0;
     pub_section.add_line();
-    let mut level_fn = FunSpec::<CppLang>::builder("level");
-    level_fn.is_abstract();
-    level_fn.returns(TypeName::primitive("LogLevel"));
-    level_fn.suffix("const");
-    level_fn.suffix("= 0");
-    pub_section.add_code(emit_fun(&level_fn.build().unwrap()));
+    pub_section.add_code(emit_fun(
+        &FunSpec::builder("level")
+            .is_abstract()
+            .returns(TypeName::primitive("LogLevel"))
+            .suffix("const")
+            .suffix("= 0")
+            .build()
+            .unwrap(),
+    ));
 
     // Virtual destructor
     pub_section.add_line();
-    let mut dtor = FunSpec::<CppLang>::builder("~Logger");
-    dtor.is_abstract();
-    dtor.suffix("= default");
-    pub_section.add_code(emit_fun(&dtor.build().unwrap()));
+    pub_section.add_code(emit_fun(
+        &FunSpec::builder("~Logger")
+            .is_abstract()
+            .suffix("= default")
+            .build()
+            .unwrap(),
+    ));
 
-    logger_b.extra_member(pub_section.build().unwrap());
+    let logger_b = logger_b.extra_member(pub_section.build().unwrap());
     let logger = logger_b.build().unwrap();
 
     // --- Derived class: ConsoleLogger ---
-    let mut console_b = TypeSpec::<CppLang>::builder("ConsoleLogger", TypeKind::Class);
-    console_b.extends(TypeName::primitive("Logger"));
-    console_b.doc("Logger that writes to stdout.");
+    let console_b = TypeSpec::builder("ConsoleLogger", TypeKind::Class);
+    let console_b = console_b.extends(TypeName::primitive("Logger"));
+    let console_b = console_b.doc("Logger that writes to stdout.");
 
     // private: section
-    let mut priv_section = CodeBlock::<CppLang>::builder();
+    let mut priv_section = CodeBlock::builder();
     priv_section.add("%<", ());
     priv_section.add("private:", ());
     priv_section.add_line();
@@ -112,10 +121,10 @@ fn main() {
         .build()
         .unwrap();
     priv_section.add_code(emit_field(&level_field));
-    console_b.extra_member(priv_section.build().unwrap());
+    let console_b = console_b.extra_member(priv_section.build().unwrap());
 
     // public: section
-    let mut pub_section2 = CodeBlock::<CppLang>::builder();
+    let mut pub_section2 = CodeBlock::builder();
     pub_section2.add_line();
     pub_section2.add("%<", ());
     pub_section2.add("public:", ());
@@ -123,65 +132,77 @@ fn main() {
     pub_section2.add("%>", ());
 
     // Constructor
-    let ctor_body =
-        CodeBlock::<CppLang>::of("name_ = name;\nlevel_ = LogLevel::Info;", ()).unwrap();
-    let mut ctor = FunSpec::<CppLang>::builder("ConsoleLogger");
-    ctor.add_param(ParameterSpec::new("name", TypeName::primitive("const std::string&")).unwrap());
-    ctor.body(ctor_body);
-    pub_section2.add_code(emit_fun(&ctor.build().unwrap()));
+    let ctor_body = CodeBlock::of("name_ = name;\nlevel_ = LogLevel::Info;", ()).unwrap();
+    pub_section2.add_code(emit_fun(
+        &FunSpec::builder("ConsoleLogger")
+            .add_param(
+                ParameterSpec::new("name", TypeName::primitive("const std::string&")).unwrap(),
+            )
+            .body(ctor_body)
+            .build()
+            .unwrap(),
+    ));
 
     // log override
     pub_section2.add_line();
-    let log_body = CodeBlock::<CppLang>::of(
+    let log_body = CodeBlock::of(
         "%T << \"[\" << name_ << \"] \" << %T(msg) << std::endl;",
         (iostream, string_h),
     )
     .unwrap();
-    let mut log_impl = FunSpec::<CppLang>::builder("log");
-    log_impl.add_param(ParameterSpec::new("msg", TypeName::primitive("const char*")).unwrap());
-    log_impl.returns(TypeName::primitive("void"));
-    log_impl.suffix("override");
-    log_impl.body(log_body);
-    pub_section2.add_code(emit_fun(&log_impl.build().unwrap()));
+    pub_section2.add_code(emit_fun(
+        &FunSpec::builder("log")
+            .add_param(ParameterSpec::new("msg", TypeName::primitive("const char*")).unwrap())
+            .returns(TypeName::primitive("void"))
+            .suffix("override")
+            .body(log_body)
+            .build()
+            .unwrap(),
+    ));
 
     // level override
     pub_section2.add_line();
-    let level_body = CodeBlock::<CppLang>::of("return level_;", ()).unwrap();
-    let mut level_impl = FunSpec::<CppLang>::builder("level");
-    level_impl.returns(TypeName::primitive("LogLevel"));
-    level_impl.suffix("const");
-    level_impl.suffix("override");
-    level_impl.body(level_body);
-    pub_section2.add_code(emit_fun(&level_impl.build().unwrap()));
+    let level_body = CodeBlock::of("return level_;", ()).unwrap();
+    pub_section2.add_code(emit_fun(
+        &FunSpec::builder("level")
+            .returns(TypeName::primitive("LogLevel"))
+            .suffix("const")
+            .suffix("override")
+            .body(level_body)
+            .build()
+            .unwrap(),
+    ));
 
-    console_b.extra_member(pub_section2.build().unwrap());
+    let console_b = console_b.extra_member(pub_section2.build().unwrap());
     let console_logger = console_b.build().unwrap();
 
     // --- Template function: make_vector ---
-    let mut make_vec_fn = FunSpec::<CppLang>::builder("make_vector");
-    make_vec_fn.annotation(CodeBlock::<CppLang>::of("template<typename T>", ()).unwrap());
-    make_vec_fn.add_param(ParameterSpec::new("first", TypeName::primitive("T")).unwrap());
-    make_vec_fn.add_param(ParameterSpec::new("second", TypeName::primitive("T")).unwrap());
-    make_vec_fn.returns(TypeName::primitive("std::vector<T>"));
-    let vec_body = CodeBlock::<CppLang>::of(
+    let make_vec_fn = FunSpec::builder("make_vector");
+    let make_vec_fn = make_vec_fn.annotation(CodeBlock::of("template<typename T>", ()).unwrap());
+    let make_vec_fn =
+        make_vec_fn.add_param(ParameterSpec::new("first", TypeName::primitive("T")).unwrap());
+    let make_vec_fn =
+        make_vec_fn.add_param(ParameterSpec::new("second", TypeName::primitive("T")).unwrap());
+    let make_vec_fn = make_vec_fn.returns(TypeName::primitive("std::vector<T>"));
+    let vec_body = CodeBlock::of(
         "%T<T> result;\nresult.push_back(first);\nresult.push_back(second);\nreturn result;",
         (vector_h,),
     )
     .unwrap();
-    make_vec_fn.body(vec_body);
+    let make_vec_fn = make_vec_fn.body(vec_body);
     let make_vector = make_vec_fn.build().unwrap();
 
     // --- Assemble file ---
-    let mut fb = FileSpec::builder_with("logging.hpp", CppLang::header());
-    fb.header(CodeBlock::<CppLang>::of("#pragma once", ()).unwrap());
-    fb.add_raw("\nnamespace app {\n\n");
-    fb.add_type(log_level);
-    fb.add_type(logger);
-    fb.add_type(console_logger);
-    fb.add_function(make_vector);
-    fb.add_raw("\n} // namespace app\n");
-
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("logging.hpp", CppLang::header())
+        .header(CodeBlock::of("#pragma once", ()).unwrap())
+        .add_raw("\nnamespace app {\n\n")
+        .add_type(log_level)
+        .add_type(logger)
+        .add_type(console_logger)
+        .add_function(make_vector)
+        .add_raw("\n} // namespace app\n")
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
     print!("{output}");
 }

--- a/examples/dart_codegen.rs
+++ b/examples/dart_codegen.rs
@@ -26,15 +26,15 @@ use sigil_stitch::type_name::TypeName;
 
 fn main() {
     // --- Imports (triggered by usage in code) ---
-    let future = TypeName::<DartLang>::importable("dart:async", "Future");
-    let convert = TypeName::<DartLang>::importable("dart:convert", "jsonDecode");
-    let http_client = TypeName::<DartLang>::importable("package:http/http.dart", "Client");
+    let future = TypeName::importable("dart:async", "Future");
+    let convert = TypeName::importable("dart:convert", "jsonDecode");
+    let http_client = TypeName::importable("package:http/http.dart", "Client");
 
     // --- Enum: Priority ---
-    let mut priority = TypeSpec::<DartLang>::builder("Priority", TypeKind::Enum);
-    priority.doc("Task priority levels.");
+    let priority = TypeSpec::builder("Priority", TypeKind::Enum);
+    let priority = priority.doc("Task priority levels.");
 
-    let mut cases = CodeBlock::<DartLang>::builder();
+    let mut cases = CodeBlock::builder();
     cases.add("low,", ());
     cases.add_line();
     cases.add("medium,", ());
@@ -43,184 +43,224 @@ fn main() {
     cases.add_line();
     cases.add("critical", ());
     cases.add_line();
-    priority.extra_member(cases.build().unwrap());
+    let priority = priority.extra_member(cases.build().unwrap());
 
     let priority_spec = priority.build().unwrap();
 
     // --- Abstract class (interface): TaskRepository ---
-    let tp = TypeParamSpec::<DartLang>::new("T");
+    let tp = TypeParamSpec::new("T");
 
-    let mut repo = TypeSpec::<DartLang>::builder("TaskRepository", TypeKind::Interface);
-    repo.add_type_param(tp);
-    repo.doc("Repository for task persistence.");
-
-    let mut find = FunSpec::<DartLang>::builder("findById");
-    find.returns(TypeName::primitive("T?"));
-    find.add_param(ParameterSpec::new("id", TypeName::primitive("String")).unwrap());
-    repo.add_method(find.build().unwrap());
-
-    let mut find_all = FunSpec::<DartLang>::builder("findAll");
-    find_all.returns(TypeName::primitive("List<T>"));
-    repo.add_method(find_all.build().unwrap());
-
-    let mut save = FunSpec::<DartLang>::builder("save");
-    save.add_param(ParameterSpec::new("entity", TypeName::primitive("T")).unwrap());
-    repo.add_method(save.build().unwrap());
-
-    let repo_spec = repo.build().unwrap();
+    let repo_spec = TypeSpec::builder("TaskRepository", TypeKind::Interface)
+        .add_type_param(tp)
+        .doc("Repository for task persistence.")
+        .add_method(
+            FunSpec::builder("findById")
+                .returns(TypeName::primitive("T?"))
+                .add_param(ParameterSpec::new("id", TypeName::primitive("String")).unwrap())
+                .build()
+                .unwrap(),
+        )
+        .add_method(
+            FunSpec::builder("findAll")
+                .returns(TypeName::primitive("List<T>"))
+                .build()
+                .unwrap(),
+        )
+        .add_method(
+            FunSpec::builder("save")
+                .add_param(ParameterSpec::new("entity", TypeName::primitive("T")).unwrap())
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
 
     // --- Class: Task ---
-    let mut task_cls = TypeSpec::<DartLang>::builder("Task", TypeKind::Class);
-    task_cls.doc("A task entity.");
+    let task_cls = TypeSpec::builder("Task", TypeKind::Class);
+    let task_cls = task_cls.doc("A task entity.");
 
     let id_field = FieldSpec::builder("id", TypeName::primitive("String"));
-    task_cls.add_field(id_field.build().unwrap());
+    let task_cls = task_cls.add_field(id_field.build().unwrap());
 
     let name_field = FieldSpec::builder("name", TypeName::primitive("String"));
-    task_cls.add_field(name_field.build().unwrap());
+    let task_cls = task_cls.add_field(name_field.build().unwrap());
 
-    let mut priority_field = FieldSpec::builder("priority", TypeName::primitive("Priority"));
-    priority_field.is_readonly();
-    task_cls.add_field(priority_field.build().unwrap());
+    let task_cls = task_cls.add_field(
+        FieldSpec::builder("priority", TypeName::primitive("Priority"))
+            .is_readonly()
+            .build()
+            .unwrap(),
+    );
 
-    let mut completed_field = FieldSpec::builder("completed", TypeName::primitive("bool"));
-    completed_field.initializer(CodeBlock::<DartLang>::of("false", ()).unwrap());
-    task_cls.add_field(completed_field.build().unwrap());
+    let task_cls = task_cls.add_field(
+        FieldSpec::builder("completed", TypeName::primitive("bool"))
+            .initializer(CodeBlock::of("false", ()).unwrap())
+            .build()
+            .unwrap(),
+    );
 
     // Constructor.
-    let ctor_body = CodeBlock::<DartLang>::of(
+    let ctor_body = CodeBlock::of(
         "this.id = id;\nthis.name = name;\nthis.priority = priority;",
         (),
     )
     .unwrap();
-    let mut ctor = FunSpec::<DartLang>::builder("Task");
-    ctor.add_param(ParameterSpec::new("id", TypeName::primitive("String")).unwrap());
-    ctor.add_param(ParameterSpec::new("name", TypeName::primitive("String")).unwrap());
-    ctor.add_param(ParameterSpec::new("priority", TypeName::primitive("Priority")).unwrap());
-    ctor.body(ctor_body);
-    task_cls.add_method(ctor.build().unwrap());
+    let task_cls = task_cls.add_method(
+        FunSpec::builder("Task")
+            .add_param(ParameterSpec::new("id", TypeName::primitive("String")).unwrap())
+            .add_param(ParameterSpec::new("name", TypeName::primitive("String")).unwrap())
+            .add_param(ParameterSpec::new("priority", TypeName::primitive("Priority")).unwrap())
+            .body(ctor_body)
+            .build()
+            .unwrap(),
+    );
 
     let task_spec = task_cls.build().unwrap();
 
     // --- Class: Constants with static final ---
-    let mut constants = TypeSpec::<DartLang>::builder("Constants", TypeKind::Class);
-    constants.doc("Application constants.");
-
-    let mut max_field = FieldSpec::builder("maxRetries", TypeName::primitive("int"));
-    max_field.is_static();
-    max_field.is_readonly();
-    max_field.initializer(CodeBlock::<DartLang>::of("3", ()).unwrap());
-    constants.add_field(max_field.build().unwrap());
-
-    let mut api_field = FieldSpec::builder("apiUrl", TypeName::primitive("String"));
-    api_field.is_static();
-    api_field.is_readonly();
-    api_field.initializer(
-        CodeBlock::<DartLang>::of("%S", (StringLitArg("https://api.example.com".to_string()),))
-            .unwrap(),
-    );
-    constants.add_field(api_field.build().unwrap());
-
-    let constants_spec = constants.build().unwrap();
+    let constants_spec = TypeSpec::builder("Constants", TypeKind::Class)
+        .doc("Application constants.")
+        .add_field(
+            FieldSpec::builder("maxRetries", TypeName::primitive("int"))
+                .is_static()
+                .is_readonly()
+                .initializer(CodeBlock::of("3", ()).unwrap())
+                .build()
+                .unwrap(),
+        )
+        .add_field(
+            FieldSpec::builder("apiUrl", TypeName::primitive("String"))
+                .is_static()
+                .is_readonly()
+                .initializer(
+                    CodeBlock::of("%S", (StringLitArg("https://api.example.com".to_string()),))
+                        .unwrap(),
+                )
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
 
     // --- Class: InMemoryTaskRepository extends nothing, implements TaskRepository ---
-    let mut impl_cls = TypeSpec::<DartLang>::builder("InMemoryTaskRepository", TypeKind::Class);
-    impl_cls.implements(TypeName::primitive("TaskRepository<Task>"));
-    impl_cls.doc("In-memory implementation of TaskRepository.");
+    let impl_cls = TypeSpec::builder("InMemoryTaskRepository", TypeKind::Class);
+    let impl_cls = impl_cls.implements(TypeName::primitive("TaskRepository<Task>"));
+    let impl_cls = impl_cls.doc("In-memory implementation of TaskRepository.");
 
-    let mut tasks_field = FieldSpec::builder("_tasks", TypeName::primitive("List<Task>"));
-    tasks_field.is_readonly();
-    tasks_field.initializer(CodeBlock::<DartLang>::of("[]", ()).unwrap());
-    impl_cls.add_field(tasks_field.build().unwrap());
+    let impl_cls = impl_cls.add_field(
+        FieldSpec::builder("_tasks", TypeName::primitive("List<Task>"))
+            .is_readonly()
+            .initializer(CodeBlock::of("[]", ()).unwrap())
+            .build()
+            .unwrap(),
+    );
 
     // findById with @override.
-    let find_body = CodeBlock::<DartLang>::of(
+    let find_body = CodeBlock::of(
         "return _tasks.cast<Task?>().firstWhere(\n  (t) => t?.id == id,\n  orElse: () => null,\n);",
         (),
     )
     .unwrap();
-    let mut find_impl = FunSpec::<DartLang>::builder("findById");
-    find_impl.returns(TypeName::primitive("Task?"));
-    find_impl.add_param(ParameterSpec::new("id", TypeName::primitive("String")).unwrap());
-    find_impl.annotation(CodeBlock::<DartLang>::of("@override", ()).unwrap());
-    find_impl.body(find_body);
-    impl_cls.add_method(find_impl.build().unwrap());
+    let impl_cls = impl_cls.add_method(
+        FunSpec::builder("findById")
+            .returns(TypeName::primitive("Task?"))
+            .add_param(ParameterSpec::new("id", TypeName::primitive("String")).unwrap())
+            .annotation(CodeBlock::of("@override", ()).unwrap())
+            .body(find_body)
+            .build()
+            .unwrap(),
+    );
 
     // findAll with @override.
-    let find_all_body = CodeBlock::<DartLang>::of("return List.unmodifiable(_tasks);", ()).unwrap();
-    let mut find_all_impl = FunSpec::<DartLang>::builder("findAll");
-    find_all_impl.returns(TypeName::primitive("List<Task>"));
-    find_all_impl.annotation(CodeBlock::<DartLang>::of("@override", ()).unwrap());
-    find_all_impl.body(find_all_body);
-    impl_cls.add_method(find_all_impl.build().unwrap());
+    let find_all_body = CodeBlock::of("return List.unmodifiable(_tasks);", ()).unwrap();
+    let impl_cls = impl_cls.add_method(
+        FunSpec::builder("findAll")
+            .returns(TypeName::primitive("List<Task>"))
+            .annotation(CodeBlock::of("@override", ()).unwrap())
+            .body(find_all_body)
+            .build()
+            .unwrap(),
+    );
 
     // save with @override.
-    let save_body = CodeBlock::<DartLang>::of("_tasks.add(entity);", ()).unwrap();
-    let mut save_impl = FunSpec::<DartLang>::builder("save");
-    save_impl.add_param(ParameterSpec::new("entity", TypeName::primitive("Task")).unwrap());
-    save_impl.annotation(CodeBlock::<DartLang>::of("@override", ()).unwrap());
-    save_impl.body(save_body);
-    impl_cls.add_method(save_impl.build().unwrap());
+    let save_body = CodeBlock::of("_tasks.add(entity);", ()).unwrap();
+    let impl_cls = impl_cls.add_method(
+        FunSpec::builder("save")
+            .add_param(ParameterSpec::new("entity", TypeName::primitive("Task")).unwrap())
+            .annotation(CodeBlock::of("@override", ()).unwrap())
+            .body(save_body)
+            .build()
+            .unwrap(),
+    );
 
     let impl_spec = impl_cls.build().unwrap();
 
     // --- Generic class: SortedList<T extends Comparable> ---
-    let sorted_tp =
-        TypeParamSpec::<DartLang>::new("T").with_bound(TypeName::primitive("Comparable"));
+    let sorted_tp = TypeParamSpec::new("T").with_bound(TypeName::primitive("Comparable"));
 
-    let mut sorted = TypeSpec::<DartLang>::builder("SortedList", TypeKind::Class);
-    sorted.add_type_param(sorted_tp);
-    sorted.doc("A sorted list backed by a type-bounded generic.");
+    let sorted = TypeSpec::builder("SortedList", TypeKind::Class);
+    let sorted = sorted.add_type_param(sorted_tp);
+    let sorted = sorted.doc("A sorted list backed by a type-bounded generic.");
 
-    let mut items_field = FieldSpec::builder("_items", TypeName::primitive("List<T>"));
-    items_field.is_readonly();
-    items_field.initializer(CodeBlock::<DartLang>::of("[]", ()).unwrap());
-    sorted.add_field(items_field.build().unwrap());
+    let sorted = sorted.add_field(
+        FieldSpec::builder("_items", TypeName::primitive("List<T>"))
+            .is_readonly()
+            .initializer(CodeBlock::of("[]", ()).unwrap())
+            .build()
+            .unwrap(),
+    );
 
-    let add_body = CodeBlock::<DartLang>::of("_items.add(item);\n_items.sort();", ()).unwrap();
-    let mut add_fn = FunSpec::<DartLang>::builder("add");
-    add_fn.returns(TypeName::primitive("void"));
-    add_fn.add_param(ParameterSpec::new("item", TypeName::primitive("T")).unwrap());
-    add_fn.body(add_body);
-    sorted.add_method(add_fn.build().unwrap());
+    let add_body = CodeBlock::of("_items.add(item);\n_items.sort();", ()).unwrap();
+    let sorted = sorted.add_method(
+        FunSpec::builder("add")
+            .returns(TypeName::primitive("void"))
+            .add_param(ParameterSpec::new("item", TypeName::primitive("T")).unwrap())
+            .body(add_body)
+            .build()
+            .unwrap(),
+    );
 
-    let get_body = CodeBlock::<DartLang>::of("return List.unmodifiable(_items);", ()).unwrap();
-    let mut get_fn = FunSpec::<DartLang>::builder("items");
-    get_fn.returns(TypeName::primitive("List<T>"));
-    get_fn.body(get_body);
-    sorted.add_method(get_fn.build().unwrap());
+    let get_body = CodeBlock::of("return List.unmodifiable(_items);", ()).unwrap();
+    let sorted = sorted.add_method(
+        FunSpec::builder("items")
+            .returns(TypeName::primitive("List<T>"))
+            .body(get_body)
+            .build()
+            .unwrap(),
+    );
 
     let sorted_spec = sorted.build().unwrap();
 
     // --- Standalone function using imports ---
-    let parse_body = CodeBlock::<DartLang>::of(
+    let parse_body = CodeBlock::of(
         "final data = %T(json);\nreturn Task.fromMap(data);",
         (convert,),
     )
     .unwrap();
-    let mut parse_fn = FunSpec::<DartLang>::builder("parseTask");
-    parse_fn.returns(TypeName::primitive("Task"));
-    parse_fn.add_param(ParameterSpec::new("json", TypeName::primitive("String")).unwrap());
-    parse_fn.body(parse_body);
-    let parse_task = parse_fn.build().unwrap();
+    let parse_task = FunSpec::builder("parseTask")
+        .returns(TypeName::primitive("Task"))
+        .add_param(ParameterSpec::new("json", TypeName::primitive("String")).unwrap())
+        .body(parse_body)
+        .build()
+        .unwrap();
 
     // Trigger Future + http imports.
-    let future_trigger = CodeBlock::<DartLang>::of("// %T", (future,)).unwrap();
-    let http_trigger = CodeBlock::<DartLang>::of("// %T", (http_client,)).unwrap();
+    let future_trigger = CodeBlock::of("// %T", (future,)).unwrap();
+    let http_trigger = CodeBlock::of("// %T", (http_client,)).unwrap();
 
     // --- Assemble file ---
-    let mut fb = FileSpec::builder_with("task_app.dart", DartLang::new());
-    fb.add_code(future_trigger);
-    fb.add_code(http_trigger);
-    fb.add_type(priority_spec);
-    fb.add_type(repo_spec);
-    fb.add_type(task_spec);
-    fb.add_type(constants_spec);
-    fb.add_type(impl_spec);
-    fb.add_type(sorted_spec);
-    fb.add_function(parse_task);
-
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("task_app.dart", DartLang::new())
+        .add_code(future_trigger)
+        .add_code(http_trigger)
+        .add_type(priority_spec)
+        .add_type(repo_spec)
+        .add_type(task_spec)
+        .add_type(constants_spec)
+        .add_type(impl_spec)
+        .add_type(sorted_spec)
+        .add_function(parse_task)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
     print!("{output}");
 }

--- a/examples/go_codegen.rs
+++ b/examples/go_codegen.rs
@@ -14,44 +14,49 @@ use sigil_stitch::type_name::TypeName;
 
 fn main() {
     // Importable types.
-    let json_marshal = TypeName::<GoLang>::importable("encoding/json", "Marshal");
-    let http_server = TypeName::<GoLang>::importable("net/http", "Server");
+    let json_marshal = TypeName::importable("encoding/json", "Marshal");
+    let http_server = TypeName::importable("net/http", "Server");
 
     // Build a struct with struct tags.
-    let mut tb = TypeSpec::<GoLang>::builder("Config", TypeKind::Struct);
-    tb.doc("Config holds application configuration.");
-
-    let mut f1 = FieldSpec::builder("Host", TypeName::primitive("string"));
-    f1.tag("json:\"host\"");
-    tb.add_field(f1.build().unwrap());
-
-    let mut f2 = FieldSpec::builder("Port", TypeName::primitive("int"));
-    f2.tag("json:\"port\"");
-    tb.add_field(f2.build().unwrap());
+    let tb = TypeSpec::builder("Config", TypeKind::Struct)
+        .doc("Config holds application configuration.")
+        .add_field(
+            FieldSpec::builder("Host", TypeName::primitive("string"))
+                .tag("json:\"host\"")
+                .build()
+                .unwrap(),
+        )
+        .add_field(
+            FieldSpec::builder("Port", TypeName::primitive("int"))
+                .tag("json:\"port\"")
+                .build()
+                .unwrap(),
+        );
 
     // Build receiver methods as separate top-level functions.
-    let mut start_fn = FunSpec::<GoLang>::builder("Start");
-    start_fn.doc("Start begins listening on the configured address.");
-    start_fn.receiver(
-        ParameterSpec::new("c", TypeName::pointer(TypeName::primitive("Config"))).unwrap(),
-    );
-    start_fn.returns(TypeName::primitive("error"));
-    start_fn.body(CodeBlock::<GoLang>::of("return %T(c.Host, nil)", (http_server,)).unwrap());
+    let start_fn = FunSpec::builder("Start")
+        .doc("Start begins listening on the configured address.")
+        .receiver(
+            ParameterSpec::new("c", TypeName::pointer(TypeName::primitive("Config"))).unwrap(),
+        )
+        .returns(TypeName::primitive("error"))
+        .body(CodeBlock::of("return %T(c.Host, nil)", (http_server,)).unwrap());
 
-    let mut to_json_fn = FunSpec::<GoLang>::builder("ToJSON");
-    to_json_fn.receiver(
-        ParameterSpec::new("c", TypeName::pointer(TypeName::primitive("Config"))).unwrap(),
-    );
-    to_json_fn.returns(TypeName::raw("([]byte, error)"));
-    to_json_fn.body(CodeBlock::<GoLang>::of("return %T(c)", (json_marshal,)).unwrap());
+    let to_json_fn = FunSpec::builder("ToJSON")
+        .receiver(
+            ParameterSpec::new("c", TypeName::pointer(TypeName::primitive("Config"))).unwrap(),
+        )
+        .returns(TypeName::raw("([]byte, error)"))
+        .body(CodeBlock::of("return %T(c)", (json_marshal,)).unwrap());
 
     // Assemble the file.
-    let mut file = FileSpec::builder_with("config.go", GoLang::new());
-    file.header(CodeBlock::<GoLang>::of("package config", ()).unwrap());
-    file.add_type(tb.build().unwrap());
-    file.add_function(start_fn.build().unwrap());
-    file.add_function(to_json_fn.build().unwrap());
-    let spec = file.build().unwrap();
+    let spec = FileSpec::builder_with("config.go", GoLang::new())
+        .header(CodeBlock::of("package config", ()).unwrap())
+        .add_type(tb.build().unwrap())
+        .add_function(start_fn.build().unwrap())
+        .add_function(to_json_fn.build().unwrap())
+        .build()
+        .unwrap();
 
     let output = spec.render(100).unwrap();
     println!("{output}");

--- a/examples/java_codegen.rs
+++ b/examples/java_codegen.rs
@@ -24,19 +24,19 @@ use sigil_stitch::type_name::TypeName;
 
 fn main() {
     // --- Imports (triggered by usage in code) ---
-    let list = TypeName::<JavaLang>::importable("java.util", "List");
-    let array_list = TypeName::<JavaLang>::importable("java.util", "ArrayList");
-    let optional = TypeName::<JavaLang>::importable("java.util", "Optional");
-    let nullable = TypeName::<JavaLang>::importable("javax.annotation", "Nullable");
-    let logger = TypeName::<JavaLang>::importable("org.slf4j", "Logger");
-    let logger_factory = TypeName::<JavaLang>::importable("org.slf4j", "LoggerFactory");
+    let list = TypeName::importable("java.util", "List");
+    let array_list = TypeName::importable("java.util", "ArrayList");
+    let optional = TypeName::importable("java.util", "Optional");
+    let nullable = TypeName::importable("javax.annotation", "Nullable");
+    let logger = TypeName::importable("org.slf4j", "Logger");
+    let logger_factory = TypeName::importable("org.slf4j", "LoggerFactory");
 
     // --- Enum: Priority ---
-    let mut priority = TypeSpec::<JavaLang>::builder("Priority", TypeKind::Enum);
-    priority.visibility(Visibility::Public);
-    priority.doc("Task priority levels.");
+    let priority = TypeSpec::builder("Priority", TypeKind::Enum);
+    let priority = priority.visibility(Visibility::Public);
+    let priority = priority.doc("Task priority levels.");
 
-    let mut constants = CodeBlock::<JavaLang>::builder();
+    let mut constants = CodeBlock::builder();
     constants.add("LOW,", ());
     constants.add_line();
     constants.add("MEDIUM,", ());
@@ -45,176 +45,207 @@ fn main() {
     constants.add_line();
     constants.add("CRITICAL", ());
     constants.add_line();
-    priority.extra_member(constants.build().unwrap());
+    let priority = priority.extra_member(constants.build().unwrap());
 
     let priority_spec = priority.build().unwrap();
 
     // --- Interface: TaskRepository<T> ---
-    let tp = TypeParamSpec::<JavaLang>::new("T").with_bound(TypeName::primitive("Serializable"));
+    let tp = TypeParamSpec::new("T").with_bound(TypeName::primitive("Serializable"));
 
-    let mut repo_iface = TypeSpec::<JavaLang>::builder("TaskRepository", TypeKind::Interface);
-    repo_iface.visibility(Visibility::Public);
-    repo_iface.add_type_param(tp);
-    repo_iface.doc("Repository for task persistence.");
-    repo_iface.doc("");
-    repo_iface.doc("@param <T> the task entity type");
-
-    let mut find = FunSpec::<JavaLang>::builder("findById");
-    find.returns(TypeName::primitive("T"));
-    find.add_param(ParameterSpec::new("id", TypeName::primitive("long")).unwrap());
-    find.annotation(CodeBlock::<JavaLang>::of("@%T", (nullable.clone(),)).unwrap());
-    repo_iface.add_method(find.build().unwrap());
-
-    let mut find_all = FunSpec::<JavaLang>::builder("findAll");
-    find_all.returns(TypeName::primitive("List<T>"));
-    repo_iface.add_method(find_all.build().unwrap());
-
-    let mut save = FunSpec::<JavaLang>::builder("save");
-    save.returns(TypeName::primitive("void"));
-    save.add_param(ParameterSpec::new("entity", TypeName::primitive("T")).unwrap());
-    repo_iface.add_method(save.build().unwrap());
-
-    let repo_spec = repo_iface.build().unwrap();
+    let repo_spec = TypeSpec::builder("TaskRepository", TypeKind::Interface)
+        .visibility(Visibility::Public)
+        .add_type_param(tp)
+        .doc("Repository for task persistence.")
+        .doc("")
+        .doc("@param <T> the task entity type")
+        .add_method(
+            FunSpec::builder("findById")
+                .returns(TypeName::primitive("T"))
+                .add_param(ParameterSpec::new("id", TypeName::primitive("long")).unwrap())
+                .annotation(CodeBlock::of("@%T", (nullable.clone(),)).unwrap())
+                .build()
+                .unwrap(),
+        )
+        .add_method(
+            FunSpec::builder("findAll")
+                .returns(TypeName::primitive("List<T>"))
+                .build()
+                .unwrap(),
+        )
+        .add_method(
+            FunSpec::builder("save")
+                .returns(TypeName::primitive("void"))
+                .add_param(ParameterSpec::new("entity", TypeName::primitive("T")).unwrap())
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
 
     // --- Abstract class: BaseTask ---
-    let mut base_task = TypeSpec::<JavaLang>::builder("BaseTask", TypeKind::Class);
-    base_task.visibility(Visibility::Public);
-    base_task.is_abstract();
-    base_task.doc("Base class for all tasks.");
+    let base_task = TypeSpec::builder("BaseTask", TypeKind::Class);
+    let base_task = base_task.visibility(Visibility::Public);
+    let base_task = base_task.is_abstract();
+    let base_task = base_task.doc("Base class for all tasks.");
 
-    let mut id_field = FieldSpec::builder("id", TypeName::primitive("long"));
-    id_field.visibility(Visibility::Private);
-    id_field.is_readonly();
-    base_task.add_field(id_field.build().unwrap());
+    let base_task = base_task.add_field(
+        FieldSpec::builder("id", TypeName::primitive("long"))
+            .visibility(Visibility::Private)
+            .is_readonly()
+            .build()
+            .unwrap(),
+    );
 
-    let mut name_field = FieldSpec::builder("name", TypeName::primitive("String"));
-    name_field.visibility(Visibility::Private);
-    base_task.add_field(name_field.build().unwrap());
+    let base_task = base_task.add_field(
+        FieldSpec::builder("name", TypeName::primitive("String"))
+            .visibility(Visibility::Private)
+            .build()
+            .unwrap(),
+    );
 
-    let mut priority_field = FieldSpec::builder("priority", TypeName::primitive("Priority"));
-    priority_field.visibility(Visibility::Private);
-    base_task.add_field(priority_field.build().unwrap());
+    let base_task = base_task.add_field(
+        FieldSpec::builder("priority", TypeName::primitive("Priority"))
+            .visibility(Visibility::Private)
+            .build()
+            .unwrap(),
+    );
 
     // Constructor
-    let ctor_body = CodeBlock::<JavaLang>::of(
+    let ctor_body = CodeBlock::of(
         "this.id = id;\nthis.name = name;\nthis.priority = priority;",
         (),
     )
     .unwrap();
-    let mut base_ctor = FunSpec::<JavaLang>::builder("BaseTask");
-    base_ctor.visibility(Visibility::Protected);
-    base_ctor.add_param(ParameterSpec::new("id", TypeName::primitive("long")).unwrap());
-    base_ctor.add_param(ParameterSpec::new("name", TypeName::primitive("String")).unwrap());
-    base_ctor.add_param(ParameterSpec::new("priority", TypeName::primitive("Priority")).unwrap());
-    base_ctor.body(ctor_body);
-    base_task.add_method(base_ctor.build().unwrap());
+    let base_task = base_task.add_method(
+        FunSpec::builder("BaseTask")
+            .visibility(Visibility::Protected)
+            .add_param(ParameterSpec::new("id", TypeName::primitive("long")).unwrap())
+            .add_param(ParameterSpec::new("name", TypeName::primitive("String")).unwrap())
+            .add_param(ParameterSpec::new("priority", TypeName::primitive("Priority")).unwrap())
+            .body(ctor_body)
+            .build()
+            .unwrap(),
+    );
 
     // Concrete getter
-    let get_id_body = CodeBlock::<JavaLang>::of("return this.id;", ()).unwrap();
-    let mut get_id = FunSpec::<JavaLang>::builder("getId");
-    get_id.visibility(Visibility::Public);
-    get_id.returns(TypeName::primitive("long"));
-    get_id.body(get_id_body);
-    base_task.add_method(get_id.build().unwrap());
+    let get_id_body = CodeBlock::of("return this.id;", ()).unwrap();
+    let base_task = base_task.add_method(
+        FunSpec::builder("getId")
+            .visibility(Visibility::Public)
+            .returns(TypeName::primitive("long"))
+            .body(get_id_body)
+            .build()
+            .unwrap(),
+    );
 
     // Abstract method
-    let mut execute = FunSpec::<JavaLang>::builder("execute");
-    execute.visibility(Visibility::Public);
-    execute.is_abstract();
-    execute.returns(TypeName::primitive("void"));
-    base_task.add_method(execute.build().unwrap());
+    let base_task = base_task.add_method(
+        FunSpec::builder("execute")
+            .visibility(Visibility::Public)
+            .is_abstract()
+            .returns(TypeName::primitive("void"))
+            .build()
+            .unwrap(),
+    );
 
     let base_task_spec = base_task.build().unwrap();
 
     // --- Concrete class: SimpleTask extends BaseTask implements Serializable ---
-    let mut simple_task = TypeSpec::<JavaLang>::builder("SimpleTask", TypeKind::Class);
-    simple_task.visibility(Visibility::Public);
-    simple_task.extends(TypeName::primitive("BaseTask"));
-    simple_task.implements(TypeName::primitive("Serializable"));
-    simple_task.doc("A simple executable task.");
+    let simple_task = TypeSpec::builder("SimpleTask", TypeKind::Class);
+    let simple_task = simple_task.visibility(Visibility::Public);
+    let simple_task = simple_task.extends(TypeName::primitive("BaseTask"));
+    let simple_task = simple_task.implements(TypeName::primitive("Serializable"));
+    let simple_task = simple_task.doc("A simple executable task.");
 
     // Logger constant — uses imports
-    let logger_init =
-        CodeBlock::<JavaLang>::of("%T.getLogger(SimpleTask.class)", (logger_factory,)).unwrap();
-    let mut log_field = FieldSpec::builder("LOG", TypeName::primitive("Logger"));
-    log_field.visibility(Visibility::Private);
-    log_field.is_static();
-    log_field.is_readonly();
-    log_field.initializer(logger_init);
-    simple_task.add_field(log_field.build().unwrap());
+    let logger_init = CodeBlock::of("%T.getLogger(SimpleTask.class)", (logger_factory,)).unwrap();
+    let simple_task = simple_task.add_field(
+        FieldSpec::builder("LOG", TypeName::primitive("Logger"))
+            .visibility(Visibility::Private)
+            .is_static()
+            .is_readonly()
+            .initializer(logger_init)
+            .build()
+            .unwrap(),
+    );
 
     // Trigger Logger import
-    let logger_trigger = CodeBlock::<JavaLang>::of("// Logger type: %T", (logger,)).unwrap();
+    let logger_trigger = CodeBlock::of("// Logger type: %T", (logger,)).unwrap();
 
     // Constructor
-    let simple_ctor_body =
-        CodeBlock::<JavaLang>::of("super(id, name, Priority.MEDIUM);", ()).unwrap();
-    let mut simple_ctor = FunSpec::<JavaLang>::builder("SimpleTask");
-    simple_ctor.visibility(Visibility::Public);
-    simple_ctor.add_param(ParameterSpec::new("id", TypeName::primitive("long")).unwrap());
-    simple_ctor.add_param(ParameterSpec::new("name", TypeName::primitive("String")).unwrap());
-    simple_ctor.body(simple_ctor_body);
-    simple_task.add_method(simple_ctor.build().unwrap());
+    let simple_ctor_body = CodeBlock::of("super(id, name, Priority.MEDIUM);", ()).unwrap();
+    let simple_task = simple_task.add_method(
+        FunSpec::builder("SimpleTask")
+            .visibility(Visibility::Public)
+            .add_param(ParameterSpec::new("id", TypeName::primitive("long")).unwrap())
+            .add_param(ParameterSpec::new("name", TypeName::primitive("String")).unwrap())
+            .body(simple_ctor_body)
+            .build()
+            .unwrap(),
+    );
 
     // execute() override
-    let exec_body = CodeBlock::<JavaLang>::of(
+    let exec_body = CodeBlock::of(
         "LOG.info(%S + this.getId());",
         (StringLitArg("Executing task: ".to_string()),),
     )
     .unwrap();
-    let mut exec = FunSpec::<JavaLang>::builder("execute");
-    exec.visibility(Visibility::Public);
-    exec.returns(TypeName::primitive("void"));
-    exec.annotation(CodeBlock::<JavaLang>::of("@Override", ()).unwrap());
-    exec.body(exec_body);
-    simple_task.add_method(exec.build().unwrap());
+    let simple_task = simple_task.add_method(
+        FunSpec::builder("execute")
+            .visibility(Visibility::Public)
+            .returns(TypeName::primitive("void"))
+            .annotation(CodeBlock::of("@Override", ()).unwrap())
+            .body(exec_body)
+            .build()
+            .unwrap(),
+    );
 
     let simple_task_spec = simple_task.build().unwrap();
 
     // --- Standalone utility function (wrapped in class body by user) ---
-    let create_body = CodeBlock::<JavaLang>::of(
+    let create_body = CodeBlock::of(
         "%T<SimpleTask> tasks = new %T<>();\ntasks.add(new SimpleTask(1, %S));\nreturn tasks;",
         (list, array_list, StringLitArg("Default Task".to_string())),
     )
     .unwrap();
-    let mut create_fn = FunSpec::<JavaLang>::builder("createDefaultTasks");
-    create_fn.visibility(Visibility::Public);
-    create_fn.is_static();
-    create_fn.returns(TypeName::primitive("List<SimpleTask>"));
-    create_fn.body(create_body);
-    let create_tasks = create_fn.build().unwrap();
+    let create_tasks = FunSpec::builder("createDefaultTasks")
+        .visibility(Visibility::Public)
+        .is_static()
+        .returns(TypeName::primitive("List<SimpleTask>"))
+        .body(create_body)
+        .build()
+        .unwrap();
 
     // findById using Optional — trigger import
-    let find_body = CodeBlock::<JavaLang>::of(
+    let find_body = CodeBlock::of(
         "return tasks.stream()\n    .filter(t -> t.getId() == id)\n    .findFirst();",
         (),
     )
     .unwrap();
-    let mut find_fn = FunSpec::<JavaLang>::builder("findTaskById");
-    find_fn.visibility(Visibility::Public);
-    find_fn.is_static();
-    find_fn.returns(TypeName::primitive("Optional<SimpleTask>"));
-    find_fn
-        .add_param(ParameterSpec::new("tasks", TypeName::primitive("List<SimpleTask>")).unwrap());
-    find_fn.add_param(ParameterSpec::new("id", TypeName::primitive("long")).unwrap());
-    find_fn.body(find_body);
+    let find_fn = FunSpec::builder("findTaskById")
+        .visibility(Visibility::Public)
+        .is_static()
+        .returns(TypeName::primitive("Optional<SimpleTask>"))
+        .add_param(ParameterSpec::new("tasks", TypeName::primitive("List<SimpleTask>")).unwrap())
+        .add_param(ParameterSpec::new("id", TypeName::primitive("long")).unwrap())
+        .body(find_body);
     let find_task = find_fn.build().unwrap();
 
     // Trigger Optional import
-    let optional_trigger = CodeBlock::<JavaLang>::of("// Optional: %T", (optional,)).unwrap();
+    let optional_trigger = CodeBlock::of("// Optional: %T", (optional,)).unwrap();
 
     // --- Assemble file ---
-    let mut fb = FileSpec::builder_with("TaskApp.java", JavaLang::new());
-    fb.add_code(logger_trigger);
-    fb.add_code(optional_trigger);
-    fb.add_type(priority_spec);
-    fb.add_type(repo_spec);
-    fb.add_type(base_task_spec);
-    fb.add_type(simple_task_spec);
-    fb.add_function(create_tasks);
-    fb.add_function(find_task);
-
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("TaskApp.java", JavaLang::new())
+        .add_code(logger_trigger)
+        .add_code(optional_trigger)
+        .add_type(priority_spec)
+        .add_type(repo_spec)
+        .add_type(base_task_spec)
+        .add_type(simple_task_spec)
+        .add_function(create_tasks)
+        .add_function(find_task)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
     print!("{output}");
 }

--- a/examples/js_codegen.rs
+++ b/examples/js_codegen.rs
@@ -21,12 +21,12 @@ use sigil_stitch::spec::type_spec::TypeSpec;
 use sigil_stitch::type_name::TypeName;
 
 /// Shorthand for a JS parameter (no type annotation).
-fn param(name: &str) -> ParameterSpec<JavaScript> {
+fn param(name: &str) -> ParameterSpec {
     ParameterSpec::new(name, TypeName::primitive("")).unwrap()
 }
 
 /// Shorthand for a JS field (no type annotation).
-fn field(name: &str) -> FieldSpec<JavaScript> {
+fn field(name: &str) -> FieldSpec {
     FieldSpec::builder(name, TypeName::primitive(""))
         .build()
         .unwrap()
@@ -34,134 +34,151 @@ fn field(name: &str) -> FieldSpec<JavaScript> {
 
 fn main() {
     // --- Imports (triggered by usage in code) ---
-    let event_emitter = TypeName::<JavaScript>::importable("events", "EventEmitter");
-    let uuid = TypeName::<JavaScript>::importable("uuid", "v4");
-    let format = TypeName::<JavaScript>::importable("./utils", "formatMessage");
+    let event_emitter = TypeName::importable("events", "EventEmitter");
+    let uuid = TypeName::importable("uuid", "v4");
+    let format = TypeName::importable("./utils", "formatMessage");
 
     // --- Base class: Logger ---
-    let mut logger_tb = TypeSpec::<JavaScript>::builder("Logger", TypeKind::Class);
-    logger_tb.visibility(Visibility::Public);
-    logger_tb.doc("Base logger class.");
-    logger_tb.doc("");
-    logger_tb.doc("@abstract");
+    let logger_tb = TypeSpec::builder("Logger", TypeKind::Class);
+    let logger_tb = logger_tb.visibility(Visibility::Public);
+    let logger_tb = logger_tb.doc("Base logger class.");
+    let logger_tb = logger_tb.doc("");
+    let logger_tb = logger_tb.doc("@abstract");
 
-    logger_tb.add_field(field("#name"));
-    logger_tb.add_field(field("#level"));
+    let logger_tb = logger_tb.add_field(field("#name"));
+    let logger_tb = logger_tb.add_field(field("#level"));
 
     // Constructor
     let ctor_body =
-        CodeBlock::<JavaScript>::of("this.#name = name;\nthis.#level = level || 'info';", ())
-            .unwrap();
-    let mut ctor = FunSpec::<JavaScript>::builder("constructor");
-    ctor.add_param(param("name"));
-    ctor.add_param(param("level"));
-    ctor.body(ctor_body);
-    logger_tb.add_method(ctor.build().unwrap());
+        CodeBlock::of("this.#name = name;\nthis.#level = level || 'info';", ()).unwrap();
+    let logger_tb = logger_tb.add_method(
+        FunSpec::builder("constructor")
+            .add_param(param("name"))
+            .add_param(param("level"))
+            .body(ctor_body)
+            .build()
+            .unwrap(),
+    );
 
     // getName method
-    let get_name_body = CodeBlock::<JavaScript>::of("return this.#name;", ()).unwrap();
-    let mut get_name = FunSpec::<JavaScript>::builder("getName");
-    get_name.body(get_name_body);
-    logger_tb.add_method(get_name.build().unwrap());
+    let get_name_body = CodeBlock::of("return this.#name;", ()).unwrap();
+    let logger_tb = logger_tb.add_method(
+        FunSpec::builder("getName")
+            .body(get_name_body)
+            .build()
+            .unwrap(),
+    );
 
     let logger = logger_tb.build().unwrap();
 
     // --- Derived class: ConsoleLogger ---
-    let mut console_tb = TypeSpec::<JavaScript>::builder("ConsoleLogger", TypeKind::Class);
-    console_tb.visibility(Visibility::Public);
-    console_tb.extends(TypeName::primitive("Logger"));
-    console_tb.doc("Logger that writes formatted messages to the console.");
+    let console_tb = TypeSpec::builder("ConsoleLogger", TypeKind::Class);
+    let console_tb = console_tb.visibility(Visibility::Public);
+    let console_tb = console_tb.extends(TypeName::primitive("Logger"));
+    let console_tb = console_tb.doc("Logger that writes formatted messages to the console.");
 
     // Constructor
-    let ctor_body2 = CodeBlock::<JavaScript>::of("super(name, 'info');", ()).unwrap();
-    let mut ctor2 = FunSpec::<JavaScript>::builder("constructor");
-    ctor2.add_param(param("name"));
-    ctor2.body(ctor_body2);
-    console_tb.add_method(ctor2.build().unwrap());
+    let ctor_body2 = CodeBlock::of("super(name, 'info');", ()).unwrap();
+    let console_tb = console_tb.add_method(
+        FunSpec::builder("constructor")
+            .add_param(param("name"))
+            .body(ctor_body2)
+            .build()
+            .unwrap(),
+    );
 
     // log method — uses imports
-    let log_body = CodeBlock::<JavaScript>::of(
+    let log_body = CodeBlock::of(
         "const msg = %T(this.getName(), message);\nconsole.log(msg);",
         (format,),
     )
     .unwrap();
-    let mut log_fn = FunSpec::<JavaScript>::builder("log");
-    log_fn.add_param(param("message"));
-    log_fn.body(log_body);
-    console_tb.add_method(log_fn.build().unwrap());
+    let console_tb = console_tb.add_method(
+        FunSpec::builder("log")
+            .add_param(param("message"))
+            .body(log_body)
+            .build()
+            .unwrap(),
+    );
 
     let console_logger = console_tb.build().unwrap();
 
     // --- EventBus class ---
-    let mut bus_tb = TypeSpec::<JavaScript>::builder("EventBus", TypeKind::Class);
-    bus_tb.visibility(Visibility::Public);
-    bus_tb.extends(TypeName::primitive("EventEmitter"));
-    bus_tb.doc("Publish-subscribe event bus.");
+    let bus_tb = TypeSpec::builder("EventBus", TypeKind::Class);
+    let bus_tb = bus_tb.visibility(Visibility::Public);
+    let bus_tb = bus_tb.extends(TypeName::primitive("EventEmitter"));
+    let bus_tb = bus_tb.doc("Publish-subscribe event bus.");
 
-    bus_tb.add_field(field("#subscribers"));
+    let bus_tb = bus_tb.add_field(field("#subscribers"));
 
-    let bus_ctor_body =
-        CodeBlock::<JavaScript>::of("super();\nthis.#subscribers = new Map();", ()).unwrap();
-    let mut bus_ctor = FunSpec::<JavaScript>::builder("constructor");
-    bus_ctor.body(bus_ctor_body);
-    bus_tb.add_method(bus_ctor.build().unwrap());
+    let bus_ctor_body = CodeBlock::of("super();\nthis.#subscribers = new Map();", ()).unwrap();
+    let bus_tb = bus_tb.add_method(
+        FunSpec::builder("constructor")
+            .body(bus_ctor_body)
+            .build()
+            .unwrap(),
+    );
 
-    let emit_body = CodeBlock::<JavaScript>::of(
+    let emit_body = CodeBlock::of(
         "const id = %T();\nthis.emit(event, { id, ...data });\nreturn id;",
         (uuid,),
     )
     .unwrap();
-    let mut emit_fn = FunSpec::<JavaScript>::builder("publish");
-    emit_fn.add_param(param("event"));
-    emit_fn.add_param(param("data"));
-    emit_fn.body(emit_body);
-    bus_tb.add_method(emit_fn.build().unwrap());
+    let bus_tb = bus_tb.add_method(
+        FunSpec::builder("publish")
+            .add_param(param("event"))
+            .add_param(param("data"))
+            .body(emit_body)
+            .build()
+            .unwrap(),
+    );
 
     let event_bus = bus_tb.build().unwrap();
 
     // --- Standalone exported functions ---
-    let create_logger_body =
-        CodeBlock::<JavaScript>::of("return new ConsoleLogger(name);", ()).unwrap();
-    let mut create_logger = FunSpec::<JavaScript>::builder("createLogger");
-    create_logger.visibility(Visibility::Public);
-    create_logger.add_param(param("name"));
-    create_logger.body(create_logger_body);
-    let create_logger_fn = create_logger.build().unwrap();
+    let create_logger_body = CodeBlock::of("return new ConsoleLogger(name);", ()).unwrap();
+    let create_logger_fn = FunSpec::builder("createLogger")
+        .visibility(Visibility::Public)
+        .add_param(param("name"))
+        .body(create_logger_body)
+        .build()
+        .unwrap();
 
-    let create_bus_body = CodeBlock::<JavaScript>::of("return new EventBus();", ()).unwrap();
-    let mut create_bus = FunSpec::<JavaScript>::builder("createEventBus");
-    create_bus.visibility(Visibility::Public);
-    create_bus.body(create_bus_body);
-    let create_bus_fn = create_bus.build().unwrap();
+    let create_bus_body = CodeBlock::of("return new EventBus();", ()).unwrap();
+    let create_bus_fn = FunSpec::builder("createEventBus")
+        .visibility(Visibility::Public)
+        .body(create_bus_body)
+        .build()
+        .unwrap();
 
     // Async function
-    let fetch_body = CodeBlock::<JavaScript>::of(
+    let fetch_body = CodeBlock::of(
         "const response = await fetch(url);\nif (!response.ok) {\n  throw new Error(%S + response.status);\n}\nreturn response.json();",
         (StringLitArg("HTTP error: ".to_string()),),
     )
     .unwrap();
-    let mut fetch_fn = FunSpec::<JavaScript>::builder("fetchJSON");
-    fetch_fn.visibility(Visibility::Public);
-    fetch_fn.is_async();
-    fetch_fn.add_param(param("url"));
-    fetch_fn.body(fetch_body);
-    let fetch_json = fetch_fn.build().unwrap();
+    let fetch_json = FunSpec::builder("fetchJSON")
+        .visibility(Visibility::Public)
+        .is_async()
+        .add_param(param("url"))
+        .body(fetch_body)
+        .build()
+        .unwrap();
 
     // --- Trigger imports for extends base types ---
-    let import_trigger =
-        CodeBlock::<JavaScript>::of("// Base classes: %T", (event_emitter,)).unwrap();
+    let import_trigger = CodeBlock::of("// Base classes: %T", (event_emitter,)).unwrap();
 
     // --- Assemble file ---
-    let mut fb = FileSpec::builder_with("app.js", JavaScript::new());
-    fb.add_code(import_trigger);
-    fb.add_type(logger);
-    fb.add_type(console_logger);
-    fb.add_type(event_bus);
-    fb.add_function(create_logger_fn);
-    fb.add_function(create_bus_fn);
-    fb.add_function(fetch_json);
-
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("app.js", JavaScript::new())
+        .add_code(import_trigger)
+        .add_type(logger)
+        .add_type(console_logger)
+        .add_type(event_bus)
+        .add_function(create_logger_fn)
+        .add_function(create_bus_fn)
+        .add_function(fetch_json)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
     print!("{output}");
 }

--- a/examples/kotlin_codegen.rs
+++ b/examples/kotlin_codegen.rs
@@ -26,17 +26,17 @@ use sigil_stitch::type_name::TypeName;
 
 fn main() {
     // --- Imports (triggered by usage in code) ---
-    let list = TypeName::<Kotlin>::importable("kotlin.collections", "List");
-    let mutable_list = TypeName::<Kotlin>::importable("kotlin.collections", "MutableList");
-    let array_list = TypeName::<Kotlin>::importable("kotlin.collections", "ArrayList");
-    let coroutine_scope = TypeName::<Kotlin>::importable("kotlinx.coroutines", "CoroutineScope");
-    let uuid = TypeName::<Kotlin>::importable("java.util", "UUID");
+    let list = TypeName::importable("kotlin.collections", "List");
+    let mutable_list = TypeName::importable("kotlin.collections", "MutableList");
+    let array_list = TypeName::importable("kotlin.collections", "ArrayList");
+    let coroutine_scope = TypeName::importable("kotlinx.coroutines", "CoroutineScope");
+    let uuid = TypeName::importable("java.util", "UUID");
 
     // --- Enum class: Priority ---
-    let mut priority = TypeSpec::<Kotlin>::builder("Priority", TypeKind::Enum);
-    priority.doc("Task priority levels.");
+    let priority = TypeSpec::builder("Priority", TypeKind::Enum);
+    let priority = priority.doc("Task priority levels.");
 
-    let mut constants = CodeBlock::<Kotlin>::builder();
+    let mut constants = CodeBlock::builder();
     constants.add("LOW,", ());
     constants.add_line();
     constants.add("MEDIUM,", ());
@@ -45,174 +45,212 @@ fn main() {
     constants.add_line();
     constants.add("CRITICAL", ());
     constants.add_line();
-    priority.extra_member(constants.build().unwrap());
+    let priority = priority.extra_member(constants.build().unwrap());
 
     let priority_spec = priority.build().unwrap();
 
     // --- Interface: Repository<T> ---
-    let tp = TypeParamSpec::<Kotlin>::new("T");
+    let tp = TypeParamSpec::new("T");
 
-    let mut repo_iface = TypeSpec::<Kotlin>::builder("Repository", TypeKind::Interface);
-    repo_iface.add_type_param(tp);
-    repo_iface.doc("Generic repository for data persistence.");
-    repo_iface.doc("");
-    repo_iface.doc("@param T the entity type");
-
-    let mut find = FunSpec::<Kotlin>::builder("findById");
-    find.returns(TypeName::primitive("T?"));
-    find.add_param(ParameterSpec::new("id", TypeName::primitive("String")).unwrap());
-    repo_iface.add_method(find.build().unwrap());
-
-    let mut find_all = FunSpec::<Kotlin>::builder("findAll");
-    find_all.returns(list.clone());
-    repo_iface.add_method(find_all.build().unwrap());
-
-    let mut save = FunSpec::<Kotlin>::builder("save");
-    save.add_param(ParameterSpec::new("entity", TypeName::primitive("T")).unwrap());
-    repo_iface.add_method(save.build().unwrap());
-
-    let repo_spec = repo_iface.build().unwrap();
+    let repo_spec = TypeSpec::builder("Repository", TypeKind::Interface)
+        .add_type_param(tp)
+        .doc("Generic repository for data persistence.")
+        .doc("")
+        .doc("@param T the entity type")
+        .add_method(
+            FunSpec::builder("findById")
+                .returns(TypeName::primitive("T?"))
+                .add_param(ParameterSpec::new("id", TypeName::primitive("String")).unwrap())
+                .build()
+                .unwrap(),
+        )
+        .add_method(
+            FunSpec::builder("findAll")
+                .returns(list.clone())
+                .build()
+                .unwrap(),
+        )
+        .add_method(
+            FunSpec::builder("save")
+                .add_param(ParameterSpec::new("entity", TypeName::primitive("T")).unwrap())
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
 
     // --- Data class: Task ---
-    let mut task_dc = TypeSpec::<Kotlin>::builder("Task", TypeKind::Struct);
-    task_dc.doc("A task entity.");
-
-    let mut id_field = FieldSpec::builder("id", TypeName::primitive("String"));
-    id_field.is_readonly();
-    task_dc.add_field(id_field.build().unwrap());
-
-    let mut name_field = FieldSpec::builder("name", TypeName::primitive("String"));
-    name_field.is_readonly();
-    task_dc.add_field(name_field.build().unwrap());
-
-    let mut priority_field = FieldSpec::builder("priority", TypeName::primitive("Priority"));
-    priority_field.is_readonly();
-    task_dc.add_field(priority_field.build().unwrap());
-
-    let mut completed_field = FieldSpec::builder("completed", TypeName::primitive("Boolean"));
-    completed_field.initializer(CodeBlock::<Kotlin>::of("false", ()).unwrap());
-    task_dc.add_field(completed_field.build().unwrap());
-
-    let task_spec = task_dc.build().unwrap();
+    let task_spec = TypeSpec::builder("Task", TypeKind::Struct)
+        .doc("A task entity.")
+        .add_field(
+            FieldSpec::builder("id", TypeName::primitive("String"))
+                .is_readonly()
+                .build()
+                .unwrap(),
+        )
+        .add_field(
+            FieldSpec::builder("name", TypeName::primitive("String"))
+                .is_readonly()
+                .build()
+                .unwrap(),
+        )
+        .add_field(
+            FieldSpec::builder("priority", TypeName::primitive("Priority"))
+                .is_readonly()
+                .build()
+                .unwrap(),
+        )
+        .add_field(
+            FieldSpec::builder("completed", TypeName::primitive("Boolean"))
+                .initializer(CodeBlock::of("false", ()).unwrap())
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
 
     // --- Abstract class: BaseService ---
-    let mut base_svc = TypeSpec::<Kotlin>::builder("BaseService", TypeKind::Class);
-    base_svc.is_abstract();
-    base_svc.doc("Base class for services with logging.");
+    let base_svc = TypeSpec::builder("BaseService", TypeKind::Class);
+    let base_svc = base_svc.is_abstract();
+    let base_svc = base_svc.doc("Base class for services with logging.");
 
-    let mut name_f = FieldSpec::builder("serviceName", TypeName::primitive("String"));
-    name_f.visibility(Visibility::Protected);
-    name_f.is_readonly();
-    base_svc.add_field(name_f.build().unwrap());
+    let base_svc = base_svc.add_field(
+        FieldSpec::builder("serviceName", TypeName::primitive("String"))
+            .visibility(Visibility::Protected)
+            .is_readonly()
+            .build()
+            .unwrap(),
+    );
 
     // Concrete method
-    let log_body = CodeBlock::<Kotlin>::of("println(\"[$serviceName] $message\")", ()).unwrap();
-    let mut log_fn = FunSpec::<Kotlin>::builder("log");
-    log_fn.visibility(Visibility::Protected);
-    log_fn.add_param(ParameterSpec::new("message", TypeName::primitive("String")).unwrap());
-    log_fn.body(log_body);
-    base_svc.add_method(log_fn.build().unwrap());
+    let log_body = CodeBlock::of("println(\"[$serviceName] $message\")", ()).unwrap();
+    let base_svc = base_svc.add_method(
+        FunSpec::builder("log")
+            .visibility(Visibility::Protected)
+            .add_param(ParameterSpec::new("message", TypeName::primitive("String")).unwrap())
+            .body(log_body)
+            .build()
+            .unwrap(),
+    );
 
     // Abstract method
-    let mut init_fn = FunSpec::<Kotlin>::builder("initialize");
-    init_fn.is_abstract();
-    base_svc.add_method(init_fn.build().unwrap());
+    let base_svc = base_svc.add_method(
+        FunSpec::builder("initialize")
+            .is_abstract()
+            .build()
+            .unwrap(),
+    );
 
     let base_svc_spec = base_svc.build().unwrap();
 
     // --- Concrete class: TaskService extends BaseService, implements Repository<Task> ---
-    let mut task_svc = TypeSpec::<Kotlin>::builder("TaskService", TypeKind::Class);
+    let task_svc = TypeSpec::builder("TaskService", TypeKind::Class);
     // All supertypes go into extends() for Kotlin's single `:` syntax
-    task_svc.extends(TypeName::primitive("BaseService"));
-    task_svc.extends(TypeName::primitive("Repository<Task>"));
-    task_svc.doc("Task management service.");
+    let task_svc = task_svc.extends(TypeName::primitive("BaseService"));
+    let task_svc = task_svc.extends(TypeName::primitive("Repository<Task>"));
+    let task_svc = task_svc.doc("Task management service.");
 
-    let mut tasks_field = FieldSpec::builder("tasks", mutable_list);
-    tasks_field.visibility(Visibility::Private);
-    tasks_field.is_readonly();
-    tasks_field.initializer(CodeBlock::<Kotlin>::of("%T()", (array_list,)).unwrap());
-    task_svc.add_field(tasks_field.build().unwrap());
+    let task_svc = task_svc.add_field(
+        FieldSpec::builder("tasks", mutable_list)
+            .visibility(Visibility::Private)
+            .is_readonly()
+            .initializer(CodeBlock::of("%T()", (array_list,)).unwrap())
+            .build()
+            .unwrap(),
+    );
 
     // initialize override
-    let init_body = CodeBlock::<Kotlin>::of(
+    let init_body = CodeBlock::of(
         "log(%S)",
         (StringLitArg("TaskService initialized".to_string()),),
     )
     .unwrap();
-    let mut init_impl = FunSpec::<Kotlin>::builder("initialize");
-    init_impl.is_override();
-    init_impl.body(init_body);
-    task_svc.add_method(init_impl.build().unwrap());
+    let task_svc = task_svc.add_method(
+        FunSpec::builder("initialize")
+            .is_override()
+            .body(init_body)
+            .build()
+            .unwrap(),
+    );
 
     // findById override — trigger UUID import
-    let find_body =
-        CodeBlock::<Kotlin>::of("return tasks.firstOrNull { it.id == id }", ()).unwrap();
-    let mut find_impl = FunSpec::<Kotlin>::builder("findById");
-    find_impl.returns(TypeName::primitive("Task?"));
-    find_impl.add_param(ParameterSpec::new("id", TypeName::primitive("String")).unwrap());
-    find_impl.is_override();
-    find_impl.body(find_body);
-    task_svc.add_method(find_impl.build().unwrap());
+    let find_body = CodeBlock::of("return tasks.firstOrNull { it.id == id }", ()).unwrap();
+    let task_svc = task_svc.add_method(
+        FunSpec::builder("findById")
+            .returns(TypeName::primitive("Task?"))
+            .add_param(ParameterSpec::new("id", TypeName::primitive("String")).unwrap())
+            .is_override()
+            .body(find_body)
+            .build()
+            .unwrap(),
+    );
 
     // findAll override
-    let find_all_body = CodeBlock::<Kotlin>::of("return %T(tasks)", (list.clone(),)).unwrap();
-    let mut find_all_impl = FunSpec::<Kotlin>::builder("findAll");
-    find_all_impl.returns(list);
-    find_all_impl.is_override();
-    find_all_impl.body(find_all_body);
-    task_svc.add_method(find_all_impl.build().unwrap());
+    let find_all_body = CodeBlock::of("return %T(tasks)", (list.clone(),)).unwrap();
+    let task_svc = task_svc.add_method(
+        FunSpec::builder("findAll")
+            .returns(list)
+            .is_override()
+            .body(find_all_body)
+            .build()
+            .unwrap(),
+    );
 
     // save override
-    let save_body = CodeBlock::<Kotlin>::of("tasks.add(entity)", ()).unwrap();
-    let mut save_impl = FunSpec::<Kotlin>::builder("save");
-    save_impl.add_param(ParameterSpec::new("entity", TypeName::primitive("Task")).unwrap());
-    save_impl.is_override();
-    save_impl.body(save_body);
-    task_svc.add_method(save_impl.build().unwrap());
+    let save_body = CodeBlock::of("tasks.add(entity)", ()).unwrap();
+    let task_svc = task_svc.add_method(
+        FunSpec::builder("save")
+            .add_param(ParameterSpec::new("entity", TypeName::primitive("Task")).unwrap())
+            .is_override()
+            .body(save_body)
+            .build()
+            .unwrap(),
+    );
 
     let task_svc_spec = task_svc.build().unwrap();
 
     // --- Suspend function: fetchTasks ---
-    let fetch_body = CodeBlock::<Kotlin>::of(
+    let fetch_body = CodeBlock::of(
         "val service = TaskService()\nservice.initialize()\nreturn service.findAll()",
         (),
     )
     .unwrap();
-    let mut fetch_fn = FunSpec::<Kotlin>::builder("fetchTasks");
-    fetch_fn.is_async();
-    fetch_fn.returns(TypeName::primitive("List<Task>"));
-    fetch_fn.body(fetch_body);
-    let fetch_tasks = fetch_fn.build().unwrap();
+    let fetch_tasks = FunSpec::builder("fetchTasks")
+        .is_async()
+        .returns(TypeName::primitive("List<Task>"))
+        .body(fetch_body)
+        .build()
+        .unwrap();
 
     // --- Standalone function using UUID + CoroutineScope ---
-    let create_body = CodeBlock::<Kotlin>::of(
+    let create_body = CodeBlock::of(
         "return Task(\n    id = %T.randomUUID().toString(),\n    name = name,\n    priority = priority\n)",
         (uuid,),
     )
     .unwrap();
-    let mut create_fn = FunSpec::<Kotlin>::builder("createTask");
-    create_fn.returns(TypeName::primitive("Task"));
-    create_fn.add_param(ParameterSpec::new("name", TypeName::primitive("String")).unwrap());
-    create_fn.add_param(ParameterSpec::new("priority", TypeName::primitive("Priority")).unwrap());
-    create_fn.body(create_body);
-    let create_task = create_fn.build().unwrap();
+    let create_task = FunSpec::builder("createTask")
+        .returns(TypeName::primitive("Task"))
+        .add_param(ParameterSpec::new("name", TypeName::primitive("String")).unwrap())
+        .add_param(ParameterSpec::new("priority", TypeName::primitive("Priority")).unwrap())
+        .body(create_body)
+        .build()
+        .unwrap();
 
     // Trigger CoroutineScope import
-    let scope_trigger =
-        CodeBlock::<Kotlin>::of("// CoroutineScope: %T", (coroutine_scope,)).unwrap();
+    let scope_trigger = CodeBlock::of("// CoroutineScope: %T", (coroutine_scope,)).unwrap();
 
     // --- Assemble file ---
-    let mut fb = FileSpec::builder_with("TaskApp.kt", Kotlin::new());
-    fb.add_code(scope_trigger);
-    fb.add_type(priority_spec);
-    fb.add_type(repo_spec);
-    fb.add_type(task_spec);
-    fb.add_type(base_svc_spec);
-    fb.add_type(task_svc_spec);
-    fb.add_function(fetch_tasks);
-    fb.add_function(create_task);
-
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("TaskApp.kt", Kotlin::new())
+        .add_code(scope_trigger)
+        .add_type(priority_spec)
+        .add_type(repo_spec)
+        .add_type(task_spec)
+        .add_type(base_svc_spec)
+        .add_type(task_svc_spec)
+        .add_function(fetch_tasks)
+        .add_function(create_task)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
     print!("{output}");
 }

--- a/examples/python_codegen.rs
+++ b/examples/python_codegen.rs
@@ -14,54 +14,57 @@ use sigil_stitch::type_name::TypeName;
 
 fn main() {
     // Importable types.
-    let json_dumps = TypeName::<Python>::importable("json", "dumps");
-    let dataclass_import = TypeName::<Python>::importable("dataclasses", "dataclass");
+    let json_dumps = TypeName::importable("json", "dumps");
+    let dataclass_import = TypeName::importable("dataclasses", "dataclass");
 
     // Build a dataclass.
-    let mut tb = TypeSpec::<Python>::builder("Config", TypeKind::Class);
-    tb.doc("Application configuration.");
-    tb.annotation(CodeBlock::<Python>::of("@%T", (dataclass_import,)).unwrap());
-
-    tb.add_field(
-        FieldSpec::builder("host", TypeName::primitive("str"))
-            .build()
-            .unwrap(),
-    );
-    tb.add_field(
-        FieldSpec::builder("port", TypeName::primitive("int"))
-            .build()
-            .unwrap(),
-    );
-
-    let mut f3 = FieldSpec::builder("debug", TypeName::primitive("bool"));
-    f3.initializer(CodeBlock::<Python>::of("False", ()).unwrap());
-    tb.add_field(f3.build().unwrap());
-
-    // Add a method.
-    let mut to_json = FunSpec::<Python>::builder("to_json");
-    to_json.doc("Serialize to JSON string.");
-    to_json.add_param(ParameterSpec::new("self", TypeName::primitive("")).unwrap());
-    to_json.returns(TypeName::primitive("str"));
-    to_json.body(
-        CodeBlock::<Python>::of(
-            "return %T({'host': self.host, 'port': self.port})",
-            (json_dumps,),
+    let tb = TypeSpec::builder("Config", TypeKind::Class)
+        .doc("Application configuration.")
+        .annotation(CodeBlock::of("@%T", (dataclass_import,)).unwrap())
+        .add_field(
+            FieldSpec::builder("host", TypeName::primitive("str"))
+                .build()
+                .unwrap(),
         )
-        .unwrap(),
-    );
-    tb.add_method(to_json.build().unwrap());
+        .add_field(
+            FieldSpec::builder("port", TypeName::primitive("int"))
+                .build()
+                .unwrap(),
+        )
+        .add_field(
+            FieldSpec::builder("debug", TypeName::primitive("bool"))
+                .initializer(CodeBlock::of("False", ()).unwrap())
+                .build()
+                .unwrap(),
+        )
+        .add_method(
+            FunSpec::builder("to_json")
+                .doc("Serialize to JSON string.")
+                .add_param(ParameterSpec::new("self", TypeName::primitive("")).unwrap())
+                .returns(TypeName::primitive("str"))
+                .body(
+                    CodeBlock::of(
+                        "return %T({'host': self.host, 'port': self.port})",
+                        (json_dumps,),
+                    )
+                    .unwrap(),
+                )
+                .build()
+                .unwrap(),
+        );
 
     // Build a standalone function.
-    let mut greet = FunSpec::<Python>::builder("greet");
-    greet.add_param(ParameterSpec::new("name", TypeName::primitive("str")).unwrap());
-    greet.returns(TypeName::primitive("str"));
-    greet.body(CodeBlock::<Python>::of("return f'Hello, {name}!'", ()).unwrap());
+    let greet = FunSpec::builder("greet")
+        .add_param(ParameterSpec::new("name", TypeName::primitive("str")).unwrap())
+        .returns(TypeName::primitive("str"))
+        .body(CodeBlock::of("return f'Hello, {name}!'", ()).unwrap());
 
     // Assemble the file.
-    let mut file = FileSpec::builder_with("config.py", Python::new());
-    file.add_type(tb.build().unwrap());
-    file.add_function(greet.build().unwrap());
-    let spec = file.build().unwrap();
+    let spec = FileSpec::builder_with("config.py", Python::new())
+        .add_type(tb.build().unwrap())
+        .add_function(greet.build().unwrap())
+        .build()
+        .unwrap();
 
     let output = spec.render(80).unwrap();
     println!("{output}");

--- a/examples/rust_codegen.rs
+++ b/examples/rust_codegen.rs
@@ -14,50 +14,59 @@ use sigil_stitch::type_name::TypeName;
 
 fn main() {
     // Define types from different crate groups.
-    let hashmap = TypeName::<RustLang>::importable("std::collections", "HashMap");
-    let serialize = TypeName::<RustLang>::importable("serde", "Serialize");
-    let deserialize = TypeName::<RustLang>::importable("serde", "Deserialize");
+    let hashmap = TypeName::importable("std::collections", "HashMap");
+    let serialize = TypeName::importable("serde", "Serialize");
+    let deserialize = TypeName::importable("serde", "Deserialize");
 
     // Build a struct using TypeSpec.
-    let mut tb = TypeSpec::<RustLang>::builder("Config", TypeKind::Struct);
-    tb.visibility(Visibility::Public);
+    let tb = TypeSpec::builder("Config", TypeKind::Struct).visibility(Visibility::Public);
 
     // Derive annotation.
-    let derive = CodeBlock::<RustLang>::of("#[derive(%T, %T)]", (serialize, deserialize)).unwrap();
-    tb.annotation(derive);
+    let derive = CodeBlock::of("#[derive(%T, %T)]", (serialize, deserialize)).unwrap();
+    let tb = tb.annotation(derive);
 
     // Fields.
-    let mut fb1 = FieldSpec::builder("name", TypeName::primitive("String"));
-    fb1.visibility(Visibility::Public);
-    tb.add_field(fb1.build().unwrap());
-
-    let mut fb2 = FieldSpec::builder(
-        "values",
-        TypeName::generic(
-            hashmap,
-            vec![TypeName::primitive("String"), TypeName::primitive("i64")],
-        ),
-    );
-    fb2.visibility(Visibility::Public);
-    tb.add_field(fb2.build().unwrap());
+    let tb = tb
+        .add_field(
+            FieldSpec::builder("name", TypeName::primitive("String"))
+                .visibility(Visibility::Public)
+                .build()
+                .unwrap(),
+        )
+        .add_field(
+            FieldSpec::builder(
+                "values",
+                TypeName::generic(
+                    hashmap,
+                    vec![TypeName::primitive("String"), TypeName::primitive("i64")],
+                ),
+            )
+            .visibility(Visibility::Public)
+            .build()
+            .unwrap(),
+        );
 
     // Constructor method.
-    let body = CodeBlock::<RustLang>::of(
+    let body = CodeBlock::of(
         "Self { name: name.to_string(), values: HashMap::new() }",
         (),
     )
     .unwrap();
-    let mut mfb = FunSpec::<RustLang>::builder("new");
-    mfb.visibility(Visibility::Public);
-    mfb.add_param(ParameterSpec::new("name", TypeName::primitive("&str")).unwrap());
-    mfb.returns(TypeName::primitive("Self"));
-    mfb.body(body);
-    tb.add_method(mfb.build().unwrap());
+    let tb = tb.add_method(
+        FunSpec::builder("new")
+            .visibility(Visibility::Public)
+            .add_param(ParameterSpec::new("name", TypeName::primitive("&str")).unwrap())
+            .returns(TypeName::primitive("Self"))
+            .body(body)
+            .build()
+            .unwrap(),
+    );
 
     // Build and render.
-    let mut file = FileSpec::builder_with("config.rs", RustLang::new());
-    file.add_type(tb.build().unwrap());
-    let spec = file.build().unwrap();
+    let spec = FileSpec::builder_with("config.rs", RustLang::new())
+        .add_type(tb.build().unwrap())
+        .build()
+        .unwrap();
 
     let output = spec.render(100).unwrap();
     println!("{output}");

--- a/examples/swift_codegen.rs
+++ b/examples/swift_codegen.rs
@@ -26,18 +26,18 @@ use sigil_stitch::type_name::TypeName;
 
 fn main() {
     // --- Imports (triggered by usage in code) ---
-    let url = TypeName::<Swift>::importable("Foundation", "URL");
-    let data = TypeName::<Swift>::importable("Foundation", "Data");
-    let json_decoder = TypeName::<Swift>::importable("Foundation", "JSONDecoder");
-    let publisher = TypeName::<Swift>::importable("Combine", "AnyPublisher");
-    let url_session = TypeName::<Swift>::importable("Foundation", "URLSession");
+    let url = TypeName::importable("Foundation", "URL");
+    let data = TypeName::importable("Foundation", "Data");
+    let json_decoder = TypeName::importable("Foundation", "JSONDecoder");
+    let publisher = TypeName::importable("Combine", "AnyPublisher");
+    let url_session = TypeName::importable("Foundation", "URLSession");
 
     // --- Enum: Priority ---
-    let mut priority = TypeSpec::<Swift>::builder("Priority", TypeKind::Enum);
-    priority.visibility(Visibility::Public);
-    priority.doc("Task priority levels.");
+    let priority = TypeSpec::builder("Priority", TypeKind::Enum);
+    let priority = priority.visibility(Visibility::Public);
+    let priority = priority.doc("Task priority levels.");
 
-    let mut cases = CodeBlock::<Swift>::builder();
+    let mut cases = CodeBlock::builder();
     cases.add("case low", ());
     cases.add_line();
     cases.add("case medium", ());
@@ -46,160 +46,194 @@ fn main() {
     cases.add_line();
     cases.add("case critical", ());
     cases.add_line();
-    priority.extra_member(cases.build().unwrap());
+    let priority = priority.extra_member(cases.build().unwrap());
 
     let priority_spec = priority.build().unwrap();
 
     // --- Protocol: TaskRepository ---
-    let tp = TypeParamSpec::<Swift>::new("T");
+    let tp = TypeParamSpec::new("T");
 
-    let mut repo_proto = TypeSpec::<Swift>::builder("TaskRepository", TypeKind::Interface);
-    repo_proto.add_type_param(tp);
-    repo_proto.doc("Repository for task persistence.");
-    repo_proto.doc("");
-    repo_proto.doc("- Parameter T: the task entity type");
-
-    let mut find = FunSpec::<Swift>::builder("findById");
-    find.returns(TypeName::primitive("T?"));
-    find.add_param(ParameterSpec::new("id", TypeName::primitive("String")).unwrap());
-    repo_proto.add_method(find.build().unwrap());
-
-    let mut find_all = FunSpec::<Swift>::builder("findAll");
-    find_all.returns(TypeName::primitive("[T]"));
-    repo_proto.add_method(find_all.build().unwrap());
-
-    let mut save = FunSpec::<Swift>::builder("save");
-    save.add_param(ParameterSpec::new("entity", TypeName::primitive("T")).unwrap());
-    repo_proto.add_method(save.build().unwrap());
-
-    let repo_spec = repo_proto.build().unwrap();
+    let repo_spec = TypeSpec::builder("TaskRepository", TypeKind::Interface)
+        .add_type_param(tp)
+        .doc("Repository for task persistence.")
+        .doc("")
+        .doc("- Parameter T: the task entity type")
+        .add_method(
+            FunSpec::builder("findById")
+                .returns(TypeName::primitive("T?"))
+                .add_param(ParameterSpec::new("id", TypeName::primitive("String")).unwrap())
+                .build()
+                .unwrap(),
+        )
+        .add_method(
+            FunSpec::builder("findAll")
+                .returns(TypeName::primitive("[T]"))
+                .build()
+                .unwrap(),
+        )
+        .add_method(
+            FunSpec::builder("save")
+                .add_param(ParameterSpec::new("entity", TypeName::primitive("T")).unwrap())
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
 
     // --- Struct: Task ---
-    let mut task_struct = TypeSpec::<Swift>::builder("Task", TypeKind::Struct);
-    task_struct.visibility(Visibility::Public);
-    task_struct.doc("A task entity.");
-
-    let mut id_field = FieldSpec::builder("id", TypeName::primitive("String"));
-    id_field.visibility(Visibility::Public);
-    id_field.is_readonly();
-    task_struct.add_field(id_field.build().unwrap());
-
-    let mut name_field = FieldSpec::builder("name", TypeName::primitive("String"));
-    name_field.visibility(Visibility::Public);
-    name_field.is_readonly();
-    task_struct.add_field(name_field.build().unwrap());
-
-    let mut priority_field = FieldSpec::builder("priority", TypeName::primitive("Priority"));
-    priority_field.visibility(Visibility::Public);
-    priority_field.is_readonly();
-    task_struct.add_field(priority_field.build().unwrap());
-
-    let mut completed_field = FieldSpec::builder("completed", TypeName::primitive("Bool"));
-    completed_field.visibility(Visibility::Public);
-    completed_field.initializer(CodeBlock::<Swift>::of("false", ()).unwrap());
-    task_struct.add_field(completed_field.build().unwrap());
-
-    let task_spec = task_struct.build().unwrap();
+    let task_spec = TypeSpec::builder("Task", TypeKind::Struct)
+        .visibility(Visibility::Public)
+        .doc("A task entity.")
+        .add_field(
+            FieldSpec::builder("id", TypeName::primitive("String"))
+                .visibility(Visibility::Public)
+                .is_readonly()
+                .build()
+                .unwrap(),
+        )
+        .add_field(
+            FieldSpec::builder("name", TypeName::primitive("String"))
+                .visibility(Visibility::Public)
+                .is_readonly()
+                .build()
+                .unwrap(),
+        )
+        .add_field(
+            FieldSpec::builder("priority", TypeName::primitive("Priority"))
+                .visibility(Visibility::Public)
+                .is_readonly()
+                .build()
+                .unwrap(),
+        )
+        .add_field(
+            FieldSpec::builder("completed", TypeName::primitive("Bool"))
+                .visibility(Visibility::Public)
+                .initializer(CodeBlock::of("false", ()).unwrap())
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
 
     // --- Class: BaseService ---
-    let mut base_svc = TypeSpec::<Swift>::builder("BaseService", TypeKind::Class);
-    base_svc.visibility(Visibility::Public);
-    base_svc.doc("Base class for services with logging.");
+    let base_svc = TypeSpec::builder("BaseService", TypeKind::Class);
+    let base_svc = base_svc.visibility(Visibility::Public);
+    let base_svc = base_svc.doc("Base class for services with logging.");
 
-    let mut svc_name_field = FieldSpec::builder("serviceName", TypeName::primitive("String"));
-    svc_name_field.visibility(Visibility::Public);
-    svc_name_field.is_readonly();
-    base_svc.add_field(svc_name_field.build().unwrap());
+    let base_svc = base_svc.add_field(
+        FieldSpec::builder("serviceName", TypeName::primitive("String"))
+            .visibility(Visibility::Public)
+            .is_readonly()
+            .build()
+            .unwrap(),
+    );
 
-    let log_body = CodeBlock::<Swift>::of("print(\"[\\(serviceName)] \\(message)\")", ()).unwrap();
-    let mut log_fn = FunSpec::<Swift>::builder("log");
-    log_fn.add_param(ParameterSpec::new("message", TypeName::primitive("String")).unwrap());
-    log_fn.body(log_body);
-    base_svc.add_method(log_fn.build().unwrap());
+    let log_body = CodeBlock::of("print(\"[\\(serviceName)] \\(message)\")", ()).unwrap();
+    let base_svc = base_svc.add_method(
+        FunSpec::builder("log")
+            .add_param(ParameterSpec::new("message", TypeName::primitive("String")).unwrap())
+            .body(log_body)
+            .build()
+            .unwrap(),
+    );
 
     let base_svc_spec = base_svc.build().unwrap();
 
     // --- Class: TaskService extends BaseService, conforms to TaskRepository ---
-    let mut task_svc = TypeSpec::<Swift>::builder("TaskService", TypeKind::Class);
-    task_svc.visibility(Visibility::Public);
-    task_svc.extends(TypeName::primitive("BaseService"));
-    task_svc.extends(TypeName::primitive("TaskRepository"));
-    task_svc.doc("Task management service.");
+    let task_svc = TypeSpec::builder("TaskService", TypeKind::Class);
+    let task_svc = task_svc.visibility(Visibility::Public);
+    let task_svc = task_svc.extends(TypeName::primitive("BaseService"));
+    let task_svc = task_svc.extends(TypeName::primitive("TaskRepository"));
+    let task_svc = task_svc.doc("Task management service.");
 
-    let mut tasks_field = FieldSpec::builder("tasks", TypeName::primitive("[Task]"));
-    tasks_field.visibility(Visibility::Private);
-    tasks_field.initializer(CodeBlock::<Swift>::of("[]", ()).unwrap());
-    task_svc.add_field(tasks_field.build().unwrap());
+    let task_svc = task_svc.add_field(
+        FieldSpec::builder("tasks", TypeName::primitive("[Task]"))
+            .visibility(Visibility::Private)
+            .initializer(CodeBlock::of("[]", ()).unwrap())
+            .build()
+            .unwrap(),
+    );
 
     // findById
-    let find_body = CodeBlock::<Swift>::of("return tasks.first { $0.id == id }", ()).unwrap();
-    let mut find_impl = FunSpec::<Swift>::builder("findById");
-    find_impl.returns(TypeName::primitive("Task?"));
-    find_impl.add_param(ParameterSpec::new("id", TypeName::primitive("String")).unwrap());
-    find_impl.body(find_body);
-    task_svc.add_method(find_impl.build().unwrap());
+    let find_body = CodeBlock::of("return tasks.first { $0.id == id }", ()).unwrap();
+    let task_svc = task_svc.add_method(
+        FunSpec::builder("findById")
+            .returns(TypeName::primitive("Task?"))
+            .add_param(ParameterSpec::new("id", TypeName::primitive("String")).unwrap())
+            .body(find_body)
+            .build()
+            .unwrap(),
+    );
 
     // findAll
-    let find_all_body = CodeBlock::<Swift>::of("return tasks", ()).unwrap();
-    let mut find_all_impl = FunSpec::<Swift>::builder("findAll");
-    find_all_impl.returns(TypeName::primitive("[Task]"));
-    find_all_impl.body(find_all_body);
-    task_svc.add_method(find_all_impl.build().unwrap());
+    let find_all_body = CodeBlock::of("return tasks", ()).unwrap();
+    let task_svc = task_svc.add_method(
+        FunSpec::builder("findAll")
+            .returns(TypeName::primitive("[Task]"))
+            .body(find_all_body)
+            .build()
+            .unwrap(),
+    );
 
     // save
-    let save_body = CodeBlock::<Swift>::of("tasks.append(entity)", ()).unwrap();
-    let mut save_impl = FunSpec::<Swift>::builder("save");
-    save_impl.add_param(ParameterSpec::new("entity", TypeName::primitive("Task")).unwrap());
-    save_impl.body(save_body);
-    task_svc.add_method(save_impl.build().unwrap());
+    let save_body = CodeBlock::of("tasks.append(entity)", ()).unwrap();
+    let task_svc = task_svc.add_method(
+        FunSpec::builder("save")
+            .add_param(ParameterSpec::new("entity", TypeName::primitive("Task")).unwrap())
+            .body(save_body)
+            .build()
+            .unwrap(),
+    );
 
     let task_svc_spec = task_svc.build().unwrap();
 
     // --- Async function: fetchTasks ---
-    let fetch_body = CodeBlock::<Swift>::of(
+    let fetch_body = CodeBlock::of(
         "let (responseData, _) = try await %T.shared.data(from: endpoint)\nlet decoder = %T()\nreturn try decoder.decode([Task].self, from: responseData)",
         (url_session, json_decoder),
     )
     .unwrap();
-    let mut fetch_fn = FunSpec::<Swift>::builder("fetchTasks");
-    fetch_fn.visibility(Visibility::Public);
-    fetch_fn.is_async();
-    fetch_fn.returns(TypeName::primitive("[Task]"));
-    fetch_fn.add_param(ParameterSpec::new("endpoint", TypeName::primitive("URL")).unwrap());
-    fetch_fn.body(fetch_body);
-    let fetch_tasks = fetch_fn.build().unwrap();
+    let fetch_tasks = FunSpec::builder("fetchTasks")
+        .visibility(Visibility::Public)
+        .is_async()
+        .returns(TypeName::primitive("[Task]"))
+        .add_param(ParameterSpec::new("endpoint", TypeName::primitive("URL")).unwrap())
+        .body(fetch_body)
+        .build()
+        .unwrap();
 
     // --- Function using URL + Combine ---
-    let create_body = CodeBlock::<Swift>::of(
+    let create_body = CodeBlock::of(
         "guard let url = %T(string: urlString) else {\n    fatalError(%S)\n}\nreturn url",
         (url, StringLitArg("Invalid URL".to_string())),
     )
     .unwrap();
-    let mut create_fn = FunSpec::<Swift>::builder("makeURL");
-    create_fn.returns(TypeName::primitive("URL"));
-    create_fn.add_param(ParameterSpec::new("urlString", TypeName::primitive("String")).unwrap());
-    create_fn.body(create_body);
-    let make_url = create_fn.build().unwrap();
+    let make_url = FunSpec::builder("makeURL")
+        .returns(TypeName::primitive("URL"))
+        .add_param(ParameterSpec::new("urlString", TypeName::primitive("String")).unwrap())
+        .body(create_body)
+        .build()
+        .unwrap();
 
     // Trigger Combine import
-    let combine_trigger = CodeBlock::<Swift>::of("// Publisher: %T", (publisher,)).unwrap();
+    let combine_trigger = CodeBlock::of("// Publisher: %T", (publisher,)).unwrap();
 
     // Trigger Data import
-    let data_trigger = CodeBlock::<Swift>::of("// Data: %T", (data,)).unwrap();
+    let data_trigger = CodeBlock::of("// Data: %T", (data,)).unwrap();
 
     // --- Assemble file ---
-    let mut fb = FileSpec::builder_with("TaskApp.swift", Swift::new());
-    fb.add_code(combine_trigger);
-    fb.add_code(data_trigger);
-    fb.add_type(priority_spec);
-    fb.add_type(repo_spec);
-    fb.add_type(task_spec);
-    fb.add_type(base_svc_spec);
-    fb.add_type(task_svc_spec);
-    fb.add_function(fetch_tasks);
-    fb.add_function(make_url);
-
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("TaskApp.swift", Swift::new())
+        .add_code(combine_trigger)
+        .add_code(data_trigger)
+        .add_type(priority_spec)
+        .add_type(repo_spec)
+        .add_type(task_spec)
+        .add_type(base_svc_spec)
+        .add_type(task_svc_spec)
+        .add_function(fetch_tasks)
+        .add_function(make_url)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
     print!("{output}");
 }

--- a/examples/typescript_hello_world.rs
+++ b/examples/typescript_hello_world.rs
@@ -3,7 +3,6 @@
 //! Run with: `cargo run --example typescript_hello_world`
 
 use sigil_stitch::code_block::{CodeBlock, StringLitArg};
-use sigil_stitch::lang::typescript::TypeScript;
 use sigil_stitch::spec::field_spec::FieldSpec;
 use sigil_stitch::spec::file_spec::FileSpec;
 use sigil_stitch::spec::fun_spec::FunSpec;
@@ -14,22 +13,23 @@ use sigil_stitch::type_name::TypeName;
 
 fn main() {
     // Define types that need imports.
-    let user_type = TypeName::<TypeScript>::importable_type("./models", "User");
-    let not_found = TypeName::<TypeScript>::importable_type("./errors", "NotFoundError");
+    let user_type = TypeName::importable_type("./models", "User");
+    let not_found = TypeName::importable_type("./errors", "NotFoundError");
 
     // Build the class using TypeSpec.
-    let mut tb = TypeSpec::<TypeScript>::builder("UserService", TypeKind::Class);
-    tb.visibility(Visibility::Public);
-    tb.doc("Service for managing users.");
-
-    // Private field.
-    let mut field_b = FieldSpec::builder("userRepo", TypeName::primitive("UserRepository"));
-    field_b.visibility(Visibility::Private);
-    field_b.is_readonly();
-    tb.add_field(field_b.build().unwrap());
+    let tb = TypeSpec::builder("UserService", TypeKind::Class)
+        .visibility(Visibility::Public)
+        .doc("Service for managing users.")
+        .add_field(
+            FieldSpec::builder("userRepo", TypeName::primitive("UserRepository"))
+                .visibility(Visibility::Private)
+                .is_readonly()
+                .build()
+                .unwrap(),
+        );
 
     // Async method with control flow body.
-    let mut body = CodeBlock::<TypeScript>::builder();
+    let mut body = CodeBlock::builder();
     body.add_statement(
         "const user = await this.userRepo.findById(%S)",
         (StringLitArg("id".to_string()),),
@@ -40,20 +40,24 @@ fn main() {
     body.add_statement("return user", ());
     let body_block = body.build().unwrap();
 
-    let mut fb = FunSpec::builder("getUser");
-    fb.is_async();
-    fb.add_param(ParameterSpec::new("id", TypeName::primitive("string")).unwrap());
-    fb.returns(TypeName::generic(
-        TypeName::primitive("Promise"),
-        vec![user_type],
-    ));
-    fb.body(body_block);
-    tb.add_method(fb.build().unwrap());
+    let tb = tb.add_method(
+        FunSpec::builder("getUser")
+            .is_async()
+            .add_param(ParameterSpec::new("id", TypeName::primitive("string")).unwrap())
+            .returns(TypeName::generic(
+                TypeName::primitive("Promise"),
+                vec![user_type],
+            ))
+            .body(body_block)
+            .build()
+            .unwrap(),
+    );
 
     // Build the file.
-    let mut file = FileSpec::<TypeScript>::builder("UserService.ts");
-    file.add_type(tb.build().unwrap());
-    let spec = file.build().unwrap();
+    let spec = FileSpec::builder("UserService.ts")
+        .add_type(tb.build().unwrap())
+        .build()
+        .unwrap();
 
     // Render at 80 columns.
     let output = spec.render(80).unwrap();

--- a/macros/src/codegen.rs
+++ b/macros/src/codegen.rs
@@ -9,12 +9,11 @@ use crate::parse::{InterpolationKind, ParsedInput, Statement, TypedArg};
 
 /// Generate the output token stream from a parsed `sigil_quote!` input.
 pub(crate) fn generate(input: ParsedInput) -> TokenStream {
-    let lang_type = &input.lang_type;
     let builder_calls = generate_statements(&input.statements);
 
     quote! {
         {
-            let mut __sigil_builder = ::sigil_stitch::code_block::CodeBlock::<#lang_type>::builder();
+            let mut __sigil_builder = ::sigil_stitch::code_block::CodeBlock::builder();
             #(#builder_calls)*
             __sigil_builder.build()
         }
@@ -95,11 +94,11 @@ fn generate_statements(statements: &[Statement]) -> Vec<TokenStream> {
 /// Build the args tuple expression from typed args.
 ///
 /// Wraps each arg according to its interpolation kind:
-/// - `$T(expr)` -> bare expr (must be `TypeName<L>`)
+/// - `$T(expr)` -> bare expr (must be `TypeName`)
 /// - `$N(expr)` -> `NameArg((expr).to_string())`
 /// - `$S(expr)` -> `StringLitArg((expr).to_string())`
-/// - `$L(expr)` -> bare expr (via `Into<Arg<L>>`)
-/// - `$C(expr)` -> bare expr (must be `CodeBlock<L>`)
+/// - `$L(expr)` -> bare expr (via `Into<Arg>`)
+/// - `$C(expr)` -> bare expr (must be `CodeBlock`)
 fn build_args_tuple(args: &[TypedArg]) -> TokenStream {
     if args.is_empty() {
         quote! { () }

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -96,7 +96,7 @@ use proc_macro::TokenStream;
 /// use sigil_stitch::prelude::*;
 /// use sigil_stitch::lang::typescript::TypeScript;
 ///
-/// let user_type = TypeName::<TypeScript>::importable_type("./models", "User");
+/// let user_type = TypeName::importable_type("./models", "User");
 ///
 /// let block = sigil_quote!(TypeScript {
 ///     const user: $T(user_type) = await getUser($S("id"));
@@ -107,7 +107,7 @@ use proc_macro::TokenStream;
 /// Control flow with interpolation:
 ///
 /// ```ignore
-/// let error_type = TypeName::<TypeScript>::importable_type("./errors", "NotFoundError");
+/// let error_type = TypeName::importable_type("./errors", "NotFoundError");
 ///
 /// let block = sigil_quote!(TypeScript {
 ///     if (!user) {

--- a/macros/src/parse.rs
+++ b/macros/src/parse.rs
@@ -7,7 +7,10 @@ use proc_macro2::{Delimiter, Spacing, Span, TokenStream, TokenTree};
 
 /// A parsed `sigil_quote!` invocation.
 pub(crate) struct ParsedInput {
-    /// The language type tokens (e.g., `TypeScript`).
+    /// The language type tokens (e.g., `TypeScript`). Parsed for backwards
+    /// compatibility but no longer used in code generation since types are
+    /// no longer parameterized by language.
+    #[allow(dead_code)]
     pub lang_type: TokenStream,
     /// The parsed body statements.
     pub statements: Vec<Statement>,

--- a/src/code_block.rs
+++ b/src/code_block.rs
@@ -1,10 +1,11 @@
+use crate::code_node::{CodeNode, parts_args_to_nodes};
 use crate::import::ImportRef;
 use crate::lang::CodeLang;
 use crate::type_name::TypeName;
 
 /// A parsed format specifier from a format string.
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
-pub enum FormatPart {
+pub(crate) enum FormatPart {
     /// Literal text (no interpolation).
     Literal(String),
     /// `%T` - type reference (consumes an Arg::TypeName).
@@ -61,11 +62,11 @@ pub enum Arg {
 
 /// An immutable code fragment with embedded type references.
 ///
-/// `CodeBlock` is the core composition primitive in sigil-stitch. It stores parsed
-/// format parts (from format strings using `%T`, `%N`, `%S`, `%L`, etc.) alongside
-/// their corresponding arguments. CodeBlocks are produced by [`CodeBlockBuilder`] and
-/// consumed by [`FileSpec`](crate::spec::file_spec::FileSpec) during rendering. Type
-/// references embedded via `%T` are automatically tracked for import resolution.
+/// `CodeBlock` is the core composition primitive in sigil-stitch. It stores a tree
+/// of [`CodeNode`] nodes — self-contained IR nodes produced from format strings
+/// (`%T`, `%N`, `%S`, `%L`, etc.). CodeBlocks are produced by [`CodeBlockBuilder`]
+/// and consumed by [`FileSpec`](crate::spec::file_spec::FileSpec) during rendering.
+/// Type references embedded via `%T` are automatically tracked for import resolution.
 ///
 /// Use [`CodeBlock::builder()`] to construct a block incrementally, or
 /// [`CodeBlock::of()`] for simple one-liners.
@@ -89,8 +90,7 @@ pub enum Arg {
 /// ```
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct CodeBlock {
-    pub(crate) parts: Vec<FormatPart>,
-    pub(crate) args: Vec<Arg>,
+    pub(crate) nodes: Vec<CodeNode>,
 }
 
 impl CodeBlock {
@@ -108,18 +108,24 @@ impl CodeBlock {
 
     /// Check if this code block is empty.
     pub fn is_empty(&self) -> bool {
-        self.parts.is_empty()
+        self.nodes.is_empty()
+    }
+
+    /// Check if this code block ends with a newline or block close.
+    pub(crate) fn ends_with_newline_or_block_close(&self) -> bool {
+        fn check_last(nodes: &[CodeNode]) -> bool {
+            match nodes.last() {
+                Some(CodeNode::Newline | CodeNode::BlockClose) => true,
+                Some(CodeNode::Sequence(children)) => check_last(children),
+                _ => false,
+            }
+        }
+        check_last(&self.nodes)
     }
 
     /// Collect all import references from this code block.
     pub fn collect_imports(&self, out: &mut Vec<ImportRef>) {
-        for arg in &self.args {
-            match arg {
-                Arg::TypeName(tn) => tn.collect_imports(out),
-                Arg::Code(cb) => cb.collect_imports(out),
-                _ => {}
-            }
-        }
+        collect_imports_from_nodes(&self.nodes, out);
     }
 
     /// Render this code block to a string without import resolution.
@@ -135,6 +141,17 @@ impl CodeBlock {
         let imports = crate::import::ImportGroup::new();
         let mut renderer = crate::code_renderer::CodeRenderer::new(lang, &imports, width);
         renderer.render(self)
+    }
+}
+
+fn collect_imports_from_nodes(nodes: &[CodeNode], out: &mut Vec<ImportRef>) {
+    for node in nodes {
+        match node {
+            CodeNode::TypeRef(tn) => tn.collect_imports(out),
+            CodeNode::Nested(block) => block.collect_imports(out),
+            CodeNode::Sequence(children) => collect_imports_from_nodes(children, out),
+            _ => {}
+        }
     }
 }
 
@@ -161,8 +178,7 @@ impl CodeBlock {
 /// ```
 #[derive(Debug)]
 pub struct CodeBlockBuilder {
-    parts: Vec<FormatPart>,
-    args: Vec<Arg>,
+    nodes: Vec<CodeNode>,
     indent_depth: i32,
     errors: Vec<crate::error::SigilStitchError>,
 }
@@ -171,8 +187,7 @@ impl CodeBlockBuilder {
     /// Create a new empty code block builder.
     pub fn new() -> Self {
         Self {
-            parts: Vec::new(),
-            args: Vec::new(),
+            nodes: Vec::new(),
             indent_depth: 0,
             errors: Vec::new(),
         }
@@ -224,26 +239,26 @@ impl CodeBlockBuilder {
             return self;
         }
 
-        self.parts.extend(parsed);
-        self.args.extend(arg_vec);
+        let new_nodes = parts_args_to_nodes(&parsed, &arg_vec);
+        self.nodes.extend(new_nodes);
         self
     }
 
     /// Add a statement (wraps in %[...%] and appends language semicolon).
     pub fn add_statement(&mut self, format: &str, args: impl IntoArgs) -> &mut Self {
-        self.parts.push(FormatPart::StatementBegin);
+        self.nodes.push(CodeNode::StatementBegin);
         self.add(format, args);
-        self.parts.push(FormatPart::StatementEnd);
-        self.parts.push(FormatPart::Newline);
+        self.nodes.push(CodeNode::StatementEnd);
+        self.nodes.push(CodeNode::Newline);
         self
     }
 
     /// Begin a control flow block (e.g., "if foo" -> "if foo {\n" + indent).
     pub fn begin_control_flow(&mut self, format: &str, args: impl IntoArgs) -> &mut Self {
         self.add(format, args);
-        self.parts.push(FormatPart::BlockOpen);
-        self.parts.push(FormatPart::Newline);
-        self.parts.push(FormatPart::Indent);
+        self.nodes.push(CodeNode::BlockOpen);
+        self.nodes.push(CodeNode::Newline);
+        self.nodes.push(CodeNode::Indent);
         self.indent_depth += 1;
         self
     }
@@ -261,55 +276,52 @@ impl CodeBlockBuilder {
     ) -> &mut Self {
         self.add(format, args);
         if !custom_open.is_empty() {
-            self.parts
-                .push(FormatPart::BlockOpenOverride(custom_open.to_string()));
+            self.nodes
+                .push(CodeNode::BlockOpenOverride(custom_open.to_string()));
         }
-        self.parts.push(FormatPart::Newline);
-        self.parts.push(FormatPart::Indent);
+        self.nodes.push(CodeNode::Newline);
+        self.nodes.push(CodeNode::Indent);
         self.indent_depth += 1;
         self
     }
 
     /// Add an else/else-if clause (e.g., "} else {" or "elif ...:" for Python).
     pub fn next_control_flow(&mut self, format: &str, args: impl IntoArgs) -> &mut Self {
-        self.parts.push(FormatPart::Dedent);
+        self.nodes.push(CodeNode::Dedent);
         self.indent_depth -= 1;
-        self.parts.push(FormatPart::BlockCloseTransition);
+        self.nodes.push(CodeNode::BlockCloseTransition);
         self.add(format, args);
-        self.parts.push(FormatPart::BlockOpen);
-        self.parts.push(FormatPart::Newline);
-        self.parts.push(FormatPart::Indent);
+        self.nodes.push(CodeNode::BlockOpen);
+        self.nodes.push(CodeNode::Newline);
+        self.nodes.push(CodeNode::Indent);
         self.indent_depth += 1;
         self
     }
 
     /// End a control flow block (emits "}" or nothing for Python, and decreases indent).
     pub fn end_control_flow(&mut self) -> &mut Self {
-        self.parts.push(FormatPart::Dedent);
+        self.nodes.push(CodeNode::Dedent);
         self.indent_depth -= 1;
-        self.parts.push(FormatPart::BlockClose);
+        self.nodes.push(CodeNode::BlockClose);
         self
     }
 
     /// Add a blank line.
     pub fn add_line(&mut self) -> &mut Self {
-        self.parts.push(FormatPart::Newline);
+        self.nodes.push(CodeNode::Newline);
         self
     }
 
     /// Add an inline comment.
     pub fn add_comment(&mut self, text: &str) -> &mut Self {
-        // Comment prefix is added during rendering based on language.
-        self.parts
-            .push(FormatPart::Literal(format!("__COMMENT__{text}")));
-        self.parts.push(FormatPart::Newline);
+        self.nodes.push(CodeNode::Comment(text.to_string()));
+        self.nodes.push(CodeNode::Newline);
         self
     }
 
     /// Add a nested CodeBlock inline.
     pub fn add_code(&mut self, block: CodeBlock) -> &mut Self {
-        self.parts.push(FormatPart::Literal_);
-        self.args.push(Arg::Code(block));
+        self.nodes.push(CodeNode::Nested(block));
         self
     }
 
@@ -327,10 +339,7 @@ impl CodeBlockBuilder {
                 depth: self.indent_depth,
             });
         }
-        Ok(CodeBlock {
-            parts: self.parts,
-            args: self.args,
-        })
+        Ok(CodeBlock { nodes: self.nodes })
     }
 
     /// Build the CodeBlock, panicking on error.
@@ -565,6 +574,7 @@ impl_into_args_tuple!(0 A, 1 B, 2 C, 3 D, 4 E, 5 F, 6 G, 7 H);
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::code_node::CodeNode;
 
     #[test]
     fn test_parse_all_specifiers() {
@@ -612,8 +622,16 @@ mod tests {
         let block = b.build().unwrap();
 
         assert!(!block.is_empty());
-        assert!(block.parts.contains(&FormatPart::StatementBegin));
-        assert!(block.parts.contains(&FormatPart::StatementEnd));
+        let has_stmt_begin = block
+            .nodes
+            .iter()
+            .any(|n| matches!(n, CodeNode::StatementBegin));
+        let has_stmt_end = block
+            .nodes
+            .iter()
+            .any(|n| matches!(n, CodeNode::StatementEnd));
+        assert!(has_stmt_begin);
+        assert!(has_stmt_end);
     }
 
     #[test]
@@ -713,8 +731,11 @@ mod tests {
         let mut b = CodeBlock::builder();
         b.add("this.%N()", (NameArg("getUser".to_string()),));
         let block = b.build().unwrap();
-        assert_eq!(block.args.len(), 1);
-        assert!(matches!(&block.args[0], Arg::Name(s) if s == "getUser"));
+        let has_name = block
+            .nodes
+            .iter()
+            .any(|n| matches!(n, CodeNode::NameRef(s) if s == "getUser"));
+        assert!(has_name);
     }
 
     #[test]
@@ -722,8 +743,11 @@ mod tests {
         let mut b = CodeBlock::builder();
         b.add("const x = %S", (StringLitArg("hello".to_string()),));
         let block = b.build().unwrap();
-        assert_eq!(block.args.len(), 1);
-        assert!(matches!(&block.args[0], Arg::StringLit(s) if s == "hello"));
+        let has_str_lit = block
+            .nodes
+            .iter()
+            .any(|n| matches!(n, CodeNode::StringLit(s) if s == "hello"));
+        assert!(has_str_lit);
     }
 
     #[test]
@@ -769,14 +793,11 @@ mod tests {
         b.end_control_flow();
         let block = b.build().unwrap();
         let has_override = block
-            .parts
+            .nodes
             .iter()
-            .any(|p| matches!(p, FormatPart::BlockOpenOverride(s) if s == " where"));
+            .any(|n| matches!(n, CodeNode::BlockOpenOverride(s) if s == " where"));
         assert!(has_override, "should contain BlockOpenOverride(\" where\")");
-        let has_block_open = block
-            .parts
-            .iter()
-            .any(|p| matches!(p, FormatPart::BlockOpen));
+        let has_block_open = block.nodes.iter().any(|n| matches!(n, CodeNode::BlockOpen));
         assert!(
             !has_block_open,
             "should NOT contain BlockOpen when override is used"
@@ -792,17 +813,14 @@ mod tests {
         b.end_control_flow();
         let block = b.build().unwrap();
         let has_override = block
-            .parts
+            .nodes
             .iter()
-            .any(|p| matches!(p, FormatPart::BlockOpenOverride(_)));
+            .any(|n| matches!(n, CodeNode::BlockOpenOverride(_)));
         assert!(
             !has_override,
             "empty custom_open should skip BlockOpenOverride"
         );
-        let has_block_open = block
-            .parts
-            .iter()
-            .any(|p| matches!(p, FormatPart::BlockOpen));
+        let has_block_open = block.nodes.iter().any(|n| matches!(n, CodeNode::BlockOpen));
         assert!(!has_block_open, "should NOT contain BlockOpen either");
     }
 }

--- a/src/code_block.rs
+++ b/src/code_block.rs
@@ -28,19 +28,19 @@ pub(crate) enum FormatPart {
     StatementEnd,
     /// Newline.
     Newline,
-    /// Block open delimiter — resolved at render time via `lang.block_open()`.
+    /// Block open delimiter — resolved at render time via `lang.block_syntax().block_open`.
     /// Emitted by control-flow builders; braces for TS/Rust/Go, colon for Python.
     BlockOpen,
-    /// Block open with an overridden delimiter (not resolved via `lang.block_open()`).
+    /// Block open with an overridden delimiter (not resolved via `lang.block_syntax().block_open`).
     /// Emitted by `begin_control_flow_with_open` for constructs that need a
     /// different opener than the language default (e.g., Haskell `where` vs `=`).
     BlockOpenOverride(String),
-    /// Block close delimiter (terminal) — resolved at render time via `lang.block_close()`.
+    /// Block close delimiter (terminal) — resolved at render time via `lang.block_syntax().block_close`.
     /// Emitted by `end_control_flow`. When non-empty, also emits a trailing newline.
     /// When empty (indent-only languages like OCaml/Haskell/Python), emits nothing.
     BlockClose,
     /// Block close delimiter (transitional) — resolved at render time via
-    /// `lang.block_close()` + `" "`. Used by `next_control_flow` to emit `} else`.
+    /// `lang.block_syntax().block_close` + `" "`. Used by `next_control_flow` to emit `} else`.
     /// When `block_close()` is empty, emits nothing (Python: dedent-only transition).
     BlockCloseTransition,
 }

--- a/src/code_block.rs
+++ b/src/code_block.rs
@@ -46,10 +46,9 @@ pub enum FormatPart {
 
 /// An argument to a CodeBlock format string.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-#[serde(bound = "")]
-pub enum Arg<L: CodeLang> {
+pub enum Arg {
     /// A type name reference (used by `%T`).
-    TypeName(TypeName<L>),
+    TypeName(TypeName),
     /// A name string (used by `%N`).
     Name(String),
     /// A string literal value (used by `%S`).
@@ -57,7 +56,7 @@ pub enum Arg<L: CodeLang> {
     /// A literal string value or nested code block (used by `%L`).
     Literal(String),
     /// A nested code block (used by `%L`).
-    Code(CodeBlock<L>),
+    Code(CodeBlock),
 }
 
 /// An immutable code fragment with embedded type references.
@@ -79,33 +78,29 @@ pub enum Arg<L: CodeLang> {
 /// use sigil_stitch::type_name::TypeName;
 ///
 /// // One-liner with a type reference:
-/// let user = TypeName::<TypeScript>::importable("./models", "User");
-/// let block = CodeBlock::<TypeScript>::of("const u: %T = getUser()", (user,)).unwrap();
+/// let user = TypeName::importable("./models", "User");
+/// let block = CodeBlock::of("const u: %T = getUser()", (user,)).unwrap();
 ///
 /// // Multi-statement block via builder:
-/// let mut cb = CodeBlock::<TypeScript>::builder();
+/// let mut cb = CodeBlock::builder();
 /// cb.add_statement("const x = 1", ());
 /// cb.add_statement("const y = 2", ());
 /// let block = cb.build().unwrap();
 /// ```
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-#[serde(bound = "")]
-pub struct CodeBlock<L: CodeLang> {
+pub struct CodeBlock {
     pub(crate) parts: Vec<FormatPart>,
-    pub(crate) args: Vec<Arg<L>>,
+    pub(crate) args: Vec<Arg>,
 }
 
-impl<L: CodeLang> CodeBlock<L> {
+impl CodeBlock {
     /// Create a new CodeBlockBuilder.
-    pub fn builder() -> CodeBlockBuilder<L> {
+    pub fn builder() -> CodeBlockBuilder {
         CodeBlockBuilder::new()
     }
 
     /// Create a CodeBlock from a single format string and arguments.
-    pub fn of(
-        format: &str,
-        args: impl IntoArgs<L>,
-    ) -> Result<Self, crate::error::SigilStitchError> {
+    pub fn of(format: &str, args: impl IntoArgs) -> Result<Self, crate::error::SigilStitchError> {
         let mut builder = CodeBlockBuilder::new();
         builder.add(format, args);
         builder.build()
@@ -126,6 +121,21 @@ impl<L: CodeLang> CodeBlock<L> {
             }
         }
     }
+
+    /// Render this code block to a string without import resolution.
+    ///
+    /// Creates a temporary empty import group and renders using the given
+    /// language and target line width. Useful for quick one-off rendering
+    /// in tests or when import management is not needed.
+    pub fn render_standalone(
+        &self,
+        lang: &dyn CodeLang,
+        width: usize,
+    ) -> Result<String, crate::error::SigilStitchError> {
+        let imports = crate::import::ImportGroup::new();
+        let mut renderer = crate::code_renderer::CodeRenderer::new(lang, &imports, width);
+        renderer.render(self)
+    }
 }
 
 /// Builder for constructing [`CodeBlock`] instances.
@@ -141,7 +151,7 @@ impl<L: CodeLang> CodeBlock<L> {
 /// use sigil_stitch::code_block::CodeBlock;
 /// use sigil_stitch::lang::typescript::TypeScript;
 ///
-/// let mut cb = CodeBlock::<TypeScript>::builder();
+/// let mut cb = CodeBlock::builder();
 /// cb.begin_control_flow("if (x > 0)", ());
 /// cb.add_statement("return x", ());
 /// cb.next_control_flow("else", ());
@@ -150,14 +160,14 @@ impl<L: CodeLang> CodeBlock<L> {
 /// let block = cb.build().unwrap();
 /// ```
 #[derive(Debug)]
-pub struct CodeBlockBuilder<L: CodeLang> {
+pub struct CodeBlockBuilder {
     parts: Vec<FormatPart>,
-    args: Vec<Arg<L>>,
+    args: Vec<Arg>,
     indent_depth: i32,
     errors: Vec<crate::error::SigilStitchError>,
 }
 
-impl<L: CodeLang> CodeBlockBuilder<L> {
+impl CodeBlockBuilder {
     /// Create a new empty code block builder.
     pub fn new() -> Self {
         Self {
@@ -169,7 +179,7 @@ impl<L: CodeLang> CodeBlockBuilder<L> {
     }
 
     /// Add a formatted code fragment.
-    pub fn add(&mut self, format: &str, args: impl IntoArgs<L>) -> &mut Self {
+    pub fn add(&mut self, format: &str, args: impl IntoArgs) -> &mut Self {
         let arg_vec = args.into_args();
         let parsed = match parse_format(format) {
             Ok(parts) => parts,
@@ -220,7 +230,7 @@ impl<L: CodeLang> CodeBlockBuilder<L> {
     }
 
     /// Add a statement (wraps in %[...%] and appends language semicolon).
-    pub fn add_statement(&mut self, format: &str, args: impl IntoArgs<L>) -> &mut Self {
+    pub fn add_statement(&mut self, format: &str, args: impl IntoArgs) -> &mut Self {
         self.parts.push(FormatPart::StatementBegin);
         self.add(format, args);
         self.parts.push(FormatPart::StatementEnd);
@@ -229,7 +239,7 @@ impl<L: CodeLang> CodeBlockBuilder<L> {
     }
 
     /// Begin a control flow block (e.g., "if foo" -> "if foo {\n" + indent).
-    pub fn begin_control_flow(&mut self, format: &str, args: impl IntoArgs<L>) -> &mut Self {
+    pub fn begin_control_flow(&mut self, format: &str, args: impl IntoArgs) -> &mut Self {
         self.add(format, args);
         self.parts.push(FormatPart::BlockOpen);
         self.parts.push(FormatPart::Newline);
@@ -246,7 +256,7 @@ impl<L: CodeLang> CodeBlockBuilder<L> {
     pub fn begin_control_flow_with_open(
         &mut self,
         format: &str,
-        args: impl IntoArgs<L>,
+        args: impl IntoArgs,
         custom_open: &str,
     ) -> &mut Self {
         self.add(format, args);
@@ -261,7 +271,7 @@ impl<L: CodeLang> CodeBlockBuilder<L> {
     }
 
     /// Add an else/else-if clause (e.g., "} else {" or "elif ...:" for Python).
-    pub fn next_control_flow(&mut self, format: &str, args: impl IntoArgs<L>) -> &mut Self {
+    pub fn next_control_flow(&mut self, format: &str, args: impl IntoArgs) -> &mut Self {
         self.parts.push(FormatPart::Dedent);
         self.indent_depth -= 1;
         self.parts.push(FormatPart::BlockCloseTransition);
@@ -297,7 +307,7 @@ impl<L: CodeLang> CodeBlockBuilder<L> {
     }
 
     /// Add a nested CodeBlock inline.
-    pub fn add_code(&mut self, block: CodeBlock<L>) -> &mut Self {
+    pub fn add_code(&mut self, block: CodeBlock) -> &mut Self {
         self.parts.push(FormatPart::Literal_);
         self.args.push(Arg::Code(block));
         self
@@ -308,7 +318,7 @@ impl<L: CodeLang> CodeBlockBuilder<L> {
     /// Returns an error if any format string had an argument count mismatch,
     /// or if indent depth is not balanced (unmatched
     /// begin_control_flow / end_control_flow).
-    pub fn build(self) -> Result<CodeBlock<L>, crate::error::SigilStitchError> {
+    pub fn build(self) -> Result<CodeBlock, crate::error::SigilStitchError> {
         if let Some(err) = self.errors.into_iter().next() {
             return Err(err);
         }
@@ -324,12 +334,12 @@ impl<L: CodeLang> CodeBlockBuilder<L> {
     }
 
     /// Build the CodeBlock, panicking on error.
-    pub fn build_unwrap(self) -> CodeBlock<L> {
+    pub fn build_unwrap(self) -> CodeBlock {
         self.build().unwrap()
     }
 }
 
-impl<L: CodeLang> Default for CodeBlockBuilder<L> {
+impl Default for CodeBlockBuilder {
     fn default() -> Self {
         Self::new()
     }
@@ -395,54 +405,54 @@ fn parse_format(format: &str) -> Result<Vec<FormatPart>, crate::error::SigilStit
 
 // === IntoArgs trait and implementations ===
 
-/// Trait for converting various types into a `Vec<Arg<L>>` for format strings.
+/// Trait for converting various types into a `Vec<Arg>` for format strings.
 ///
 /// Implemented for `()` (no args), `TypeName`, `&str`, `String`, `CodeBlock`,
-/// `NameArg`, `StringLitArg`, `Vec<Arg<L>>`, and tuples up to 8 elements.
+/// `NameArg`, `StringLitArg`, `Vec<Arg>`, and tuples up to 8 elements.
 /// Bare strings convert to `Arg::Literal`; use [`NameArg`] or [`StringLitArg`]
 /// wrappers to target `%N` or `%S` specifiers instead.
-pub trait IntoArgs<L: CodeLang> {
+pub trait IntoArgs {
     /// Convert into a vector of format arguments.
-    fn into_args(self) -> Vec<Arg<L>>;
+    fn into_args(self) -> Vec<Arg>;
 }
 
 /// Empty args (for format strings with no specifiers).
-impl<L: CodeLang> IntoArgs<L> for () {
-    fn into_args(self) -> Vec<Arg<L>> {
+impl IntoArgs for () {
+    fn into_args(self) -> Vec<Arg> {
         Vec::new()
     }
 }
 
 /// Single TypeName arg.
-impl<L: CodeLang> IntoArgs<L> for TypeName<L> {
-    fn into_args(self) -> Vec<Arg<L>> {
+impl IntoArgs for TypeName {
+    fn into_args(self) -> Vec<Arg> {
         vec![Arg::TypeName(self)]
     }
 }
 
 /// Single string arg (as literal).
-impl<L: CodeLang> IntoArgs<L> for &str {
-    fn into_args(self) -> Vec<Arg<L>> {
+impl IntoArgs for &str {
+    fn into_args(self) -> Vec<Arg> {
         vec![Arg::Literal(self.to_string())]
     }
 }
 
-impl<L: CodeLang> IntoArgs<L> for String {
-    fn into_args(self) -> Vec<Arg<L>> {
+impl IntoArgs for String {
+    fn into_args(self) -> Vec<Arg> {
         vec![Arg::Literal(self)]
     }
 }
 
 /// Single CodeBlock arg.
-impl<L: CodeLang> IntoArgs<L> for CodeBlock<L> {
-    fn into_args(self) -> Vec<Arg<L>> {
+impl IntoArgs for CodeBlock {
+    fn into_args(self) -> Vec<Arg> {
         vec![Arg::Code(self)]
     }
 }
 
 /// Pre-built args vector (used by specs that dynamically build format strings).
-impl<L: CodeLang> IntoArgs<L> for Vec<Arg<L>> {
-    fn into_args(self) -> Vec<Arg<L>> {
+impl IntoArgs for Vec<Arg> {
+    fn into_args(self) -> Vec<Arg> {
         self
     }
 }
@@ -458,14 +468,14 @@ impl<L: CodeLang> IntoArgs<L> for Vec<Arg<L>> {
 /// use sigil_stitch::code_block::{CodeBlock, NameArg};
 /// use sigil_stitch::lang::typescript::TypeScript;
 ///
-/// let mut cb = CodeBlock::<TypeScript>::builder();
+/// let mut cb = CodeBlock::builder();
 /// cb.add("this.%N()", (NameArg("getData".to_string()),));
 /// let block = cb.build().unwrap();
 /// ```
 pub struct NameArg(pub String);
 
-impl<L: CodeLang> IntoArgs<L> for NameArg {
-    fn into_args(self) -> Vec<Arg<L>> {
+impl IntoArgs for NameArg {
+    fn into_args(self) -> Vec<Arg> {
         vec![Arg::Name(self.0)]
     }
 }
@@ -481,62 +491,62 @@ impl<L: CodeLang> IntoArgs<L> for NameArg {
 /// use sigil_stitch::code_block::{CodeBlock, StringLitArg};
 /// use sigil_stitch::lang::typescript::TypeScript;
 ///
-/// let mut cb = CodeBlock::<TypeScript>::builder();
+/// let mut cb = CodeBlock::builder();
 /// cb.add_statement("const msg = %S", (StringLitArg("hello".to_string()),));
 /// let block = cb.build().unwrap();
 /// ```
 pub struct StringLitArg(pub String);
 
-impl<L: CodeLang> IntoArgs<L> for StringLitArg {
-    fn into_args(self) -> Vec<Arg<L>> {
+impl IntoArgs for StringLitArg {
+    fn into_args(self) -> Vec<Arg> {
         vec![Arg::StringLit(self.0)]
     }
 }
 
 // Individual Arg conversions.
-impl<L: CodeLang> From<TypeName<L>> for Arg<L> {
-    fn from(tn: TypeName<L>) -> Self {
+impl From<TypeName> for Arg {
+    fn from(tn: TypeName) -> Self {
         Arg::TypeName(tn)
     }
 }
 
-impl<L: CodeLang> From<&str> for Arg<L> {
+impl From<&str> for Arg {
     fn from(s: &str) -> Self {
         Arg::Literal(s.to_string())
     }
 }
 
-impl<L: CodeLang> From<String> for Arg<L> {
+impl From<String> for Arg {
     fn from(s: String) -> Self {
         Arg::Literal(s)
     }
 }
 
-impl<L: CodeLang> From<CodeBlock<L>> for Arg<L> {
-    fn from(cb: CodeBlock<L>) -> Self {
+impl From<CodeBlock> for Arg {
+    fn from(cb: CodeBlock) -> Self {
         Arg::Code(cb)
     }
 }
 
-impl<L: CodeLang> From<NameArg> for Arg<L> {
+impl From<NameArg> for Arg {
     fn from(n: NameArg) -> Self {
         Arg::Name(n.0)
     }
 }
 
-impl<L: CodeLang> From<StringLitArg> for Arg<L> {
+impl From<StringLitArg> for Arg {
     fn from(s: StringLitArg) -> Self {
         Arg::StringLit(s.0)
     }
 }
 
 // Tuple implementations for IntoArgs.
-// Each element must implement Into<Arg<L>>.
+// Each element must implement Into<Arg>.
 
 macro_rules! impl_into_args_tuple {
     ($($idx:tt $T:ident),+) => {
-        impl<L: CodeLang, $($T: Into<Arg<L>>),+> IntoArgs<L> for ($($T,)+) {
-            fn into_args(self) -> Vec<Arg<L>> {
+        impl<$($T: Into<Arg>),+> IntoArgs for ($($T,)+) {
+            fn into_args(self) -> Vec<Arg> {
                 vec![$(self.$idx.into()),+]
             }
         }
@@ -555,7 +565,6 @@ impl_into_args_tuple!(0 A, 1 B, 2 C, 3 D, 4 E, 5 F, 6 G, 7 H);
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::lang::typescript::TypeScript;
 
     #[test]
     fn test_parse_all_specifiers() {
@@ -598,7 +607,7 @@ mod tests {
 
     #[test]
     fn test_builder_add_statement() {
-        let mut b = CodeBlock::<TypeScript>::builder();
+        let mut b = CodeBlock::builder();
         b.add_statement("const x = %L", "42");
         let block = b.build().unwrap();
 
@@ -609,7 +618,7 @@ mod tests {
 
     #[test]
     fn test_builder_control_flow() {
-        let mut b = CodeBlock::<TypeScript>::builder();
+        let mut b = CodeBlock::builder();
         b.begin_control_flow("if (x > 0)", ());
         b.add_statement("return x", ());
         b.end_control_flow();
@@ -620,7 +629,7 @@ mod tests {
 
     #[test]
     fn test_builder_unbalanced_control_flow() {
-        let mut b = CodeBlock::<TypeScript>::builder();
+        let mut b = CodeBlock::builder();
         b.begin_control_flow("if (x)", ());
         b.add_statement("y()", ());
         // missing end_control_flow
@@ -631,7 +640,7 @@ mod tests {
 
     #[test]
     fn test_mismatched_arg_count() {
-        let mut b = CodeBlock::<TypeScript>::builder();
+        let mut b = CodeBlock::builder();
         b.add("%T", ());
         let result = b.build();
         assert!(result.is_err());
@@ -645,8 +654,8 @@ mod tests {
 
     #[test]
     fn test_into_args_tuple() {
-        let user = TypeName::<TypeScript>::importable("./models", "User");
-        let args: Vec<Arg<TypeScript>> = (user, "hello").into_args();
+        let user = TypeName::importable("./models", "User");
+        let args: Vec<Arg> = (user, "hello").into_args();
         assert_eq!(args.len(), 2);
         assert!(matches!(&args[0], Arg::TypeName(_)));
         assert!(matches!(&args[1], Arg::Literal(s) if s == "hello"));
@@ -654,23 +663,23 @@ mod tests {
 
     #[test]
     fn test_into_args_single_typename() {
-        let user = TypeName::<TypeScript>::importable("./models", "User");
-        let args: Vec<Arg<TypeScript>> = user.into_args();
+        let user = TypeName::importable("./models", "User");
+        let args: Vec<Arg> = user.into_args();
         assert_eq!(args.len(), 1);
     }
 
     #[test]
     fn test_into_args_single_str() {
-        let args: Vec<Arg<TypeScript>> = "hello".into_args();
+        let args: Vec<Arg> = "hello".into_args();
         assert_eq!(args.len(), 1);
         assert!(matches!(&args[0], Arg::Literal(s) if s == "hello"));
     }
 
     #[test]
     fn test_collect_imports_from_codeblock() {
-        let user = TypeName::<TypeScript>::importable("./models", "User");
-        let tag = TypeName::<TypeScript>::importable("./models", "Tag");
-        let mut b = CodeBlock::<TypeScript>::builder();
+        let user = TypeName::importable("./models", "User");
+        let tag = TypeName::importable("./models", "Tag");
+        let mut b = CodeBlock::builder();
         b.add_statement("const u: %T = getUser()", (user,));
         b.add_statement("const t: %T = getTag()", (tag,));
         let block = b.build().unwrap();
@@ -684,12 +693,12 @@ mod tests {
 
     #[test]
     fn test_nested_codeblock_imports() {
-        let user = TypeName::<TypeScript>::importable("./models", "User");
-        let mut ib = CodeBlock::<TypeScript>::builder();
+        let user = TypeName::importable("./models", "User");
+        let mut ib = CodeBlock::builder();
         ib.add_statement("return new %T()", (user,));
         let inner = ib.build().unwrap();
 
-        let mut ob = CodeBlock::<TypeScript>::builder();
+        let mut ob = CodeBlock::builder();
         ob.add_code(inner);
         let outer = ob.build().unwrap();
 
@@ -701,7 +710,7 @@ mod tests {
 
     #[test]
     fn test_name_arg() {
-        let mut b = CodeBlock::<TypeScript>::builder();
+        let mut b = CodeBlock::builder();
         b.add("this.%N()", (NameArg("getUser".to_string()),));
         let block = b.build().unwrap();
         assert_eq!(block.args.len(), 1);
@@ -710,7 +719,7 @@ mod tests {
 
     #[test]
     fn test_string_lit_arg() {
-        let mut b = CodeBlock::<TypeScript>::builder();
+        let mut b = CodeBlock::builder();
         b.add("const x = %S", (StringLitArg("hello".to_string()),));
         let block = b.build().unwrap();
         assert_eq!(block.args.len(), 1);
@@ -719,7 +728,7 @@ mod tests {
 
     #[test]
     fn test_invalid_format_specifier() {
-        let mut b = CodeBlock::<TypeScript>::builder();
+        let mut b = CodeBlock::builder();
         b.add("hello %X world", ());
         let result = b.build();
         assert!(result.is_err());
@@ -739,8 +748,8 @@ mod tests {
 
     #[test]
     fn test_mismatched_arg_count_includes_specifiers_and_kinds() {
-        let user = TypeName::<TypeScript>::importable("./models", "User");
-        let mut b = CodeBlock::<TypeScript>::builder();
+        let user = TypeName::importable("./models", "User");
+        let mut b = CodeBlock::builder();
         b.add("%T %S %L", (user,));
         let result = b.build();
         assert!(result.is_err());
@@ -754,7 +763,7 @@ mod tests {
 
     #[test]
     fn test_begin_control_flow_with_open_non_empty() {
-        let mut b = CodeBlock::<TypeScript>::builder();
+        let mut b = CodeBlock::builder();
         b.begin_control_flow_with_open("class Functor f", (), " where");
         b.add_statement("fmap :: (a -> b) -> f a -> f b", ());
         b.end_control_flow();
@@ -776,7 +785,7 @@ mod tests {
 
     #[test]
     fn test_begin_control_flow_with_open_empty() {
-        let mut b = CodeBlock::<TypeScript>::builder();
+        let mut b = CodeBlock::builder();
         b.begin_control_flow_with_open("match x with", (), "");
         b.add("| Red -> red", ());
         b.add_line();

--- a/src/code_node.rs
+++ b/src/code_node.rs
@@ -1,0 +1,226 @@
+//! Tree-based intermediate representation for code generation.
+//!
+//! `CodeNode` is the internal IR used by [`CodeBlock`](crate::code_block::CodeBlock).
+//! Each node is self-contained — type references, names, and nested blocks are
+//! stored inline rather than in a separate argument vector. This enables natural
+//! tree traversal for import collection, structural transformation, and rendering.
+
+use crate::code_block::{Arg, CodeBlock, FormatPart};
+use crate::type_name::TypeName;
+
+/// A single node in the code generation tree.
+///
+/// Each variant is self-contained: a type reference is `CodeNode::TypeRef(TypeName)`,
+/// not a separate format tag plus a positional argument.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[non_exhaustive]
+pub enum CodeNode {
+    /// Literal text (no interpolation).
+    Literal(String),
+    /// A type reference with import tracking (was `%T` + `Arg::TypeName`).
+    TypeRef(TypeName),
+    /// A name identifier (was `%N` + `Arg::Name`).
+    NameRef(String),
+    /// A string literal value, rendered with language-specific quoting
+    /// (was `%S` + `Arg::StringLit`).
+    StringLit(String),
+    /// An inline literal string (was `%L` + `Arg::Literal`).
+    InlineLiteral(String),
+    /// A nested code block (was `%L` + `Arg::Code`).
+    Nested(CodeBlock),
+    /// A comment line. Rendered as `{prefix} {text}{suffix}` using the
+    /// language's comment syntax.
+    Comment(String),
+    /// Soft line break point (`%W`). In direct mode emits a space; in pretty
+    /// mode becomes `BoxDoc::softline()`.
+    SoftBreak,
+    /// Increase indent level (`%>`).
+    Indent,
+    /// Decrease indent level (`%<`).
+    Dedent,
+    /// Statement begin marker (`%[`). Triggers `ensure_indent()`.
+    StatementBegin,
+    /// Statement end marker (`%]`). Emits `;` if the language uses semicolons.
+    StatementEnd,
+    /// Hard newline.
+    Newline,
+    /// Block open delimiter, resolved at render time via `lang.block_syntax().block_open`.
+    BlockOpen,
+    /// Block open with an overridden delimiter string.
+    BlockOpenOverride(String),
+    /// Terminal block close delimiter, resolved via `lang.block_syntax().block_close`.
+    BlockClose,
+    /// Transitional block close delimiter (e.g. `} else`), resolved via
+    /// `lang.block_syntax().block_close` + `" "`.
+    BlockCloseTransition,
+    /// A sequence of nodes (for grouping, e.g. a statement or control flow block).
+    Sequence(Vec<CodeNode>),
+}
+
+/// Convert legacy `(FormatPart, Arg)` parallel vectors into `Vec<CodeNode>`.
+///
+/// Used by `CodeBlockBuilder::add()` which still calls `parse_format()` to get
+/// `Vec<FormatPart>`, then zips with args into self-contained nodes.
+pub(crate) fn parts_args_to_nodes(parts: &[FormatPart], args: &[Arg]) -> Vec<CodeNode> {
+    let mut nodes = Vec::with_capacity(parts.len());
+    let mut arg_index = 0;
+
+    for part in parts {
+        let node = match part {
+            FormatPart::Literal(text) => CodeNode::Literal(text.clone()),
+            FormatPart::Type => {
+                let arg = &args[arg_index];
+                arg_index += 1;
+                match arg {
+                    Arg::TypeName(tn) => CodeNode::TypeRef(tn.clone()),
+                    _ => CodeNode::Literal(String::new()),
+                }
+            }
+            FormatPart::Name => {
+                let arg = &args[arg_index];
+                arg_index += 1;
+                match arg {
+                    Arg::Name(n) => CodeNode::NameRef(n.clone()),
+                    _ => CodeNode::Literal(String::new()),
+                }
+            }
+            FormatPart::StringLit => {
+                let arg = &args[arg_index];
+                arg_index += 1;
+                match arg {
+                    Arg::StringLit(s) => CodeNode::StringLit(s.clone()),
+                    _ => CodeNode::Literal(String::new()),
+                }
+            }
+            FormatPart::Literal_ => {
+                let arg = &args[arg_index];
+                arg_index += 1;
+                match arg {
+                    Arg::Literal(s) => CodeNode::InlineLiteral(s.clone()),
+                    Arg::Code(block) => CodeNode::Nested(block.clone()),
+                    _ => CodeNode::Literal(String::new()),
+                }
+            }
+            FormatPart::Wrap => CodeNode::SoftBreak,
+            FormatPart::Indent => CodeNode::Indent,
+            FormatPart::Dedent => CodeNode::Dedent,
+            FormatPart::StatementBegin => CodeNode::StatementBegin,
+            FormatPart::StatementEnd => CodeNode::StatementEnd,
+            FormatPart::Newline => CodeNode::Newline,
+            FormatPart::BlockOpen => CodeNode::BlockOpen,
+            FormatPart::BlockOpenOverride(s) => CodeNode::BlockOpenOverride(s.clone()),
+            FormatPart::BlockClose => CodeNode::BlockClose,
+            FormatPart::BlockCloseTransition => CodeNode::BlockCloseTransition,
+        };
+        nodes.push(node);
+    }
+
+    nodes
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::code_block::CodeBlock;
+    use crate::type_name::TypeName;
+
+    #[test]
+    fn test_literal_conversion() {
+        let parts = vec![FormatPart::Literal("hello".to_string())];
+        let args = vec![];
+        let nodes = parts_args_to_nodes(&parts, &args);
+        assert_eq!(nodes.len(), 1);
+        assert!(matches!(&nodes[0], CodeNode::Literal(s) if s == "hello"));
+    }
+
+    #[test]
+    fn test_type_ref_conversion() {
+        let tn = TypeName::primitive("string");
+        let parts = vec![FormatPart::Literal("x: ".to_string()), FormatPart::Type];
+        let args = vec![Arg::TypeName(tn)];
+        let nodes = parts_args_to_nodes(&parts, &args);
+        assert_eq!(nodes.len(), 2);
+        assert!(matches!(&nodes[0], CodeNode::Literal(s) if s == "x: "));
+        assert!(matches!(&nodes[1], CodeNode::TypeRef(_)));
+    }
+
+    #[test]
+    fn test_nested_block_conversion() {
+        let inner = CodeBlock::of("inner()", ()).unwrap();
+        let parts = vec![FormatPart::Literal_];
+        let args = vec![Arg::Code(inner)];
+        let nodes = parts_args_to_nodes(&parts, &args);
+        assert_eq!(nodes.len(), 1);
+        assert!(matches!(&nodes[0], CodeNode::Nested(_)));
+    }
+
+    #[test]
+    fn test_structural_nodes() {
+        let parts = vec![
+            FormatPart::Indent,
+            FormatPart::StatementBegin,
+            FormatPart::Literal("x".to_string()),
+            FormatPart::StatementEnd,
+            FormatPart::Newline,
+            FormatPart::Dedent,
+        ];
+        let nodes = parts_args_to_nodes(&parts, &[]);
+        assert_eq!(nodes.len(), 6);
+        assert!(matches!(nodes[0], CodeNode::Indent));
+        assert!(matches!(nodes[1], CodeNode::StatementBegin));
+        assert!(matches!(nodes[3], CodeNode::StatementEnd));
+        assert!(matches!(nodes[4], CodeNode::Newline));
+        assert!(matches!(nodes[5], CodeNode::Dedent));
+    }
+
+    #[test]
+    fn test_soft_break_conversion() {
+        let parts = vec![
+            FormatPart::Literal("a".to_string()),
+            FormatPart::Wrap,
+            FormatPart::Literal("b".to_string()),
+        ];
+        let nodes = parts_args_to_nodes(&parts, &[]);
+        assert_eq!(nodes.len(), 3);
+        assert!(matches!(nodes[1], CodeNode::SoftBreak));
+    }
+
+    #[test]
+    fn test_block_open_close_conversion() {
+        let parts = vec![
+            FormatPart::BlockOpen,
+            FormatPart::BlockClose,
+            FormatPart::BlockOpenOverride("where".to_string()),
+            FormatPart::BlockCloseTransition,
+        ];
+        let nodes = parts_args_to_nodes(&parts, &[]);
+        assert_eq!(nodes.len(), 4);
+        assert!(matches!(nodes[0], CodeNode::BlockOpen));
+        assert!(matches!(nodes[1], CodeNode::BlockClose));
+        assert!(matches!(&nodes[2], CodeNode::BlockOpenOverride(s) if s == "where"));
+        assert!(matches!(nodes[3], CodeNode::BlockCloseTransition));
+    }
+
+    #[test]
+    fn test_mixed_args_conversion() {
+        let tn = TypeName::primitive("number");
+        let parts = vec![
+            FormatPart::Literal("let ".to_string()),
+            FormatPart::Name,
+            FormatPart::Literal(": ".to_string()),
+            FormatPart::Type,
+            FormatPart::Literal(" = ".to_string()),
+            FormatPart::StringLit,
+        ];
+        let args = vec![
+            Arg::Name("x".to_string()),
+            Arg::TypeName(tn),
+            Arg::StringLit("hello".to_string()),
+        ];
+        let nodes = parts_args_to_nodes(&parts, &args);
+        assert_eq!(nodes.len(), 6);
+        assert!(matches!(&nodes[1], CodeNode::NameRef(s) if s == "x"));
+        assert!(matches!(&nodes[3], CodeNode::TypeRef(_)));
+        assert!(matches!(&nodes[5], CodeNode::StringLit(s) if s == "hello"));
+    }
+}

--- a/src/code_renderer.rs
+++ b/src/code_renderer.rs
@@ -166,7 +166,7 @@ impl<'a> CodeRenderer<'a> {
                     self.ensure_indent();
                 }
                 FormatPart::StatementEnd => {
-                    if self.lang.uses_semicolons() {
+                    if self.lang.block_syntax().uses_semicolons {
                         self.emit(";");
                     }
                 }
@@ -174,13 +174,13 @@ impl<'a> CodeRenderer<'a> {
                     self.emit_newline();
                 }
                 FormatPart::BlockOpen => {
-                    self.emit(self.lang.block_open());
+                    self.emit(self.lang.block_syntax().block_open);
                 }
                 FormatPart::BlockOpenOverride(s) => {
                     self.emit(s);
                 }
                 FormatPart::BlockClose => {
-                    let close = self.lang.block_close();
+                    let close = self.lang.block_syntax().block_close;
                     if !close.is_empty() {
                         self.ensure_indent();
                         self.emit(close);
@@ -188,7 +188,7 @@ impl<'a> CodeRenderer<'a> {
                     }
                 }
                 FormatPart::BlockCloseTransition => {
-                    let close = self.lang.block_close();
+                    let close = self.lang.block_syntax().block_close;
                     if !close.is_empty() {
                         self.ensure_indent();
                         self.emit(close);
@@ -306,17 +306,19 @@ impl<'a> CodeRenderer<'a> {
                 }
                 FormatPart::StatementBegin => BoxDoc::nil(),
                 FormatPart::StatementEnd => {
-                    if self.lang.uses_semicolons() {
+                    if self.lang.block_syntax().uses_semicolons {
                         BoxDoc::text(";")
                     } else {
                         BoxDoc::nil()
                     }
                 }
                 FormatPart::Newline => BoxDoc::hardline(),
-                FormatPart::BlockOpen => BoxDoc::text(self.lang.block_open().to_string()),
+                FormatPart::BlockOpen => {
+                    BoxDoc::text(self.lang.block_syntax().block_open.to_string())
+                }
                 FormatPart::BlockOpenOverride(s) => BoxDoc::text(s.clone()),
                 FormatPart::BlockClose => {
-                    let close = self.lang.block_close();
+                    let close = self.lang.block_syntax().block_close;
                     if close.is_empty() {
                         BoxDoc::nil()
                     } else {
@@ -324,7 +326,7 @@ impl<'a> CodeRenderer<'a> {
                     }
                 }
                 FormatPart::BlockCloseTransition => {
-                    let close = self.lang.block_close();
+                    let close = self.lang.block_syntax().block_close;
                     if close.is_empty() {
                         BoxDoc::nil()
                     } else {
@@ -360,7 +362,7 @@ impl<'a> CodeRenderer<'a> {
 
     fn ensure_indent(&mut self) {
         if self.at_line_start {
-            let indent_str = self.lang.indent_unit();
+            let indent_str = self.lang.block_syntax().indent_unit;
             for _ in 0..self.indent_level {
                 self.output.push_str(indent_str);
                 self.current_column += indent_str.len();

--- a/src/code_renderer.rs
+++ b/src/code_renderer.rs
@@ -1,6 +1,7 @@
 use pretty::BoxDoc;
 
-use crate::code_block::{Arg, CodeBlock, FormatPart};
+use crate::code_block::CodeBlock;
+use crate::code_node::CodeNode;
 use crate::error::SigilStitchError;
 use crate::import::ImportGroup;
 use crate::lang::CodeLang;
@@ -38,148 +39,113 @@ impl<'a> CodeRenderer<'a> {
 
     /// Render a CodeBlock to string.
     pub fn render(&mut self, block: &CodeBlock) -> Result<String, SigilStitchError> {
-        let mut arg_index = 0;
-        self.render_parts(&block.parts, &block.args, &mut arg_index)?;
+        self.render_nodes(&block.nodes)?;
         Ok(std::mem::take(&mut self.output))
     }
 
-    fn render_parts(
-        &mut self,
-        parts: &[FormatPart],
-        args: &[Arg],
-        arg_index: &mut usize,
-    ) -> Result<(), SigilStitchError> {
-        // Check if this sequence of parts contains any %W (soft breaks).
-        // If so, we build the whole thing as a BoxDoc and let pretty decide.
-        let has_wrap = parts.iter().any(|p| matches!(p, FormatPart::Wrap));
-
-        if has_wrap {
-            self.render_with_pretty(parts, args, arg_index)
+    fn render_nodes(&mut self, nodes: &[CodeNode]) -> Result<(), SigilStitchError> {
+        if contains_soft_break(nodes) {
+            self.render_nodes_pretty(nodes)
         } else {
-            self.render_direct(parts, args, arg_index)
+            self.render_nodes_direct(nodes)
         }
     }
 
-    /// Direct string rendering (no %W in this segment).
-    fn render_direct(
-        &mut self,
-        parts: &[FormatPart],
-        args: &[Arg],
-        arg_index: &mut usize,
-    ) -> Result<(), SigilStitchError> {
-        for part in parts {
-            match part {
-                FormatPart::Literal(text) => {
-                    if let Some(comment_text) = text.strip_prefix("__COMMENT__") {
-                        self.ensure_indent();
-                        let prefix = self.lang.line_comment_prefix();
-                        let suffix = self.lang.line_comment_suffix();
-                        self.emit(&format!("{prefix} {comment_text}{suffix}"));
-                    } else {
-                        self.emit_possibly_multiline(text);
-                    }
+    fn resolve_type_doc(&self, tn: &crate::type_name::TypeName) -> BoxDoc<'static, ()> {
+        let lang = self.lang;
+        let resolve = |module: &str, name: &str| -> String {
+            let resolved = self
+                .imports
+                .resolved_name(module, name)
+                .unwrap_or(name)
+                .to_string();
+            lang.qualify_import_name(module, &resolved)
+        };
+        tn.to_doc_with_lang(&resolve, self.lang)
+    }
+
+    /// Direct string rendering (no SoftBreak in this segment).
+    fn render_nodes_direct(&mut self, nodes: &[CodeNode]) -> Result<(), SigilStitchError> {
+        for node in nodes {
+            match node {
+                CodeNode::Literal(text) => {
+                    self.emit_possibly_multiline(text);
                 }
-                FormatPart::Type => {
-                    let arg = &args[*arg_index];
-                    *arg_index += 1;
-                    if let Arg::TypeName(tn) = arg {
-                        self.ensure_indent();
-                        let remaining_width = self.width.saturating_sub(self.current_column);
-                        let lang = self.lang;
-                        let resolve = |module: &str, name: &str| -> String {
-                            let resolved = self
-                                .imports
-                                .resolved_name(module, name)
-                                .unwrap_or(name)
-                                .to_string();
-                            lang.qualify_import_name(module, &resolved)
-                        };
-                        let doc = tn.to_doc_with_lang(&resolve, self.lang);
-                        let mut buf = Vec::new();
-                        doc.render(remaining_width, &mut buf).map_err(|e| {
-                            SigilStitchError::Render {
-                                context: "CodeRenderer::render_direct %T".to_string(),
-                                message: e.to_string(),
-                            }
+                CodeNode::TypeRef(tn) => {
+                    self.ensure_indent();
+                    let remaining_width = self.width.saturating_sub(self.current_column);
+                    let doc = self.resolve_type_doc(tn);
+                    let mut buf = Vec::new();
+                    doc.render(remaining_width, &mut buf).map_err(|e| {
+                        SigilStitchError::Render {
+                            context: "CodeRenderer::render_nodes_direct TypeRef".to_string(),
+                            message: e.to_string(),
+                        }
+                    })?;
+                    let rendered =
+                        String::from_utf8(buf).map_err(|e| SigilStitchError::Render {
+                            context: "CodeRenderer::render_nodes_direct TypeRef UTF-8".to_string(),
+                            message: e.to_string(),
                         })?;
-                        let rendered =
-                            String::from_utf8(buf).map_err(|e| SigilStitchError::Render {
-                                context: "CodeRenderer::render_direct %T UTF-8".to_string(),
-                                message: e.to_string(),
-                            })?;
-                        // Handle multi-line output: indent continuation lines.
-                        let lines: Vec<&str> = rendered.split('\n').collect();
-                        for (i, line) in lines.iter().enumerate() {
-                            if i > 0 {
-                                self.emit_newline();
-                                self.ensure_indent();
-                                // Add continuation indent to align with first line.
-                                let padding = " ".repeat(self.current_column);
-                                self.emit(&padding);
-                            }
-                            self.emit(line);
+                    let lines: Vec<&str> = rendered.split('\n').collect();
+                    for (i, line) in lines.iter().enumerate() {
+                        if i > 0 {
+                            self.emit_newline();
+                            self.ensure_indent();
+                            let padding = " ".repeat(self.current_column);
+                            self.emit(&padding);
                         }
+                        self.emit(line);
                     }
                 }
-                FormatPart::Name => {
-                    let arg = &args[*arg_index];
-                    *arg_index += 1;
-                    if let Arg::Name(name) = arg {
-                        self.ensure_indent();
-                        self.emit(name);
-                    }
+                CodeNode::NameRef(name) => {
+                    self.ensure_indent();
+                    self.emit(name);
                 }
-                FormatPart::StringLit => {
-                    let arg = &args[*arg_index];
-                    *arg_index += 1;
-                    if let Arg::StringLit(s) = arg {
-                        self.ensure_indent();
-                        let rendered = self.lang.render_string_literal(s);
-                        self.emit(&rendered);
-                    }
+                CodeNode::StringLit(s) => {
+                    self.ensure_indent();
+                    let rendered = self.lang.render_string_literal(s);
+                    self.emit(&rendered);
                 }
-                FormatPart::Literal_ => {
-                    let arg = &args[*arg_index];
-                    *arg_index += 1;
-                    match arg {
-                        Arg::Literal(s) => {
-                            self.emit_possibly_multiline(s);
-                        }
-                        Arg::Code(block) => {
-                            let mut inner_idx = 0;
-                            self.render_parts(&block.parts, &block.args, &mut inner_idx)?;
-                        }
-                        _ => {}
-                    }
+                CodeNode::InlineLiteral(s) => {
+                    self.emit_possibly_multiline(s);
                 }
-                FormatPart::Wrap => {
-                    // Should not reach here in direct mode, but just emit a space.
+                CodeNode::Nested(block) => {
+                    self.render_nodes(&block.nodes)?;
+                }
+                CodeNode::Comment(text) => {
+                    self.ensure_indent();
+                    let prefix = self.lang.line_comment_prefix();
+                    let suffix = self.lang.line_comment_suffix();
+                    self.emit(&format!("{prefix} {text}{suffix}"));
+                }
+                CodeNode::SoftBreak => {
                     self.emit(" ");
                 }
-                FormatPart::Indent => {
+                CodeNode::Indent => {
                     self.indent_level += 1;
                 }
-                FormatPart::Dedent => {
+                CodeNode::Dedent => {
                     self.indent_level = self.indent_level.saturating_sub(1);
                 }
-                FormatPart::StatementBegin => {
+                CodeNode::StatementBegin => {
                     self.ensure_indent();
                 }
-                FormatPart::StatementEnd => {
+                CodeNode::StatementEnd => {
                     if self.lang.block_syntax().uses_semicolons {
                         self.emit(";");
                     }
                 }
-                FormatPart::Newline => {
+                CodeNode::Newline => {
                     self.emit_newline();
                 }
-                FormatPart::BlockOpen => {
+                CodeNode::BlockOpen => {
                     self.emit(self.lang.block_syntax().block_open);
                 }
-                FormatPart::BlockOpenOverride(s) => {
+                CodeNode::BlockOpenOverride(s) => {
                     self.emit(s);
                 }
-                FormatPart::BlockClose => {
+                CodeNode::BlockClose => {
                     let close = self.lang.block_syntax().block_close;
                     if !close.is_empty() {
                         self.ensure_indent();
@@ -187,7 +153,7 @@ impl<'a> CodeRenderer<'a> {
                         self.emit_newline();
                     }
                 }
-                FormatPart::BlockCloseTransition => {
+                CodeNode::BlockCloseTransition => {
                     let close = self.lang.block_syntax().block_close;
                     if !close.is_empty() {
                         self.ensure_indent();
@@ -195,29 +161,26 @@ impl<'a> CodeRenderer<'a> {
                         self.emit(" ");
                     }
                 }
+                CodeNode::Sequence(children) => {
+                    self.render_nodes(children)?;
+                }
             }
         }
         Ok(())
     }
 
-    /// Render a segment containing %W using the pretty crate.
-    fn render_with_pretty(
-        &mut self,
-        parts: &[FormatPart],
-        args: &[Arg],
-        arg_index: &mut usize,
-    ) -> Result<(), SigilStitchError> {
-        // Build a BoxDoc from the parts, using softline() for %W.
-        let doc = self.build_doc_from_parts(parts, args, arg_index);
+    /// Render a segment containing SoftBreak using the pretty crate.
+    fn render_nodes_pretty(&mut self, nodes: &[CodeNode]) -> Result<(), SigilStitchError> {
+        let doc = self.nodes_to_doc(nodes);
         let remaining_width = self.width.saturating_sub(self.current_column);
         let mut buf = Vec::new();
         doc.render(remaining_width, &mut buf)
             .map_err(|e| SigilStitchError::Render {
-                context: "CodeRenderer::render_with_pretty".to_string(),
+                context: "CodeRenderer::render_nodes_pretty".to_string(),
                 message: e.to_string(),
             })?;
         let rendered = String::from_utf8(buf).map_err(|e| SigilStitchError::Render {
-            context: "CodeRenderer::render_with_pretty UTF-8".to_string(),
+            context: "CodeRenderer::render_nodes_pretty UTF-8".to_string(),
             message: e.to_string(),
         })?;
 
@@ -232,92 +195,38 @@ impl<'a> CodeRenderer<'a> {
         Ok(())
     }
 
-    fn build_doc_from_parts(
-        &self,
-        parts: &[FormatPart],
-        args: &[Arg],
-        arg_index: &mut usize,
-    ) -> BoxDoc<'static, ()> {
+    fn nodes_to_doc(&self, nodes: &[CodeNode]) -> BoxDoc<'static, ()> {
         let mut doc = BoxDoc::nil();
 
-        for part in parts {
-            let part_doc = match part {
-                FormatPart::Literal(text) => {
-                    if let Some(comment_text) = text.strip_prefix("__COMMENT__") {
-                        let prefix = self.lang.line_comment_prefix();
-                        let suffix = self.lang.line_comment_suffix();
-                        BoxDoc::text(format!("{prefix} {comment_text}{suffix}"))
-                    } else {
-                        BoxDoc::text(text.clone())
-                    }
+        for node in nodes {
+            let node_doc = match node {
+                CodeNode::Literal(text) => BoxDoc::text(text.clone()),
+                CodeNode::TypeRef(tn) => self.resolve_type_doc(tn),
+                CodeNode::NameRef(name) => BoxDoc::text(name.clone()),
+                CodeNode::StringLit(s) => BoxDoc::text(self.lang.render_string_literal(s)),
+                CodeNode::InlineLiteral(s) => BoxDoc::text(s.clone()),
+                CodeNode::Nested(block) => self.nodes_to_doc(&block.nodes),
+                CodeNode::Comment(text) => {
+                    let prefix = self.lang.line_comment_prefix();
+                    let suffix = self.lang.line_comment_suffix();
+                    BoxDoc::text(format!("{prefix} {text}{suffix}"))
                 }
-                FormatPart::Type => {
-                    let arg = &args[*arg_index];
-                    *arg_index += 1;
-                    if let Arg::TypeName(tn) = arg {
-                        let lang = self.lang;
-                        let resolve = |module: &str, name: &str| -> String {
-                            let resolved = self
-                                .imports
-                                .resolved_name(module, name)
-                                .unwrap_or(name)
-                                .to_string();
-                            lang.qualify_import_name(module, &resolved)
-                        };
-                        tn.to_doc_with_lang(&resolve, self.lang)
-                    } else {
-                        BoxDoc::nil()
-                    }
-                }
-                FormatPart::Name => {
-                    let arg = &args[*arg_index];
-                    *arg_index += 1;
-                    if let Arg::Name(name) = arg {
-                        BoxDoc::text(name.clone())
-                    } else {
-                        BoxDoc::nil()
-                    }
-                }
-                FormatPart::StringLit => {
-                    let arg = &args[*arg_index];
-                    *arg_index += 1;
-                    if let Arg::StringLit(s) = arg {
-                        BoxDoc::text(self.lang.render_string_literal(s))
-                    } else {
-                        BoxDoc::nil()
-                    }
-                }
-                FormatPart::Literal_ => {
-                    let arg = &args[*arg_index];
-                    *arg_index += 1;
-                    match arg {
-                        Arg::Literal(s) => BoxDoc::text(s.clone()),
-                        Arg::Code(block) => {
-                            let mut inner_idx = 0;
-                            self.build_doc_from_parts(&block.parts, &block.args, &mut inner_idx)
-                        }
-                        _ => BoxDoc::nil(),
-                    }
-                }
-                FormatPart::Wrap => BoxDoc::softline(),
-                FormatPart::Indent | FormatPart::Dedent => {
-                    // Indent/dedent in pretty mode is handled by nest().
-                    BoxDoc::nil()
-                }
-                FormatPart::StatementBegin => BoxDoc::nil(),
-                FormatPart::StatementEnd => {
+                CodeNode::SoftBreak => BoxDoc::softline(),
+                CodeNode::Indent | CodeNode::Dedent => BoxDoc::nil(),
+                CodeNode::StatementBegin => BoxDoc::nil(),
+                CodeNode::StatementEnd => {
                     if self.lang.block_syntax().uses_semicolons {
                         BoxDoc::text(";")
                     } else {
                         BoxDoc::nil()
                     }
                 }
-                FormatPart::Newline => BoxDoc::hardline(),
-                FormatPart::BlockOpen => {
+                CodeNode::Newline => BoxDoc::hardline(),
+                CodeNode::BlockOpen => {
                     BoxDoc::text(self.lang.block_syntax().block_open.to_string())
                 }
-                FormatPart::BlockOpenOverride(s) => BoxDoc::text(s.clone()),
-                FormatPart::BlockClose => {
+                CodeNode::BlockOpenOverride(s) => BoxDoc::text(s.clone()),
+                CodeNode::BlockClose => {
                     let close = self.lang.block_syntax().block_close;
                     if close.is_empty() {
                         BoxDoc::nil()
@@ -325,7 +234,7 @@ impl<'a> CodeRenderer<'a> {
                         BoxDoc::text(close.to_string()).append(BoxDoc::hardline())
                     }
                 }
-                FormatPart::BlockCloseTransition => {
+                CodeNode::BlockCloseTransition => {
                     let close = self.lang.block_syntax().block_close;
                     if close.is_empty() {
                         BoxDoc::nil()
@@ -333,8 +242,9 @@ impl<'a> CodeRenderer<'a> {
                         BoxDoc::text(format!("{} ", close))
                     }
                 }
+                CodeNode::Sequence(children) => self.nodes_to_doc(children),
             };
-            doc = doc.append(part_doc);
+            doc = doc.append(node_doc);
         }
 
         doc.group()
@@ -373,7 +283,6 @@ impl<'a> CodeRenderer<'a> {
 
     fn emit(&mut self, text: &str) {
         self.output.push_str(text);
-        // Update column tracking. Only count from last newline.
         if let Some(last_nl) = text.rfind('\n') {
             self.current_column = text.len() - last_nl - 1;
         } else {
@@ -386,6 +295,14 @@ impl<'a> CodeRenderer<'a> {
         self.current_column = 0;
         self.at_line_start = true;
     }
+}
+
+fn contains_soft_break(nodes: &[CodeNode]) -> bool {
+    nodes.iter().any(|n| match n {
+        CodeNode::SoftBreak => true,
+        CodeNode::Sequence(children) => contains_soft_break(children),
+        _ => false,
+    })
 }
 
 #[cfg(test)]
@@ -500,9 +417,6 @@ mod tests {
 
     #[test]
     fn test_multiline_literal_via_percent_l_reindents_each_line() {
-        // Simulate the FieldSpec/FunSpec doc-comment path: a multi-line string
-        // flowing through %L (Arg::Literal) inside an indented block must have
-        // every continuation line re-indented, not just the first.
         let mut b = CodeBlock::builder();
         b.begin_control_flow("interface User", ());
         b.add("%L", "/**\n * The user's name.\n */".to_string());
@@ -536,8 +450,6 @@ mod tests {
 
     #[test]
     fn test_multiline_literal_direct_reindents_each_line() {
-        // Exercises the FormatPart::Literal branch: the literal itself carries
-        // an embedded newline (no %L substitution involved).
         let mut b = CodeBlock::builder();
         b.begin_control_flow("function f()", ());
         b.add("line1\nline2\nline3", ());

--- a/src/code_renderer.rs
+++ b/src/code_renderer.rs
@@ -12,8 +12,8 @@ use crate::lang::CodeLang;
 /// - Column tracking for width-aware `%T` rendering
 /// - `%W` soft break support via `pretty` crate
 /// - Proper indentation via `%>` / `%<`
-pub struct CodeRenderer<'a, L: CodeLang> {
-    lang: &'a L,
+pub struct CodeRenderer<'a> {
+    lang: &'a dyn CodeLang,
     imports: &'a ImportGroup,
     width: usize,
     output: String,
@@ -22,9 +22,9 @@ pub struct CodeRenderer<'a, L: CodeLang> {
     at_line_start: bool,
 }
 
-impl<'a, L: CodeLang> CodeRenderer<'a, L> {
+impl<'a> CodeRenderer<'a> {
     /// Create a new renderer with the given language, imports, and target width.
-    pub fn new(lang: &'a L, imports: &'a ImportGroup, width: usize) -> Self {
+    pub fn new(lang: &'a dyn CodeLang, imports: &'a ImportGroup, width: usize) -> Self {
         Self {
             lang,
             imports,
@@ -37,7 +37,7 @@ impl<'a, L: CodeLang> CodeRenderer<'a, L> {
     }
 
     /// Render a CodeBlock to string.
-    pub fn render(&mut self, block: &CodeBlock<L>) -> Result<String, SigilStitchError> {
+    pub fn render(&mut self, block: &CodeBlock) -> Result<String, SigilStitchError> {
         let mut arg_index = 0;
         self.render_parts(&block.parts, &block.args, &mut arg_index)?;
         Ok(std::mem::take(&mut self.output))
@@ -46,7 +46,7 @@ impl<'a, L: CodeLang> CodeRenderer<'a, L> {
     fn render_parts(
         &mut self,
         parts: &[FormatPart],
-        args: &[Arg<L>],
+        args: &[Arg],
         arg_index: &mut usize,
     ) -> Result<(), SigilStitchError> {
         // Check if this sequence of parts contains any %W (soft breaks).
@@ -64,7 +64,7 @@ impl<'a, L: CodeLang> CodeRenderer<'a, L> {
     fn render_direct(
         &mut self,
         parts: &[FormatPart],
-        args: &[Arg<L>],
+        args: &[Arg],
         arg_index: &mut usize,
     ) -> Result<(), SigilStitchError> {
         for part in parts {
@@ -204,7 +204,7 @@ impl<'a, L: CodeLang> CodeRenderer<'a, L> {
     fn render_with_pretty(
         &mut self,
         parts: &[FormatPart],
-        args: &[Arg<L>],
+        args: &[Arg],
         arg_index: &mut usize,
     ) -> Result<(), SigilStitchError> {
         // Build a BoxDoc from the parts, using softline() for %W.
@@ -235,7 +235,7 @@ impl<'a, L: CodeLang> CodeRenderer<'a, L> {
     fn build_doc_from_parts(
         &self,
         parts: &[FormatPart],
-        args: &[Arg<L>],
+        args: &[Arg],
         arg_index: &mut usize,
     ) -> BoxDoc<'static, ()> {
         let mut doc = BoxDoc::nil();
@@ -394,7 +394,7 @@ mod tests {
     use crate::lang::typescript::TypeScript;
     use crate::type_name::TypeName;
 
-    fn render_block(block: &CodeBlock<TypeScript>, width: usize) -> String {
+    fn render_block(block: &CodeBlock, width: usize) -> String {
         let ts = TypeScript::new();
         let imports = ImportGroup::new();
         let mut renderer = CodeRenderer::new(&ts, &imports, width);
@@ -403,7 +403,7 @@ mod tests {
 
     #[test]
     fn test_simple_statement() {
-        let mut b = CodeBlock::<TypeScript>::builder();
+        let mut b = CodeBlock::builder();
         b.add_statement("const x = 42", ());
         let block = b.build().unwrap();
         let output = render_block(&block, 80);
@@ -412,7 +412,7 @@ mod tests {
 
     #[test]
     fn test_control_flow() {
-        let mut b = CodeBlock::<TypeScript>::builder();
+        let mut b = CodeBlock::builder();
         b.begin_control_flow("if (x > 0)", ());
         b.add_statement("return x", ());
         b.end_control_flow();
@@ -425,7 +425,7 @@ mod tests {
 
     #[test]
     fn test_if_else() {
-        let mut b = CodeBlock::<TypeScript>::builder();
+        let mut b = CodeBlock::builder();
         b.begin_control_flow("if (x > 0)", ());
         b.add_statement("return x", ());
         b.next_control_flow("else", ());
@@ -440,7 +440,7 @@ mod tests {
 
     #[test]
     fn test_type_rendering() {
-        let user = TypeName::<TypeScript>::importable("./models", "User");
+        let user = TypeName::importable("./models", "User");
         let imports = ImportGroup {
             entries: vec![crate::import::ImportEntry {
                 module: "./models".to_string(),
@@ -452,7 +452,7 @@ mod tests {
             }],
         };
 
-        let mut b = CodeBlock::<TypeScript>::builder();
+        let mut b = CodeBlock::builder();
         b.add_statement("const u: %T = getUser()", (user,));
         let block = b.build().unwrap();
 
@@ -464,7 +464,7 @@ mod tests {
 
     #[test]
     fn test_string_literal() {
-        let mut b = CodeBlock::<TypeScript>::builder();
+        let mut b = CodeBlock::builder();
         b.add_statement(
             "const x = %S",
             (crate::code_block::StringLitArg("hello".to_string()),),
@@ -476,7 +476,7 @@ mod tests {
 
     #[test]
     fn test_nested_indent() {
-        let mut b = CodeBlock::<TypeScript>::builder();
+        let mut b = CodeBlock::builder();
         b.begin_control_flow("if (a)", ());
         b.begin_control_flow("if (b)", ());
         b.add_statement("return c", ());
@@ -489,7 +489,7 @@ mod tests {
 
     #[test]
     fn test_comment() {
-        let mut b = CodeBlock::<TypeScript>::builder();
+        let mut b = CodeBlock::builder();
         b.add_comment("This is a comment");
         let block = b.build().unwrap();
         let output = render_block(&block, 80);
@@ -501,7 +501,7 @@ mod tests {
         // Simulate the FieldSpec/FunSpec doc-comment path: a multi-line string
         // flowing through %L (Arg::Literal) inside an indented block must have
         // every continuation line re-indented, not just the first.
-        let mut b = CodeBlock::<TypeScript>::builder();
+        let mut b = CodeBlock::builder();
         b.begin_control_flow("interface User", ());
         b.add("%L", "/**\n * The user's name.\n */".to_string());
         b.add_line();
@@ -536,7 +536,7 @@ mod tests {
     fn test_multiline_literal_direct_reindents_each_line() {
         // Exercises the FormatPart::Literal branch: the literal itself carries
         // an embedded newline (no %L substitution involved).
-        let mut b = CodeBlock::<TypeScript>::builder();
+        let mut b = CodeBlock::builder();
         b.begin_control_flow("function f()", ());
         b.add("line1\nline2\nline3", ());
         b.add_line();
@@ -564,7 +564,7 @@ mod tests {
 
     #[test]
     fn test_block_open_override() {
-        let mut b = CodeBlock::<TypeScript>::builder();
+        let mut b = CodeBlock::builder();
         b.begin_control_flow_with_open("class Functor f", (), " where");
         b.add_statement("fmap :: a -> b", ());
         b.end_control_flow();

--- a/src/code_template.rs
+++ b/src/code_template.rs
@@ -423,8 +423,13 @@ mod tests {
         let ty = TypeName::primitive("number");
         let block = tmpl.apply().set("t", ty).build().unwrap();
         assert!(!block.is_empty());
-        // Should have 2 args (one for each occurrence).
-        assert_eq!(block.args.len(), 2);
+        // Should have 2 type refs (one for each occurrence).
+        let type_ref_count = block
+            .nodes
+            .iter()
+            .filter(|n| matches!(n, crate::code_node::CodeNode::TypeRef(_)))
+            .count();
+        assert_eq!(type_ref_count, 2);
     }
 
     #[test]

--- a/src/code_template.rs
+++ b/src/code_template.rs
@@ -5,10 +5,10 @@
 //!
 //! | Kind | Specifier | Argument Type |
 //! |------|-----------|---------------|
-//! | `T`  | `%T`      | `TypeName<L>` |
+//! | `T`  | `%T`      | `TypeName` |
 //! | `N`  | `%N`      | `NameArg`     |
 //! | `S`  | `%S`      | `StringLitArg`|
-//! | `L`  | `%L`      | `&str`, `String`, or `CodeBlock<L>` |
+//! | `L`  | `%L`      | `&str`, `String`, or `CodeBlock` |
 //!
 //! # Example
 //!
@@ -19,9 +19,9 @@
 //! use sigil_stitch::type_name::TypeName;
 //!
 //! let tmpl = CodeTemplate::new("const #{var:N}: #{type:T} = #{init:L}").unwrap();
-//! let user_type = TypeName::<TypeScript>::primitive("string");
+//! let user_type = TypeName::primitive("string");
 //!
-//! let block = tmpl.apply::<TypeScript>()
+//! let block = tmpl.apply()
 //!     .set("var", NameArg("user".into()))
 //!     .set("type", user_type)
 //!     .set("init", "null")
@@ -30,10 +30,8 @@
 //! ```
 
 use std::collections::HashMap;
-use std::marker::PhantomData;
 
 use crate::code_block::{Arg, CodeBlock};
-use crate::lang::CodeLang;
 
 /// The kind of a template parameter, matching the format specifier system.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -68,7 +66,7 @@ impl ParamKind {
         }
     }
 
-    fn matches_arg<L: CodeLang>(&self, arg: &Arg<L>) -> bool {
+    fn matches_arg(&self, arg: &Arg) -> bool {
         matches!(
             (self, arg),
             (ParamKind::Type, Arg::TypeName(_))
@@ -115,9 +113,9 @@ struct TemplateParam {
 ///
 /// let tmpl = CodeTemplate::new("const #{var:N}: #{type:T} = #{init:L}").unwrap();
 ///
-/// let block = tmpl.apply::<TypeScript>()
+/// let block = tmpl.apply()
 ///     .set("var", NameArg("user".into()))
-///     .set("type", TypeName::<TypeScript>::primitive("string"))
+///     .set("type", TypeName::primitive("string"))
 ///     .set("init", "null")
 ///     .build()
 ///     .unwrap();
@@ -147,11 +145,10 @@ impl CodeTemplate {
     }
 
     /// Begin applying this template with concrete arguments.
-    pub fn apply<L: CodeLang>(&self) -> TemplateApply<'_, L> {
+    pub fn apply(&self) -> TemplateApply<'_> {
         TemplateApply {
             template: self,
             args: HashMap::new(),
-            _phantom: PhantomData,
         }
     }
 
@@ -170,26 +167,25 @@ impl CodeTemplate {
 ///
 /// Created by [`CodeTemplate::apply()`]. Set named parameters with `set()`,
 /// then call `build()` to produce a `CodeBlock`.
-pub struct TemplateApply<'t, L: CodeLang> {
+pub struct TemplateApply<'t> {
     template: &'t CodeTemplate,
-    args: HashMap<String, Arg<L>>,
-    _phantom: PhantomData<L>,
+    args: HashMap<String, Arg>,
 }
 
-impl<L: CodeLang> TemplateApply<'_, L> {
+impl TemplateApply<'_> {
     /// Set a named parameter value.
     ///
     /// The argument kind is validated against the declared parameter kind
     /// in [`build`](TemplateApply::build).
-    pub fn set(&mut self, name: &str, arg: impl Into<Arg<L>>) -> &mut Self {
+    pub fn set(&mut self, name: &str, arg: impl Into<Arg>) -> &mut Self {
         self.args.insert(name.to_string(), arg.into());
         self
     }
 
     /// Build the `CodeBlock`, validating all parameters are provided and
     /// kind-correct.
-    pub fn build(&mut self) -> Result<CodeBlock<L>, crate::error::SigilStitchError> {
-        let mut positional_args: Vec<Arg<L>> = Vec::with_capacity(self.template.params.len());
+    pub fn build(&mut self) -> Result<CodeBlock, crate::error::SigilStitchError> {
+        let mut positional_args: Vec<Arg> = Vec::with_capacity(self.template.params.len());
 
         for param in &self.template.params {
             let arg = self.args.get(&param.name).ok_or_else(|| {
@@ -220,7 +216,7 @@ impl<L: CodeLang> TemplateApply<'_, L> {
     }
 }
 
-fn arg_kind_label<L: CodeLang>(arg: &Arg<L>) -> &'static str {
+fn arg_kind_label(arg: &Arg) -> &'static str {
     match arg {
         Arg::TypeName(_) => "TypeName",
         Arg::Name(_) => "Name",
@@ -367,8 +363,7 @@ mod tests {
     use crate::code_block::NameArg;
     use crate::code_block::StringLitArg;
     use crate::import_collector;
-    use crate::lang::rust_lang::RustLang;
-    use crate::lang::typescript::TypeScript;
+
     use crate::type_name::TypeName;
 
     #[test]
@@ -385,9 +380,9 @@ mod tests {
     #[test]
     fn test_apply_simple() {
         let tmpl = CodeTemplate::new("const #{var:N}: #{type:T} = #{init:L}").unwrap();
-        let ty = TypeName::<TypeScript>::primitive("string");
+        let ty = TypeName::primitive("string");
         let block = tmpl
-            .apply::<TypeScript>()
+            .apply()
             .set("var", NameArg("user".into()))
             .set("type", ty)
             .set("init", "null")
@@ -399,10 +394,7 @@ mod tests {
     #[test]
     fn test_missing_param_error() {
         let tmpl = CodeTemplate::new("#{a:N} #{b:T}").unwrap();
-        let result = tmpl
-            .apply::<TypeScript>()
-            .set("a", NameArg("x".into()))
-            .build();
+        let result = tmpl.apply().set("a", NameArg("x".into())).build();
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert!(
@@ -416,8 +408,8 @@ mod tests {
         let tmpl = CodeTemplate::new("#{name:N}").unwrap();
         // Pass a TypeName where Name is expected.
         let result = tmpl
-            .apply::<TypeScript>()
-            .set("name", TypeName::<TypeScript>::primitive("string"))
+            .apply()
+            .set("name", TypeName::primitive("string"))
             .build();
         assert!(result.is_err());
         let err = result.unwrap_err();
@@ -428,8 +420,8 @@ mod tests {
     #[test]
     fn test_duplicate_param_name() {
         let tmpl = CodeTemplate::new("#{t:T} and #{t:T}").unwrap();
-        let ty = TypeName::<TypeScript>::primitive("number");
-        let block = tmpl.apply::<TypeScript>().set("t", ty).build().unwrap();
+        let ty = TypeName::primitive("number");
+        let block = tmpl.apply().set("t", ty).build().unwrap();
         assert!(!block.is_empty());
         // Should have 2 args (one for each occurrence).
         assert_eq!(block.args.len(), 2);
@@ -482,8 +474,8 @@ mod tests {
     #[test]
     fn test_template_with_imports() {
         let tmpl = CodeTemplate::new("const x: #{type:T} = init()").unwrap();
-        let ty = TypeName::<TypeScript>::importable_type("./models", "User");
-        let block = tmpl.apply::<TypeScript>().set("type", ty).build().unwrap();
+        let ty = TypeName::importable_type("./models", "User");
+        let block = tmpl.apply().set("type", ty).build().unwrap();
         let refs = import_collector::collect_imports(&block);
         assert_eq!(refs.len(), 1);
         assert_eq!(refs[0].name, "User");
@@ -495,18 +487,18 @@ mod tests {
 
         // Apply to TypeScript.
         let ts_block = tmpl
-            .apply::<TypeScript>()
+            .apply()
             .set("name", NameArg("x".into()))
-            .set("type", TypeName::<TypeScript>::primitive("string"))
+            .set("type", TypeName::primitive("string"))
             .build()
             .unwrap();
         assert!(!ts_block.is_empty());
 
         // Same template applied to Rust.
         let rs_block = tmpl
-            .apply::<RustLang>()
+            .apply()
             .set("name", NameArg("x".into()))
-            .set("type", TypeName::<RustLang>::primitive("String"))
+            .set("type", TypeName::primitive("String"))
             .build()
             .unwrap();
         assert!(!rs_block.is_empty());
@@ -565,7 +557,7 @@ mod tests {
     fn test_string_lit_param() {
         let tmpl = CodeTemplate::new("console.log(#{msg:S})").unwrap();
         let block = tmpl
-            .apply::<TypeScript>()
+            .apply()
             .set("msg", StringLitArg("hello".into()))
             .build()
             .unwrap();
@@ -575,8 +567,8 @@ mod tests {
     #[test]
     fn test_code_block_param() {
         let tmpl = CodeTemplate::new("fn main() { #{body:L} }").unwrap();
-        let body = CodeBlock::<RustLang>::of("println!(\"hi\")", ()).unwrap();
-        let block = tmpl.apply::<RustLang>().set("body", body).build().unwrap();
+        let body = CodeBlock::of("println!(\"hi\")", ()).unwrap();
+        let block = tmpl.apply().set("body", body).build().unwrap();
         assert!(!block.is_empty());
     }
 }

--- a/src/import_collector.rs
+++ b/src/import_collector.rs
@@ -1,4 +1,5 @@
-use crate::code_block::{Arg, CodeBlock};
+use crate::code_block::CodeBlock;
+use crate::code_node::CodeNode;
 use crate::import::ImportRef;
 
 /// Pass 1 of the three-pass rendering model.
@@ -7,19 +8,21 @@ use crate::import::ImportRef;
 /// references. No rendering, no column tracking, no pretty printing.
 pub fn collect_imports(block: &CodeBlock) -> Vec<ImportRef> {
     let mut refs = Vec::new();
-    walk_parts(block, &mut refs);
+    walk_nodes(&block.nodes, &mut refs);
     refs
 }
 
-fn walk_parts(block: &CodeBlock, refs: &mut Vec<ImportRef>) {
-    // Walk args (which contain the actual TypeName/CodeBlock data).
-    for arg in &block.args {
-        match arg {
-            Arg::TypeName(tn) => {
+fn walk_nodes(nodes: &[CodeNode], refs: &mut Vec<ImportRef>) {
+    for node in nodes {
+        match node {
+            CodeNode::TypeRef(tn) => {
                 tn.collect_imports(refs);
             }
-            Arg::Code(inner) => {
-                walk_parts(inner, refs);
+            CodeNode::Nested(inner) => {
+                walk_nodes(&inner.nodes, refs);
+            }
+            CodeNode::Sequence(children) => {
+                walk_nodes(children, refs);
             }
             _ => {}
         }
@@ -30,7 +33,7 @@ fn walk_parts(block: &CodeBlock, refs: &mut Vec<ImportRef>) {
 pub fn collect_imports_many(blocks: &[&CodeBlock]) -> Vec<ImportRef> {
     let mut refs = Vec::new();
     for block in blocks {
-        walk_parts(block, &mut refs);
+        walk_nodes(&block.nodes, &mut refs);
     }
     refs
 }
@@ -96,7 +99,6 @@ mod tests {
 
     #[test]
     fn test_collect_from_raw_content() {
-        // Raw types should not produce imports.
         let raw = TypeName::raw("any");
         let mut builder = CodeBlock::builder();
         builder.add_statement("const x: %T = null", (raw,));

--- a/src/import_collector.rs
+++ b/src/import_collector.rs
@@ -1,18 +1,17 @@
 use crate::code_block::{Arg, CodeBlock};
 use crate::import::ImportRef;
-use crate::lang::CodeLang;
 
 /// Pass 1 of the three-pass rendering model.
 ///
 /// Walks a CodeBlock tree structurally, collecting all `TypeName::Importable`
 /// references. No rendering, no column tracking, no pretty printing.
-pub fn collect_imports<L: CodeLang>(block: &CodeBlock<L>) -> Vec<ImportRef> {
+pub fn collect_imports(block: &CodeBlock) -> Vec<ImportRef> {
     let mut refs = Vec::new();
     walk_parts(block, &mut refs);
     refs
 }
 
-fn walk_parts<L: CodeLang>(block: &CodeBlock<L>, refs: &mut Vec<ImportRef>) {
+fn walk_parts(block: &CodeBlock, refs: &mut Vec<ImportRef>) {
     // Walk args (which contain the actual TypeName/CodeBlock data).
     for arg in &block.args {
         match arg {
@@ -28,7 +27,7 @@ fn walk_parts<L: CodeLang>(block: &CodeBlock<L>, refs: &mut Vec<ImportRef>) {
 }
 
 /// Collect imports from multiple CodeBlocks.
-pub fn collect_imports_many<L: CodeLang>(blocks: &[&CodeBlock<L>]) -> Vec<ImportRef> {
+pub fn collect_imports_many(blocks: &[&CodeBlock]) -> Vec<ImportRef> {
     let mut refs = Vec::new();
     for block in blocks {
         walk_parts(block, &mut refs);
@@ -39,13 +38,13 @@ pub fn collect_imports_many<L: CodeLang>(blocks: &[&CodeBlock<L>]) -> Vec<Import
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::lang::typescript::TypeScript;
+
     use crate::type_name::TypeName;
 
     #[test]
     fn test_collect_from_single_type() {
-        let user = TypeName::<TypeScript>::importable("./models", "User");
-        let mut builder = CodeBlock::<TypeScript>::builder();
+        let user = TypeName::importable("./models", "User");
+        let mut builder = CodeBlock::builder();
         builder.add_statement("const u: %T = getUser()", (user,));
         let block = builder.build().unwrap();
 
@@ -57,12 +56,12 @@ mod tests {
 
     #[test]
     fn test_collect_from_nested_codeblock() {
-        let user = TypeName::<TypeScript>::importable("./models", "User");
-        let mut inner_builder = CodeBlock::<TypeScript>::builder();
+        let user = TypeName::importable("./models", "User");
+        let mut inner_builder = CodeBlock::builder();
         inner_builder.add_statement("return new %T()", (user,));
         let inner = inner_builder.build().unwrap();
 
-        let mut outer_builder = CodeBlock::<TypeScript>::builder();
+        let mut outer_builder = CodeBlock::builder();
         outer_builder.add_code(inner);
         let outer = outer_builder.build().unwrap();
 
@@ -73,11 +72,11 @@ mod tests {
 
     #[test]
     fn test_collect_three_types() {
-        let user = TypeName::<TypeScript>::importable("./models", "User");
-        let tag = TypeName::<TypeScript>::importable("./models", "Tag");
-        let base = TypeName::<TypeScript>::importable("./base", "BaseApi");
+        let user = TypeName::importable("./models", "User");
+        let tag = TypeName::importable("./models", "Tag");
+        let base = TypeName::importable("./base", "BaseApi");
 
-        let mut builder = CodeBlock::<TypeScript>::builder();
+        let mut builder = CodeBlock::builder();
         builder.add("const u: %T = get%T(%T)", (user, tag, base));
         let block = builder.build().unwrap();
 
@@ -87,7 +86,7 @@ mod tests {
 
     #[test]
     fn test_collect_no_types() {
-        let mut builder = CodeBlock::<TypeScript>::builder();
+        let mut builder = CodeBlock::builder();
         builder.add_statement("const x = 42", ());
         let block = builder.build().unwrap();
 
@@ -98,8 +97,8 @@ mod tests {
     #[test]
     fn test_collect_from_raw_content() {
         // Raw types should not produce imports.
-        let raw = TypeName::<TypeScript>::raw("any");
-        let mut builder = CodeBlock::<TypeScript>::builder();
+        let raw = TypeName::raw("any");
+        let mut builder = CodeBlock::builder();
         builder.add_statement("const x: %T = null", (raw,));
         let block = builder.build().unwrap();
 

--- a/src/lang/bash.rs
+++ b/src/lang/bash.rs
@@ -2,6 +2,10 @@
 
 use crate::import::ImportGroup;
 use crate::lang::CodeLang;
+use crate::lang::config::{
+    BlockSyntaxConfig, EnumAndAnnotationConfig, FunctionSyntaxConfig, GenericSyntaxConfig,
+    TypeDeclSyntaxConfig, TypePresentationConfig,
+};
 use crate::spec::modifiers::{DeclarationContext, TypeKind, Visibility};
 
 /// Bash shell language implementation.
@@ -187,14 +191,6 @@ impl CodeLang for Bash {
         "#"
     }
 
-    fn indent_unit(&self) -> &str {
-        &self.indent
-    }
-
-    fn uses_semicolons(&self) -> bool {
-        false
-    }
-
     // --- Spec support ---
     // Shell has no visibility, generics, inheritance, or interfaces.
     // Return empty/no-op for all structural methods.
@@ -207,15 +203,7 @@ impl CodeLang for Bash {
         "function"
     }
 
-    fn return_type_separator(&self) -> &str {
-        ""
-    }
-
     fn type_keyword(&self, _kind: TypeKind) -> &str {
-        ""
-    }
-
-    fn field_terminator(&self) -> &str {
         ""
     }
 
@@ -223,20 +211,42 @@ impl CodeLang for Bash {
         true
     }
 
-    fn generic_constraint_keyword(&self) -> &str {
-        ""
+    // --- Config struct accessors ---
+
+    fn type_presentation(&self) -> TypePresentationConfig<'_> {
+        TypePresentationConfig::default()
     }
 
-    fn generic_constraint_separator(&self) -> &str {
-        ""
+    fn generic_syntax(&self) -> GenericSyntaxConfig<'_> {
+        GenericSyntaxConfig {
+            constraint_keyword: "",
+            constraint_separator: "",
+            ..Default::default()
+        }
     }
 
-    fn super_type_keyword(&self) -> &str {
-        ""
+    fn block_syntax(&self) -> BlockSyntaxConfig<'_> {
+        BlockSyntaxConfig {
+            indent_unit: &self.indent,
+            uses_semicolons: false,
+            field_terminator: "",
+            ..Default::default()
+        }
     }
 
-    fn implements_keyword(&self) -> &str {
-        ""
+    fn function_syntax(&self) -> FunctionSyntaxConfig<'_> {
+        FunctionSyntaxConfig {
+            return_type_separator: "",
+            ..Default::default()
+        }
+    }
+
+    fn type_decl_syntax(&self) -> TypeDeclSyntaxConfig<'_> {
+        TypeDeclSyntaxConfig::default()
+    }
+
+    fn enum_and_annotation(&self) -> EnumAndAnnotationConfig<'_> {
+        EnumAndAnnotationConfig::default()
     }
 }
 
@@ -382,7 +392,7 @@ mod tests {
     #[test]
     fn test_no_semicolons() {
         let bash = Bash::new();
-        assert!(!bash.uses_semicolons());
+        assert!(!bash.block_syntax().uses_semicolons);
     }
 
     #[test]
@@ -403,14 +413,14 @@ mod tests {
     #[test]
     fn test_block_delimiters() {
         let bash = Bash::new();
-        assert_eq!(bash.block_open(), " {");
-        assert_eq!(bash.block_close(), "}");
+        assert_eq!(bash.block_syntax().block_open, " {");
+        assert_eq!(bash.block_syntax().block_close, "}");
     }
 
     #[test]
     fn test_bash_builder_fluent() {
         let bash = Bash::new().with_indent("  ").with_extension("sh");
         assert_eq!(bash.file_extension(), "sh");
-        assert_eq!(bash.indent_unit(), "  ");
+        assert_eq!(bash.block_syntax().indent_unit, "  ");
     }
 }

--- a/src/lang/bash.rs
+++ b/src/lang/bash.rs
@@ -65,7 +65,7 @@ use crate::spec::modifiers::{DeclarationContext, TypeKind, Visibility};
 /// bodies since functions use `{ }` braces:
 ///
 /// ```text
-/// let mut fb = FunSpec::<Bash>::builder("greet");
+/// let mut fb = FunSpec::builder("greet");
 /// fb.body(body);
 /// let fun = fb.build().unwrap();
 /// // function greet {
@@ -78,7 +78,7 @@ use crate::spec::modifiers::{DeclarationContext, TypeKind, Visibility};
 /// Use `FileSpec::header()` for the shebang line:
 ///
 /// ```text
-/// let mut header_b = CodeBlock::<Bash>::builder();
+/// let mut header_b = CodeBlock::builder();
 /// header_b.add("#!/usr/bin/env bash\n", ());
 /// header_b.add("set -euo pipefail", ());
 /// fb.header(header_b.build().unwrap());

--- a/src/lang/c_lang.rs
+++ b/src/lang/c_lang.rs
@@ -223,14 +223,6 @@ impl CodeLang for CLang {
         "//"
     }
 
-    fn indent_unit(&self) -> &str {
-        &self.indent
-    }
-
-    fn uses_semicolons(&self) -> bool {
-        true
-    }
-
     fn render_visibility(&self, _vis: Visibility, _ctx: DeclarationContext) -> &str {
         // C has no visibility keywords.
         ""
@@ -239,11 +231,6 @@ impl CodeLang for CLang {
     fn function_keyword(&self, _ctx: DeclarationContext) -> &str {
         // C has no function keyword.
         ""
-    }
-
-    fn return_type_separator(&self) -> &str {
-        // Unused when return_type_is_prefix() is true, but set for safety.
-        " "
     }
 
     fn type_keyword(&self, kind: TypeKind) -> &str {
@@ -256,84 +243,74 @@ impl CodeLang for CLang {
         }
     }
 
-    fn field_terminator(&self) -> &str {
-        ";"
-    }
-
     fn methods_inside_type_body(&self, _kind: TypeKind) -> bool {
         false
-    }
-
-    fn type_alias_target_first(&self) -> bool {
-        true
     }
 
     fn render_newtype_line(&self, _vis: &str, name: &str, inner: &str) -> String {
         format!("typedef {inner} {name};")
     }
 
-    fn generic_constraint_keyword(&self) -> &str {
-        ""
-    }
-
-    fn generic_constraint_separator(&self) -> &str {
-        ""
-    }
-
-    fn super_type_keyword(&self) -> &str {
-        ""
-    }
-
-    fn implements_keyword(&self) -> &str {
-        ""
-    }
-
-    fn type_before_name(&self) -> bool {
-        true
-    }
-
-    fn return_type_is_prefix(&self) -> bool {
-        true
-    }
-
-    fn type_close_terminator(&self) -> &str {
-        ";"
-    }
-
-    fn render_annotation_prefix(&self) -> (&str, &str) {
-        ("__attribute__((", "))")
-    }
-
     fn optional_field_style(&self) -> crate::lang::config::OptionalFieldStyle {
         crate::lang::config::OptionalFieldStyle::TypePrefix("*")
     }
 
-    fn present_pointer(&self) -> crate::type_name::TypePresentation<'_> {
-        crate::type_name::TypePresentation::Postfix { suffix: "*" }
-    }
-
-    fn present_reference(&self) -> crate::type_name::TypePresentation<'_> {
-        crate::type_name::TypePresentation::Surround {
-            prefix: "const ",
-            suffix: "*",
+    fn type_presentation(&self) -> crate::lang::config::TypePresentationConfig<'_> {
+        crate::lang::config::TypePresentationConfig {
+            pointer: crate::type_name::TypePresentation::Postfix { suffix: "*" },
+            reference: crate::type_name::TypePresentation::Surround {
+                prefix: "const ",
+                suffix: "*",
+            },
+            reference_mut: crate::type_name::TypePresentation::Postfix { suffix: "*" },
+            function: crate::type_name::FunctionPresentation {
+                arrow: "",
+                return_first: true,
+                ..Default::default()
+            },
+            ..Default::default()
         }
     }
 
-    fn present_reference_mut(&self) -> crate::type_name::TypePresentation<'_> {
-        crate::type_name::TypePresentation::Postfix { suffix: "*" }
+    fn generic_syntax(&self) -> crate::lang::config::GenericSyntaxConfig<'_> {
+        crate::lang::config::GenericSyntaxConfig {
+            constraint_keyword: "",
+            constraint_separator: "",
+            context_bound_keyword: "",
+            ..Default::default()
+        }
     }
 
-    fn present_function(&self) -> crate::type_name::FunctionPresentation<'_> {
-        crate::type_name::FunctionPresentation {
-            keyword: "",
-            params_open: "(",
-            params_sep: ", ",
-            params_close: ")",
-            arrow: "",
-            return_first: true,
-            curried: false,
-            wrapper_open: "",
-            wrapper_close: "",
+    fn block_syntax(&self) -> crate::lang::config::BlockSyntaxConfig<'_> {
+        crate::lang::config::BlockSyntaxConfig {
+            indent_unit: &self.indent,
+            field_terminator: ";",
+            type_close_terminator: ";",
+            ..Default::default()
+        }
+    }
+
+    fn function_syntax(&self) -> crate::lang::config::FunctionSyntaxConfig<'_> {
+        crate::lang::config::FunctionSyntaxConfig {
+            return_type_separator: " ",
+            ..Default::default()
+        }
+    }
+
+    fn type_decl_syntax(&self) -> crate::lang::config::TypeDeclSyntaxConfig<'_> {
+        crate::lang::config::TypeDeclSyntaxConfig {
+            type_before_name: true,
+            return_type_is_prefix: true,
+            type_alias_target_first: true,
+            ..Default::default()
+        }
+    }
+
+    fn enum_and_annotation(&self) -> crate::lang::config::EnumAndAnnotationConfig<'_> {
+        crate::lang::config::EnumAndAnnotationConfig {
+            annotation_prefix: "__attribute__((",
+            annotation_suffix: "))",
+            ..Default::default()
         }
     }
 }
@@ -490,19 +467,19 @@ mod tests {
     #[test]
     fn test_type_before_name() {
         let c = CLang::new();
-        assert!(c.type_before_name());
+        assert!(c.type_decl_syntax().type_before_name);
     }
 
     #[test]
     fn test_return_type_is_prefix() {
         let c = CLang::new();
-        assert!(c.return_type_is_prefix());
+        assert!(c.type_decl_syntax().return_type_is_prefix);
     }
 
     #[test]
     fn test_type_close_terminator() {
         let c = CLang::new();
-        assert_eq!(c.type_close_terminator(), ";");
+        assert_eq!(c.block_syntax().type_close_terminator, ";");
     }
 
     #[test]
@@ -518,6 +495,6 @@ mod tests {
     fn test_c_builder_fluent() {
         let c = CLang::new().with_indent("\t").with_extension("h");
         assert_eq!(c.file_extension(), "h");
-        assert_eq!(c.indent_unit(), "\t");
+        assert_eq!(c.block_syntax().indent_unit, "\t");
     }
 }

--- a/src/lang/c_lang.rs
+++ b/src/lang/c_lang.rs
@@ -30,7 +30,7 @@ use crate::spec::modifiers::{DeclarationContext, TypeKind, Visibility};
 ///
 /// Use `FileSpec::header` for `#pragma once` or include guards:
 /// ```text
-/// fb.header(CodeBlock::<CLang>::of("#pragma once", ()).unwrap());
+/// fb.header(CodeBlock::of("#pragma once", ()).unwrap());
 /// ```
 #[derive(Debug, Clone)]
 pub struct CLang {

--- a/src/lang/config.rs
+++ b/src/lang/config.rs
@@ -2,7 +2,14 @@
 //!
 //! These types live here (rather than inside individual `src/lang/*.rs` files)
 //! because they represent cross-cutting concepts — quote style, optional-field
-//! semantics — that multiple languages express in similar ways.
+//! semantics, type presentation — that multiple languages express in similar ways.
+
+use crate::spec::fun_spec::{FunctionSignatureStyle, ParamListStyle, WhereClauseStyle};
+use crate::spec::modifiers::ConstructorDelegationStyle;
+use crate::type_name::{
+    AssociatedTypeStyle, BoundsPresentation, FunctionPresentation, GenericApplicationStyle,
+    TypePresentation, WildcardPresentation,
+};
 
 /// Quote style for rendering string literals.
 ///
@@ -70,4 +77,275 @@ pub enum OptionalFieldStyle {
     /// Optional fields are not expressible in this language's type system.
     /// The field is rendered without any marker.
     Ignored,
+}
+
+// ── Config structs ─────────────────────────────────────────────────
+
+/// How each compound `TypeName` variant renders.
+#[derive(Debug, Clone, Copy)]
+pub struct TypePresentationConfig<'a> {
+    /// `TypeName::Array(T)` — e.g. `T[]`, `Vec<T>`.
+    pub array: TypePresentation<'a>,
+    /// `TypeName::ReadonlyArray(T)` — `None` falls back to `readonly` + `array`.
+    pub readonly_array: Option<TypePresentation<'a>>,
+    /// `TypeName::Optional(T)` — e.g. `T | null`, `T?`.
+    pub optional: TypePresentation<'a>,
+    /// The absent literal for `Optional` with `Infix` presentation (e.g. `"null"`, `"None"`).
+    pub optional_absent_literal: &'a str,
+    /// `TypeName::Map { K, V }` — e.g. `Map<K, V>`, `dict[K, V]`.
+    pub map: TypePresentation<'a>,
+    /// `TypeName::Union(members)` — e.g. `A | B`.
+    pub union: TypePresentation<'a>,
+    /// `TypeName::Intersection(members)` — e.g. `A & B`.
+    pub intersection: TypePresentation<'a>,
+    /// `TypeName::Pointer(T)` — e.g. `*T`, `*const T`.
+    pub pointer: TypePresentation<'a>,
+    /// `TypeName::Slice(T)` — e.g. `[]T`, `[T]`.
+    pub slice: TypePresentation<'a>,
+    /// `TypeName::Tuple(elements)` — e.g. `(A, B)`.
+    pub tuple: TypePresentation<'a>,
+    /// `TypeName::Reference { mutable: false }` — e.g. `&T`.
+    pub reference: TypePresentation<'a>,
+    /// `TypeName::Reference { mutable: true }` — e.g. `&mut T`.
+    pub reference_mut: TypePresentation<'a>,
+    /// `TypeName::Function { params, return_type }` — e.g. `(A, B) => R`.
+    pub function: FunctionPresentation<'a>,
+    /// `TypeName::AssociatedType` — e.g. `<T as Trait>::Assoc`.
+    pub associated_type: AssociatedTypeStyle<'a>,
+    /// `TypeName::ImplTrait` — e.g. `impl Trait`.
+    pub impl_trait: BoundsPresentation<'a>,
+    /// `TypeName::DynTrait` — e.g. `dyn Trait`.
+    pub dyn_trait: BoundsPresentation<'a>,
+    /// `TypeName::Wildcard` — e.g. `?`, `? extends T`.
+    pub wildcard: WildcardPresentation<'a>,
+}
+
+impl Default for TypePresentationConfig<'_> {
+    fn default() -> Self {
+        Self {
+            array: TypePresentation::Postfix { suffix: "[]" },
+            readonly_array: None,
+            optional: TypePresentation::Infix { sep: " | " },
+            optional_absent_literal: "null",
+            map: TypePresentation::GenericWrap { name: "Map" },
+            union: TypePresentation::Infix { sep: " | " },
+            intersection: TypePresentation::Infix { sep: " & " },
+            pointer: TypePresentation::Prefix { prefix: "*" },
+            slice: TypePresentation::Prefix { prefix: "[]" },
+            tuple: TypePresentation::Delimited {
+                open: "(",
+                sep: ", ",
+                close: ")",
+            },
+            reference: TypePresentation::Prefix { prefix: "" },
+            reference_mut: TypePresentation::Prefix { prefix: "" },
+            function: FunctionPresentation {
+                keyword: "",
+                params_open: "(",
+                params_sep: ", ",
+                params_close: ")",
+                arrow: " => ",
+                return_first: false,
+                curried: false,
+                wrapper_open: "",
+                wrapper_close: "",
+            },
+            associated_type: AssociatedTypeStyle::QualifiedPath {
+                open: "<",
+                as_kw: " as ",
+                close_sep: ">::",
+                simple_sep: "::",
+            },
+            impl_trait: BoundsPresentation {
+                keyword: "impl ",
+                separator: " + ",
+            },
+            dyn_trait: BoundsPresentation {
+                keyword: "dyn ",
+                separator: " + ",
+            },
+            wildcard: WildcardPresentation {
+                unbounded: "?",
+                upper_keyword: "? extends ",
+                lower_keyword: "? super ",
+            },
+        }
+    }
+}
+
+/// Generic type parameter delimiters and constraints.
+#[derive(Debug, Clone, Copy)]
+pub struct GenericSyntaxConfig<'a> {
+    /// Opening delimiter (e.g. `"<"`, `"["`).
+    pub open: &'a str,
+    /// Closing delimiter (e.g. `">"`, `"]"`).
+    pub close: &'a str,
+    /// How `TypeName::Generic` application renders.
+    pub application_style: GenericApplicationStyle,
+    /// Keyword introducing a bound (e.g. `": "`, `" extends "`).
+    pub constraint_keyword: &'a str,
+    /// Separator between multiple bounds (e.g. `" + "`, `" & "`).
+    pub constraint_separator: &'a str,
+    /// Keyword for context bounds (e.g. Scala `" : "`). Defaults to `constraint_keyword`.
+    pub context_bound_keyword: &'a str,
+}
+
+impl Default for GenericSyntaxConfig<'_> {
+    fn default() -> Self {
+        Self {
+            open: "<",
+            close: ">",
+            application_style: GenericApplicationStyle::Delimited,
+            constraint_keyword: ": ",
+            constraint_separator: " + ",
+            context_bound_keyword: ": ",
+        }
+    }
+}
+
+/// Block delimiters, indentation, and statement termination.
+#[derive(Debug, Clone, Copy)]
+pub struct BlockSyntaxConfig<'a> {
+    /// Opening block delimiter after a signature (e.g. `" {"`, `":"`).
+    pub block_open: &'a str,
+    /// Closing block delimiter (e.g. `"}"`, `""`).
+    pub block_close: &'a str,
+    /// Indentation unit (e.g. `"  "`, `"\t"`).
+    pub indent_unit: &'a str,
+    /// Whether statements end with semicolons.
+    pub uses_semicolons: bool,
+    /// Terminator after a field declaration (e.g. `","`, `";"`).
+    pub field_terminator: &'a str,
+    /// Terminator after a type's closing brace (e.g. `";"` for C structs).
+    pub type_close_terminator: &'a str,
+    /// Closing delimiter for base class / implements list (e.g. `")"` for Python).
+    pub bases_close: &'a str,
+}
+
+impl Default for BlockSyntaxConfig<'_> {
+    fn default() -> Self {
+        Self {
+            block_open: " {",
+            block_close: "}",
+            indent_unit: "  ",
+            uses_semicolons: true,
+            field_terminator: ",",
+            type_close_terminator: "",
+            bases_close: "",
+        }
+    }
+}
+
+/// Function signature syntax.
+#[derive(Debug, Clone, Copy)]
+pub struct FunctionSyntaxConfig<'a> {
+    /// Separator between parameters and return type (e.g. `" -> "`, `": "`).
+    pub return_type_separator: &'a str,
+    /// Keyword for async functions (e.g. `"async "`).
+    pub async_keyword: &'a str,
+    /// Keyword for abstract methods (e.g. `"abstract "`, `"virtual "`).
+    pub abstract_keyword: &'a str,
+    /// How parameter lists are formatted (tupled vs curried).
+    pub param_list_style: ParamListStyle,
+    /// How signatures are rendered (merged vs split type signature).
+    pub function_signature_style: FunctionSignatureStyle,
+    /// Function keyword for constructors (e.g. `""`, `"def"`, `"fn"`).
+    pub constructor_keyword: &'a str,
+    /// Where constructor delegation calls are placed (body vs signature).
+    pub constructor_delegation_style: ConstructorDelegationStyle,
+    /// How where-clause constraints are rendered (inline vs block).
+    pub where_clause_style: WhereClauseStyle,
+    /// Content emitted for abstract methods with no body (e.g. `""`, `"..."`).
+    pub empty_body: &'a str,
+}
+
+impl Default for FunctionSyntaxConfig<'_> {
+    fn default() -> Self {
+        Self {
+            return_type_separator: ": ",
+            async_keyword: "async ",
+            abstract_keyword: "abstract ",
+            param_list_style: ParamListStyle::Tupled,
+            function_signature_style: FunctionSignatureStyle::Merged,
+            constructor_keyword: "",
+            constructor_delegation_style: ConstructorDelegationStyle::Body,
+            where_clause_style: WhereClauseStyle::Inline,
+            empty_body: "",
+        }
+    }
+}
+
+/// Type declaration syntax (inheritance, annotation, field order).
+#[derive(Debug, Clone, Copy)]
+pub struct TypeDeclSyntaxConfig<'a> {
+    /// Whether type annotations use type-before-name order (e.g. C: `int count`).
+    pub type_before_name: bool,
+    /// Whether the return type appears before the function name (e.g. C: `int add(...)`).
+    pub return_type_is_prefix: bool,
+    /// Separator between name and type annotation (e.g. `": "`).
+    pub type_annotation_separator: &'a str,
+    /// Keyword for super type / base class (e.g. `" extends "`, `": "`).
+    pub super_type_keyword: &'a str,
+    /// Separator between super types (e.g. `", "`, `", public "`).
+    pub super_type_separator: &'a str,
+    /// Override separator for 2nd+ super type (e.g. Scala: `Some(" with ")`).
+    pub super_type_subsequent_separator: Option<&'a str>,
+    /// Keyword for interface implementation (e.g. `" implements "`).
+    pub implements_keyword: &'a str,
+    /// Whether type alias uses `typedef target name` order (C).
+    pub type_alias_target_first: bool,
+    /// Whether the language supports primary constructors on type declarations.
+    pub supports_primary_constructor: bool,
+}
+
+impl Default for TypeDeclSyntaxConfig<'_> {
+    fn default() -> Self {
+        Self {
+            type_before_name: false,
+            return_type_is_prefix: false,
+            type_annotation_separator: ": ",
+            super_type_keyword: "",
+            super_type_separator: ", ",
+            super_type_subsequent_separator: None,
+            implements_keyword: "",
+            type_alias_target_first: false,
+            supports_primary_constructor: false,
+        }
+    }
+}
+
+/// Enum variant formatting, annotation syntax, and field mutability keywords.
+#[derive(Debug, Clone, Copy)]
+pub struct EnumAndAnnotationConfig<'a> {
+    /// Prefix before each enum variant (e.g. `""`, `"case "`).
+    pub variant_prefix: &'a str,
+    /// Prefix before the first variant only. `None` = same as `variant_prefix`.
+    pub variant_prefix_first: Option<&'a str>,
+    /// Separator after each variant (e.g. `","`).
+    pub variant_separator: &'a str,
+    /// Whether the separator appears after the last variant too.
+    pub variant_trailing_separator: bool,
+    /// Prefix wrapping an annotation name (e.g. `"@"`, `"#["`).
+    pub annotation_prefix: &'a str,
+    /// Suffix closing an annotation (e.g. `""`, `"]"`).
+    pub annotation_suffix: &'a str,
+    /// Keyword for readonly/immutable fields (e.g. `"const "`, `"readonly "`).
+    pub readonly_keyword: &'a str,
+    /// Keyword for mutable fields (e.g. `""`, `"var "`).
+    pub mutable_field_keyword: &'a str,
+}
+
+impl Default for EnumAndAnnotationConfig<'_> {
+    fn default() -> Self {
+        Self {
+            variant_prefix: "",
+            variant_prefix_first: None,
+            variant_separator: ",",
+            variant_trailing_separator: false,
+            annotation_prefix: "@",
+            annotation_suffix: "",
+            readonly_keyword: "const ",
+            mutable_field_keyword: "",
+        }
+    }
 }

--- a/src/lang/cpp_lang.rs
+++ b/src/lang/cpp_lang.rs
@@ -227,14 +227,6 @@ impl CodeLang for CppLang {
         "//"
     }
 
-    fn indent_unit(&self) -> &str {
-        &self.indent
-    }
-
-    fn uses_semicolons(&self) -> bool {
-        true
-    }
-
     fn render_visibility(&self, _vis: Visibility, _ctx: DeclarationContext) -> &str {
         // C++ uses section-header access specifiers, not per-member keywords.
         // Users add `public:` / `private:` / `protected:` via extra_member.
@@ -244,11 +236,6 @@ impl CodeLang for CppLang {
     fn function_keyword(&self, _ctx: DeclarationContext) -> &str {
         // C++ has no function keyword.
         ""
-    }
-
-    fn return_type_separator(&self) -> &str {
-        // Unused when return_type_is_prefix() is true, but set for safety.
-        " "
     }
 
     fn type_keyword(&self, kind: TypeKind) -> &str {
@@ -262,55 +249,11 @@ impl CodeLang for CppLang {
         }
     }
 
-    fn field_terminator(&self) -> &str {
-        ";"
-    }
-
     fn methods_inside_type_body(&self, kind: TypeKind) -> bool {
         match kind {
             TypeKind::Class | TypeKind::Interface | TypeKind::Trait => true,
             TypeKind::Struct | TypeKind::Enum | TypeKind::TypeAlias | TypeKind::Newtype => false,
         }
-    }
-
-    fn generic_constraint_keyword(&self) -> &str {
-        ""
-    }
-
-    fn generic_constraint_separator(&self) -> &str {
-        ""
-    }
-
-    fn super_type_keyword(&self) -> &str {
-        " : public "
-    }
-
-    fn super_type_separator(&self) -> &str {
-        ", public "
-    }
-
-    fn implements_keyword(&self) -> &str {
-        ""
-    }
-
-    fn type_before_name(&self) -> bool {
-        true
-    }
-
-    fn return_type_is_prefix(&self) -> bool {
-        true
-    }
-
-    fn type_close_terminator(&self) -> &str {
-        ";"
-    }
-
-    fn abstract_keyword(&self) -> &str {
-        "virtual "
-    }
-
-    fn render_annotation_prefix(&self) -> (&str, &str) {
-        ("[[", "]]")
     }
 
     fn optional_field_style(&self) -> crate::lang::config::OptionalFieldStyle {
@@ -321,59 +264,78 @@ impl CodeLang for CppLang {
         }
     }
 
-    fn present_array(&self) -> crate::type_name::TypePresentation<'_> {
-        crate::type_name::TypePresentation::GenericWrap {
-            name: "std::vector",
+    fn type_presentation(&self) -> crate::lang::config::TypePresentationConfig<'_> {
+        crate::lang::config::TypePresentationConfig {
+            array: crate::type_name::TypePresentation::GenericWrap {
+                name: "std::vector",
+            },
+            readonly_array: Some(crate::type_name::TypePresentation::GenericWrap {
+                name: "std::vector",
+            }),
+            optional: crate::type_name::TypePresentation::GenericWrap {
+                name: "std::optional",
+            },
+            map: crate::type_name::TypePresentation::GenericWrap { name: "std::map" },
+            pointer: crate::type_name::TypePresentation::Postfix { suffix: "*" },
+            reference: crate::type_name::TypePresentation::Surround {
+                prefix: "const ",
+                suffix: "&",
+            },
+            reference_mut: crate::type_name::TypePresentation::Postfix { suffix: "&" },
+            function: crate::type_name::FunctionPresentation {
+                arrow: "",
+                return_first: true,
+                wrapper_open: "std::function<",
+                wrapper_close: ">",
+                ..Default::default()
+            },
+            tuple: crate::type_name::TypePresentation::GenericWrap { name: "std::tuple" },
+            ..Default::default()
         }
     }
 
-    fn present_readonly_array(&self) -> Option<crate::type_name::TypePresentation<'_>> {
-        Some(crate::type_name::TypePresentation::GenericWrap {
-            name: "std::vector",
-        })
-    }
-
-    fn present_optional(&self) -> crate::type_name::TypePresentation<'_> {
-        crate::type_name::TypePresentation::GenericWrap {
-            name: "std::optional",
+    fn generic_syntax(&self) -> crate::lang::config::GenericSyntaxConfig<'_> {
+        crate::lang::config::GenericSyntaxConfig {
+            constraint_keyword: "",
+            constraint_separator: "",
+            context_bound_keyword: "",
+            ..Default::default()
         }
     }
 
-    fn present_map(&self) -> crate::type_name::TypePresentation<'_> {
-        crate::type_name::TypePresentation::GenericWrap { name: "std::map" }
-    }
-
-    fn present_pointer(&self) -> crate::type_name::TypePresentation<'_> {
-        crate::type_name::TypePresentation::Postfix { suffix: "*" }
-    }
-
-    fn present_reference(&self) -> crate::type_name::TypePresentation<'_> {
-        crate::type_name::TypePresentation::Surround {
-            prefix: "const ",
-            suffix: "&",
+    fn block_syntax(&self) -> crate::lang::config::BlockSyntaxConfig<'_> {
+        crate::lang::config::BlockSyntaxConfig {
+            indent_unit: &self.indent,
+            field_terminator: ";",
+            type_close_terminator: ";",
+            ..Default::default()
         }
     }
 
-    fn present_reference_mut(&self) -> crate::type_name::TypePresentation<'_> {
-        crate::type_name::TypePresentation::Postfix { suffix: "&" }
-    }
-
-    fn present_function(&self) -> crate::type_name::FunctionPresentation<'_> {
-        crate::type_name::FunctionPresentation {
-            keyword: "",
-            params_open: "(",
-            params_sep: ", ",
-            params_close: ")",
-            arrow: "",
-            return_first: true,
-            curried: false,
-            wrapper_open: "std::function<",
-            wrapper_close: ">",
+    fn function_syntax(&self) -> crate::lang::config::FunctionSyntaxConfig<'_> {
+        crate::lang::config::FunctionSyntaxConfig {
+            return_type_separator: " ",
+            abstract_keyword: "virtual ",
+            ..Default::default()
         }
     }
 
-    fn present_tuple(&self) -> crate::type_name::TypePresentation<'_> {
-        crate::type_name::TypePresentation::GenericWrap { name: "std::tuple" }
+    fn type_decl_syntax(&self) -> crate::lang::config::TypeDeclSyntaxConfig<'_> {
+        crate::lang::config::TypeDeclSyntaxConfig {
+            type_before_name: true,
+            return_type_is_prefix: true,
+            super_type_keyword: " : public ",
+            super_type_separator: ", public ",
+            ..Default::default()
+        }
+    }
+
+    fn enum_and_annotation(&self) -> crate::lang::config::EnumAndAnnotationConfig<'_> {
+        crate::lang::config::EnumAndAnnotationConfig {
+            annotation_prefix: "[[",
+            annotation_suffix: "]]",
+            ..Default::default()
+        }
     }
 }
 
@@ -532,19 +494,19 @@ mod tests {
     #[test]
     fn test_type_before_name() {
         let cpp = CppLang::new();
-        assert!(cpp.type_before_name());
+        assert!(cpp.type_decl_syntax().type_before_name);
     }
 
     #[test]
     fn test_return_type_is_prefix() {
         let cpp = CppLang::new();
-        assert!(cpp.return_type_is_prefix());
+        assert!(cpp.type_decl_syntax().return_type_is_prefix);
     }
 
     #[test]
     fn test_type_close_terminator() {
         let cpp = CppLang::new();
-        assert_eq!(cpp.type_close_terminator(), ";");
+        assert_eq!(cpp.block_syntax().type_close_terminator, ";");
     }
 
     #[test]
@@ -559,19 +521,19 @@ mod tests {
     #[test]
     fn test_abstract_keyword() {
         let cpp = CppLang::new();
-        assert_eq!(cpp.abstract_keyword(), "virtual ");
+        assert_eq!(cpp.function_syntax().abstract_keyword, "virtual ");
     }
 
     #[test]
     fn test_super_type_keyword() {
         let cpp = CppLang::new();
-        assert_eq!(cpp.super_type_keyword(), " : public ");
+        assert_eq!(cpp.type_decl_syntax().super_type_keyword, " : public ");
     }
 
     #[test]
     fn test_super_type_separator() {
         let cpp = CppLang::new();
-        assert_eq!(cpp.super_type_separator(), ", public ");
+        assert_eq!(cpp.type_decl_syntax().super_type_separator, ", public ");
     }
 
     #[test]
@@ -596,6 +558,6 @@ mod tests {
     fn test_cpp_builder_fluent() {
         let cpp = CppLang::new().with_indent("  ").with_extension("cxx");
         assert_eq!(cpp.file_extension(), "cxx");
-        assert_eq!(cpp.indent_unit(), "  ");
+        assert_eq!(cpp.block_syntax().indent_unit, "  ");
     }
 }

--- a/src/lang/cpp_lang.rs
+++ b/src/lang/cpp_lang.rs
@@ -33,7 +33,7 @@ use crate::spec::modifiers::{DeclarationContext, TypeKind, Visibility};
 ///
 /// C++ uses section-header access specifiers. Add them as `extra_member`:
 /// ```text
-/// let mut access = CodeBlock::<CppLang>::builder();
+/// let mut access = CodeBlock::builder();
 /// access.add("%<", ());          // dedent
 /// access.add("public:", ());
 /// access.add_line();
@@ -45,7 +45,7 @@ use crate::spec::modifiers::{DeclarationContext, TypeKind, Visibility};
 ///
 /// Use annotations for `template<typename T>`:
 /// ```text
-/// fb.annotation(CodeBlock::<CppLang>::of("template<typename T>", ()).unwrap());
+/// fb.annotation(CodeBlock::of("template<typename T>", ()).unwrap());
 /// ```
 ///
 /// # Virtual / pure virtual

--- a/src/lang/dart.rs
+++ b/src/lang/dart.rs
@@ -198,14 +198,6 @@ impl CodeLang for DartLang {
         "//"
     }
 
-    fn indent_unit(&self) -> &str {
-        &self.indent
-    }
-
-    fn uses_semicolons(&self) -> bool {
-        true
-    }
-
     fn render_visibility(&self, _vis: Visibility, _ctx: DeclarationContext) -> &str {
         // Dart has no visibility keywords; privacy is via _ prefix naming.
         ""
@@ -214,11 +206,6 @@ impl CodeLang for DartLang {
     fn function_keyword(&self, _ctx: DeclarationContext) -> &str {
         // Dart has no function keyword (like Java/C).
         ""
-    }
-
-    fn return_type_separator(&self) -> &str {
-        // Unused when return_type_is_prefix() is true, but set for safety.
-        " "
     }
 
     fn type_keyword(&self, kind: TypeKind) -> &str {
@@ -231,79 +218,73 @@ impl CodeLang for DartLang {
         }
     }
 
-    fn field_terminator(&self) -> &str {
-        ";"
-    }
-
     fn methods_inside_type_body(&self, _kind: TypeKind) -> bool {
         true
-    }
-
-    fn generic_constraint_keyword(&self) -> &str {
-        " extends "
-    }
-
-    fn generic_constraint_separator(&self) -> &str {
-        ", "
-    }
-
-    fn super_type_keyword(&self) -> &str {
-        " extends "
-    }
-
-    fn implements_keyword(&self) -> &str {
-        " implements "
-    }
-
-    fn type_before_name(&self) -> bool {
-        true
-    }
-
-    fn return_type_is_prefix(&self) -> bool {
-        true
-    }
-
-    fn async_keyword(&self) -> &str {
-        // Dart's `async` is a body modifier, not a signature prefix.
-        // Use Future<T> as return type instead.
-        ""
-    }
-
-    fn readonly_keyword(&self) -> &str {
-        "final "
     }
 
     fn optional_field_style(&self) -> crate::lang::config::OptionalFieldStyle {
         crate::lang::config::OptionalFieldStyle::TypeSuffix("?")
     }
 
-    fn present_array(&self) -> crate::type_name::TypePresentation<'_> {
-        crate::type_name::TypePresentation::GenericWrap { name: "List" }
+    fn type_presentation(&self) -> crate::lang::config::TypePresentationConfig<'_> {
+        crate::lang::config::TypePresentationConfig {
+            array: crate::type_name::TypePresentation::GenericWrap { name: "List" },
+            readonly_array: Some(crate::type_name::TypePresentation::GenericWrap { name: "List" }),
+            optional: crate::type_name::TypePresentation::Postfix { suffix: "?" },
+            function: crate::type_name::FunctionPresentation {
+                keyword: " Function",
+                params_open: "(",
+                params_sep: ", ",
+                params_close: ")",
+                arrow: "",
+                return_first: true,
+                curried: false,
+                wrapper_open: "",
+                wrapper_close: "",
+            },
+            ..Default::default()
+        }
     }
 
-    fn present_readonly_array(&self) -> Option<crate::type_name::TypePresentation<'_>> {
-        Some(crate::type_name::TypePresentation::GenericWrap { name: "List" })
+    fn generic_syntax(&self) -> crate::lang::config::GenericSyntaxConfig<'_> {
+        crate::lang::config::GenericSyntaxConfig {
+            constraint_keyword: " extends ",
+            constraint_separator: ", ",
+            context_bound_keyword: " extends ",
+            ..Default::default()
+        }
     }
 
-    fn present_optional(&self) -> crate::type_name::TypePresentation<'_> {
-        crate::type_name::TypePresentation::Postfix { suffix: "?" }
+    fn block_syntax(&self) -> crate::lang::config::BlockSyntaxConfig<'_> {
+        crate::lang::config::BlockSyntaxConfig {
+            indent_unit: &self.indent,
+            field_terminator: ";",
+            ..Default::default()
+        }
     }
 
-    fn present_map(&self) -> crate::type_name::TypePresentation<'_> {
-        crate::type_name::TypePresentation::GenericWrap { name: "Map" }
+    fn function_syntax(&self) -> crate::lang::config::FunctionSyntaxConfig<'_> {
+        crate::lang::config::FunctionSyntaxConfig {
+            return_type_separator: " ",
+            async_keyword: "",
+            ..Default::default()
+        }
     }
 
-    fn present_function(&self) -> crate::type_name::FunctionPresentation<'_> {
-        crate::type_name::FunctionPresentation {
-            keyword: " Function",
-            params_open: "(",
-            params_sep: ", ",
-            params_close: ")",
-            arrow: "",
-            return_first: true,
-            curried: false,
-            wrapper_open: "",
-            wrapper_close: "",
+    fn type_decl_syntax(&self) -> crate::lang::config::TypeDeclSyntaxConfig<'_> {
+        crate::lang::config::TypeDeclSyntaxConfig {
+            type_before_name: true,
+            return_type_is_prefix: true,
+            super_type_keyword: " extends ",
+            implements_keyword: " implements ",
+            ..Default::default()
+        }
+    }
+
+    fn enum_and_annotation(&self) -> crate::lang::config::EnumAndAnnotationConfig<'_> {
+        crate::lang::config::EnumAndAnnotationConfig {
+            readonly_keyword: "final ",
+            ..Default::default()
         }
     }
 }
@@ -504,25 +485,25 @@ mod tests {
     #[test]
     fn test_type_before_name() {
         let d = DartLang::new();
-        assert!(d.type_before_name());
+        assert!(d.type_decl_syntax().type_before_name);
     }
 
     #[test]
     fn test_return_type_is_prefix() {
         let d = DartLang::new();
-        assert!(d.return_type_is_prefix());
+        assert!(d.type_decl_syntax().return_type_is_prefix);
     }
 
     #[test]
     fn test_readonly_keyword() {
         let d = DartLang::new();
-        assert_eq!(d.readonly_keyword(), "final ");
+        assert_eq!(d.enum_and_annotation().readonly_keyword, "final ");
     }
 
     #[test]
     fn test_no_async_keyword() {
         let d = DartLang::new();
-        assert_eq!(d.async_keyword(), "");
+        assert_eq!(d.function_syntax().async_keyword, "");
     }
 
     #[test]
@@ -539,6 +520,6 @@ mod tests {
     fn test_dart_builder_fluent() {
         let d = DartLang::new().with_indent("    ").with_extension("g.dart");
         assert_eq!(d.file_extension(), "g.dart");
-        assert_eq!(d.indent_unit(), "    ");
+        assert_eq!(d.block_syntax().indent_unit, "    ");
     }
 }

--- a/src/lang/go_lang.rs
+++ b/src/lang/go_lang.rs
@@ -2,7 +2,12 @@
 
 use crate::import::{ImportEntry, ImportGroup};
 use crate::lang::CodeLang;
+use crate::lang::config::{
+    BlockSyntaxConfig, EnumAndAnnotationConfig, FunctionSyntaxConfig, GenericSyntaxConfig,
+    TypeDeclSyntaxConfig, TypePresentationConfig,
+};
 use crate::spec::modifiers::{DeclarationContext, TypeKind, Visibility};
+use crate::type_name::{FunctionPresentation, TypePresentation, WildcardPresentation};
 
 /// Go language implementation.
 ///
@@ -206,14 +211,6 @@ impl CodeLang for GoLang {
         "//"
     }
 
-    fn indent_unit(&self) -> &str {
-        &self.indent
-    }
-
-    fn uses_semicolons(&self) -> bool {
-        false
-    }
-
     fn render_visibility(&self, _vis: Visibility, _ctx: DeclarationContext) -> &str {
         // Go uses name capitalization for visibility, not keywords.
         ""
@@ -228,18 +225,10 @@ impl CodeLang for GoLang {
         }
     }
 
-    fn return_type_separator(&self) -> &str {
-        " "
-    }
-
     fn type_keyword(&self, _kind: TypeKind) -> &str {
         // Go uses `type Name struct/interface`, so the prefix keyword is always `type`.
         // The kind-specific keyword (struct/interface) is handled by `type_kind_suffix`.
         "type"
-    }
-
-    fn field_terminator(&self) -> &str {
-        ""
     }
 
     fn methods_inside_type_body(&self, kind: TypeKind) -> bool {
@@ -257,35 +246,6 @@ impl CodeLang for GoLang {
         format!("type {name} {inner}")
     }
 
-    fn generic_constraint_keyword(&self) -> &str {
-        " "
-    }
-
-    fn generic_constraint_separator(&self) -> &str {
-        // Not commonly used; Go multi-constraints use `interface{ A; B }`.
-        " "
-    }
-
-    fn super_type_keyword(&self) -> &str {
-        ""
-    }
-
-    fn implements_keyword(&self) -> &str {
-        ""
-    }
-
-    fn type_annotation_separator(&self) -> &str {
-        " "
-    }
-
-    fn generic_open(&self) -> &str {
-        "["
-    }
-
-    fn generic_close(&self) -> &str {
-        "]"
-    }
-
     fn qualify_import_name(&self, module: &str, resolved_name: &str) -> String {
         let pkg = package_name(module);
         format!("{pkg}.{resolved_name}")
@@ -299,65 +259,83 @@ impl CodeLang for GoLang {
         }
     }
 
-    fn enum_variant_separator(&self) -> &str {
-        ""
-    }
-
     fn optional_field_style(&self) -> crate::lang::config::OptionalFieldStyle {
         crate::lang::config::OptionalFieldStyle::TypePrefix("*")
     }
 
-    fn present_array(&self) -> crate::type_name::TypePresentation<'_> {
-        crate::type_name::TypePresentation::Prefix { prefix: "[]" }
-    }
+    // --- Config struct accessors ---
 
-    fn present_readonly_array(&self) -> Option<crate::type_name::TypePresentation<'_>> {
-        Some(crate::type_name::TypePresentation::Prefix { prefix: "[]" })
-    }
-
-    fn present_optional(&self) -> crate::type_name::TypePresentation<'_> {
-        crate::type_name::TypePresentation::Prefix { prefix: "*" }
-    }
-
-    fn present_map(&self) -> crate::type_name::TypePresentation<'_> {
-        crate::type_name::TypePresentation::Delimited {
-            open: "map[",
-            sep: "]",
-            close: "",
+    fn type_presentation(&self) -> TypePresentationConfig<'_> {
+        TypePresentationConfig {
+            array: TypePresentation::Prefix { prefix: "[]" },
+            readonly_array: Some(TypePresentation::Prefix { prefix: "[]" }),
+            optional: TypePresentation::Prefix { prefix: "*" },
+            map: TypePresentation::Delimited {
+                open: "map[",
+                sep: "]",
+                close: "",
+            },
+            pointer: TypePresentation::Prefix { prefix: "*" },
+            slice: TypePresentation::Prefix { prefix: "[]" },
+            reference_mut: TypePresentation::Prefix { prefix: "*" },
+            function: FunctionPresentation {
+                keyword: "func",
+                params_open: "(",
+                params_sep: ", ",
+                params_close: ")",
+                arrow: " ",
+                return_first: false,
+                curried: false,
+                wrapper_open: "",
+                wrapper_close: "",
+            },
+            wildcard: WildcardPresentation {
+                unbounded: "any",
+                upper_keyword: "any ",
+                lower_keyword: "any ",
+            },
+            ..Default::default()
         }
     }
 
-    fn present_pointer(&self) -> crate::type_name::TypePresentation<'_> {
-        crate::type_name::TypePresentation::Prefix { prefix: "*" }
-    }
-
-    fn present_slice(&self) -> crate::type_name::TypePresentation<'_> {
-        crate::type_name::TypePresentation::Prefix { prefix: "[]" }
-    }
-
-    fn present_reference_mut(&self) -> crate::type_name::TypePresentation<'_> {
-        crate::type_name::TypePresentation::Prefix { prefix: "*" }
-    }
-
-    fn present_function(&self) -> crate::type_name::FunctionPresentation<'_> {
-        crate::type_name::FunctionPresentation {
-            keyword: "func",
-            params_open: "(",
-            params_sep: ", ",
-            params_close: ")",
-            arrow: " ",
-            return_first: false,
-            curried: false,
-            wrapper_open: "",
-            wrapper_close: "",
+    fn generic_syntax(&self) -> GenericSyntaxConfig<'_> {
+        GenericSyntaxConfig {
+            open: "[",
+            close: "]",
+            constraint_keyword: " ",
+            constraint_separator: " ",
+            context_bound_keyword: " ",
+            ..Default::default()
         }
     }
 
-    fn present_wildcard(&self) -> crate::type_name::WildcardPresentation<'_> {
-        crate::type_name::WildcardPresentation {
-            unbounded: "any",
-            upper_keyword: "any ",
-            lower_keyword: "any ",
+    fn block_syntax(&self) -> BlockSyntaxConfig<'_> {
+        BlockSyntaxConfig {
+            indent_unit: &self.indent,
+            uses_semicolons: false,
+            field_terminator: "",
+            ..Default::default()
+        }
+    }
+
+    fn function_syntax(&self) -> FunctionSyntaxConfig<'_> {
+        FunctionSyntaxConfig {
+            return_type_separator: " ",
+            ..Default::default()
+        }
+    }
+
+    fn type_decl_syntax(&self) -> TypeDeclSyntaxConfig<'_> {
+        TypeDeclSyntaxConfig {
+            type_annotation_separator: " ",
+            ..Default::default()
+        }
+    }
+
+    fn enum_and_annotation(&self) -> EnumAndAnnotationConfig<'_> {
+        EnumAndAnnotationConfig {
+            variant_separator: "",
+            ..Default::default()
         }
     }
 }
@@ -513,8 +491,8 @@ mod tests {
     #[test]
     fn test_generic_delimiters() {
         let go = GoLang::new();
-        assert_eq!(go.generic_open(), "[");
-        assert_eq!(go.generic_close(), "]");
+        assert_eq!(go.generic_syntax().open, "[");
+        assert_eq!(go.generic_syntax().close, "]");
     }
 
     #[test]
@@ -529,6 +507,6 @@ mod tests {
     fn test_go_builder_fluent() {
         let go = GoLang::new().with_indent("    ").with_extension("go2");
         assert_eq!(go.file_extension(), "go2");
-        assert_eq!(go.indent_unit(), "    ");
+        assert_eq!(go.block_syntax().indent_unit, "    ");
     }
 }

--- a/src/lang/haskell.rs
+++ b/src/lang/haskell.rs
@@ -210,24 +210,12 @@ impl CodeLang for Haskell {
         "--"
     }
 
-    fn indent_unit(&self) -> &str {
-        &self.indent
-    }
-
-    fn uses_semicolons(&self) -> bool {
-        false
-    }
-
     fn render_visibility(&self, _vis: Visibility, _ctx: DeclarationContext) -> &str {
         ""
     }
 
     fn function_keyword(&self, _ctx: DeclarationContext) -> &str {
         ""
-    }
-
-    fn return_type_separator(&self) -> &str {
-        " -> "
     }
 
     fn type_keyword(&self, kind: TypeKind) -> &str {
@@ -240,60 +228,8 @@ impl CodeLang for Haskell {
         }
     }
 
-    fn field_terminator(&self) -> &str {
-        ","
-    }
-
     fn methods_inside_type_body(&self, kind: TypeKind) -> bool {
         matches!(kind, TypeKind::Trait | TypeKind::Interface)
-    }
-
-    fn generic_constraint_keyword(&self) -> &str {
-        ""
-    }
-
-    fn generic_constraint_separator(&self) -> &str {
-        ""
-    }
-
-    fn super_type_keyword(&self) -> &str {
-        ""
-    }
-
-    fn implements_keyword(&self) -> &str {
-        ""
-    }
-
-    fn type_annotation_separator(&self) -> &str {
-        " :: "
-    }
-
-    fn generic_application_style(&self) -> crate::type_name::GenericApplicationStyle {
-        crate::type_name::GenericApplicationStyle::PrefixJuxtaposition
-    }
-
-    fn generic_open(&self) -> &str {
-        ""
-    }
-
-    fn generic_close(&self) -> &str {
-        ""
-    }
-
-    fn enum_variant_separator(&self) -> &str {
-        ""
-    }
-
-    fn enum_variant_prefix(&self) -> &str {
-        "| "
-    }
-
-    fn enum_variant_prefix_first(&self) -> &str {
-        ""
-    }
-
-    fn block_open(&self) -> &str {
-        " ="
     }
 
     fn type_header_block_open(&self, kind: crate::spec::modifiers::TypeKind) -> &str {
@@ -303,66 +239,12 @@ impl CodeLang for Haskell {
         }
     }
 
-    fn block_close(&self) -> &str {
-        ""
-    }
-
-    fn present_array(&self) -> crate::type_name::TypePresentation<'_> {
-        crate::type_name::TypePresentation::Delimited {
-            open: "[",
-            sep: "",
-            close: "]",
-        }
-    }
-
-    fn present_readonly_array(&self) -> Option<crate::type_name::TypePresentation<'_>> {
-        Some(crate::type_name::TypePresentation::Delimited {
-            open: "[",
-            sep: "",
-            close: "]",
-        })
-    }
-
-    fn present_optional(&self) -> crate::type_name::TypePresentation<'_> {
-        crate::type_name::TypePresentation::GenericWrap { name: "Maybe" }
-    }
-
-    fn present_map(&self) -> crate::type_name::TypePresentation<'_> {
-        crate::type_name::TypePresentation::GenericWrap { name: "Map" }
-    }
-
-    fn present_tuple(&self) -> crate::type_name::TypePresentation<'_> {
-        crate::type_name::TypePresentation::Delimited {
-            open: "(",
-            sep: ", ",
-            close: ")",
-        }
-    }
-
-    fn present_function(&self) -> crate::type_name::FunctionPresentation<'_> {
-        crate::type_name::FunctionPresentation {
-            keyword: "",
-            params_open: "",
-            params_sep: " -> ",
-            params_close: "",
-            arrow: " -> ",
-            return_first: false,
-            curried: true,
-            wrapper_open: "",
-            wrapper_close: "",
-        }
-    }
-
-    fn present_union(&self) -> crate::type_name::TypePresentation<'_> {
-        crate::type_name::TypePresentation::Infix { sep: " | " }
+    fn fun_block_open(&self) -> &str {
+        " ="
     }
 
     fn render_newtype_line(&self, _vis: &str, name: &str, inner: &str) -> String {
         format!("newtype {name} = {name} {inner}")
-    }
-
-    fn function_signature_style(&self) -> crate::spec::fun_spec::FunctionSignatureStyle {
-        crate::spec::fun_spec::FunctionSignatureStyle::Split
     }
 
     fn render_type_context(&self, type_params: &[crate::spec::fun_spec::TypeParamSpec]) -> String {
@@ -407,6 +289,77 @@ impl CodeLang for Haskell {
             return String::new();
         }
         format!("  deriving ({})", impl_types.join(", "))
+    }
+
+    fn type_presentation(&self) -> crate::lang::config::TypePresentationConfig<'_> {
+        crate::lang::config::TypePresentationConfig {
+            array: crate::type_name::TypePresentation::Delimited {
+                open: "[",
+                sep: "",
+                close: "]",
+            },
+            readonly_array: Some(crate::type_name::TypePresentation::Delimited {
+                open: "[",
+                sep: "",
+                close: "]",
+            }),
+            optional: crate::type_name::TypePresentation::GenericWrap { name: "Maybe" },
+            function: crate::type_name::FunctionPresentation {
+                params_open: "",
+                params_sep: " -> ",
+                params_close: "",
+                arrow: " -> ",
+                curried: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    }
+
+    fn generic_syntax(&self) -> crate::lang::config::GenericSyntaxConfig<'_> {
+        crate::lang::config::GenericSyntaxConfig {
+            open: "",
+            close: "",
+            application_style: crate::type_name::GenericApplicationStyle::PrefixJuxtaposition,
+            constraint_keyword: "",
+            constraint_separator: "",
+            context_bound_keyword: "",
+        }
+    }
+
+    fn block_syntax(&self) -> crate::lang::config::BlockSyntaxConfig<'_> {
+        crate::lang::config::BlockSyntaxConfig {
+            block_open: " =",
+            block_close: "",
+            indent_unit: &self.indent,
+            uses_semicolons: false,
+            field_terminator: ",",
+            ..Default::default()
+        }
+    }
+
+    fn function_syntax(&self) -> crate::lang::config::FunctionSyntaxConfig<'_> {
+        crate::lang::config::FunctionSyntaxConfig {
+            return_type_separator: " -> ",
+            function_signature_style: crate::spec::fun_spec::FunctionSignatureStyle::Split,
+            ..Default::default()
+        }
+    }
+
+    fn type_decl_syntax(&self) -> crate::lang::config::TypeDeclSyntaxConfig<'_> {
+        crate::lang::config::TypeDeclSyntaxConfig {
+            type_annotation_separator: " :: ",
+            ..Default::default()
+        }
+    }
+
+    fn enum_and_annotation(&self) -> crate::lang::config::EnumAndAnnotationConfig<'_> {
+        crate::lang::config::EnumAndAnnotationConfig {
+            variant_prefix: "| ",
+            variant_prefix_first: Some(""),
+            variant_separator: "",
+            ..Default::default()
+        }
     }
 }
 
@@ -552,14 +505,14 @@ mod tests {
     #[test]
     fn test_no_semicolons() {
         let hs = Haskell::new();
-        assert!(!hs.uses_semicolons());
+        assert!(!hs.block_syntax().uses_semicolons);
     }
 
     #[test]
     fn test_generic_application_style() {
         let hs = Haskell::new();
         assert!(matches!(
-            hs.generic_application_style(),
+            hs.generic_syntax().application_style,
             crate::type_name::GenericApplicationStyle::PrefixJuxtaposition
         ));
     }
@@ -567,14 +520,14 @@ mod tests {
     #[test]
     fn test_type_annotation_separator() {
         let hs = Haskell::new();
-        assert_eq!(hs.type_annotation_separator(), " :: ");
+        assert_eq!(hs.type_decl_syntax().type_annotation_separator, " :: ");
     }
 
     #[test]
     fn test_haskell_builder_fluent() {
         let hs = Haskell::new().with_indent("    ").with_extension("lhs");
         assert_eq!(hs.file_extension(), "lhs");
-        assert_eq!(hs.indent_unit(), "    ");
+        assert_eq!(hs.block_syntax().indent_unit, "    ");
     }
 
     #[test]
@@ -663,7 +616,7 @@ mod tests {
     fn test_function_signature_style() {
         let hs = Haskell::new();
         assert_eq!(
-            hs.function_signature_style(),
+            hs.function_syntax().function_signature_style,
             crate::spec::fun_spec::FunctionSignatureStyle::Split
         );
     }

--- a/src/lang/haskell.rs
+++ b/src/lang/haskell.rs
@@ -365,10 +365,7 @@ impl CodeLang for Haskell {
         crate::spec::fun_spec::FunctionSignatureStyle::Split
     }
 
-    fn render_type_context(
-        &self,
-        type_params: &[crate::spec::fun_spec::TypeParamSpec<Self>],
-    ) -> String {
+    fn render_type_context(&self, type_params: &[crate::spec::fun_spec::TypeParamSpec]) -> String {
         let resolve = |_module: &str, name: &str| name.to_string();
         let mut constraints: Vec<String> = Vec::new();
         for tp in type_params {
@@ -593,7 +590,7 @@ mod tests {
     #[test]
     fn test_render_type_context_empty() {
         let hs = Haskell::new();
-        let params: Vec<crate::spec::fun_spec::TypeParamSpec<Haskell>> = vec![];
+        let params: Vec<crate::spec::fun_spec::TypeParamSpec> = vec![];
         assert_eq!(hs.render_type_context(&params), "");
     }
 

--- a/src/lang/java_lang.rs
+++ b/src/lang/java_lang.rs
@@ -198,14 +198,6 @@ impl CodeLang for JavaLang {
         "//"
     }
 
-    fn indent_unit(&self) -> &str {
-        &self.indent
-    }
-
-    fn uses_semicolons(&self) -> bool {
-        true
-    }
-
     fn render_visibility(&self, vis: Visibility, ctx: DeclarationContext) -> &str {
         match ctx {
             DeclarationContext::TopLevel => match vis {
@@ -226,11 +218,6 @@ impl CodeLang for JavaLang {
         ""
     }
 
-    fn return_type_separator(&self) -> &str {
-        // Unused when return_type_is_prefix() is true, but set for safety.
-        " "
-    }
-
     fn type_keyword(&self, kind: TypeKind) -> &str {
         match kind {
             TypeKind::Class | TypeKind::Struct => "class",
@@ -240,45 +227,8 @@ impl CodeLang for JavaLang {
         }
     }
 
-    fn field_terminator(&self) -> &str {
-        ";"
-    }
-
     fn methods_inside_type_body(&self, _kind: TypeKind) -> bool {
         true
-    }
-
-    fn generic_constraint_keyword(&self) -> &str {
-        " extends "
-    }
-
-    fn generic_constraint_separator(&self) -> &str {
-        " & "
-    }
-
-    fn super_type_keyword(&self) -> &str {
-        " extends "
-    }
-
-    fn implements_keyword(&self) -> &str {
-        " implements "
-    }
-
-    fn type_before_name(&self) -> bool {
-        true
-    }
-
-    fn return_type_is_prefix(&self) -> bool {
-        true
-    }
-
-    fn async_keyword(&self) -> &str {
-        // Java has no async keyword.
-        ""
-    }
-
-    fn readonly_keyword(&self) -> &str {
-        "final "
     }
 
     fn optional_field_style(&self) -> crate::lang::config::OptionalFieldStyle {
@@ -291,24 +241,56 @@ impl CodeLang for JavaLang {
         }
     }
 
-    fn present_array(&self) -> crate::type_name::TypePresentation<'_> {
-        crate::type_name::TypePresentation::GenericWrap { name: "List" }
+    fn type_presentation(&self) -> crate::lang::config::TypePresentationConfig<'_> {
+        crate::lang::config::TypePresentationConfig {
+            array: crate::type_name::TypePresentation::GenericWrap { name: "List" },
+            readonly_array: Some(crate::type_name::TypePresentation::GenericWrap { name: "List" }),
+            optional: crate::type_name::TypePresentation::GenericWrap { name: "Optional" },
+            associated_type: crate::type_name::AssociatedTypeStyle::DotAccess,
+            ..Default::default()
+        }
     }
 
-    fn present_readonly_array(&self) -> Option<crate::type_name::TypePresentation<'_>> {
-        Some(crate::type_name::TypePresentation::GenericWrap { name: "List" })
+    fn generic_syntax(&self) -> crate::lang::config::GenericSyntaxConfig<'_> {
+        crate::lang::config::GenericSyntaxConfig {
+            constraint_keyword: " extends ",
+            constraint_separator: " & ",
+            context_bound_keyword: " extends ",
+            ..Default::default()
+        }
     }
 
-    fn present_optional(&self) -> crate::type_name::TypePresentation<'_> {
-        crate::type_name::TypePresentation::GenericWrap { name: "Optional" }
+    fn block_syntax(&self) -> crate::lang::config::BlockSyntaxConfig<'_> {
+        crate::lang::config::BlockSyntaxConfig {
+            indent_unit: &self.indent,
+            field_terminator: ";",
+            ..Default::default()
+        }
     }
 
-    fn present_map(&self) -> crate::type_name::TypePresentation<'_> {
-        crate::type_name::TypePresentation::GenericWrap { name: "Map" }
+    fn function_syntax(&self) -> crate::lang::config::FunctionSyntaxConfig<'_> {
+        crate::lang::config::FunctionSyntaxConfig {
+            return_type_separator: " ",
+            async_keyword: "",
+            ..Default::default()
+        }
     }
 
-    fn present_associated_type(&self) -> crate::type_name::AssociatedTypeStyle<'_> {
-        crate::type_name::AssociatedTypeStyle::DotAccess
+    fn type_decl_syntax(&self) -> crate::lang::config::TypeDeclSyntaxConfig<'_> {
+        crate::lang::config::TypeDeclSyntaxConfig {
+            type_before_name: true,
+            return_type_is_prefix: true,
+            super_type_keyword: " extends ",
+            implements_keyword: " implements ",
+            ..Default::default()
+        }
+    }
+
+    fn enum_and_annotation(&self) -> crate::lang::config::EnumAndAnnotationConfig<'_> {
+        crate::lang::config::EnumAndAnnotationConfig {
+            readonly_keyword: "final ",
+            ..Default::default()
+        }
     }
 }
 
@@ -522,25 +504,25 @@ mod tests {
     #[test]
     fn test_type_before_name() {
         let java = JavaLang::new();
-        assert!(java.type_before_name());
+        assert!(java.type_decl_syntax().type_before_name);
     }
 
     #[test]
     fn test_return_type_is_prefix() {
         let java = JavaLang::new();
-        assert!(java.return_type_is_prefix());
+        assert!(java.type_decl_syntax().return_type_is_prefix);
     }
 
     #[test]
     fn test_readonly_keyword() {
         let java = JavaLang::new();
-        assert_eq!(java.readonly_keyword(), "final ");
+        assert_eq!(java.enum_and_annotation().readonly_keyword, "final ");
     }
 
     #[test]
     fn test_no_async() {
         let java = JavaLang::new();
-        assert_eq!(java.async_keyword(), "");
+        assert_eq!(java.function_syntax().async_keyword, "");
     }
 
     #[test]
@@ -556,6 +538,6 @@ mod tests {
     fn test_java_builder_fluent() {
         let java = JavaLang::new().with_indent("\t").with_extension("jav");
         assert_eq!(java.file_extension(), "jav");
-        assert_eq!(java.indent_unit(), "\t");
+        assert_eq!(java.block_syntax().indent_unit, "\t");
     }
 }

--- a/src/lang/java_lang.rs
+++ b/src/lang/java_lang.rs
@@ -32,8 +32,8 @@ use crate::spec::modifiers::{DeclarationContext, TypeKind, Visibility};
 ///
 /// Use `annotation()` on builders for Java annotations:
 /// ```text
-/// fb.annotation(CodeBlock::<JavaLang>::of("@Override", ()).unwrap());
-/// fb.annotation(CodeBlock::<JavaLang>::of("@Nullable", ()).unwrap());
+/// fb.annotation(CodeBlock::of("@Override", ()).unwrap());
+/// fb.annotation(CodeBlock::of("@Nullable", ()).unwrap());
 /// ```
 ///
 /// # Constructors

--- a/src/lang/javascript.rs
+++ b/src/lang/javascript.rs
@@ -2,8 +2,12 @@
 
 use crate::import::{ImportEntry, ImportGroup};
 use crate::lang::CodeLang;
-use crate::lang::config::QuoteStyle;
+use crate::lang::config::{
+    BlockSyntaxConfig, EnumAndAnnotationConfig, FunctionSyntaxConfig, GenericSyntaxConfig,
+    QuoteStyle, TypeDeclSyntaxConfig, TypePresentationConfig,
+};
 use crate::spec::modifiers::{DeclarationContext, TypeKind, Visibility};
+use crate::type_name::TypePresentation;
 
 /// JavaScript language implementation.
 ///
@@ -214,14 +218,6 @@ impl CodeLang for JavaScript {
         "//"
     }
 
-    fn indent_unit(&self) -> &str {
-        &self.indent
-    }
-
-    fn uses_semicolons(&self) -> bool {
-        self.semicolons
-    }
-
     fn render_visibility(&self, vis: Visibility, ctx: DeclarationContext) -> &str {
         match ctx {
             DeclarationContext::TopLevel => match vis {
@@ -241,12 +237,6 @@ impl CodeLang for JavaScript {
         }
     }
 
-    fn return_type_separator(&self) -> &str {
-        // Not used in practice (JS users don't call .returns()),
-        // but kept for safety.
-        ": "
-    }
-
     fn type_keyword(&self, kind: TypeKind) -> &str {
         match kind {
             TypeKind::Class | TypeKind::Struct => "class",
@@ -256,50 +246,59 @@ impl CodeLang for JavaScript {
         }
     }
 
-    fn field_terminator(&self) -> &str {
-        ";"
-    }
-
     fn methods_inside_type_body(&self, _kind: TypeKind) -> bool {
         true
     }
 
-    fn generic_constraint_keyword(&self) -> &str {
-        // JavaScript has no generics.
-        ""
+    // --- Config struct accessors ---
+
+    fn type_presentation(&self) -> TypePresentationConfig<'_> {
+        TypePresentationConfig {
+            tuple: TypePresentation::Delimited {
+                open: "[",
+                sep: ", ",
+                close: "]",
+            },
+            ..Default::default()
+        }
     }
 
-    fn generic_constraint_separator(&self) -> &str {
-        ""
+    fn generic_syntax(&self) -> GenericSyntaxConfig<'_> {
+        GenericSyntaxConfig {
+            constraint_keyword: "",
+            constraint_separator: "",
+            context_bound_keyword: "",
+            ..Default::default()
+        }
     }
 
-    fn super_type_keyword(&self) -> &str {
-        " extends "
+    fn block_syntax(&self) -> BlockSyntaxConfig<'_> {
+        BlockSyntaxConfig {
+            indent_unit: &self.indent,
+            uses_semicolons: self.semicolons,
+            field_terminator: ";",
+            ..Default::default()
+        }
     }
 
-    fn implements_keyword(&self) -> &str {
-        // JavaScript has no implements keyword.
-        ""
+    fn function_syntax(&self) -> FunctionSyntaxConfig<'_> {
+        FunctionSyntaxConfig {
+            abstract_keyword: "",
+            ..Default::default()
+        }
     }
 
-    fn abstract_keyword(&self) -> &str {
-        // JavaScript has no abstract keyword.
-        ""
+    fn type_decl_syntax(&self) -> TypeDeclSyntaxConfig<'_> {
+        TypeDeclSyntaxConfig {
+            super_type_keyword: " extends ",
+            ..Default::default()
+        }
     }
 
-    fn enum_variant_separator(&self) -> &str {
-        ""
-    }
-
-    fn enum_variant_trailing_separator(&self) -> bool {
-        false
-    }
-
-    fn present_tuple(&self) -> crate::type_name::TypePresentation<'_> {
-        crate::type_name::TypePresentation::Delimited {
-            open: "[",
-            sep: ", ",
-            close: "]",
+    fn enum_and_annotation(&self) -> EnumAndAnnotationConfig<'_> {
+        EnumAndAnnotationConfig {
+            variant_separator: "",
+            ..Default::default()
         }
     }
 }
@@ -497,9 +496,9 @@ mod tests {
             .with_quote_style(QuoteStyle::Double)
             .with_extension("mjs")
             .with_indent("    ");
-        assert!(!js.uses_semicolons());
+        assert!(!js.block_syntax().uses_semicolons);
         assert_eq!(js.file_extension(), "mjs");
-        assert_eq!(js.indent_unit(), "    ");
+        assert_eq!(js.block_syntax().indent_unit, "    ");
         assert_eq!(js.render_string_literal("hi"), "\"hi\"");
     }
 
@@ -537,13 +536,13 @@ mod tests {
     #[test]
     fn test_no_abstract() {
         let js = JavaScript::new();
-        assert_eq!(js.abstract_keyword(), "");
+        assert_eq!(js.function_syntax().abstract_keyword, "");
     }
 
     #[test]
     fn test_no_implements() {
         let js = JavaScript::new();
-        assert_eq!(js.implements_keyword(), "");
+        assert_eq!(js.type_decl_syntax().implements_keyword, "");
     }
 
     #[test]

--- a/src/lang/javascript.rs
+++ b/src/lang/javascript.rs
@@ -27,7 +27,7 @@ use crate::spec::modifiers::{DeclarationContext, TypeKind, Visibility};
 /// FieldSpec::builder("count", TypeName::primitive("")).build()
 ///
 /// // Function without return type — just don't call .returns():
-/// let mut fb = FunSpec::<JavaScript>::builder("greet");
+/// let mut fb = FunSpec::builder("greet");
 /// fb.add_param(ParameterSpec::new("name", TypeName::primitive("")));
 /// fb.body(body);
 /// ```

--- a/src/lang/kotlin.rs
+++ b/src/lang/kotlin.rs
@@ -258,14 +258,6 @@ impl CodeLang for Kotlin {
         "//"
     }
 
-    fn indent_unit(&self) -> &str {
-        &self.indent
-    }
-
-    fn uses_semicolons(&self) -> bool {
-        false
-    }
-
     fn render_visibility(&self, vis: Visibility, ctx: DeclarationContext) -> &str {
         match ctx {
             DeclarationContext::TopLevel => match vis {
@@ -287,10 +279,6 @@ impl CodeLang for Kotlin {
         "fun"
     }
 
-    fn return_type_separator(&self) -> &str {
-        ": "
-    }
-
     fn type_keyword(&self, kind: TypeKind) -> &str {
         match kind {
             TypeKind::Class => "class",
@@ -302,50 +290,12 @@ impl CodeLang for Kotlin {
         }
     }
 
-    fn field_terminator(&self) -> &str {
-        ""
-    }
-
     fn methods_inside_type_body(&self, _kind: TypeKind) -> bool {
         true
     }
 
     fn render_newtype_line(&self, vis: &str, name: &str, inner: &str) -> String {
         format!("{vis}value class {name}(val value: {inner})")
-    }
-
-    fn generic_constraint_keyword(&self) -> &str {
-        " : "
-    }
-
-    fn generic_constraint_separator(&self) -> &str {
-        ", "
-    }
-
-    fn super_type_keyword(&self) -> &str {
-        " : "
-    }
-
-    fn implements_keyword(&self) -> &str {
-        // Kotlin uses a single `:` list for both extends and implements.
-        // Put all supertypes in super_types(); leave impl_types() empty.
-        ""
-    }
-
-    fn type_annotation_separator(&self) -> &str {
-        ": "
-    }
-
-    fn async_keyword(&self) -> &str {
-        "suspend "
-    }
-
-    fn readonly_keyword(&self) -> &str {
-        "val "
-    }
-
-    fn mutable_field_keyword(&self) -> &str {
-        "var "
     }
 
     fn property_style(&self) -> crate::spec::modifiers::PropertyStyle {
@@ -356,57 +306,77 @@ impl CodeLang for Kotlin {
         "get()"
     }
 
-    fn constructor_delegation_style(&self) -> crate::spec::modifiers::ConstructorDelegationStyle {
-        crate::spec::modifiers::ConstructorDelegationStyle::Signature
-    }
-
-    fn supports_primary_constructor(&self) -> bool {
-        true
-    }
-
     fn optional_field_style(&self) -> crate::lang::config::OptionalFieldStyle {
         crate::lang::config::OptionalFieldStyle::TypeSuffix("?")
     }
 
-    fn present_array(&self) -> crate::type_name::TypePresentation<'_> {
-        crate::type_name::TypePresentation::GenericWrap { name: "List" }
-    }
-
-    fn present_readonly_array(&self) -> Option<crate::type_name::TypePresentation<'_>> {
-        Some(crate::type_name::TypePresentation::GenericWrap { name: "List" })
-    }
-
-    fn present_optional(&self) -> crate::type_name::TypePresentation<'_> {
-        crate::type_name::TypePresentation::Postfix { suffix: "?" }
-    }
-
-    fn present_map(&self) -> crate::type_name::TypePresentation<'_> {
-        crate::type_name::TypePresentation::GenericWrap { name: "Map" }
-    }
-
-    fn present_function(&self) -> crate::type_name::FunctionPresentation<'_> {
-        crate::type_name::FunctionPresentation {
-            keyword: "",
-            params_open: "(",
-            params_sep: ", ",
-            params_close: ")",
-            arrow: " -> ",
-            return_first: false,
-            curried: false,
-            wrapper_open: "",
-            wrapper_close: "",
+    fn type_presentation(&self) -> crate::lang::config::TypePresentationConfig<'_> {
+        crate::lang::config::TypePresentationConfig {
+            array: crate::type_name::TypePresentation::GenericWrap { name: "List" },
+            readonly_array: Some(crate::type_name::TypePresentation::GenericWrap { name: "List" }),
+            optional: crate::type_name::TypePresentation::Postfix { suffix: "?" },
+            function: crate::type_name::FunctionPresentation {
+                keyword: "",
+                params_open: "(",
+                params_sep: ", ",
+                params_close: ")",
+                arrow: " -> ",
+                return_first: false,
+                curried: false,
+                wrapper_open: "",
+                wrapper_close: "",
+            },
+            associated_type: crate::type_name::AssociatedTypeStyle::DotAccess,
+            wildcard: crate::type_name::WildcardPresentation {
+                unbounded: "*",
+                upper_keyword: "out ",
+                lower_keyword: "in ",
+            },
+            ..Default::default()
         }
     }
 
-    fn present_associated_type(&self) -> crate::type_name::AssociatedTypeStyle<'_> {
-        crate::type_name::AssociatedTypeStyle::DotAccess
+    fn generic_syntax(&self) -> crate::lang::config::GenericSyntaxConfig<'_> {
+        crate::lang::config::GenericSyntaxConfig {
+            constraint_keyword: " : ",
+            constraint_separator: ", ",
+            context_bound_keyword: " : ",
+            ..Default::default()
+        }
     }
 
-    fn present_wildcard(&self) -> crate::type_name::WildcardPresentation<'_> {
-        crate::type_name::WildcardPresentation {
-            unbounded: "*",
-            upper_keyword: "out ",
-            lower_keyword: "in ",
+    fn block_syntax(&self) -> crate::lang::config::BlockSyntaxConfig<'_> {
+        crate::lang::config::BlockSyntaxConfig {
+            indent_unit: &self.indent,
+            uses_semicolons: false,
+            field_terminator: "",
+            ..Default::default()
+        }
+    }
+
+    fn function_syntax(&self) -> crate::lang::config::FunctionSyntaxConfig<'_> {
+        crate::lang::config::FunctionSyntaxConfig {
+            return_type_separator: ": ",
+            async_keyword: "suspend ",
+            constructor_delegation_style:
+                crate::spec::modifiers::ConstructorDelegationStyle::Signature,
+            ..Default::default()
+        }
+    }
+
+    fn type_decl_syntax(&self) -> crate::lang::config::TypeDeclSyntaxConfig<'_> {
+        crate::lang::config::TypeDeclSyntaxConfig {
+            super_type_keyword: " : ",
+            supports_primary_constructor: true,
+            ..Default::default()
+        }
+    }
+
+    fn enum_and_annotation(&self) -> crate::lang::config::EnumAndAnnotationConfig<'_> {
+        crate::lang::config::EnumAndAnnotationConfig {
+            readonly_keyword: "val ",
+            mutable_field_keyword: "var ",
+            ..Default::default()
         }
     }
 }
@@ -631,20 +601,20 @@ mod tests {
     #[test]
     fn test_no_semicolons() {
         let kt = Kotlin::new();
-        assert!(!kt.uses_semicolons());
+        assert!(!kt.block_syntax().uses_semicolons);
     }
 
     #[test]
     fn test_async_keyword() {
         let kt = Kotlin::new();
-        assert_eq!(kt.async_keyword(), "suspend ");
+        assert_eq!(kt.function_syntax().async_keyword, "suspend ");
     }
 
     #[test]
     fn test_field_keywords() {
         let kt = Kotlin::new();
-        assert_eq!(kt.readonly_keyword(), "val ");
-        assert_eq!(kt.mutable_field_keyword(), "var ");
+        assert_eq!(kt.enum_and_annotation().readonly_keyword, "val ");
+        assert_eq!(kt.enum_and_annotation().mutable_field_keyword, "var ");
     }
 
     #[test]
@@ -661,6 +631,6 @@ mod tests {
     fn test_kotlin_builder_fluent() {
         let kt = Kotlin::new().with_indent("  ").with_extension("kts");
         assert_eq!(kt.file_extension(), "kts");
-        assert_eq!(kt.indent_unit(), "  ");
+        assert_eq!(kt.block_syntax().indent_unit, "  ");
     }
 }

--- a/src/lang/kotlin.rs
+++ b/src/lang/kotlin.rs
@@ -42,7 +42,7 @@ use crate::spec::modifiers::{DeclarationContext, TypeKind, Visibility};
 ///
 /// Use annotations for modifier-like keywords:
 /// ```text
-/// tb.annotation(CodeBlock::<Kotlin>::of("sealed", ()).unwrap());
+/// tb.annotation(CodeBlock::of("sealed", ()).unwrap());
 /// // Combined with TypeKind::Class → "sealed\nclass Foo {"
 /// ```
 ///
@@ -50,7 +50,7 @@ use crate::spec::modifiers::{DeclarationContext, TypeKind, Visibility};
 ///
 /// Use `add_primary_constructor_param()` on `TypeSpecBuilder`:
 /// ```text
-/// let mut tb = TypeSpec::<Kotlin>::builder("Person", TypeKind::Class);
+/// let mut tb = TypeSpec::builder("Person", TypeKind::Class);
 /// tb.add_primary_constructor_param(ParameterSpec::new("val name", TypeName::primitive("String")));
 /// tb.add_primary_constructor_param(ParameterSpec::new("val age", TypeName::primitive("Int")));
 /// // Emits: class Person(val name: String, val age: Int) {
@@ -61,7 +61,7 @@ use crate::spec::modifiers::{DeclarationContext, TypeKind, Visibility};
 /// Use `delegation()` on `FunSpecBuilder` for `super(...)` / `this(...)` calls.
 /// Kotlin places delegation in the signature (after params, before body):
 /// ```text
-/// let mut ctor = FunSpec::<Kotlin>::builder("constructor");
+/// let mut ctor = FunSpec::builder("constructor");
 /// ctor.is_constructor();
 /// ctor.add_param(ParameterSpec::new("name", TypeName::primitive("String")));
 /// ctor.delegation(CodeBlock::of("this(name, 0)", ()).unwrap());

--- a/src/lang/mod.rs
+++ b/src/lang/mod.rs
@@ -41,10 +41,12 @@ use crate::import::ImportGroup;
 /// the same CodeBlock and TypeName structures to generate output for any
 /// supported language.
 ///
-/// Methods that may vary per configuration (indent_unit, uses_semicolons,
-/// render_string_literal) take `&self`. Methods that are truly invariant
-/// per language (file_extension, reserved_words) also take `&self` for
-/// consistency and future flexibility.
+/// Language-specific configuration is exposed through six config accessor
+/// methods (`type_presentation`, `generic_syntax`, `block_syntax`,
+/// `function_syntax`, `type_decl_syntax`, `enum_and_annotation`) that
+/// return config structs. Languages override these accessors to customise
+/// rendering. The remaining methods on the trait have real logic, take
+/// parameters, or are not representable as plain data.
 pub trait CodeLang: std::fmt::Debug + 'static {
     /// File extension for this language (e.g., "ts", "go", "rs").
     fn file_extension(&self) -> &str;
@@ -73,12 +75,6 @@ pub trait CodeLang: std::fmt::Debug + 'static {
         ""
     }
 
-    /// Indentation unit (e.g., "  " for 2-space, "\t" for tabs).
-    fn indent_unit(&self) -> &str;
-
-    /// Whether this language uses semicolons to terminate statements.
-    fn uses_semicolons(&self) -> bool;
-
     /// Escape a name if it collides with a reserved word.
     /// Default: append underscore.
     fn escape_reserved(&self, name: &str) -> String {
@@ -88,8 +84,6 @@ pub trait CodeLang: std::fmt::Debug + 'static {
             name.to_string()
         }
     }
-
-    // --- Phase 2: structural spec support ---
 
     /// Render a visibility modifier for the given declaration context.
     fn render_visibility(
@@ -101,210 +95,12 @@ pub trait CodeLang: std::fmt::Debug + 'static {
     /// The keyword used to declare a function (e.g., "fn", "function").
     fn function_keyword(&self, ctx: crate::spec::modifiers::DeclarationContext) -> &str;
 
-    /// Separator between a function and its return type (e.g., " -> ", ": ").
-    fn return_type_separator(&self) -> &str;
-
     /// The keyword for a type declaration (e.g., "struct", "class").
     fn type_keyword(&self, kind: crate::spec::modifiers::TypeKind) -> &str;
-
-    /// Terminator after a field declaration (e.g., "," for Rust, ";" for TS).
-    fn field_terminator(&self) -> &str;
 
     /// Whether methods are declared inside the type body (true for TS class, Rust trait)
     /// vs in a separate impl block (Rust struct/enum).
     fn methods_inside_type_body(&self, kind: crate::spec::modifiers::TypeKind) -> bool;
-
-    /// Keyword introducing a generic constraint (e.g., ": " for Rust, " extends " for TS).
-    fn generic_constraint_keyword(&self) -> &str;
-
-    /// Separator between multiple generic bounds (e.g., " + " for Rust, " & " for TS).
-    fn generic_constraint_separator(&self) -> &str;
-
-    /// Keyword for super type / base class (e.g., "" for Rust, " extends " for TS).
-    fn super_type_keyword(&self) -> &str;
-
-    /// Keyword for interface implementation (e.g., "" for Rust, " implements " for TS).
-    fn implements_keyword(&self) -> &str;
-
-    /// Separator between name and type annotation (e.g., ": ").
-    fn type_annotation_separator(&self) -> &str {
-        ": "
-    }
-
-    /// The async keyword with trailing space (e.g., "async ").
-    fn async_keyword(&self) -> &str {
-        "async "
-    }
-
-    /// Opening delimiter for generic type parameters (e.g., "<" for Rust/TS, "[" for Go).
-    fn generic_open(&self) -> &str {
-        "<"
-    }
-
-    /// Closing delimiter for generic type parameters (e.g., ">" for Rust/TS, "]" for Go).
-    fn generic_close(&self) -> &str {
-        ">"
-    }
-
-    /// How `TypeName::Generic` application is rendered.
-    ///
-    /// Default: `Delimited` — `Base<P1, P2>` using `generic_open()`/`generic_close()`.
-    fn generic_application_style(&self) -> crate::type_name::GenericApplicationStyle {
-        crate::type_name::GenericApplicationStyle::Delimited
-    }
-
-    // --- Type presentation (data-driven, no BoxDoc) ---
-
-    /// How `TypeName::Array(T)` renders.
-    ///
-    /// Default: `Postfix { suffix: "[]" }` (TypeScript `T[]`).
-    fn present_array(&self) -> crate::type_name::TypePresentation<'_> {
-        crate::type_name::TypePresentation::Postfix { suffix: "[]" }
-    }
-
-    /// How `TypeName::ReadonlyArray(T)` renders.
-    ///
-    /// Default: `None` — renders as `readonly ` + the array presentation.
-    /// Override to return `Some(...)` for languages with distinct readonly array syntax.
-    fn present_readonly_array(&self) -> Option<crate::type_name::TypePresentation<'_>> {
-        None
-    }
-
-    /// How `TypeName::Optional(T)` renders.
-    ///
-    /// Default: `Infix { sep: " | " }` — renders `T | null` (TypeScript style).
-    /// When using `Infix`, the absent literal from `optional_absent_literal()` is
-    /// automatically appended as the second member.
-    fn present_optional(&self) -> crate::type_name::TypePresentation<'_> {
-        crate::type_name::TypePresentation::Infix { sep: " | " }
-    }
-
-    /// The literal used for the "absent" case in Optional when using `Infix` presentation.
-    ///
-    /// Default: `"null"`. Python: `"None"`.
-    fn optional_absent_literal(&self) -> &str {
-        "null"
-    }
-
-    /// How `TypeName::Map { K, V }` renders.
-    ///
-    /// Default: `GenericWrap { name: "Map" }`.
-    fn present_map(&self) -> crate::type_name::TypePresentation<'_> {
-        crate::type_name::TypePresentation::GenericWrap { name: "Map" }
-    }
-
-    /// How `TypeName::Union(members)` renders.
-    ///
-    /// Default: `Infix { sep: " | " }`.
-    fn present_union(&self) -> crate::type_name::TypePresentation<'_> {
-        crate::type_name::TypePresentation::Infix { sep: " | " }
-    }
-
-    /// How `TypeName::Intersection(members)` renders.
-    ///
-    /// Default: `Infix { sep: " & " }`.
-    fn present_intersection(&self) -> crate::type_name::TypePresentation<'_> {
-        crate::type_name::TypePresentation::Infix { sep: " & " }
-    }
-
-    /// How `TypeName::Pointer(T)` renders.
-    ///
-    /// Default: `Prefix { prefix: "*" }`.
-    fn present_pointer(&self) -> crate::type_name::TypePresentation<'_> {
-        crate::type_name::TypePresentation::Prefix { prefix: "*" }
-    }
-
-    /// How `TypeName::Slice(T)` renders.
-    ///
-    /// Default: `Prefix { prefix: "[]" }`.
-    fn present_slice(&self) -> crate::type_name::TypePresentation<'_> {
-        crate::type_name::TypePresentation::Prefix { prefix: "[]" }
-    }
-
-    /// How `TypeName::Tuple(elements)` renders.
-    ///
-    /// Default: `Delimited { open: "(", sep: ", ", close: ")" }` (Rust/Swift `(A, B, C)`).
-    fn present_tuple(&self) -> crate::type_name::TypePresentation<'_> {
-        crate::type_name::TypePresentation::Delimited {
-            open: "(",
-            sep: ", ",
-            close: ")",
-        }
-    }
-
-    /// How `TypeName::Reference { mutable: false }` renders.
-    ///
-    /// Default: `Prefix { prefix: "" }` — GC languages render as bare inner type.
-    fn present_reference(&self) -> crate::type_name::TypePresentation<'_> {
-        crate::type_name::TypePresentation::Prefix { prefix: "" }
-    }
-
-    /// How `TypeName::Reference { mutable: true }` renders.
-    ///
-    /// Default: `Prefix { prefix: "" }` — GC languages render as bare inner type.
-    fn present_reference_mut(&self) -> crate::type_name::TypePresentation<'_> {
-        crate::type_name::TypePresentation::Prefix { prefix: "" }
-    }
-
-    /// How `TypeName::Function { params, return_type }` renders.
-    ///
-    /// Default: TypeScript `(A, B) => R`.
-    fn present_function(&self) -> crate::type_name::FunctionPresentation<'_> {
-        crate::type_name::FunctionPresentation {
-            keyword: "",
-            params_open: "(",
-            params_sep: ", ",
-            params_close: ")",
-            arrow: " => ",
-            return_first: false,
-            curried: false,
-            wrapper_open: "",
-            wrapper_close: "",
-        }
-    }
-
-    /// How `TypeName::AssociatedType` renders.
-    ///
-    /// Default: Rust-style `<Base as Qual>::Member` / `Base::Member`.
-    fn present_associated_type(&self) -> crate::type_name::AssociatedTypeStyle<'_> {
-        crate::type_name::AssociatedTypeStyle::QualifiedPath {
-            open: "<",
-            as_kw: " as ",
-            close_sep: ">::",
-            simple_sep: "::",
-        }
-    }
-
-    /// How `TypeName::ImplTrait` bounds render.
-    ///
-    /// Default: Rust-style `impl Bound1 + Bound2`.
-    fn present_impl_trait(&self) -> crate::type_name::BoundsPresentation<'_> {
-        crate::type_name::BoundsPresentation {
-            keyword: "impl ",
-            separator: " + ",
-        }
-    }
-
-    /// How `TypeName::DynTrait` bounds render.
-    ///
-    /// Default: Rust-style `dyn Bound1 + Bound2`.
-    fn present_dyn_trait(&self) -> crate::type_name::BoundsPresentation<'_> {
-        crate::type_name::BoundsPresentation {
-            keyword: "dyn ",
-            separator: " + ",
-        }
-    }
-
-    /// How `TypeName::Wildcard` renders.
-    ///
-    /// Default: Java-style `?`, `? extends T`, `? super T`.
-    fn present_wildcard(&self) -> crate::type_name::WildcardPresentation<'_> {
-        crate::type_name::WildcardPresentation {
-            unbounded: "?",
-            upper_keyword: "? extends ",
-            lower_keyword: "? super ",
-        }
-    }
 
     /// Qualify an import name for rendering in code.
     ///
@@ -321,13 +117,6 @@ pub trait CodeLang: std::fmt::Debug + 'static {
         ""
     }
 
-    /// Whether type alias uses reversed order (`typedef target name;` in C).
-    ///
-    /// Default: `false` (most languages: `type name = target`).
-    fn type_alias_target_first(&self) -> bool {
-        false
-    }
-
     /// Render a newtype declaration line from pre-rendered components.
     ///
     /// Default: Rust tuple-struct `{vis}struct {name}({inner});`.
@@ -335,42 +124,20 @@ pub trait CodeLang: std::fmt::Debug + 'static {
         format!("{vis}struct {name}({inner});")
     }
 
-    /// Opening block delimiter appended after a function signature or type header.
-    ///
-    /// Default: `" {"` (brace languages). Python overrides to `":"`.
-    fn block_open(&self) -> &str {
-        " {"
-    }
-
     /// Opening block delimiter for function bodies specifically.
     ///
-    /// Default: delegates to `block_open()`.
+    /// Default: `" {"`.
     /// Scala overrides to `" = {"` since Scala function definitions use `=`.
     fn fun_block_open(&self) -> &str {
-        self.block_open()
+        " {"
     }
 
     /// Opening block delimiter for type headers, parameterized by type kind.
     ///
-    /// Default: delegates to `block_open()`.
+    /// Default: `" {"`.
     /// Haskell overrides: Trait -> `" where"`, others -> `" ="`.
     fn type_header_block_open(&self, _kind: crate::spec::modifiers::TypeKind) -> &str {
-        self.block_open()
-    }
-
-    /// How function parameter lists are formatted (tupled vs curried).
-    ///
-    /// Default: `Tupled` — `(a: T, b: U)`.
-    /// OCaml overrides to `Curried` — `(a : T) (b : U)`.
-    fn param_list_style(&self) -> crate::spec::fun_spec::ParamListStyle {
-        crate::spec::fun_spec::ParamListStyle::Tupled
-    }
-
-    /// Closing block delimiter emitted after a dedent at the end of a block.
-    ///
-    /// Default: `"}"` (brace languages). Python overrides to `""` (indent-only).
-    fn block_close(&self) -> &str {
-        "}"
+        " {"
     }
 
     /// Whether doc comments should be rendered inside the body (after block open)
@@ -389,71 +156,31 @@ pub trait CodeLang: std::fmt::Debug + 'static {
         true
     }
 
-    /// Closing delimiter for base class / implements list.
+    /// How this language expresses that a field is optional (key may be absent).
     ///
-    /// Default: `""`. Python overrides to `")"` to close `class Foo(Base):`.
-    fn bases_close(&self) -> &str {
-        ""
+    /// Consulted by `FieldSpec::emit()` when `is_optional` is set. Languages
+    /// that can't express optional fields return `OptionalFieldStyle::Ignored`
+    /// and the field is rendered as if it were required.
+    ///
+    /// Default: `OptionalFieldStyle::Ignored`.
+    fn optional_field_style(&self) -> crate::lang::config::OptionalFieldStyle {
+        crate::lang::config::OptionalFieldStyle::Ignored
     }
 
-    /// Content to emit for an abstract method with no body.
+    /// How `PropertySpec` renders: accessor methods or inline field body.
     ///
-    /// Default: `""` (no body emitted). Python overrides to `"..."` (Ellipsis).
-    fn empty_body(&self) -> &str {
-        ""
+    /// Default: `Accessor` — emits `get name()` / `set name(v)` methods (TS/JS).
+    /// Swift and Kotlin override to `Field` — emits a field with inline `get`/`set` blocks.
+    fn property_style(&self) -> crate::spec::modifiers::PropertyStyle {
+        crate::spec::modifiers::PropertyStyle::Accessor
     }
 
-    /// Whether type annotations use type-before-name order (e.g., C: `int count`)
-    /// rather than name-before-type (e.g., Rust: `count: i32`).
+    /// The keyword for a property getter in field-style rendering.
     ///
-    /// Default: `false`. C overrides to `true`.
-    fn type_before_name(&self) -> bool {
-        false
-    }
-
-    /// Whether the return type appears before the function name (e.g., C: `int add(...)`)
-    /// rather than after the parameters (e.g., Rust: `fn add(...) -> int`).
-    ///
-    /// Default: `false`. C overrides to `true`.
-    fn return_type_is_prefix(&self) -> bool {
-        false
-    }
-
-    /// Terminator appended after a type declaration's closing brace.
-    ///
-    /// Default: `""`. C overrides to `";"` for `struct Config { ... };`.
-    fn type_close_terminator(&self) -> &str {
-        ""
-    }
-
-    /// The keyword emitted when `is_abstract` is set on a function.
-    ///
-    /// Default: `"abstract "` (TypeScript). C++ overrides to `"virtual "`.
-    fn abstract_keyword(&self) -> &str {
-        "abstract "
-    }
-
-    /// Separator between super types in an inheritance list.
-    ///
-    /// Default: `", "`. C++ overrides to `", public "` for `class D : public B1, public B2`.
-    fn super_type_separator(&self) -> &str {
-        ", "
-    }
-
-    /// Keyword for context bounds on type parameters (e.g., Scala `[T : Ordering]`).
-    ///
-    /// Default: delegates to `generic_constraint_keyword()`.
-    /// Scala overrides to `" : "`.
-    fn context_bound_keyword(&self) -> &str {
-        self.generic_constraint_keyword()
-    }
-
-    /// How function signatures are rendered.
-    ///
-    /// Default: `Merged` — single-line `fn add(x: Int) -> Int {`.
-    /// Haskell overrides to `Split` — separate type signature and definition.
-    fn function_signature_style(&self) -> crate::spec::fun_spec::FunctionSignatureStyle {
-        crate::spec::fun_spec::FunctionSignatureStyle::Merged
+    /// Default: `"get"` (Swift: `get { ... }`).
+    /// Kotlin overrides to `"get()"`.
+    fn property_getter_keyword(&self) -> &str {
+        "get"
     }
 
     /// Render a type context / constraint prefix for split function signatures.
@@ -492,159 +219,43 @@ pub trait CodeLang: std::fmt::Debug + 'static {
         String::new()
     }
 
-    /// Override separator for the 2nd+ super type in an inheritance list.
-    ///
-    /// When `Some(sep)`, the first super type uses `super_type_keyword()` and
-    /// subsequent ones use `sep` instead of `super_type_separator()`.
-    ///
-    /// Default: `None`. Scala overrides to `Some(" with ")` so that
-    /// `class Foo extends Base with Trait1 with Trait2` is emitted.
-    fn super_type_subsequent_separator(&self) -> Option<&str> {
-        None
-    }
-
-    /// Keyword emitted for readonly/immutable fields.
-    ///
-    /// In type-before-name languages (C/C++/Java): appears before the type.
-    /// In name-before-type languages (TS/Kotlin): appears before the name.
-    ///
-    /// Default: `"const "` (C/C++). Java overrides to `"final "`,
-    /// TypeScript to `"readonly "`, Kotlin to `"val "`.
-    fn readonly_keyword(&self) -> &str {
-        "const "
-    }
-
-    /// Keyword emitted for mutable fields in name-before-type languages.
-    ///
-    /// Default: `""` (most languages have no mutable keyword).
-    /// Kotlin overrides to `"var "`.
-    fn mutable_field_keyword(&self) -> &str {
-        ""
-    }
-
-    /// How this language expresses that a field is optional (key may be absent).
-    ///
-    /// Consulted by `FieldSpec::emit()` when `is_optional` is set. Languages
-    /// that can't express optional fields return `OptionalFieldStyle::Ignored`
-    /// and the field is rendered as if it were required.
-    ///
-    /// Default: `OptionalFieldStyle::Ignored`.
-    fn optional_field_style(&self) -> crate::lang::config::OptionalFieldStyle {
-        crate::lang::config::OptionalFieldStyle::Ignored
-    }
-
-    // --- Phase 3: enum variant support ---
-
-    /// Prefix before each enum variant name.
-    ///
-    /// Default: `""`. Swift overrides to `"case "`.
-    fn enum_variant_prefix(&self) -> &str {
-        ""
-    }
-
-    /// Prefix before the first enum variant only.
-    ///
-    /// Default: delegates to `enum_variant_prefix()`.
-    /// Haskell overrides to `""` (first constructor after `=` has no prefix),
-    /// while subsequent constructors use `"| "` via `enum_variant_prefix()`.
-    fn enum_variant_prefix_first(&self) -> &str {
-        self.enum_variant_prefix()
-    }
-
-    /// Separator after each enum variant (e.g., `","` for most languages).
-    ///
-    /// Default: `","`. Python and Swift override to `""`.
-    fn enum_variant_separator(&self) -> &str {
-        ","
-    }
-
-    /// Whether the separator appears after the last variant too (trailing comma).
-    ///
-    /// Default: `false`. Rust and TypeScript override to `true`.
-    fn enum_variant_trailing_separator(&self) -> bool {
-        false
-    }
-
-    // --- Phase 3: annotation support ---
-
-    /// Prefix and suffix wrapping an annotation name.
-    ///
-    /// Default: `("@", "")` → `@Name(args)`.
-    /// Rust: `("#[", "]")` → `#[name(args)]`.
-    /// C++: `("[[", "]]")` → `[[name(args)]]`.
-    /// C: `("__attribute__((", "))")` → `__attribute__((name(args)))`.
-    fn render_annotation_prefix(&self) -> (&str, &str) {
-        ("@", "")
-    }
-
-    // --- Phase 3: constructor support ---
-
-    /// Function keyword used for constructors.
-    ///
-    /// When `FunSpec::is_constructor()` is set, this keyword is used instead of
-    /// `function_keyword()`. Default: `""` (no keyword prefix — works for TS/JS,
-    /// Java, C++, Dart, Swift, Kotlin where constructors have no function keyword).
-    ///
-    /// Python overrides to `"def"` (`def __init__`).
-    /// Rust overrides to `"fn"` (`fn new`).
-    fn constructor_keyword(&self) -> &str {
-        ""
-    }
-
-    /// Where a constructor delegation call (`super(...)` / `this(...)`) is placed.
-    ///
-    /// Default: `Body` — the delegation call is emitted as the first statement
-    /// in the constructor body (TS, JS, Java, Dart, Swift, Python, C++).
-    ///
-    /// Kotlin overrides to `Signature` — the delegation call appears between the
-    /// parameter list and the body: `constructor(x: Int) : this(x, 0) { ... }`.
-    fn constructor_delegation_style(&self) -> crate::spec::modifiers::ConstructorDelegationStyle {
-        crate::spec::modifiers::ConstructorDelegationStyle::Body
-    }
-
-    /// Whether this language supports primary constructors on type declarations.
-    ///
-    /// When true, `TypeSpec` will render primary constructor parameters after the
-    /// type name: `class Foo(val x: Int, val y: String)`.
-    ///
-    /// Default: `false`. Kotlin overrides to `true`.
-    fn supports_primary_constructor(&self) -> bool {
-        false
-    }
-
-    // --- Phase 3: property support ---
-
-    /// How `PropertySpec` renders: accessor methods or inline field body.
-    ///
-    /// Default: `Accessor` — emits `get name()` / `set name(v)` methods (TS/JS).
-    /// Swift and Kotlin override to `Field` — emits a field with inline `get`/`set` blocks.
-    fn property_style(&self) -> crate::spec::modifiers::PropertyStyle {
-        crate::spec::modifiers::PropertyStyle::Accessor
-    }
-
-    /// The keyword for a property getter in field-style rendering.
-    ///
-    /// Default: `"get"` (Swift: `get { ... }`).
-    /// Kotlin overrides to `"get()"`.
-    fn property_getter_keyword(&self) -> &str {
-        "get"
-    }
-
-    // --- Where clause support ---
-
-    /// How where-clause constraints are rendered.
-    ///
-    /// Default: `Inline` — bounds stay in the generic parameter list.
-    /// Rust overrides to `WhereBlock`.
-    fn where_clause_style(&self) -> crate::spec::fun_spec::WhereClauseStyle {
-        crate::spec::fun_spec::WhereClauseStyle::Inline
-    }
-
     /// Render a type parameter's kind annotation (for higher-kinded types).
     ///
     /// Default: empty string (no kind annotation).
     fn render_type_param_kind(&self, _kind: &crate::spec::fun_spec::TypeParamKind) -> String {
         String::new()
+    }
+
+    // --- Config struct accessors ---
+
+    /// How each compound `TypeName` variant renders.
+    fn type_presentation(&self) -> config::TypePresentationConfig<'_> {
+        config::TypePresentationConfig::default()
+    }
+
+    /// Generic type parameter delimiters and constraints.
+    fn generic_syntax(&self) -> config::GenericSyntaxConfig<'_> {
+        config::GenericSyntaxConfig::default()
+    }
+
+    /// Block delimiters, indentation, and statement termination.
+    fn block_syntax(&self) -> config::BlockSyntaxConfig<'_> {
+        config::BlockSyntaxConfig::default()
+    }
+
+    /// Function signature syntax.
+    fn function_syntax(&self) -> config::FunctionSyntaxConfig<'_> {
+        config::FunctionSyntaxConfig::default()
+    }
+
+    /// Type declaration syntax (inheritance, field order).
+    fn type_decl_syntax(&self) -> config::TypeDeclSyntaxConfig<'_> {
+        config::TypeDeclSyntaxConfig::default()
+    }
+
+    /// Enum variant formatting, annotation syntax, and field mutability keywords.
+    fn enum_and_annotation(&self) -> config::EnumAndAnnotationConfig<'_> {
+        config::EnumAndAnnotationConfig::default()
     }
 }
 

--- a/src/lang/mod.rs
+++ b/src/lang/mod.rs
@@ -37,9 +37,9 @@ use crate::import::ImportGroup;
 
 /// Trait defining language-specific behavior for code generation.
 ///
-/// All types in sigil-stitch are parameterized by `L: CodeLang`, allowing
-/// the same CodeBlock and TypeName structures to generate output for any
-/// supported language.
+/// Concrete language structs (e.g. `TypeScript`, `Rust`, `Python`) implement
+/// this trait so the same CodeBlock and TypeName structures can generate
+/// output for any supported language via `&dyn CodeLang`.
 ///
 /// Language-specific configuration is exposed through six config accessor
 /// methods (`type_presentation`, `generic_syntax`, `block_syntax`,

--- a/src/lang/mod.rs
+++ b/src/lang/mod.rs
@@ -45,7 +45,7 @@ use crate::import::ImportGroup;
 /// render_string_literal) take `&self`. Methods that are truly invariant
 /// per language (file_extension, reserved_words) also take `&self` for
 /// consistency and future flexibility.
-pub trait CodeLang: Sized + Clone + 'static {
+pub trait CodeLang: std::fmt::Debug + 'static {
     /// File extension for this language (e.g., "ts", "go", "rs").
     fn file_extension(&self) -> &str;
 
@@ -462,10 +462,7 @@ pub trait CodeLang: Sized + Clone + 'static {
     /// signature line. Used for Haskell's `(Show a, Eq a) => ...` prefix.
     ///
     /// Default: `""` (no context).
-    fn render_type_context(
-        &self,
-        _type_params: &[crate::spec::fun_spec::TypeParamSpec<Self>],
-    ) -> String {
+    fn render_type_context(&self, _type_params: &[crate::spec::fun_spec::TypeParamSpec]) -> String {
         String::new()
     }
 
@@ -668,5 +665,30 @@ pub(crate) fn module_to_alias(module: &str) -> String {
             let upper: String = first.to_uppercase().collect();
             format!("{upper}{}", chars.as_str())
         }
+    }
+}
+
+/// Create a default `CodeLang` implementation from a file extension.
+///
+/// Returns `None` if the extension is not recognized.
+pub fn lang_from_extension(ext: &str) -> Option<Box<dyn CodeLang>> {
+    match ext {
+        "ts" | "tsx" => Some(Box::new(typescript::TypeScript::default())),
+        "js" | "jsx" | "mjs" | "cjs" => Some(Box::new(javascript::JavaScript::default())),
+        "rs" => Some(Box::new(rust_lang::RustLang::default())),
+        "go" => Some(Box::new(go_lang::GoLang::default())),
+        "py" | "pyi" => Some(Box::new(python::Python::default())),
+        "java" => Some(Box::new(java_lang::JavaLang::default())),
+        "kt" | "kts" => Some(Box::new(kotlin::Kotlin::default())),
+        "swift" => Some(Box::new(swift::Swift::default())),
+        "dart" => Some(Box::new(dart::DartLang::default())),
+        "scala" | "sc" => Some(Box::new(scala::Scala::default())),
+        "hs" => Some(Box::new(haskell::Haskell::default())),
+        "ml" | "mli" => Some(Box::new(ocaml::OCaml::default())),
+        "c" | "h" => Some(Box::new(c_lang::CLang::default())),
+        "cpp" | "cxx" | "cc" | "hpp" | "hxx" => Some(Box::new(cpp_lang::CppLang::default())),
+        "sh" | "bash" => Some(Box::new(bash::Bash::default())),
+        "zsh" => Some(Box::new(zsh::Zsh::default())),
+        _ => None,
     }
 }

--- a/src/lang/ocaml.rs
+++ b/src/lang/ocaml.rs
@@ -2,7 +2,14 @@
 
 use crate::import::ImportGroup;
 use crate::lang::CodeLang;
+use crate::lang::config::{
+    BlockSyntaxConfig, EnumAndAnnotationConfig, FunctionSyntaxConfig, GenericSyntaxConfig,
+    TypeDeclSyntaxConfig, TypePresentationConfig,
+};
 use crate::spec::modifiers::{DeclarationContext, TypeKind, Visibility};
+use crate::type_name::{
+    AssociatedTypeStyle, FunctionPresentation, GenericApplicationStyle, TypePresentation,
+};
 
 /// OCaml language implementation.
 ///
@@ -198,14 +205,6 @@ impl CodeLang for OCaml {
         " *)"
     }
 
-    fn indent_unit(&self) -> &str {
-        &self.indent
-    }
-
-    fn uses_semicolons(&self) -> bool {
-        false
-    }
-
     fn render_visibility(&self, _vis: Visibility, _ctx: DeclarationContext) -> &str {
         ""
     }
@@ -214,110 +213,20 @@ impl CodeLang for OCaml {
         "let"
     }
 
-    fn return_type_separator(&self) -> &str {
-        " : "
-    }
-
     fn type_keyword(&self, _kind: TypeKind) -> &str {
         "type"
-    }
-
-    fn field_terminator(&self) -> &str {
-        ";"
     }
 
     fn methods_inside_type_body(&self, _kind: TypeKind) -> bool {
         false
     }
 
-    fn generic_constraint_keyword(&self) -> &str {
-        ""
-    }
-
-    fn generic_constraint_separator(&self) -> &str {
-        ""
-    }
-
-    fn super_type_keyword(&self) -> &str {
-        ""
-    }
-
-    fn implements_keyword(&self) -> &str {
-        ""
-    }
-
-    fn type_annotation_separator(&self) -> &str {
-        " : "
-    }
-
-    fn generic_application_style(&self) -> crate::type_name::GenericApplicationStyle {
-        crate::type_name::GenericApplicationStyle::PostfixJuxtaposition
-    }
-
-    fn generic_open(&self) -> &str {
-        "("
-    }
-
-    fn generic_close(&self) -> &str {
-        ")"
-    }
-
-    fn block_open(&self) -> &str {
+    fn fun_block_open(&self) -> &str {
         " ="
     }
 
-    fn block_close(&self) -> &str {
-        ""
-    }
-
-    fn present_array(&self) -> crate::type_name::TypePresentation<'_> {
-        crate::type_name::TypePresentation::GenericWrap { name: "list" }
-    }
-
-    fn present_readonly_array(&self) -> Option<crate::type_name::TypePresentation<'_>> {
-        Some(crate::type_name::TypePresentation::GenericWrap { name: "list" })
-    }
-
-    fn present_optional(&self) -> crate::type_name::TypePresentation<'_> {
-        crate::type_name::TypePresentation::GenericWrap { name: "option" }
-    }
-
-    fn present_map(&self) -> crate::type_name::TypePresentation<'_> {
-        crate::type_name::TypePresentation::Delimited {
-            open: "(",
-            sep: ", ",
-            close: ") Hashtbl.t",
-        }
-    }
-
-    fn present_tuple(&self) -> crate::type_name::TypePresentation<'_> {
-        crate::type_name::TypePresentation::Infix { sep: " * " }
-    }
-
-    fn present_function(&self) -> crate::type_name::FunctionPresentation<'_> {
-        crate::type_name::FunctionPresentation {
-            keyword: "",
-            params_open: "",
-            params_sep: " -> ",
-            params_close: "",
-            arrow: " -> ",
-            return_first: false,
-            curried: true,
-            wrapper_open: "",
-            wrapper_close: "",
-        }
-    }
-
-    fn present_associated_type(&self) -> crate::type_name::AssociatedTypeStyle<'_> {
-        crate::type_name::AssociatedTypeStyle::DotAccess
-    }
-
-    fn present_union(&self) -> crate::type_name::TypePresentation<'_> {
-        crate::type_name::TypePresentation::Infix { sep: " | " }
-    }
-
-    fn param_list_style(&self) -> crate::spec::fun_spec::ParamListStyle {
-        crate::spec::fun_spec::ParamListStyle::Curried
+    fn type_header_block_open(&self, _kind: TypeKind) -> &str {
+        " ="
     }
 
     fn type_body_prefix(&self, _name: &str, kind: crate::spec::modifiers::TypeKind) -> String {
@@ -332,6 +241,77 @@ impl CodeLang for OCaml {
             crate::spec::modifiers::TypeKind::Struct => "}".to_string(),
             _ => String::new(),
         }
+    }
+
+    // --- Config struct accessors ---
+
+    fn type_presentation(&self) -> TypePresentationConfig<'_> {
+        TypePresentationConfig {
+            array: TypePresentation::GenericWrap { name: "list" },
+            readonly_array: Some(TypePresentation::GenericWrap { name: "list" }),
+            optional: TypePresentation::GenericWrap { name: "option" },
+            map: TypePresentation::Delimited {
+                open: "(",
+                sep: ", ",
+                close: ") Hashtbl.t",
+            },
+            tuple: TypePresentation::Infix { sep: " * " },
+            function: FunctionPresentation {
+                keyword: "",
+                params_open: "",
+                params_sep: " -> ",
+                params_close: "",
+                arrow: " -> ",
+                return_first: false,
+                curried: true,
+                wrapper_open: "",
+                wrapper_close: "",
+            },
+            associated_type: AssociatedTypeStyle::DotAccess,
+            union: TypePresentation::Infix { sep: " | " },
+            ..Default::default()
+        }
+    }
+
+    fn generic_syntax(&self) -> GenericSyntaxConfig<'_> {
+        GenericSyntaxConfig {
+            open: "(",
+            close: ")",
+            application_style: GenericApplicationStyle::PostfixJuxtaposition,
+            constraint_keyword: "",
+            constraint_separator: "",
+            ..Default::default()
+        }
+    }
+
+    fn block_syntax(&self) -> BlockSyntaxConfig<'_> {
+        BlockSyntaxConfig {
+            block_open: " =",
+            block_close: "",
+            indent_unit: &self.indent,
+            uses_semicolons: false,
+            field_terminator: ";",
+            ..Default::default()
+        }
+    }
+
+    fn function_syntax(&self) -> FunctionSyntaxConfig<'_> {
+        FunctionSyntaxConfig {
+            return_type_separator: " : ",
+            param_list_style: crate::spec::fun_spec::ParamListStyle::Curried,
+            ..Default::default()
+        }
+    }
+
+    fn type_decl_syntax(&self) -> TypeDeclSyntaxConfig<'_> {
+        TypeDeclSyntaxConfig {
+            type_annotation_separator: " : ",
+            ..Default::default()
+        }
+    }
+
+    fn enum_and_annotation(&self) -> EnumAndAnnotationConfig<'_> {
+        EnumAndAnnotationConfig::default()
     }
 }
 
@@ -460,14 +440,14 @@ mod tests {
     #[test]
     fn test_no_semicolons() {
         let ml = OCaml::new();
-        assert!(!ml.uses_semicolons());
+        assert!(!ml.block_syntax().uses_semicolons);
     }
 
     #[test]
     fn test_generic_application_style() {
         let ml = OCaml::new();
         assert!(matches!(
-            ml.generic_application_style(),
+            ml.generic_syntax().application_style,
             crate::type_name::GenericApplicationStyle::PostfixJuxtaposition
         ));
     }
@@ -476,6 +456,6 @@ mod tests {
     fn test_ocaml_builder_fluent() {
         let ml = OCaml::new().with_indent("\t").with_extension("mli");
         assert_eq!(ml.file_extension(), "mli");
-        assert_eq!(ml.indent_unit(), "\t");
+        assert_eq!(ml.block_syntax().indent_unit, "\t");
     }
 }

--- a/src/lang/ocaml.rs
+++ b/src/lang/ocaml.rs
@@ -83,9 +83,9 @@ impl OCaml {
     /// multiple types and values), so they are built as raw `CodeBlock`s.
     pub fn module_block(
         name: &str,
-        body: crate::code_block::CodeBlock<OCaml>,
-    ) -> Result<crate::code_block::CodeBlock<OCaml>, crate::error::SigilStitchError> {
-        let mut cb = crate::code_block::CodeBlock::<OCaml>::builder();
+        body: crate::code_block::CodeBlock,
+    ) -> Result<crate::code_block::CodeBlock, crate::error::SigilStitchError> {
+        let mut cb = crate::code_block::CodeBlock::builder();
         cb.begin_control_flow_with_open(&format!("module {name}"), (), " = struct");
         cb.add_code(body);
         cb.end_control_flow();
@@ -96,9 +96,9 @@ impl OCaml {
     /// Build a `module type Name = sig ... end` block.
     pub fn module_sig_block(
         name: &str,
-        body: crate::code_block::CodeBlock<OCaml>,
-    ) -> Result<crate::code_block::CodeBlock<OCaml>, crate::error::SigilStitchError> {
-        let mut cb = crate::code_block::CodeBlock::<OCaml>::builder();
+        body: crate::code_block::CodeBlock,
+    ) -> Result<crate::code_block::CodeBlock, crate::error::SigilStitchError> {
+        let mut cb = crate::code_block::CodeBlock::builder();
         cb.begin_control_flow_with_open(&format!("module type {name}"), (), " = sig");
         cb.add_code(body);
         cb.end_control_flow();

--- a/src/lang/python.rs
+++ b/src/lang/python.rs
@@ -2,8 +2,12 @@
 
 use crate::import::{ImportEntry, ImportGroup};
 use crate::lang::CodeLang;
-use crate::lang::config::QuoteStyle;
+use crate::lang::config::{
+    BlockSyntaxConfig, EnumAndAnnotationConfig, FunctionSyntaxConfig, GenericSyntaxConfig,
+    QuoteStyle, TypeDeclSyntaxConfig, TypePresentationConfig,
+};
 use crate::spec::modifiers::{DeclarationContext, TypeKind, Visibility};
+use crate::type_name::{AssociatedTypeStyle, FunctionPresentation, TypePresentation};
 
 /// Python language implementation.
 ///
@@ -279,14 +283,6 @@ impl CodeLang for Python {
         "#"
     }
 
-    fn indent_unit(&self) -> &str {
-        &self.indent
-    }
-
-    fn uses_semicolons(&self) -> bool {
-        false
-    }
-
     fn render_visibility(&self, _vis: Visibility, _ctx: DeclarationContext) -> &str {
         // Python uses naming conventions (_private, __mangled), not keywords.
         ""
@@ -294,10 +290,6 @@ impl CodeLang for Python {
 
     fn function_keyword(&self, _ctx: DeclarationContext) -> &str {
         "def"
-    }
-
-    fn return_type_separator(&self) -> &str {
-        " -> "
     }
 
     fn type_keyword(&self, kind: TypeKind) -> &str {
@@ -308,10 +300,6 @@ impl CodeLang for Python {
         }
     }
 
-    fn field_terminator(&self) -> &str {
-        ""
-    }
-
     fn methods_inside_type_body(&self, _kind: TypeKind) -> bool {
         true
     }
@@ -320,105 +308,96 @@ impl CodeLang for Python {
         format!("{name} = NewType(\"{name}\", {inner})")
     }
 
-    fn generic_constraint_keyword(&self) -> &str {
-        // Python uses TypeVar("T", bound=X) — not inline syntax.
-        ""
-    }
-
-    fn generic_constraint_separator(&self) -> &str {
-        ""
-    }
-
-    fn super_type_keyword(&self) -> &str {
-        // Python uses parenthesized bases: `class Foo(Base):`
-        "("
-    }
-
-    fn implements_keyword(&self) -> &str {
-        // Both super_types and impl_types go in the same parenthesized list.
-        ", "
-    }
-
-    fn generic_open(&self) -> &str {
-        "["
-    }
-
-    fn generic_close(&self) -> &str {
-        "]"
-    }
-
-    fn block_open(&self) -> &str {
-        ":"
-    }
-
-    fn block_close(&self) -> &str {
-        ""
-    }
-
     fn doc_comment_inside_body(&self) -> bool {
         true
     }
 
-    fn bases_close(&self) -> &str {
-        ")"
+    fn fun_block_open(&self) -> &str {
+        ":"
     }
 
-    fn empty_body(&self) -> &str {
-        "..."
-    }
-
-    fn enum_variant_separator(&self) -> &str {
-        ""
-    }
-
-    fn constructor_keyword(&self) -> &str {
-        "def"
+    fn type_header_block_open(&self, _kind: crate::spec::modifiers::TypeKind) -> &str {
+        ":"
     }
 
     fn optional_field_style(&self) -> crate::lang::config::OptionalFieldStyle {
         crate::lang::config::OptionalFieldStyle::UnionWithNone(" | ")
     }
 
-    fn present_array(&self) -> crate::type_name::TypePresentation<'_> {
-        crate::type_name::TypePresentation::GenericWrap { name: "list" }
+    // --- Config struct accessors ---
+
+    fn type_presentation(&self) -> TypePresentationConfig<'_> {
+        TypePresentationConfig {
+            array: TypePresentation::GenericWrap { name: "list" },
+            readonly_array: Some(TypePresentation::GenericWrap { name: "list" }),
+            optional_absent_literal: "None",
+            map: TypePresentation::Delimited {
+                open: "dict[",
+                sep: ", ",
+                close: "]",
+            },
+            tuple: TypePresentation::GenericWrap { name: "tuple" },
+            function: FunctionPresentation {
+                keyword: "",
+                params_open: "Callable[[",
+                params_sep: ", ",
+                params_close: "]",
+                arrow: ", ",
+                return_first: false,
+                curried: false,
+                wrapper_open: "",
+                wrapper_close: "]",
+            },
+            associated_type: AssociatedTypeStyle::DotAccess,
+            ..Default::default()
+        }
     }
 
-    fn present_readonly_array(&self) -> Option<crate::type_name::TypePresentation<'_>> {
-        Some(crate::type_name::TypePresentation::GenericWrap { name: "list" })
-    }
-
-    fn optional_absent_literal(&self) -> &str {
-        "None"
-    }
-
-    fn present_map(&self) -> crate::type_name::TypePresentation<'_> {
-        crate::type_name::TypePresentation::Delimited {
-            open: "dict[",
-            sep: ", ",
+    fn generic_syntax(&self) -> GenericSyntaxConfig<'_> {
+        GenericSyntaxConfig {
+            open: "[",
             close: "]",
+            constraint_keyword: "",
+            constraint_separator: "",
+            context_bound_keyword: "",
+            ..Default::default()
         }
     }
 
-    fn present_function(&self) -> crate::type_name::FunctionPresentation<'_> {
-        crate::type_name::FunctionPresentation {
-            keyword: "",
-            params_open: "Callable[[",
-            params_sep: ", ",
-            params_close: "]",
-            arrow: ", ",
-            return_first: false,
-            curried: false,
-            wrapper_open: "",
-            wrapper_close: "]",
+    fn block_syntax(&self) -> BlockSyntaxConfig<'_> {
+        BlockSyntaxConfig {
+            block_open: ":",
+            block_close: "",
+            indent_unit: &self.indent,
+            uses_semicolons: false,
+            field_terminator: "",
+            bases_close: ")",
+            ..Default::default()
         }
     }
 
-    fn present_tuple(&self) -> crate::type_name::TypePresentation<'_> {
-        crate::type_name::TypePresentation::GenericWrap { name: "tuple" }
+    fn function_syntax(&self) -> FunctionSyntaxConfig<'_> {
+        FunctionSyntaxConfig {
+            return_type_separator: " -> ",
+            constructor_keyword: "def",
+            empty_body: "...",
+            ..Default::default()
+        }
     }
 
-    fn present_associated_type(&self) -> crate::type_name::AssociatedTypeStyle<'_> {
-        crate::type_name::AssociatedTypeStyle::DotAccess
+    fn type_decl_syntax(&self) -> TypeDeclSyntaxConfig<'_> {
+        TypeDeclSyntaxConfig {
+            super_type_keyword: "(",
+            implements_keyword: ", ",
+            ..Default::default()
+        }
+    }
+
+    fn enum_and_annotation(&self) -> EnumAndAnnotationConfig<'_> {
+        EnumAndAnnotationConfig {
+            variant_separator: "",
+            ..Default::default()
+        }
     }
 }
 
@@ -564,15 +543,15 @@ mod tests {
     #[test]
     fn test_block_delimiters() {
         let py = Python::new();
-        assert_eq!(py.block_open(), ":");
-        assert_eq!(py.block_close(), "");
+        assert_eq!(py.block_syntax().block_open, ":");
+        assert_eq!(py.block_syntax().block_close, "");
     }
 
     #[test]
     fn test_generic_delimiters() {
         let py = Python::new();
-        assert_eq!(py.generic_open(), "[");
-        assert_eq!(py.generic_close(), "]");
+        assert_eq!(py.generic_syntax().open, "[");
+        assert_eq!(py.generic_syntax().close, "]");
     }
 
     #[test]
@@ -595,7 +574,7 @@ mod tests {
     #[test]
     fn test_empty_body() {
         let py = Python::new();
-        assert_eq!(py.empty_body(), "...");
+        assert_eq!(py.function_syntax().empty_body, "...");
     }
 
     #[test]
@@ -605,7 +584,7 @@ mod tests {
             .with_extension("pyi")
             .with_indent("  ");
         assert_eq!(py.file_extension(), "pyi");
-        assert_eq!(py.indent_unit(), "  ");
+        assert_eq!(py.block_syntax().indent_unit, "  ");
         assert_eq!(py.render_string_literal("hi"), "\"hi\"");
     }
 }

--- a/src/lang/rust_lang.rs
+++ b/src/lang/rust_lang.rs
@@ -1,6 +1,12 @@
 use crate::import::{ImportEntry, ImportGroup};
 use crate::lang::CodeLang;
+use crate::lang::config::{
+    BlockSyntaxConfig, EnumAndAnnotationConfig, FunctionSyntaxConfig, GenericSyntaxConfig,
+    TypeDeclSyntaxConfig, TypePresentationConfig,
+};
+use crate::spec::fun_spec::WhereClauseStyle;
 use crate::spec::modifiers::{DeclarationContext, TypeKind, Visibility};
+use crate::type_name::{FunctionPresentation, TypePresentation, WildcardPresentation};
 
 /// Rust language implementation.
 #[derive(Debug, Clone)]
@@ -173,16 +179,6 @@ impl CodeLang for RustLang {
         "//"
     }
 
-    fn indent_unit(&self) -> &str {
-        &self.indent
-    }
-
-    fn uses_semicolons(&self) -> bool {
-        // Rust uses semicolons for statements but not for the last expression.
-        // For code generation purposes, we default to true.
-        true
-    }
-
     fn escape_reserved(&self, name: &str) -> String {
         if self.reserved_words().contains(&name) {
             format!("r#{name}")
@@ -206,10 +202,6 @@ impl CodeLang for RustLang {
         "fn"
     }
 
-    fn return_type_separator(&self) -> &str {
-        " -> "
-    }
-
     fn type_keyword(&self, kind: TypeKind) -> &str {
         match kind {
             TypeKind::Struct | TypeKind::Class => "struct",
@@ -218,10 +210,6 @@ impl CodeLang for RustLang {
             TypeKind::TypeAlias => "type",
             TypeKind::Newtype => "struct",
         }
-    }
-
-    fn field_terminator(&self) -> &str {
-        ","
     }
 
     fn methods_inside_type_body(&self, kind: TypeKind) -> bool {
@@ -235,34 +223,6 @@ impl CodeLang for RustLang {
         }
     }
 
-    fn generic_constraint_keyword(&self) -> &str {
-        ": "
-    }
-
-    fn generic_constraint_separator(&self) -> &str {
-        " + "
-    }
-
-    fn super_type_keyword(&self) -> &str {
-        ""
-    }
-
-    fn implements_keyword(&self) -> &str {
-        ""
-    }
-
-    fn enum_variant_trailing_separator(&self) -> bool {
-        true
-    }
-
-    fn render_annotation_prefix(&self) -> (&str, &str) {
-        ("#[", "]")
-    }
-
-    fn constructor_keyword(&self) -> &str {
-        "fn"
-    }
-
     fn optional_field_style(&self) -> crate::lang::config::OptionalFieldStyle {
         crate::lang::config::OptionalFieldStyle::TypeWrap {
             open: "Option<",
@@ -270,74 +230,74 @@ impl CodeLang for RustLang {
         }
     }
 
-    fn present_array(&self) -> crate::type_name::TypePresentation<'_> {
-        crate::type_name::TypePresentation::GenericWrap { name: "Vec" }
-    }
+    // --- Config struct accessors ---
 
-    fn present_readonly_array(&self) -> Option<crate::type_name::TypePresentation<'_>> {
-        Some(crate::type_name::TypePresentation::GenericWrap { name: "Vec" })
-    }
-
-    fn present_optional(&self) -> crate::type_name::TypePresentation<'_> {
-        crate::type_name::TypePresentation::GenericWrap { name: "Option" }
-    }
-
-    fn present_map(&self) -> crate::type_name::TypePresentation<'_> {
-        crate::type_name::TypePresentation::GenericWrap { name: "HashMap" }
-    }
-
-    fn present_intersection(&self) -> crate::type_name::TypePresentation<'_> {
-        crate::type_name::TypePresentation::Infix { sep: " + " }
-    }
-
-    fn present_pointer(&self) -> crate::type_name::TypePresentation<'_> {
-        crate::type_name::TypePresentation::Prefix { prefix: "*const " }
-    }
-
-    fn present_slice(&self) -> crate::type_name::TypePresentation<'_> {
-        crate::type_name::TypePresentation::Delimited {
-            open: "&[",
-            sep: "",
-            close: "]",
+    fn type_presentation(&self) -> TypePresentationConfig<'_> {
+        TypePresentationConfig {
+            array: TypePresentation::GenericWrap { name: "Vec" },
+            readonly_array: Some(TypePresentation::GenericWrap { name: "Vec" }),
+            optional: TypePresentation::GenericWrap { name: "Option" },
+            map: TypePresentation::GenericWrap { name: "HashMap" },
+            intersection: TypePresentation::Infix { sep: " + " },
+            pointer: TypePresentation::Prefix { prefix: "*const " },
+            slice: TypePresentation::Delimited {
+                open: "&[",
+                sep: "",
+                close: "]",
+            },
+            reference: TypePresentation::Prefix { prefix: "&" },
+            reference_mut: TypePresentation::Prefix { prefix: "&mut " },
+            function: FunctionPresentation {
+                keyword: "fn",
+                params_open: "(",
+                params_sep: ", ",
+                params_close: ")",
+                arrow: " -> ",
+                return_first: false,
+                curried: false,
+                wrapper_open: "",
+                wrapper_close: "",
+            },
+            wildcard: WildcardPresentation {
+                unbounded: "_",
+                upper_keyword: "impl ",
+                lower_keyword: "impl ",
+            },
+            ..Default::default()
         }
     }
 
-    fn present_reference(&self) -> crate::type_name::TypePresentation<'_> {
-        crate::type_name::TypePresentation::Prefix { prefix: "&" }
+    fn generic_syntax(&self) -> GenericSyntaxConfig<'_> {
+        GenericSyntaxConfig::default()
     }
 
-    fn present_reference_mut(&self) -> crate::type_name::TypePresentation<'_> {
-        crate::type_name::TypePresentation::Prefix { prefix: "&mut " }
-    }
-
-    fn present_function(&self) -> crate::type_name::FunctionPresentation<'_> {
-        crate::type_name::FunctionPresentation {
-            keyword: "fn",
-            params_open: "(",
-            params_sep: ", ",
-            params_close: ")",
-            arrow: " -> ",
-            return_first: false,
-            curried: false,
-            wrapper_open: "",
-            wrapper_close: "",
+    fn block_syntax(&self) -> BlockSyntaxConfig<'_> {
+        BlockSyntaxConfig {
+            indent_unit: &self.indent,
+            ..Default::default()
         }
     }
 
-    fn present_wildcard(&self) -> crate::type_name::WildcardPresentation<'_> {
-        // Rust doesn't have Java/Kotlin-style bounded wildcards.
-        // Unbounded `_` is valid (type inference placeholder).
-        // Bounded: maps to `impl T` as the closest approximation.
-        // For precise Rust bounds, use `TypeName::impl_trait()` / `dyn_trait()` directly.
-        crate::type_name::WildcardPresentation {
-            unbounded: "_",
-            upper_keyword: "impl ",
-            lower_keyword: "impl ",
+    fn function_syntax(&self) -> FunctionSyntaxConfig<'_> {
+        FunctionSyntaxConfig {
+            return_type_separator: " -> ",
+            constructor_keyword: "fn",
+            where_clause_style: WhereClauseStyle::WhereBlock,
+            ..Default::default()
         }
     }
 
-    fn where_clause_style(&self) -> crate::spec::fun_spec::WhereClauseStyle {
-        crate::spec::fun_spec::WhereClauseStyle::WhereBlock
+    fn type_decl_syntax(&self) -> TypeDeclSyntaxConfig<'_> {
+        TypeDeclSyntaxConfig::default()
+    }
+
+    fn enum_and_annotation(&self) -> EnumAndAnnotationConfig<'_> {
+        EnumAndAnnotationConfig {
+            variant_trailing_separator: true,
+            annotation_prefix: "#[",
+            annotation_suffix: "]",
+            ..Default::default()
+        }
     }
 }
 
@@ -450,6 +410,6 @@ mod tests {
     fn test_rust_builder_fluent() {
         let rs = RustLang::new().with_indent("\t").with_extension("rsi");
         assert_eq!(rs.file_extension(), "rsi");
-        assert_eq!(rs.indent_unit(), "\t");
+        assert_eq!(rs.block_syntax().indent_unit, "\t");
     }
 }

--- a/src/lang/scala.rs
+++ b/src/lang/scala.rs
@@ -217,14 +217,6 @@ impl CodeLang for Scala {
         "//"
     }
 
-    fn indent_unit(&self) -> &str {
-        &self.indent
-    }
-
-    fn uses_semicolons(&self) -> bool {
-        false
-    }
-
     fn render_visibility(&self, vis: Visibility, _ctx: DeclarationContext) -> &str {
         match vis {
             Visibility::Public | Visibility::Inherited => "",
@@ -239,10 +231,6 @@ impl CodeLang for Scala {
         "def"
     }
 
-    fn return_type_separator(&self) -> &str {
-        ": "
-    }
-
     fn type_keyword(&self, kind: TypeKind) -> &str {
         match kind {
             TypeKind::Class => "class",
@@ -254,63 +242,7 @@ impl CodeLang for Scala {
         }
     }
 
-    fn field_terminator(&self) -> &str {
-        ""
-    }
-
     fn methods_inside_type_body(&self, _kind: TypeKind) -> bool {
-        true
-    }
-
-    fn generic_constraint_keyword(&self) -> &str {
-        " <: "
-    }
-
-    fn generic_constraint_separator(&self) -> &str {
-        " with "
-    }
-
-    fn super_type_keyword(&self) -> &str {
-        " extends "
-    }
-
-    fn abstract_keyword(&self) -> &str {
-        ""
-    }
-
-    fn super_type_subsequent_separator(&self) -> Option<&str> {
-        Some(" with ")
-    }
-
-    fn context_bound_keyword(&self) -> &str {
-        " : "
-    }
-
-    fn implements_keyword(&self) -> &str {
-        " with "
-    }
-
-    fn type_annotation_separator(&self) -> &str {
-        ": "
-    }
-
-    fn generic_open(&self) -> &str {
-        "["
-    }
-
-    fn generic_close(&self) -> &str {
-        "]"
-    }
-
-    fn readonly_keyword(&self) -> &str {
-        "val "
-    }
-
-    fn mutable_field_keyword(&self) -> &str {
-        "var "
-    }
-
-    fn supports_primary_constructor(&self) -> bool {
         true
     }
 
@@ -318,52 +250,6 @@ impl CodeLang for Scala {
         crate::lang::config::OptionalFieldStyle::TypeWrap {
             open: "Option[",
             close: "]",
-        }
-    }
-
-    fn present_array(&self) -> crate::type_name::TypePresentation<'_> {
-        crate::type_name::TypePresentation::GenericWrap { name: "Array" }
-    }
-
-    fn present_readonly_array(&self) -> Option<crate::type_name::TypePresentation<'_>> {
-        Some(crate::type_name::TypePresentation::GenericWrap { name: "List" })
-    }
-
-    fn present_optional(&self) -> crate::type_name::TypePresentation<'_> {
-        crate::type_name::TypePresentation::GenericWrap { name: "Option" }
-    }
-
-    fn present_map(&self) -> crate::type_name::TypePresentation<'_> {
-        crate::type_name::TypePresentation::GenericWrap { name: "Map" }
-    }
-
-    fn present_intersection(&self) -> crate::type_name::TypePresentation<'_> {
-        crate::type_name::TypePresentation::Infix { sep: " with " }
-    }
-
-    fn present_function(&self) -> crate::type_name::FunctionPresentation<'_> {
-        crate::type_name::FunctionPresentation {
-            keyword: "",
-            params_open: "(",
-            params_sep: ", ",
-            params_close: ")",
-            arrow: " => ",
-            return_first: false,
-            curried: false,
-            wrapper_open: "",
-            wrapper_close: "",
-        }
-    }
-
-    fn present_associated_type(&self) -> crate::type_name::AssociatedTypeStyle<'_> {
-        crate::type_name::AssociatedTypeStyle::DotAccess
-    }
-
-    fn present_wildcard(&self) -> crate::type_name::WildcardPresentation<'_> {
-        crate::type_name::WildcardPresentation {
-            unbounded: "_",
-            upper_keyword: "_ <: ",
-            lower_keyword: "_ >: ",
         }
     }
 
@@ -379,12 +265,69 @@ impl CodeLang for Scala {
         format!("{vis}class {name}(val value: {inner})")
     }
 
-    fn enum_variant_trailing_separator(&self) -> bool {
-        false
-    }
-
     fn fun_block_open(&self) -> &str {
         " = {"
+    }
+
+    fn type_presentation(&self) -> crate::lang::config::TypePresentationConfig<'_> {
+        crate::lang::config::TypePresentationConfig {
+            array: crate::type_name::TypePresentation::GenericWrap { name: "Array" },
+            readonly_array: Some(crate::type_name::TypePresentation::GenericWrap { name: "List" }),
+            optional: crate::type_name::TypePresentation::GenericWrap { name: "Option" },
+            intersection: crate::type_name::TypePresentation::Infix { sep: " with " },
+            associated_type: crate::type_name::AssociatedTypeStyle::DotAccess,
+            wildcard: crate::type_name::WildcardPresentation {
+                unbounded: "_",
+                upper_keyword: "_ <: ",
+                lower_keyword: "_ >: ",
+            },
+            ..Default::default()
+        }
+    }
+
+    fn generic_syntax(&self) -> crate::lang::config::GenericSyntaxConfig<'_> {
+        crate::lang::config::GenericSyntaxConfig {
+            open: "[",
+            close: "]",
+            constraint_keyword: " <: ",
+            constraint_separator: " with ",
+            context_bound_keyword: " : ",
+            ..Default::default()
+        }
+    }
+
+    fn block_syntax(&self) -> crate::lang::config::BlockSyntaxConfig<'_> {
+        crate::lang::config::BlockSyntaxConfig {
+            indent_unit: &self.indent,
+            uses_semicolons: false,
+            field_terminator: "",
+            ..Default::default()
+        }
+    }
+
+    fn function_syntax(&self) -> crate::lang::config::FunctionSyntaxConfig<'_> {
+        crate::lang::config::FunctionSyntaxConfig {
+            abstract_keyword: "",
+            ..Default::default()
+        }
+    }
+
+    fn type_decl_syntax(&self) -> crate::lang::config::TypeDeclSyntaxConfig<'_> {
+        crate::lang::config::TypeDeclSyntaxConfig {
+            super_type_keyword: " extends ",
+            super_type_subsequent_separator: Some(" with "),
+            implements_keyword: " with ",
+            supports_primary_constructor: true,
+            ..Default::default()
+        }
+    }
+
+    fn enum_and_annotation(&self) -> crate::lang::config::EnumAndAnnotationConfig<'_> {
+        crate::lang::config::EnumAndAnnotationConfig {
+            readonly_keyword: "val ",
+            mutable_field_keyword: "var ",
+            ..Default::default()
+        }
     }
 }
 
@@ -593,21 +536,21 @@ mod tests {
     #[test]
     fn test_no_semicolons() {
         let sc = Scala::new();
-        assert!(!sc.uses_semicolons());
+        assert!(!sc.block_syntax().uses_semicolons);
     }
 
     #[test]
     fn test_generic_brackets() {
         let sc = Scala::new();
-        assert_eq!(sc.generic_open(), "[");
-        assert_eq!(sc.generic_close(), "]");
+        assert_eq!(sc.generic_syntax().open, "[");
+        assert_eq!(sc.generic_syntax().close, "]");
     }
 
     #[test]
     fn test_field_keywords() {
         let sc = Scala::new();
-        assert_eq!(sc.readonly_keyword(), "val ");
-        assert_eq!(sc.mutable_field_keyword(), "var ");
+        assert_eq!(sc.enum_and_annotation().readonly_keyword, "val ");
+        assert_eq!(sc.enum_and_annotation().mutable_field_keyword, "var ");
     }
 
     #[test]
@@ -641,19 +584,22 @@ mod tests {
     fn test_scala_builder_fluent() {
         let sc = Scala::new().with_indent("\t").with_extension("sc");
         assert_eq!(sc.file_extension(), "sc");
-        assert_eq!(sc.indent_unit(), "\t");
+        assert_eq!(sc.block_syntax().indent_unit, "\t");
     }
 
     #[test]
     fn test_super_type_subsequent_separator() {
         let sc = Scala::new();
-        assert_eq!(sc.super_type_subsequent_separator(), Some(" with "));
+        assert_eq!(
+            sc.type_decl_syntax().super_type_subsequent_separator,
+            Some(" with ")
+        );
     }
 
     #[test]
     fn test_context_bound_keyword() {
         let sc = Scala::new();
-        assert_eq!(sc.context_bound_keyword(), " : ");
+        assert_eq!(sc.generic_syntax().context_bound_keyword, " : ");
     }
 
     #[test]

--- a/src/lang/scala.rs
+++ b/src/lang/scala.rs
@@ -43,14 +43,14 @@ use crate::spec::modifiers::{DeclarationContext, TypeKind, Visibility};
 /// Use `TypeKind::Trait` for traits and `TypeKind::Struct` for case classes.
 /// For sealed modifiers, use annotations:
 /// ```text
-/// tb.annotation(CodeBlock::<Scala>::of("sealed", ()).unwrap());
+/// tb.annotation(CodeBlock::of("sealed", ()).unwrap());
 /// ```
 ///
 /// # Primary constructors
 ///
 /// Use `add_primary_constructor_param()` on `TypeSpecBuilder`:
 /// ```text
-/// let mut tb = TypeSpec::<Scala>::builder("Person", TypeKind::Class);
+/// let mut tb = TypeSpec::builder("Person", TypeKind::Class);
 /// tb.add_primary_constructor_param(ParameterSpec::new("val name", TypeName::primitive("String")));
 /// tb.add_primary_constructor_param(ParameterSpec::new("val age", TypeName::primitive("Int")));
 /// // Emits: class Person(val name: String, val age: Int) {

--- a/src/lang/swift.rs
+++ b/src/lang/swift.rs
@@ -254,14 +254,6 @@ impl CodeLang for Swift {
         "//"
     }
 
-    fn indent_unit(&self) -> &str {
-        &self.indent
-    }
-
-    fn uses_semicolons(&self) -> bool {
-        false
-    }
-
     fn render_visibility(&self, vis: Visibility, _ctx: DeclarationContext) -> &str {
         match vis {
             Visibility::Public => "public ",
@@ -277,10 +269,6 @@ impl CodeLang for Swift {
         "func"
     }
 
-    fn return_type_separator(&self) -> &str {
-        " -> "
-    }
-
     fn type_keyword(&self, kind: TypeKind) -> &str {
         match kind {
             TypeKind::Class => "class",
@@ -291,51 +279,8 @@ impl CodeLang for Swift {
         }
     }
 
-    fn field_terminator(&self) -> &str {
-        ""
-    }
-
     fn methods_inside_type_body(&self, _kind: TypeKind) -> bool {
         true
-    }
-
-    fn generic_constraint_keyword(&self) -> &str {
-        ": "
-    }
-
-    fn generic_constraint_separator(&self) -> &str {
-        " & "
-    }
-
-    fn super_type_keyword(&self) -> &str {
-        ": "
-    }
-
-    fn implements_keyword(&self) -> &str {
-        // Swift uses a single `:` list for both superclass and protocols.
-        // Put all conformances in super_types(); leave impl_types() empty.
-        ""
-    }
-
-    fn readonly_keyword(&self) -> &str {
-        "let "
-    }
-
-    fn mutable_field_keyword(&self) -> &str {
-        "var "
-    }
-
-    fn abstract_keyword(&self) -> &str {
-        // Swift protocols declare requirements by omitting the body — no keyword.
-        ""
-    }
-
-    fn enum_variant_prefix(&self) -> &str {
-        "case "
-    }
-
-    fn enum_variant_separator(&self) -> &str {
-        ""
     }
 
     fn property_style(&self) -> crate::spec::modifiers::PropertyStyle {
@@ -346,31 +291,68 @@ impl CodeLang for Swift {
         crate::lang::config::OptionalFieldStyle::TypeSuffix("?")
     }
 
-    fn present_array(&self) -> crate::type_name::TypePresentation<'_> {
-        crate::type_name::TypePresentation::Delimited {
-            open: "[",
-            sep: "",
-            close: "]",
+    fn type_presentation(&self) -> crate::lang::config::TypePresentationConfig<'_> {
+        crate::lang::config::TypePresentationConfig {
+            array: crate::type_name::TypePresentation::Delimited {
+                open: "[",
+                sep: "",
+                close: "]",
+            },
+            readonly_array: Some(crate::type_name::TypePresentation::Delimited {
+                open: "[",
+                sep: "",
+                close: "]",
+            }),
+            optional: crate::type_name::TypePresentation::Postfix { suffix: "?" },
+            map: crate::type_name::TypePresentation::Delimited {
+                open: "[",
+                sep: ": ",
+                close: "]",
+            },
+            ..Default::default()
         }
     }
 
-    fn present_readonly_array(&self) -> Option<crate::type_name::TypePresentation<'_>> {
-        Some(crate::type_name::TypePresentation::Delimited {
-            open: "[",
-            sep: "",
-            close: "]",
-        })
+    fn generic_syntax(&self) -> crate::lang::config::GenericSyntaxConfig<'_> {
+        crate::lang::config::GenericSyntaxConfig {
+            constraint_keyword: ": ",
+            constraint_separator: " & ",
+            context_bound_keyword: ": ",
+            ..Default::default()
+        }
     }
 
-    fn present_optional(&self) -> crate::type_name::TypePresentation<'_> {
-        crate::type_name::TypePresentation::Postfix { suffix: "?" }
+    fn block_syntax(&self) -> crate::lang::config::BlockSyntaxConfig<'_> {
+        crate::lang::config::BlockSyntaxConfig {
+            indent_unit: &self.indent,
+            uses_semicolons: false,
+            field_terminator: "",
+            ..Default::default()
+        }
     }
 
-    fn present_map(&self) -> crate::type_name::TypePresentation<'_> {
-        crate::type_name::TypePresentation::Delimited {
-            open: "[",
-            sep: ": ",
-            close: "]",
+    fn function_syntax(&self) -> crate::lang::config::FunctionSyntaxConfig<'_> {
+        crate::lang::config::FunctionSyntaxConfig {
+            return_type_separator: " -> ",
+            abstract_keyword: "",
+            ..Default::default()
+        }
+    }
+
+    fn type_decl_syntax(&self) -> crate::lang::config::TypeDeclSyntaxConfig<'_> {
+        crate::lang::config::TypeDeclSyntaxConfig {
+            super_type_keyword: ": ",
+            ..Default::default()
+        }
+    }
+
+    fn enum_and_annotation(&self) -> crate::lang::config::EnumAndAnnotationConfig<'_> {
+        crate::lang::config::EnumAndAnnotationConfig {
+            variant_prefix: "case ",
+            variant_separator: "",
+            readonly_keyword: "let ",
+            mutable_field_keyword: "var ",
+            ..Default::default()
         }
     }
 }
@@ -547,20 +529,20 @@ mod tests {
     #[test]
     fn test_no_semicolons() {
         let sw = Swift::new();
-        assert!(!sw.uses_semicolons());
+        assert!(!sw.block_syntax().uses_semicolons);
     }
 
     #[test]
     fn test_return_type_separator() {
         let sw = Swift::new();
-        assert_eq!(sw.return_type_separator(), " -> ");
+        assert_eq!(sw.function_syntax().return_type_separator, " -> ");
     }
 
     #[test]
     fn test_field_keywords() {
         let sw = Swift::new();
-        assert_eq!(sw.readonly_keyword(), "let ");
-        assert_eq!(sw.mutable_field_keyword(), "var ");
+        assert_eq!(sw.enum_and_annotation().readonly_keyword, "let ");
+        assert_eq!(sw.enum_and_annotation().mutable_field_keyword, "var ");
     }
 
     #[test]
@@ -583,7 +565,7 @@ mod tests {
     #[test]
     fn test_abstract_keyword_empty() {
         let sw = Swift::new();
-        assert_eq!(sw.abstract_keyword(), "");
+        assert_eq!(sw.function_syntax().abstract_keyword, "");
     }
 
     #[test]
@@ -592,6 +574,6 @@ mod tests {
             .with_indent("  ")
             .with_extension("swiftinterface");
         assert_eq!(sw.file_extension(), "swiftinterface");
-        assert_eq!(sw.indent_unit(), "  ");
+        assert_eq!(sw.block_syntax().indent_unit, "  ");
     }
 }

--- a/src/lang/swift.rs
+++ b/src/lang/swift.rs
@@ -46,8 +46,8 @@ use crate::spec::modifiers::{DeclarationContext, TypeKind, Visibility};
 ///
 /// Use `annotation()` for Swift attributes:
 /// ```text
-/// fb.annotation(CodeBlock::<Swift>::of("@objc", ()).unwrap());
-/// fb.annotation(CodeBlock::<Swift>::of("@discardableResult", ()).unwrap());
+/// fb.annotation(CodeBlock::of("@objc", ()).unwrap());
+/// fb.annotation(CodeBlock::of("@discardableResult", ()).unwrap());
 /// ```
 #[derive(Debug, Clone)]
 pub struct Swift {

--- a/src/lang/typescript.rs
+++ b/src/lang/typescript.rs
@@ -1,7 +1,13 @@
 use crate::import::{ImportEntry, ImportGroup};
 use crate::lang::CodeLang;
-use crate::lang::config::QuoteStyle;
+use crate::lang::config::{
+    BlockSyntaxConfig, EnumAndAnnotationConfig, FunctionSyntaxConfig, GenericSyntaxConfig,
+    QuoteStyle, TypeDeclSyntaxConfig, TypePresentationConfig,
+};
 use crate::spec::modifiers::{DeclarationContext, TypeKind, Visibility};
+use crate::type_name::{
+    AssociatedTypeStyle, BoundsPresentation, TypePresentation, WildcardPresentation,
+};
 
 /// TypeScript language implementation.
 ///
@@ -259,14 +265,6 @@ impl CodeLang for TypeScript {
         "//"
     }
 
-    fn indent_unit(&self) -> &str {
-        &self.indent
-    }
-
-    fn uses_semicolons(&self) -> bool {
-        self.uses_semicolons
-    }
-
     fn render_visibility(&self, vis: Visibility, ctx: DeclarationContext) -> &str {
         match ctx {
             DeclarationContext::TopLevel => match vis {
@@ -289,10 +287,6 @@ impl CodeLang for TypeScript {
         }
     }
 
-    fn return_type_separator(&self) -> &str {
-        ": "
-    }
-
     fn type_keyword(&self, kind: TypeKind) -> &str {
         match kind {
             TypeKind::Class | TypeKind::Struct => "class",
@@ -302,35 +296,7 @@ impl CodeLang for TypeScript {
         }
     }
 
-    fn field_terminator(&self) -> &str {
-        ";"
-    }
-
     fn methods_inside_type_body(&self, _kind: TypeKind) -> bool {
-        true
-    }
-
-    fn generic_constraint_keyword(&self) -> &str {
-        " extends "
-    }
-
-    fn generic_constraint_separator(&self) -> &str {
-        " & "
-    }
-
-    fn super_type_keyword(&self) -> &str {
-        " extends "
-    }
-
-    fn implements_keyword(&self) -> &str {
-        " implements "
-    }
-
-    fn readonly_keyword(&self) -> &str {
-        "readonly "
-    }
-
-    fn enum_variant_trailing_separator(&self) -> bool {
         true
     }
 
@@ -338,37 +304,67 @@ impl CodeLang for TypeScript {
         crate::lang::config::OptionalFieldStyle::NameSuffix("?")
     }
 
-    fn present_map(&self) -> crate::type_name::TypePresentation<'_> {
-        crate::type_name::TypePresentation::GenericWrap { name: "Record" }
-    }
+    // --- Config struct accessors ---
 
-    fn present_tuple(&self) -> crate::type_name::TypePresentation<'_> {
-        crate::type_name::TypePresentation::Delimited {
-            open: "[",
-            sep: ", ",
-            close: "]",
+    fn type_presentation(&self) -> TypePresentationConfig<'_> {
+        TypePresentationConfig {
+            map: TypePresentation::GenericWrap { name: "Record" },
+            tuple: TypePresentation::Delimited {
+                open: "[",
+                sep: ", ",
+                close: "]",
+            },
+            associated_type: AssociatedTypeStyle::IndexAccess {
+                open: "[\"",
+                close: "\"]",
+            },
+            impl_trait: BoundsPresentation {
+                keyword: "",
+                separator: " & ",
+            },
+            wildcard: WildcardPresentation {
+                unbounded: "unknown",
+                upper_keyword: "unknown ",
+                lower_keyword: "unknown ",
+            },
+            ..Default::default()
         }
     }
 
-    fn present_associated_type(&self) -> crate::type_name::AssociatedTypeStyle<'_> {
-        crate::type_name::AssociatedTypeStyle::IndexAccess {
-            open: "[\"",
-            close: "\"]",
+    fn generic_syntax(&self) -> GenericSyntaxConfig<'_> {
+        GenericSyntaxConfig {
+            constraint_keyword: " extends ",
+            constraint_separator: " & ",
+            ..Default::default()
         }
     }
 
-    fn present_impl_trait(&self) -> crate::type_name::BoundsPresentation<'_> {
-        crate::type_name::BoundsPresentation {
-            keyword: "",
-            separator: " & ",
+    fn block_syntax(&self) -> BlockSyntaxConfig<'_> {
+        BlockSyntaxConfig {
+            indent_unit: &self.indent,
+            uses_semicolons: self.uses_semicolons,
+            field_terminator: ";",
+            ..Default::default()
         }
     }
 
-    fn present_wildcard(&self) -> crate::type_name::WildcardPresentation<'_> {
-        crate::type_name::WildcardPresentation {
-            unbounded: "unknown",
-            upper_keyword: "unknown ",
-            lower_keyword: "unknown ",
+    fn function_syntax(&self) -> FunctionSyntaxConfig<'_> {
+        FunctionSyntaxConfig::default()
+    }
+
+    fn type_decl_syntax(&self) -> TypeDeclSyntaxConfig<'_> {
+        TypeDeclSyntaxConfig {
+            super_type_keyword: " extends ",
+            implements_keyword: " implements ",
+            ..Default::default()
+        }
+    }
+
+    fn enum_and_annotation(&self) -> EnumAndAnnotationConfig<'_> {
+        EnumAndAnnotationConfig {
+            readonly_keyword: "readonly ",
+            variant_trailing_separator: true,
+            ..Default::default()
         }
     }
 }
@@ -396,9 +392,9 @@ mod tests {
             .with_semicolons(false)
             .with_extension("tsx")
             .with_indent("    ");
-        assert!(!ts.uses_semicolons());
+        assert!(!ts.block_syntax().uses_semicolons);
         assert_eq!(ts.file_extension(), "tsx");
-        assert_eq!(ts.indent_unit(), "    ");
+        assert_eq!(ts.block_syntax().indent_unit, "    ");
 
         let imports = ImportGroup {
             entries: vec![ImportEntry {

--- a/src/lang/zsh.rs
+++ b/src/lang/zsh.rs
@@ -2,6 +2,10 @@
 
 use crate::import::ImportGroup;
 use crate::lang::CodeLang;
+use crate::lang::config::{
+    BlockSyntaxConfig, EnumAndAnnotationConfig, FunctionSyntaxConfig, GenericSyntaxConfig,
+    TypeDeclSyntaxConfig, TypePresentationConfig,
+};
 use crate::spec::modifiers::{DeclarationContext, TypeKind, Visibility};
 
 /// Zsh shell language implementation.
@@ -133,14 +137,6 @@ impl CodeLang for Zsh {
         "#"
     }
 
-    fn indent_unit(&self) -> &str {
-        &self.indent
-    }
-
-    fn uses_semicolons(&self) -> bool {
-        false
-    }
-
     fn render_visibility(&self, _vis: Visibility, _ctx: DeclarationContext) -> &str {
         ""
     }
@@ -149,15 +145,7 @@ impl CodeLang for Zsh {
         "function"
     }
 
-    fn return_type_separator(&self) -> &str {
-        ""
-    }
-
     fn type_keyword(&self, _kind: TypeKind) -> &str {
-        ""
-    }
-
-    fn field_terminator(&self) -> &str {
         ""
     }
 
@@ -165,20 +153,42 @@ impl CodeLang for Zsh {
         true
     }
 
-    fn generic_constraint_keyword(&self) -> &str {
-        ""
+    // --- Config struct accessors ---
+
+    fn type_presentation(&self) -> TypePresentationConfig<'_> {
+        TypePresentationConfig::default()
     }
 
-    fn generic_constraint_separator(&self) -> &str {
-        ""
+    fn generic_syntax(&self) -> GenericSyntaxConfig<'_> {
+        GenericSyntaxConfig {
+            constraint_keyword: "",
+            constraint_separator: "",
+            ..Default::default()
+        }
     }
 
-    fn super_type_keyword(&self) -> &str {
-        ""
+    fn block_syntax(&self) -> BlockSyntaxConfig<'_> {
+        BlockSyntaxConfig {
+            indent_unit: &self.indent,
+            uses_semicolons: false,
+            field_terminator: "",
+            ..Default::default()
+        }
     }
 
-    fn implements_keyword(&self) -> &str {
-        ""
+    fn function_syntax(&self) -> FunctionSyntaxConfig<'_> {
+        FunctionSyntaxConfig {
+            return_type_separator: "",
+            ..Default::default()
+        }
+    }
+
+    fn type_decl_syntax(&self) -> TypeDeclSyntaxConfig<'_> {
+        TypeDeclSyntaxConfig::default()
+    }
+
+    fn enum_and_annotation(&self) -> EnumAndAnnotationConfig<'_> {
+        EnumAndAnnotationConfig::default()
     }
 }
 
@@ -290,7 +300,7 @@ mod tests {
     #[test]
     fn test_no_semicolons() {
         let zsh = Zsh::new();
-        assert!(!zsh.uses_semicolons());
+        assert!(!zsh.block_syntax().uses_semicolons);
     }
 
     #[test]
@@ -306,6 +316,6 @@ mod tests {
     fn test_zsh_builder_fluent() {
         let zsh = Zsh::new().with_indent("\t").with_extension("sh");
         assert_eq!(zsh.file_extension(), "sh");
-        assert_eq!(zsh.indent_unit(), "\t");
+        assert_eq!(zsh.block_syntax().indent_unit, "\t");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,7 +71,9 @@
 
 /// Composable code fragments with format specifiers (`%T`, `%N`, `%S`, `%L`, etc.).
 pub mod code_block;
-/// Rendering engine that walks `CodeBlock` format parts into final output.
+/// Tree-based intermediate representation for code generation.
+pub mod code_node;
+/// Rendering engine that walks `CodeNode` trees into final output.
 pub mod code_renderer;
 /// Reusable named-parameter templates that produce `CodeBlock`s.
 pub mod code_template;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,10 +13,10 @@
 //!
 //! | Specifier | Name | Argument Type | Purpose |
 //! |-----------|------|---------------|---------|
-//! | `%T` | Type | `TypeName<L>` | Emit type reference, track import |
+//! | `%T` | Type | `TypeName` | Emit type reference, track import |
 //! | `%N` | Name | `&str` or `Nameable` | Emit identifier name |
 //! | `%S` | String | `&str` | Emit escaped string literal |
-//! | `%L` | Literal | `&str`, number, `CodeBlock<L>` | Emit raw value or nested block |
+//! | `%L` | Literal | `&str`, number, `CodeBlock` | Emit raw value or nested block |
 //! | `%W` | Wrap | (none) | Soft line break point |
 //! | `%>` | Indent | (none) | Increase indent level |
 //! | `%<` | Dedent | (none) | Decrease indent level |
@@ -29,16 +29,16 @@
 //! use sigil_stitch::prelude::*;
 //! use sigil_stitch::lang::typescript::TypeScript;
 //!
-//! let user_type = TypeName::<TypeScript>::importable_type("./models", "User");
+//! let user_type = TypeName::importable_type("./models", "User");
 //!
-//! let mut cb = CodeBlock::<TypeScript>::builder();
+//! let mut cb = CodeBlock::builder();
 //! cb.add_statement("const user = await getUser(%S)", ("id",));
 //! cb.add_statement("return user as %T", (user_type.clone(),));
 //! let body = cb.build().unwrap();
 //!
-//! let mut fb = FileSpec::<TypeScript>::builder("user.ts");
-//! fb.add_code(body);
-//! let file = fb.build().unwrap();
+//! let file = FileSpec::builder("user.ts")
+//!     .add_code(body)
+//!     .build().unwrap();
 //!
 //! let output = file.render(80).unwrap();
 //! assert!(output.contains("import type { User } from './models'"));
@@ -52,7 +52,7 @@
 //! use sigil_stitch::prelude::*;
 //! use sigil_stitch::lang::typescript::TypeScript;
 //!
-//! let user_type = TypeName::<TypeScript>::importable_type("./models", "User");
+//! let user_type = TypeName::importable_type("./models", "User");
 //!
 //! let block = sigil_quote!(TypeScript {
 //!     const user: $T(user_type) = await getUser($S("id"));
@@ -92,18 +92,22 @@ pub mod type_name;
 
 /// Common re-exports for convenient usage.
 pub mod prelude {
-    pub use crate::code_block::{CodeBlock, CodeBlockBuilder};
+    pub use crate::code_block::{CodeBlock, CodeBlockBuilder, NameArg, StringLitArg};
     pub use crate::code_template::{CodeTemplate, ParamKind};
     pub use crate::error::SigilStitchError;
     pub use crate::lang::CodeLang;
+    pub use crate::spec::annotation_spec::AnnotationSpec;
+    pub use crate::spec::enum_variant_spec::EnumVariantSpec;
     pub use crate::spec::field_spec::FieldSpec;
-    pub use crate::spec::file_spec::FileSpec;
+    pub use crate::spec::file_spec::{FileMember, FileSpec};
     pub use crate::spec::fun_spec::{
         FunSpec, TypeParamKind, TypeParamSpec, WhereClauseStyle, WhereConstraint,
     };
+    pub use crate::spec::import_spec::ImportSpec;
     pub use crate::spec::modifiers::{DeclarationContext, Modifiers, TypeKind, Visibility};
     pub use crate::spec::parameter_spec::ParameterSpec;
     pub use crate::spec::project_spec::{ProjectSpec, RenderedFile};
+    pub use crate::spec::property_spec::PropertySpec;
     pub use crate::spec::type_spec::TypeSpec;
     pub use crate::type_name::TypeName;
     pub use sigil_stitch_macros::sigil_quote;

--- a/src/spec/annotation_spec.rs
+++ b/src/spec/annotation_spec.rs
@@ -108,7 +108,8 @@ impl AnnotationSpec {
     ///
     /// Called during spec `emit()` methods which have access to `&L`.
     pub fn emit(&self, lang: &dyn CodeLang) -> Result<CodeBlock, crate::error::SigilStitchError> {
-        let (prefix, suffix) = lang.render_annotation_prefix();
+        let ea = lang.enum_and_annotation();
+        let (prefix, suffix) = (ea.annotation_prefix, ea.annotation_suffix);
 
         // Build the argument list portion: "(arg1, arg2)" or empty.
         let args_str = if self.arguments.is_empty() {

--- a/src/spec/annotation_spec.rs
+++ b/src/spec/annotation_spec.rs
@@ -32,35 +32,33 @@ use crate::type_name::TypeName;
 /// use sigil_stitch::lang::rust_lang::RustLang;
 ///
 /// // Simple: #[allow(dead_code)]
-/// let ann = AnnotationSpec::<RustLang>::new("allow").arg("dead_code");
+/// let ann = AnnotationSpec::new("allow").arg("dead_code");
 ///
 /// // Multiple args: #[cfg(test, feature = "nightly")]
-/// let ann = AnnotationSpec::<RustLang>::new("cfg")
+/// let ann = AnnotationSpec::new("cfg")
 ///     .arg("test")
 ///     .arg("feature = \"nightly\"");
 /// ```
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-#[serde(bound = "")]
-pub struct AnnotationSpec<L: CodeLang> {
-    pub(crate) name: AnnotationName<L>,
+pub struct AnnotationSpec {
+    pub(crate) name: AnnotationName,
     pub(crate) arguments: Vec<String>,
 }
 
 /// The name of an annotation — either a simple string or an import-tracked type.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-#[serde(bound = "")]
-pub(crate) enum AnnotationName<L: CodeLang> {
+pub(crate) enum AnnotationName {
     /// A simple name string (e.g., "Override", "deprecated").
     Simple(String),
     /// An importable type name that triggers import tracking via `%T`.
-    Importable(TypeName<L>),
+    Importable(TypeName),
 }
 
-impl<L: CodeLang> AnnotationSpec<L> {
+impl AnnotationSpec {
     /// Create an annotation with a simple (non-imported) name.
     ///
     /// ```text
-    /// AnnotationSpec::<TypeScript>::new("deprecated")
+    /// AnnotationSpec::new("deprecated")
     /// // TS: @deprecated
     /// // Rust: #[deprecated]
     /// ```
@@ -76,12 +74,12 @@ impl<L: CodeLang> AnnotationSpec<L> {
     /// The `TypeName` is rendered via `%T` so the import collector picks it up.
     ///
     /// ```text
-    /// AnnotationSpec::<JavaLang>::importable(
+    /// AnnotationSpec::importable(
     ///     TypeName::importable("javax.annotation", "Nullable")
     /// )
     /// // Java: @Nullable (with import javax.annotation.Nullable)
     /// ```
-    pub fn importable(type_name: TypeName<L>) -> Self {
+    pub fn importable(type_name: TypeName) -> Self {
         Self {
             name: AnnotationName::Importable(type_name),
             arguments: Vec::new(),
@@ -93,11 +91,11 @@ impl<L: CodeLang> AnnotationSpec<L> {
     /// Arguments are joined with `", "` inside parentheses.
     ///
     /// ```text
-    /// AnnotationSpec::<RustLang>::new("allow")
+    /// AnnotationSpec::new("allow")
     ///     .arg("dead_code")
     /// // Rust: #[allow(dead_code)]
     ///
-    /// AnnotationSpec::<JavaLang>::new("SuppressWarnings")
+    /// AnnotationSpec::new("SuppressWarnings")
     ///     .arg("\"unchecked\"")
     /// // Java: @SuppressWarnings("unchecked")
     /// ```
@@ -109,7 +107,7 @@ impl<L: CodeLang> AnnotationSpec<L> {
     /// Emit this annotation as a `CodeBlock` using the language's annotation syntax.
     ///
     /// Called during spec `emit()` methods which have access to `&L`.
-    pub fn emit(&self, lang: &L) -> Result<CodeBlock<L>, crate::error::SigilStitchError> {
+    pub fn emit(&self, lang: &dyn CodeLang) -> Result<CodeBlock, crate::error::SigilStitchError> {
         let (prefix, suffix) = lang.render_annotation_prefix();
 
         // Build the argument list portion: "(arg1, arg2)" or empty.
@@ -152,7 +150,7 @@ mod tests {
     #[test]
     fn test_simple_annotation_ts() {
         let ts = TypeScript::new();
-        let ann = AnnotationSpec::<TypeScript>::new("deprecated");
+        let ann = AnnotationSpec::new("deprecated");
         let cb = ann.emit(&ts).unwrap();
         assert!(!cb.is_empty());
     }
@@ -160,7 +158,7 @@ mod tests {
     #[test]
     fn test_simple_annotation_with_args() {
         let ts = TypeScript::new();
-        let ann = AnnotationSpec::<TypeScript>::new("deprecated").arg("reason: 'use v2'");
+        let ann = AnnotationSpec::new("deprecated").arg("reason: 'use v2'");
         let cb = ann.emit(&ts).unwrap();
         assert!(!cb.is_empty());
     }
@@ -168,7 +166,7 @@ mod tests {
     #[test]
     fn test_rust_prefix() {
         let rs = RustLang::new();
-        let ann = AnnotationSpec::<RustLang>::new("allow").arg("dead_code");
+        let ann = AnnotationSpec::new("allow").arg("dead_code");
         let cb = ann.emit(&rs).unwrap();
         assert!(!cb.is_empty());
     }
@@ -176,7 +174,7 @@ mod tests {
     #[test]
     fn test_importable_annotation() {
         let ts = TypeScript::new();
-        let type_name = TypeName::<TypeScript>::importable("./decorators", "Component");
+        let type_name = TypeName::importable("./decorators", "Component");
         let ann = AnnotationSpec::importable(type_name);
         let cb = ann.emit(&ts).unwrap();
         assert!(!cb.is_empty());
@@ -185,7 +183,7 @@ mod tests {
     #[test]
     fn test_arg_chaining() {
         let rs = RustLang::new();
-        let ann = AnnotationSpec::<RustLang>::new("cfg")
+        let ann = AnnotationSpec::new("cfg")
             .arg("test")
             .arg("feature = \"nightly\"");
         let cb = ann.emit(&rs).unwrap();

--- a/src/spec/enum_variant_spec.rs
+++ b/src/spec/enum_variant_spec.rs
@@ -8,9 +8,9 @@ use crate::type_name::TypeName;
 /// A single enum variant (e.g., `Red`, `Up = 'UP'`, `case red`).
 ///
 /// Used with [`TypeSpec`](crate::spec::type_spec::TypeSpec) via `add_variant()`.
-/// The language's [`CodeLang::enum_variant_prefix`],
-/// [`CodeLang::enum_variant_separator`],
-/// and [`CodeLang::enum_variant_trailing_separator`]
+/// The language's [`EnumAndAnnotationConfig::variant_prefix`](crate::lang::config::EnumAndAnnotationConfig::variant_prefix),
+/// [`variant_separator`](crate::lang::config::EnumAndAnnotationConfig::variant_separator),
+/// and [`variant_trailing_separator`](crate::lang::config::EnumAndAnnotationConfig::variant_trailing_separator)
 /// control rendering.
 ///
 /// For simple variants use [`EnumVariantSpec::new()`]; for variants with values,

--- a/src/spec/enum_variant_spec.rs
+++ b/src/spec/enum_variant_spec.rs
@@ -1,7 +1,6 @@
 //! Enum variant specification for type-safe enum generation.
 
 use crate::code_block::CodeBlock;
-use crate::lang::CodeLang;
 use crate::spec::annotation_spec::AnnotationSpec;
 use crate::spec::field_spec::FieldSpec;
 use crate::type_name::TypeName;
@@ -33,30 +32,29 @@ use crate::type_name::TypeName;
 /// use sigil_stitch::spec::enum_variant_spec::EnumVariantSpec;
 /// use sigil_stitch::lang::typescript::TypeScript;
 ///
-/// let mut tb = TypeSpec::<TypeScript>::builder("Direction", TypeKind::Enum);
-/// tb.add_variant(EnumVariantSpec::new("Up").unwrap());
-///
-/// let mut v = EnumVariantSpec::builder("Down");
-/// v.value(CodeBlock::<TypeScript>::of("'DOWN'", ()).unwrap());
-/// tb.add_variant(v.build().unwrap());
-///
-/// let type_spec = tb.build().unwrap();
+/// let type_spec = TypeSpec::builder("Direction", TypeKind::Enum)
+///     .add_variant(EnumVariantSpec::new("Up").unwrap())
+///     .add_variant(
+///         EnumVariantSpec::builder("Down")
+///             .value(CodeBlock::of("'DOWN'", ()).unwrap())
+///             .build().unwrap(),
+///     )
+///     .build().unwrap();
 /// ```
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-#[serde(bound = "")]
-pub struct EnumVariantSpec<L: CodeLang> {
+pub struct EnumVariantSpec {
     pub(crate) name: String,
     pub(crate) doc: Vec<String>,
-    pub(crate) value: Option<CodeBlock<L>>,
-    pub(crate) annotations: Vec<CodeBlock<L>>,
-    pub(crate) annotation_specs: Vec<AnnotationSpec<L>>,
+    pub(crate) value: Option<CodeBlock>,
+    pub(crate) annotations: Vec<CodeBlock>,
+    pub(crate) annotation_specs: Vec<AnnotationSpec>,
     /// Associated types for tuple-style variants (e.g., `Some(T)`, `case .success(Data)`).
-    pub(crate) associated_types: Vec<TypeName<L>>,
+    pub(crate) associated_types: Vec<TypeName>,
     /// Named fields for struct-style variants (e.g., Rust `Move { x: i32, y: i32 }`).
-    pub(crate) fields: Vec<FieldSpec<L>>,
+    pub(crate) fields: Vec<FieldSpec>,
 }
 
-impl<L: CodeLang> EnumVariantSpec<L> {
+impl EnumVariantSpec {
     /// Create a simple variant with just a name.
     ///
     /// # Errors
@@ -81,7 +79,7 @@ impl<L: CodeLang> EnumVariantSpec<L> {
     }
 
     /// Create a variant builder for more complex variants.
-    pub fn builder(name: &str) -> EnumVariantSpecBuilder<L> {
+    pub fn builder(name: &str) -> EnumVariantSpecBuilder {
         EnumVariantSpecBuilder {
             name: name.to_string(),
             doc: Vec::new(),
@@ -96,37 +94,37 @@ impl<L: CodeLang> EnumVariantSpec<L> {
 
 /// Builder for [`EnumVariantSpec`].
 #[derive(Debug)]
-pub struct EnumVariantSpecBuilder<L: CodeLang> {
+pub struct EnumVariantSpecBuilder {
     name: String,
     doc: Vec<String>,
-    value: Option<CodeBlock<L>>,
-    annotations: Vec<CodeBlock<L>>,
-    annotation_specs: Vec<AnnotationSpec<L>>,
-    associated_types: Vec<TypeName<L>>,
-    fields: Vec<FieldSpec<L>>,
+    value: Option<CodeBlock>,
+    annotations: Vec<CodeBlock>,
+    annotation_specs: Vec<AnnotationSpec>,
+    associated_types: Vec<TypeName>,
+    fields: Vec<FieldSpec>,
 }
 
-impl<L: CodeLang> EnumVariantSpecBuilder<L> {
+impl EnumVariantSpecBuilder {
     /// Add a doc comment line.
-    pub fn doc(&mut self, line: &str) -> &mut Self {
+    pub fn doc(mut self, line: &str) -> Self {
         self.doc.push(line.to_string());
         self
     }
 
     /// Set the variant's value (e.g., `= 0`, `= 'UP'`, `= auto()`).
-    pub fn value(&mut self, val: CodeBlock<L>) -> &mut Self {
+    pub fn value(mut self, val: CodeBlock) -> Self {
         self.value = Some(val);
         self
     }
 
     /// Add an annotation (e.g., `#[default]`, `@JsonValue`).
-    pub fn annotation(&mut self, ann: CodeBlock<L>) -> &mut Self {
+    pub fn annotation(mut self, ann: CodeBlock) -> Self {
         self.annotations.push(ann);
         self
     }
 
     /// Add a structured annotation.
-    pub fn annotate(&mut self, spec: AnnotationSpec<L>) -> &mut Self {
+    pub fn annotate(mut self, spec: AnnotationSpec) -> Self {
         self.annotation_specs.push(spec);
         self
     }
@@ -135,7 +133,7 @@ impl<L: CodeLang> EnumVariantSpecBuilder<L> {
     ///
     /// Call multiple times for multi-element tuples.
     /// Example: `Some(i32)` or `case .success(Data, Int)`.
-    pub fn associated_type(&mut self, ty: TypeName<L>) -> &mut Self {
+    pub fn associated_type(mut self, ty: TypeName) -> Self {
         self.associated_types.push(ty);
         self
     }
@@ -143,7 +141,7 @@ impl<L: CodeLang> EnumVariantSpecBuilder<L> {
     /// Add a named field for struct-style variants.
     ///
     /// Example: Rust `Move { x: i32, y: i32 }`.
-    pub fn add_field(&mut self, field: FieldSpec<L>) -> &mut Self {
+    pub fn add_field(mut self, field: FieldSpec) -> Self {
         self.fields.push(field);
         self
     }
@@ -153,7 +151,7 @@ impl<L: CodeLang> EnumVariantSpecBuilder<L> {
     /// # Errors
     ///
     /// Returns [`SigilStitchError::EmptyName`](crate::error::SigilStitchError::EmptyName) if `name` is empty.
-    pub fn build(self) -> Result<EnumVariantSpec<L>, crate::error::SigilStitchError> {
+    pub fn build(self) -> Result<EnumVariantSpec, crate::error::SigilStitchError> {
         snafu::ensure!(
             !self.name.is_empty(),
             crate::error::EmptyNameSnafu {
@@ -175,6 +173,7 @@ impl<L: CodeLang> EnumVariantSpecBuilder<L> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::lang::CodeLang;
     use crate::lang::rust_lang::RustLang;
     use crate::lang::swift::Swift;
     use crate::lang::typescript::TypeScript;
@@ -183,7 +182,7 @@ mod tests {
     use crate::spec::type_spec::TypeSpec;
     use crate::type_name::TypeName;
 
-    fn render_enum<L: CodeLang>(ts: &TypeSpec<L>, lang: &L) -> String {
+    fn render_enum(ts: &TypeSpec, lang: &dyn CodeLang) -> String {
         let blocks = ts.emit(lang).unwrap();
         let imports = crate::import::ImportGroup::new();
         let mut output = String::new();
@@ -199,11 +198,12 @@ mod tests {
 
     #[test]
     fn test_simple_variants() {
-        let mut tb = TypeSpec::<RustLang>::builder("Color", TypeKind::Enum);
-        tb.add_variant(EnumVariantSpec::new("Red").unwrap());
-        tb.add_variant(EnumVariantSpec::new("Green").unwrap());
-        tb.add_variant(EnumVariantSpec::new("Blue").unwrap());
-        let ts = tb.build().unwrap();
+        let ts = TypeSpec::builder("Color", TypeKind::Enum)
+            .add_variant(EnumVariantSpec::new("Red").unwrap())
+            .add_variant(EnumVariantSpec::new("Green").unwrap())
+            .add_variant(EnumVariantSpec::new("Blue").unwrap())
+            .build()
+            .unwrap();
         let output = render_enum(&ts, &RustLang::new());
         assert!(output.contains("Red,"));
         assert!(output.contains("Green,"));
@@ -212,21 +212,26 @@ mod tests {
 
     #[test]
     fn test_variant_with_value() {
-        let mut tb = TypeSpec::<TypeScript>::builder("Direction", TypeKind::Enum);
-        let mut v = EnumVariantSpec::builder("Up");
-        v.value(CodeBlock::<TypeScript>::of("'UP'", ()).unwrap());
-        tb.add_variant(v.build().unwrap());
-        let ts = tb.build().unwrap();
+        let ts = TypeSpec::builder("Direction", TypeKind::Enum)
+            .add_variant(
+                EnumVariantSpec::builder("Up")
+                    .value(CodeBlock::of("'UP'", ()).unwrap())
+                    .build()
+                    .unwrap(),
+            )
+            .build()
+            .unwrap();
         let output = render_enum(&ts, &TypeScript::new());
         assert!(output.contains("Up = 'UP',"));
     }
 
     #[test]
     fn test_swift_variant_prefix() {
-        let mut tb = TypeSpec::<Swift>::builder("Color", TypeKind::Enum);
-        tb.add_variant(EnumVariantSpec::new("red").unwrap());
-        tb.add_variant(EnumVariantSpec::new("green").unwrap());
-        let ts = tb.build().unwrap();
+        let ts = TypeSpec::builder("Color", TypeKind::Enum)
+            .add_variant(EnumVariantSpec::new("red").unwrap())
+            .add_variant(EnumVariantSpec::new("green").unwrap())
+            .build()
+            .unwrap();
         let output = render_enum(&ts, &Swift::new());
         assert!(output.contains("case red"));
         assert!(output.contains("case green"));
@@ -236,9 +241,10 @@ mod tests {
 
     #[test]
     fn test_trailing_separator() {
-        let mut tb = TypeSpec::<RustLang>::builder("Color", TypeKind::Enum);
-        tb.add_variant(EnumVariantSpec::new("Red").unwrap());
-        let ts = tb.build().unwrap();
+        let ts = TypeSpec::builder("Color", TypeKind::Enum)
+            .add_variant(EnumVariantSpec::new("Red").unwrap())
+            .build()
+            .unwrap();
         let output = render_enum(&ts, &RustLang::new());
         // Rust has trailing comma.
         assert!(output.contains("Red,"));
@@ -246,10 +252,11 @@ mod tests {
 
     #[test]
     fn test_no_trailing_separator() {
-        let mut tb = TypeSpec::<crate::lang::c_lang::CLang>::builder("Color", TypeKind::Enum);
-        tb.add_variant(EnumVariantSpec::new("RED").unwrap());
-        tb.add_variant(EnumVariantSpec::new("GREEN").unwrap());
-        let ts = tb.build().unwrap();
+        let ts = TypeSpec::builder("Color", TypeKind::Enum)
+            .add_variant(EnumVariantSpec::new("RED").unwrap())
+            .add_variant(EnumVariantSpec::new("GREEN").unwrap())
+            .build()
+            .unwrap();
         let output = render_enum(&ts, &crate::lang::c_lang::CLang::new());
         assert!(output.contains("RED,"));
         // Last variant has no trailing comma in C.
@@ -259,7 +266,7 @@ mod tests {
 
     #[test]
     fn test_new_empty_name_errors() {
-        let result = EnumVariantSpec::<TypeScript>::new("");
+        let result = EnumVariantSpec::new("");
         assert!(result.is_err());
         assert!(
             result
@@ -271,7 +278,7 @@ mod tests {
 
     #[test]
     fn test_build_empty_name_errors() {
-        let result = EnumVariantSpec::<TypeScript>::builder("").build();
+        let result = EnumVariantSpec::builder("").build();
         assert!(result.is_err());
         assert!(
             result
@@ -283,12 +290,16 @@ mod tests {
 
     #[test]
     fn test_tuple_variant() {
-        let mut tb = TypeSpec::<RustLang>::builder("Expr", TypeKind::Enum);
-        let mut v = EnumVariantSpec::<RustLang>::builder("Literal");
-        v.associated_type(TypeName::primitive("i64"));
-        tb.add_variant(v.build().unwrap());
-        tb.add_variant(EnumVariantSpec::new("Unit").unwrap());
-        let ts = tb.build().unwrap();
+        let ts = TypeSpec::builder("Expr", TypeKind::Enum)
+            .add_variant(
+                EnumVariantSpec::builder("Literal")
+                    .associated_type(TypeName::primitive("i64"))
+                    .build()
+                    .unwrap(),
+            )
+            .add_variant(EnumVariantSpec::new("Unit").unwrap())
+            .build()
+            .unwrap();
         let output = render_enum(&ts, &RustLang::new());
         assert!(output.contains("Literal(i64),"));
         assert!(output.contains("Unit,"));
@@ -296,33 +307,41 @@ mod tests {
 
     #[test]
     fn test_multi_tuple_variant() {
-        let mut tb = TypeSpec::<RustLang>::builder("Pair", TypeKind::Enum);
-        let mut v = EnumVariantSpec::<RustLang>::builder("Both");
-        v.associated_type(TypeName::primitive("String"));
-        v.associated_type(TypeName::primitive("i32"));
-        tb.add_variant(v.build().unwrap());
-        let ts = tb.build().unwrap();
+        let ts = TypeSpec::builder("Pair", TypeKind::Enum)
+            .add_variant(
+                EnumVariantSpec::builder("Both")
+                    .associated_type(TypeName::primitive("String"))
+                    .associated_type(TypeName::primitive("i32"))
+                    .build()
+                    .unwrap(),
+            )
+            .build()
+            .unwrap();
         let output = render_enum(&ts, &RustLang::new());
         assert!(output.contains("Both(String, i32),"));
     }
 
     #[test]
     fn test_struct_variant() {
-        let mut tb = TypeSpec::<RustLang>::builder("Msg", TypeKind::Enum);
-        tb.add_variant(EnumVariantSpec::new("Quit").unwrap());
-        let mut v = EnumVariantSpec::<RustLang>::builder("Move");
-        v.add_field(
-            FieldSpec::builder("x", TypeName::primitive("i32"))
-                .build()
-                .unwrap(),
-        );
-        v.add_field(
-            FieldSpec::builder("y", TypeName::primitive("i32"))
-                .build()
-                .unwrap(),
-        );
-        tb.add_variant(v.build().unwrap());
-        let ts = tb.build().unwrap();
+        let ts = TypeSpec::builder("Msg", TypeKind::Enum)
+            .add_variant(EnumVariantSpec::new("Quit").unwrap())
+            .add_variant(
+                EnumVariantSpec::builder("Move")
+                    .add_field(
+                        FieldSpec::builder("x", TypeName::primitive("i32"))
+                            .build()
+                            .unwrap(),
+                    )
+                    .add_field(
+                        FieldSpec::builder("y", TypeName::primitive("i32"))
+                            .build()
+                            .unwrap(),
+                    )
+                    .build()
+                    .unwrap(),
+            )
+            .build()
+            .unwrap();
         let output = render_enum(&ts, &RustLang::new());
         assert!(output.contains("Quit,"));
         assert!(output.contains("Move {"));
@@ -332,12 +351,16 @@ mod tests {
 
     #[test]
     fn test_swift_associated_value() {
-        let mut tb = TypeSpec::<Swift>::builder("Result", TypeKind::Enum);
-        let mut v_success = EnumVariantSpec::<Swift>::builder("success");
-        v_success.associated_type(TypeName::primitive("Data"));
-        tb.add_variant(v_success.build().unwrap());
-        tb.add_variant(EnumVariantSpec::new("failure").unwrap());
-        let ts = tb.build().unwrap();
+        let ts = TypeSpec::builder("Result", TypeKind::Enum)
+            .add_variant(
+                EnumVariantSpec::builder("success")
+                    .associated_type(TypeName::primitive("Data"))
+                    .build()
+                    .unwrap(),
+            )
+            .add_variant(EnumVariantSpec::new("failure").unwrap())
+            .build()
+            .unwrap();
         let output = render_enum(&ts, &Swift::new());
         assert!(output.contains("case success(Data)"));
         assert!(output.contains("case failure"));

--- a/src/spec/field_spec.rs
+++ b/src/spec/field_spec.rs
@@ -128,7 +128,7 @@ impl FieldSpec {
 
         // Build the field line.
         let vis = lang.render_visibility(self.modifiers.visibility, ctx);
-        let term = lang.field_terminator();
+        let term = lang.block_syntax().field_terminator;
 
         let mut fmt = String::new();
         let mut args: Vec<Arg> = Vec::new();
@@ -144,7 +144,7 @@ impl FieldSpec {
         } else {
             OptionalFieldStyle::Ignored
         };
-        let type_before = lang.type_before_name();
+        let type_before = lang.type_decl_syntax().type_before_name;
 
         let name_suffix: &str = match opt_style {
             OptionalFieldStyle::NameSuffix(s) => s,
@@ -169,7 +169,7 @@ impl FieldSpec {
         if type_before {
             // C-style: type name
             if self.modifiers.is_readonly {
-                fmt.push_str(lang.readonly_keyword());
+                fmt.push_str(lang.enum_and_annotation().readonly_keyword);
             }
             if !self.field_type.is_empty() {
                 fmt.push_str(&type_pre);
@@ -184,9 +184,9 @@ impl FieldSpec {
         } else {
             // TS/Rust/Go/Python-style: name sep type
             if self.modifiers.is_readonly {
-                fmt.push_str(lang.readonly_keyword());
+                fmt.push_str(lang.enum_and_annotation().readonly_keyword);
             } else {
-                let mk = lang.mutable_field_keyword();
+                let mk = lang.enum_and_annotation().mutable_field_keyword;
                 if !mk.is_empty() {
                     fmt.push_str(mk);
                 }
@@ -196,7 +196,7 @@ impl FieldSpec {
 
             // Skip type annotation when the type is empty (e.g., Python enum members).
             if !self.field_type.is_empty() {
-                let sep = lang.type_annotation_separator();
+                let sep = lang.type_decl_syntax().type_annotation_separator;
                 fmt.push_str(sep);
                 fmt.push_str(&type_pre);
                 fmt.push_str("%T");

--- a/src/spec/field_spec.rs
+++ b/src/spec/field_spec.rs
@@ -23,21 +23,20 @@ use crate::type_name::TypeName;
 /// use sigil_stitch::prelude::*;
 /// use sigil_stitch::lang::typescript::TypeScript;
 ///
-/// let mut fb = FieldSpec::builder("name", TypeName::<TypeScript>::primitive("string"));
-/// fb.visibility(Visibility::Private);
-/// fb.is_readonly();
-/// let field = fb.build().unwrap();
+/// let field = FieldSpec::builder("name", TypeName::primitive("string"))
+///     .visibility(Visibility::Private)
+///     .is_readonly()
+///     .build().unwrap();
 /// ```
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-#[serde(bound = "")]
-pub struct FieldSpec<L: CodeLang> {
+pub struct FieldSpec {
     pub(crate) name: String,
-    pub(crate) field_type: TypeName<L>,
+    pub(crate) field_type: TypeName,
     pub(crate) modifiers: Modifiers,
     pub(crate) doc: Vec<String>,
-    pub(crate) initializer: Option<CodeBlock<L>>,
-    pub(crate) annotations: Vec<CodeBlock<L>>,
-    pub(crate) annotation_specs: Vec<AnnotationSpec<L>>,
+    pub(crate) initializer: Option<CodeBlock>,
+    pub(crate) annotations: Vec<CodeBlock>,
+    pub(crate) annotation_specs: Vec<AnnotationSpec>,
     /// Struct tag (e.g., Go: `` `json:"name"` ``). Emitted inline after the type.
     pub(crate) tag: Option<String>,
     /// Whether this field is optional (key may be absent from the containing value).
@@ -48,9 +47,9 @@ pub struct FieldSpec<L: CodeLang> {
     pub(crate) is_optional: bool,
 }
 
-impl<L: CodeLang> FieldSpec<L> {
+impl FieldSpec {
     /// Create a new [`FieldSpecBuilder`] with the given name and type.
-    pub fn builder(name: &str, field_type: TypeName<L>) -> FieldSpecBuilder<L> {
+    pub fn builder(name: &str, field_type: TypeName) -> FieldSpecBuilder {
         FieldSpecBuilder {
             name: name.to_string(),
             field_type,
@@ -64,23 +63,37 @@ impl<L: CodeLang> FieldSpec<L> {
         }
     }
 
+    /// Convenience constructor for a simple field (name + type, no modifiers).
+    pub fn new(name: &str, field_type: TypeName) -> Result<Self, crate::error::SigilStitchError> {
+        Self::builder(name, field_type).build()
+    }
+
+    /// Infallible convenience constructor for a simple field.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `name` is empty.
+    pub fn of(name: &str, field_type: TypeName) -> Self {
+        Self::new(name, field_type).expect("FieldSpec name must not be empty")
+    }
+
     /// Returns the field name.
     pub fn name(&self) -> &str {
         &self.name
     }
 
     /// Returns the field type.
-    pub fn field_type(&self) -> &TypeName<L> {
+    pub fn field_type(&self) -> &TypeName {
         &self.field_type
     }
 
     /// Emit this field as a CodeBlock.
     pub fn emit(
         &self,
-        lang: &L,
+        lang: &dyn CodeLang,
         ctx: DeclarationContext,
-    ) -> Result<CodeBlock<L>, crate::error::SigilStitchError> {
-        let mut cb = CodeBlock::<L>::builder();
+    ) -> Result<CodeBlock, crate::error::SigilStitchError> {
+        let mut cb = CodeBlock::builder();
 
         let emit_doc = || -> Option<String> {
             if self.doc.is_empty() {
@@ -118,7 +131,7 @@ impl<L: CodeLang> FieldSpec<L> {
         let term = lang.field_terminator();
 
         let mut fmt = String::new();
-        let mut args: Vec<Arg<L>> = Vec::new();
+        let mut args: Vec<Arg> = Vec::new();
 
         fmt.push_str(vis);
         if self.modifiers.is_static {
@@ -213,33 +226,33 @@ impl<L: CodeLang> FieldSpec<L> {
 
 /// Builder for [`FieldSpec`].
 #[derive(Debug)]
-pub struct FieldSpecBuilder<L: CodeLang> {
+pub struct FieldSpecBuilder {
     name: String,
-    field_type: TypeName<L>,
+    field_type: TypeName,
     modifiers: Modifiers,
     doc: Vec<String>,
-    initializer: Option<CodeBlock<L>>,
-    annotations: Vec<CodeBlock<L>>,
-    annotation_specs: Vec<AnnotationSpec<L>>,
+    initializer: Option<CodeBlock>,
+    annotations: Vec<CodeBlock>,
+    annotation_specs: Vec<AnnotationSpec>,
     tag: Option<String>,
     is_optional: bool,
 }
 
-impl<L: CodeLang> FieldSpecBuilder<L> {
+impl FieldSpecBuilder {
     /// Set the visibility modifier.
-    pub fn visibility(&mut self, vis: Visibility) -> &mut Self {
+    pub fn visibility(mut self, vis: Visibility) -> Self {
         self.modifiers.visibility = vis;
         self
     }
 
     /// Mark this field as static.
-    pub fn is_static(&mut self) -> &mut Self {
+    pub fn is_static(mut self) -> Self {
         self.modifiers.is_static = true;
         self
     }
 
     /// Mark this field as readonly.
-    pub fn is_readonly(&mut self) -> &mut Self {
+    pub fn is_readonly(mut self) -> Self {
         self.modifiers.is_readonly = true;
         self
     }
@@ -251,37 +264,37 @@ impl<L: CodeLang> FieldSpecBuilder<L> {
     /// emits `Option<T>`, Go emits `*T`, etc. Languages that cannot express
     /// optionality (JavaScript, Bash, Zsh) render the field as if it were
     /// required.
-    pub fn is_optional(&mut self) -> &mut Self {
+    pub fn is_optional(mut self) -> Self {
         self.is_optional = true;
         self
     }
 
     /// Add a doc comment line.
-    pub fn doc(&mut self, line: &str) -> &mut Self {
+    pub fn doc(mut self, line: &str) -> Self {
         self.doc.push(line.to_string());
         self
     }
 
     /// Set the field initializer expression.
-    pub fn initializer(&mut self, init: CodeBlock<L>) -> &mut Self {
+    pub fn initializer(mut self, init: CodeBlock) -> Self {
         self.initializer = Some(init);
         self
     }
 
     /// Add a raw annotation [`CodeBlock`].
-    pub fn annotation(&mut self, ann: CodeBlock<L>) -> &mut Self {
+    pub fn annotation(mut self, ann: CodeBlock) -> Self {
         self.annotations.push(ann);
         self
     }
 
     /// Add a structured [`AnnotationSpec`].
-    pub fn annotate(&mut self, spec: AnnotationSpec<L>) -> &mut Self {
+    pub fn annotate(mut self, spec: AnnotationSpec) -> Self {
         self.annotation_specs.push(spec);
         self
     }
 
     /// Set the struct tag (e.g., Go's `` `json:"name"` ``).
-    pub fn tag(&mut self, t: &str) -> &mut Self {
+    pub fn tag(mut self, t: &str) -> Self {
         self.tag = Some(t.to_string());
         self
     }
@@ -291,7 +304,7 @@ impl<L: CodeLang> FieldSpecBuilder<L> {
     /// # Errors
     ///
     /// Returns [`SigilStitchError::EmptyName`](crate::error::SigilStitchError::EmptyName) if `name` is empty.
-    pub fn build(self) -> Result<FieldSpec<L>, crate::error::SigilStitchError> {
+    pub fn build(self) -> Result<FieldSpec, crate::error::SigilStitchError> {
         snafu::ensure!(
             !self.name.is_empty(),
             crate::error::EmptyNameSnafu {
@@ -318,7 +331,7 @@ mod tests {
     use crate::lang::rust_lang::RustLang;
     use crate::lang::typescript::TypeScript;
 
-    fn emit_field_ts(spec: &FieldSpec<TypeScript>, ctx: DeclarationContext) -> String {
+    fn emit_field_ts(spec: &FieldSpec, ctx: DeclarationContext) -> String {
         let lang = TypeScript::new();
         let block = spec.emit(&lang, ctx).unwrap();
         let imports = crate::import::ImportGroup::new();
@@ -326,7 +339,7 @@ mod tests {
         renderer.render(&block).unwrap()
     }
 
-    fn emit_field_rs(spec: &FieldSpec<RustLang>, ctx: DeclarationContext) -> String {
+    fn emit_field_rs(spec: &FieldSpec, ctx: DeclarationContext) -> String {
         let lang = RustLang::new();
         let block = spec.emit(&lang, ctx).unwrap();
         let imports = crate::import::ImportGroup::new();
@@ -336,7 +349,7 @@ mod tests {
 
     #[test]
     fn test_ts_field_basic() {
-        let field = FieldSpec::builder("name", TypeName::<TypeScript>::primitive("string"))
+        let field = FieldSpec::builder("name", TypeName::primitive("string"))
             .build()
             .unwrap();
         let output = emit_field_ts(&field, DeclarationContext::Member);
@@ -345,35 +358,38 @@ mod tests {
 
     #[test]
     fn test_ts_field_with_visibility() {
-        let mut fb = FieldSpec::builder("name", TypeName::<TypeScript>::primitive("string"));
-        fb.visibility(Visibility::Private);
-        let field = fb.build().unwrap();
+        let field = FieldSpec::builder("name", TypeName::primitive("string"))
+            .visibility(Visibility::Private)
+            .build()
+            .unwrap();
         let output = emit_field_ts(&field, DeclarationContext::Member);
         assert_eq!(output.trim(), "private name: string;");
     }
 
     #[test]
     fn test_rust_field_basic() {
-        let mut fb = FieldSpec::builder("name", TypeName::<RustLang>::primitive("String"));
-        fb.visibility(Visibility::Public);
-        let field = fb.build().unwrap();
+        let field = FieldSpec::builder("name", TypeName::primitive("String"))
+            .visibility(Visibility::Public)
+            .build()
+            .unwrap();
         let output = emit_field_rs(&field, DeclarationContext::Member);
         assert_eq!(output.trim(), "pub name: String,");
     }
 
     #[test]
     fn test_ts_field_readonly_static() {
-        let mut fb = FieldSpec::builder("MAX", TypeName::<TypeScript>::primitive("number"));
-        fb.is_static();
-        fb.is_readonly();
-        let field = fb.build().unwrap();
+        let field = FieldSpec::builder("MAX", TypeName::primitive("number"))
+            .is_static()
+            .is_readonly()
+            .build()
+            .unwrap();
         let output = emit_field_ts(&field, DeclarationContext::Member);
         assert_eq!(output.trim(), "static readonly MAX: number;");
     }
 
     #[test]
     fn test_build_empty_name_errors() {
-        let result = FieldSpec::builder("", TypeName::<TypeScript>::primitive("string")).build();
+        let result = FieldSpec::builder("", TypeName::primitive("string")).build();
         assert!(result.is_err());
         assert!(
             result
@@ -385,29 +401,30 @@ mod tests {
 
     // --- Optional field rendering across languages ---
 
-    fn emit_for<L: CodeLang>(lang: &L, spec: &FieldSpec<L>, ctx: DeclarationContext) -> String {
+    fn emit_for(lang: &dyn CodeLang, spec: &FieldSpec, ctx: DeclarationContext) -> String {
         let block = spec.emit(lang, ctx).unwrap();
         let imports = crate::import::ImportGroup::new();
         let mut renderer = crate::code_renderer::CodeRenderer::new(lang, &imports, 80);
         renderer.render(&block).unwrap()
     }
 
-    fn optional_field<L: CodeLang>(type_name: TypeName<L>) -> FieldSpec<L> {
-        let mut fb = FieldSpec::builder("name", type_name);
-        fb.is_optional();
-        fb.build().unwrap()
+    fn optional_field(type_name: TypeName) -> FieldSpec {
+        FieldSpec::builder("name", type_name)
+            .is_optional()
+            .build()
+            .unwrap()
     }
 
     #[test]
     fn test_ts_optional_field_uses_name_suffix() {
-        let field = optional_field(TypeName::<TypeScript>::primitive("string"));
+        let field = optional_field(TypeName::primitive("string"));
         let out = emit_for(&TypeScript::new(), &field, DeclarationContext::Member);
         assert_eq!(out.trim(), "name?: string;");
     }
 
     #[test]
     fn test_rust_optional_field_wraps_with_option() {
-        let field = optional_field(TypeName::<RustLang>::primitive("String"));
+        let field = optional_field(TypeName::primitive("String"));
         let out = emit_for(&RustLang::new(), &field, DeclarationContext::Member);
         assert_eq!(out.trim(), "name: Option<String>,");
     }
@@ -415,7 +432,7 @@ mod tests {
     #[test]
     fn test_go_optional_field_prefixes_type_with_pointer() {
         use crate::lang::go_lang::GoLang;
-        let field = optional_field(TypeName::<GoLang>::primitive("string"));
+        let field = optional_field(TypeName::primitive("string"));
         let out = emit_for(&GoLang::new(), &field, DeclarationContext::Member);
         assert_eq!(out.trim(), "name *string");
     }
@@ -423,7 +440,7 @@ mod tests {
     #[test]
     fn test_python_optional_field_unions_with_none() {
         use crate::lang::python::Python;
-        let field = optional_field(TypeName::<Python>::primitive("str"));
+        let field = optional_field(TypeName::primitive("str"));
         let out = emit_for(&Python::new(), &field, DeclarationContext::Member);
         assert_eq!(out.trim(), "name: str | None");
     }
@@ -431,7 +448,7 @@ mod tests {
     #[test]
     fn test_java_optional_field_wraps_with_optional() {
         use crate::lang::java_lang::JavaLang;
-        let field = optional_field(TypeName::<JavaLang>::primitive("String"));
+        let field = optional_field(TypeName::primitive("String"));
         let out = emit_for(&JavaLang::new(), &field, DeclarationContext::Member);
         assert_eq!(out.trim(), "Optional<String> name;");
     }
@@ -439,7 +456,7 @@ mod tests {
     #[test]
     fn test_kotlin_optional_field_suffixes_type() {
         use crate::lang::kotlin::Kotlin;
-        let field = optional_field(TypeName::<Kotlin>::primitive("String"));
+        let field = optional_field(TypeName::primitive("String"));
         let out = emit_for(&Kotlin::new(), &field, DeclarationContext::Member);
         // Kotlin renders a mutable `var` and its default visibility keyword.
         assert!(
@@ -451,7 +468,7 @@ mod tests {
     #[test]
     fn test_swift_optional_field_suffixes_type() {
         use crate::lang::swift::Swift;
-        let field = optional_field(TypeName::<Swift>::primitive("String"));
+        let field = optional_field(TypeName::primitive("String"));
         let out = emit_for(&Swift::new(), &field, DeclarationContext::Member);
         // Swift prepends `var` for mutable stored properties.
         assert!(
@@ -463,7 +480,7 @@ mod tests {
     #[test]
     fn test_dart_optional_field_suffixes_type() {
         use crate::lang::dart::DartLang;
-        let field = optional_field(TypeName::<DartLang>::primitive("String"));
+        let field = optional_field(TypeName::primitive("String"));
         let out = emit_for(&DartLang::new(), &field, DeclarationContext::Member);
         assert_eq!(out.trim(), "String? name;");
     }
@@ -471,7 +488,7 @@ mod tests {
     #[test]
     fn test_c_optional_field_prefixes_name_with_pointer() {
         use crate::lang::c_lang::CLang;
-        let field = optional_field(TypeName::<CLang>::primitive("int"));
+        let field = optional_field(TypeName::primitive("int"));
         let out = emit_for(&CLang::new(), &field, DeclarationContext::Member);
         assert_eq!(out.trim(), "int *name;");
     }
@@ -479,7 +496,7 @@ mod tests {
     #[test]
     fn test_cpp_optional_field_wraps_with_std_optional() {
         use crate::lang::cpp_lang::CppLang;
-        let field = optional_field(TypeName::<CppLang>::primitive("int"));
+        let field = optional_field(TypeName::primitive("int"));
         let out = emit_for(&CppLang::new(), &field, DeclarationContext::Member);
         assert_eq!(out.trim(), "std::optional<int> name;");
     }
@@ -487,7 +504,7 @@ mod tests {
     #[test]
     fn test_javascript_optional_field_is_ignored() {
         use crate::lang::javascript::JavaScript;
-        let field = optional_field(TypeName::<JavaScript>::primitive("any"));
+        let field = optional_field(TypeName::primitive("any"));
         let out = emit_for(&JavaScript::new(), &field, DeclarationContext::Member);
         // JavaScript cannot express optional fields, so renders as required.
         assert!(out.contains("name"), "expected name in output, got {out:?}");

--- a/src/spec/file_spec.rs
+++ b/src/spec/file_spec.rs
@@ -12,10 +12,9 @@ use crate::type_name::TypeName;
 
 /// A member of a file.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-#[serde(bound = "")]
-pub enum FileMember<L: CodeLang> {
+pub enum FileMember {
     /// A CodeBlock (e.g., module-level statements, class declarations).
-    Code(CodeBlock<L>),
+    Code(CodeBlock),
     /// Raw content string (escape hatch, no import tracking).
     RawContent(String),
     /// Raw content string with associated types for import tracking.
@@ -27,12 +26,12 @@ pub enum FileMember<L: CodeLang> {
         /// The raw content to emit verbatim.
         content: String,
         /// Types to register for import collection.
-        types: Vec<TypeName<L>>,
+        types: Vec<TypeName>,
     },
     /// A type declaration (struct, class, interface, trait, enum).
-    Type(TypeSpec<L>),
+    Type(TypeSpec),
     /// A top-level function.
-    Fun(FunSpec<L>),
+    Fun(FunSpec),
 }
 
 /// A complete source file with automatic import management.
@@ -51,54 +50,56 @@ pub enum FileMember<L: CodeLang> {
 /// use sigil_stitch::prelude::*;
 /// use sigil_stitch::lang::typescript::TypeScript;
 ///
-/// let user = TypeName::<TypeScript>::importable_type("./models", "User");
+/// let user = TypeName::importable_type("./models", "User");
 ///
-/// let mut cb = CodeBlock::<TypeScript>::builder();
+/// let mut cb = CodeBlock::builder();
 /// cb.add_statement("const u: %T = getUser()", (user,));
 /// let body = cb.build().unwrap();
 ///
-/// let mut fb = FileSpec::<TypeScript>::builder("user.ts");
-/// fb.add_code(body);
-/// let file = fb.build().unwrap();
+/// let file = FileSpec::builder("user.ts")
+///     .add_code(body)
+///     .build().unwrap();
 ///
 /// let output = file.render(80).unwrap();
 /// // output contains: import type { User } from './models'
 /// // output contains: const u: User = getUser();
 /// ```
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-#[serde(bound(serialize = "", deserialize = "L: Default"))]
-pub struct FileSpec<L: CodeLang> {
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub struct FileSpec {
     filename: String,
-    header: Option<CodeBlock<L>>,
-    members: Vec<FileMember<L>>,
-    explicit_imports: Vec<ImportSpec<L>>,
+    header: Option<CodeBlock>,
+    members: Vec<FileMember>,
+    explicit_imports: Vec<ImportSpec>,
     #[serde(skip)]
-    lang: L,
+    lang: Option<Box<dyn CodeLang>>,
 }
 
-impl<L: CodeLang> FileSpec<L> {
-    /// Create a new FileSpec builder.
-    pub fn builder(filename: &str) -> FileSpecBuilder<L>
-    where
-        L: Default,
-    {
-        FileSpecBuilder {
-            filename: filename.to_string(),
-            header: None,
-            members: Vec::new(),
-            explicit_imports: Vec::new(),
-            lang: L::default(),
-        }
-    }
-
-    /// Create a builder with a specific language configuration.
-    pub fn builder_with(filename: &str, lang: L) -> FileSpecBuilder<L> {
+impl FileSpec {
+    /// Create a builder that auto-detects the language from the filename extension.
+    ///
+    /// If the extension is not recognized, [`build()`](FileSpecBuilder::build) will
+    /// return an error. Use [`builder_with`](FileSpec::builder_with) for explicit
+    /// language control or unsupported extensions.
+    pub fn builder(filename: &str) -> FileSpecBuilder {
+        let ext = filename.rsplit('.').next().unwrap_or("");
+        let lang = crate::lang::lang_from_extension(ext);
         FileSpecBuilder {
             filename: filename.to_string(),
             header: None,
             members: Vec::new(),
             explicit_imports: Vec::new(),
             lang,
+        }
+    }
+
+    /// Create a builder with a specific language configuration.
+    pub fn builder_with(filename: &str, lang: impl CodeLang) -> FileSpecBuilder {
+        FileSpecBuilder {
+            filename: filename.to_string(),
+            header: None,
+            members: Vec::new(),
+            explicit_imports: Vec::new(),
+            lang: Some(Box::new(lang)),
         }
     }
 
@@ -111,17 +112,21 @@ impl<L: CodeLang> FileSpec<L> {
     ///
     /// `width` controls the target line width for pretty-printing.
     pub fn render(&self, width: usize) -> Result<String, SigilStitchError> {
+        let lang: &dyn CodeLang = self.lang.as_deref().expect(
+            "FileSpec requires a language — use builder_with() or set lang via deserialization",
+        );
+
         // Phase 0: Materialize specs into CodeBlocks.
-        enum Materialized<L: CodeLang> {
-            Blocks(Vec<CodeBlock<L>>),
+        enum Materialized {
+            Blocks(Vec<CodeBlock>),
             Raw(String),
             RawWithImports {
                 content: String,
-                types: Vec<TypeName<L>>,
+                types: Vec<TypeName>,
             },
         }
 
-        let mut materialized: Vec<Materialized<L>> = Vec::with_capacity(self.members.len());
+        let mut materialized: Vec<Materialized> = Vec::with_capacity(self.members.len());
         for m in &self.members {
             materialized.push(match m {
                 FileMember::Code(b) => Materialized::Blocks(vec![b.clone()]),
@@ -132,9 +137,9 @@ impl<L: CodeLang> FileSpec<L> {
                         types: types.clone(),
                     }
                 }
-                FileMember::Type(spec) => Materialized::Blocks(spec.emit(&self.lang)?),
+                FileMember::Type(spec) => Materialized::Blocks(spec.emit(lang)?),
                 FileMember::Fun(spec) => {
-                    Materialized::Blocks(vec![spec.emit(&self.lang, DeclarationContext::TopLevel)?])
+                    Materialized::Blocks(vec![spec.emit(lang, DeclarationContext::TopLevel)?])
                 }
             });
         }
@@ -177,7 +182,7 @@ impl<L: CodeLang> FileSpec<L> {
 
         // Render header block if present (e.g., license comment, Go package declaration).
         if let Some(header) = &self.header {
-            let mut renderer = CodeRenderer::new(&self.lang, &imports, width);
+            let mut renderer = CodeRenderer::new(lang, &imports, width);
             let header_output = renderer.render(header)?;
             if !header_output.is_empty() {
                 output.push_str(&header_output);
@@ -189,7 +194,7 @@ impl<L: CodeLang> FileSpec<L> {
         }
 
         // Render import header.
-        let import_header = self.lang.render_imports(&imports);
+        let import_header = lang.render_imports(&imports);
         if !import_header.is_empty() {
             output.push_str(&import_header);
             output.push_str("\n\n");
@@ -206,7 +211,7 @@ impl<L: CodeLang> FileSpec<L> {
                         if j > 0 {
                             output.push('\n');
                         }
-                        let mut renderer = CodeRenderer::new(&self.lang, &imports, width);
+                        let mut renderer = CodeRenderer::new(lang, &imports, width);
                         let member_output = renderer.render(block)?;
                         output.push_str(&member_output);
                         if !member_output.ends_with('\n') {
@@ -238,29 +243,29 @@ impl<L: CodeLang> FileSpec<L> {
 /// Use [`FileSpec::builder()`] to create. Add members with `add_code()`,
 /// `add_type()`, `add_function()`, or `add_raw()`, then call `build()`.
 #[derive(Debug)]
-pub struct FileSpecBuilder<L: CodeLang> {
+pub struct FileSpecBuilder {
     filename: String,
-    header: Option<CodeBlock<L>>,
-    members: Vec<FileMember<L>>,
-    explicit_imports: Vec<ImportSpec<L>>,
-    lang: L,
+    header: Option<CodeBlock>,
+    members: Vec<FileMember>,
+    explicit_imports: Vec<ImportSpec>,
+    lang: Option<Box<dyn CodeLang>>,
 }
 
-impl<L: CodeLang> FileSpecBuilder<L> {
+impl FileSpecBuilder {
     /// Set a file header (e.g., license comment, package declaration).
-    pub fn header(&mut self, block: CodeBlock<L>) -> &mut Self {
+    pub fn header(mut self, block: CodeBlock) -> Self {
         self.header = Some(block);
         self
     }
 
     /// Add a CodeBlock member.
-    pub fn add_code(&mut self, block: CodeBlock<L>) -> &mut Self {
+    pub fn add_code(mut self, block: CodeBlock) -> Self {
         self.members.push(FileMember::Code(block));
         self
     }
 
     /// Add raw content (no import tracking).
-    pub fn add_raw(&mut self, content: &str) -> &mut Self {
+    pub fn add_raw(mut self, content: &str) -> Self {
         self.members
             .push(FileMember::RawContent(content.to_string()));
         self
@@ -270,7 +275,7 @@ impl<L: CodeLang> FileSpecBuilder<L> {
     ///
     /// The content is emitted verbatim (no substitution). The types are walked
     /// during import collection so the correct import statements are generated.
-    pub fn add_raw_with_imports(&mut self, content: &str, types: Vec<TypeName<L>>) -> &mut Self {
+    pub fn add_raw_with_imports(mut self, content: &str, types: Vec<TypeName>) -> Self {
         self.members.push(FileMember::RawContentWithImports {
             content: content.to_string(),
             types,
@@ -279,31 +284,31 @@ impl<L: CodeLang> FileSpecBuilder<L> {
     }
 
     /// Add a generic member.
-    pub fn add_member(&mut self, member: FileMember<L>) -> &mut Self {
+    pub fn add_member(mut self, member: FileMember) -> Self {
         self.members.push(member);
         self
     }
 
     /// Add a type declaration (struct, class, interface, trait, enum).
-    pub fn add_type(&mut self, spec: TypeSpec<L>) -> &mut Self {
+    pub fn add_type(mut self, spec: TypeSpec) -> Self {
         self.members.push(FileMember::Type(spec));
         self
     }
 
     /// Add a top-level function.
-    pub fn add_function(&mut self, spec: FunSpec<L>) -> &mut Self {
+    pub fn add_function(mut self, spec: FunSpec) -> Self {
         self.members.push(FileMember::Fun(spec));
         self
     }
 
     /// Set the language configuration.
-    pub fn lang(&mut self, lang: L) -> &mut Self {
-        self.lang = lang;
+    pub fn lang(mut self, lang: impl CodeLang) -> Self {
+        self.lang = Some(Box::new(lang));
         self
     }
 
     /// Add an explicit import (forced, aliased, side-effect, or wildcard).
-    pub fn add_import(&mut self, spec: ImportSpec<L>) -> &mut Self {
+    pub fn add_import(mut self, spec: ImportSpec) -> Self {
         self.explicit_imports.push(spec);
         self
     }
@@ -313,19 +318,31 @@ impl<L: CodeLang> FileSpecBuilder<L> {
     /// # Errors
     ///
     /// Returns [`SigilStitchError::EmptyName`] if `filename` is empty.
-    pub fn build(self) -> Result<FileSpec<L>, SigilStitchError> {
+    /// Returns an error if no language was detected or configured.
+    pub fn build(self) -> Result<FileSpec, SigilStitchError> {
         snafu::ensure!(
             !self.filename.is_empty(),
             crate::error::EmptyNameSnafu {
                 builder: "FileSpecBuilder",
             }
         );
+        let lang = self.lang.ok_or_else(|| {
+            let ext = self.filename.rsplit('.').next().unwrap_or("");
+            SigilStitchError::Render {
+                context: "FileSpecBuilder::build()".to_string(),
+                message: format!(
+                    "unrecognized file extension '.{ext}' in filename '{}'; \
+                     use FileSpec::builder_with() to specify the language explicitly",
+                    self.filename
+                ),
+            }
+        })?;
         Ok(FileSpec {
             filename: self.filename,
             header: self.header,
             members: self.members,
             explicit_imports: self.explicit_imports,
-            lang: self.lang,
+            lang: Some(lang),
         })
     }
 }
@@ -333,27 +350,28 @@ impl<L: CodeLang> FileSpecBuilder<L> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::lang::typescript::TypeScript;
+
     use crate::type_name::TypeName;
 
     #[test]
     fn test_empty_file() {
-        let file = FileSpec::<TypeScript>::builder("empty.ts").build().unwrap();
+        let file = FileSpec::builder("empty.ts").build().unwrap();
         let output = file.render(80).unwrap();
         assert!(output.is_empty() || output.trim().is_empty());
     }
 
     #[test]
     fn test_simple_file_with_import() {
-        let user = TypeName::<TypeScript>::importable_type("./models", "User");
+        let user = TypeName::importable_type("./models", "User");
 
-        let mut b = CodeBlock::<TypeScript>::builder();
+        let mut b = CodeBlock::builder();
         b.add_statement("const u: %T = getUser()", (user,));
         let block = b.build().unwrap();
 
-        let mut fb = FileSpec::<TypeScript>::builder("user.ts");
-        fb.add_code(block);
-        let file = fb.build().unwrap();
+        let file = FileSpec::builder("user.ts")
+            .add_code(block)
+            .build()
+            .unwrap();
 
         let output = file.render(80).unwrap();
         assert!(output.contains("import type { User } from './models'"));
@@ -362,17 +380,18 @@ mod tests {
 
     #[test]
     fn test_conflicting_imports() {
-        let user1 = TypeName::<TypeScript>::importable_type("./models", "User");
-        let user2 = TypeName::<TypeScript>::importable_type("./other", "User");
+        let user1 = TypeName::importable_type("./models", "User");
+        let user2 = TypeName::importable_type("./other", "User");
 
-        let mut b = CodeBlock::<TypeScript>::builder();
+        let mut b = CodeBlock::builder();
         b.add_statement("const u1: %T = get1()", (user1,));
         b.add_statement("const u2: %T = get2()", (user2,));
         let block = b.build().unwrap();
 
-        let mut fb = FileSpec::<TypeScript>::builder("user.ts");
-        fb.add_code(block);
-        let file = fb.build().unwrap();
+        let file = FileSpec::builder("user.ts")
+            .add_code(block)
+            .build()
+            .unwrap();
 
         let output = file.render(80).unwrap();
         // First wins simple name.
@@ -384,9 +403,10 @@ mod tests {
 
     #[test]
     fn test_raw_content_no_import_tracking() {
-        let mut fb = FileSpec::<TypeScript>::builder("raw.ts");
-        fb.add_raw("// This is raw content\nexport const VERSION = '1.0.0';\n");
-        let file = fb.build().unwrap();
+        let file = FileSpec::builder("raw.ts")
+            .add_raw("// This is raw content\nexport const VERSION = '1.0.0';\n")
+            .build()
+            .unwrap();
 
         let output = file.render(80).unwrap();
         assert!(output.contains("// This is raw content"));
@@ -397,16 +417,17 @@ mod tests {
 
     #[test]
     fn test_mixed_code_and_raw() {
-        let user = TypeName::<TypeScript>::importable_type("./models", "User");
+        let user = TypeName::importable_type("./models", "User");
 
-        let mut b = CodeBlock::<TypeScript>::builder();
+        let mut b = CodeBlock::builder();
         b.add_statement("const u: %T = getUser()", (user,));
         let block = b.build().unwrap();
 
-        let mut fb = FileSpec::<TypeScript>::builder("mixed.ts");
-        fb.add_raw("// Generated file, do not edit.\n");
-        fb.add_code(block);
-        let file = fb.build().unwrap();
+        let file = FileSpec::builder("mixed.ts")
+            .add_raw("// Generated file, do not edit.\n")
+            .add_code(block)
+            .build()
+            .unwrap();
 
         let output = file.render(80).unwrap();
         assert!(output.contains("import type { User }"));
@@ -416,18 +437,19 @@ mod tests {
 
     #[test]
     fn test_file_with_header() {
-        let mut header_builder = CodeBlock::<TypeScript>::builder();
+        let mut header_builder = CodeBlock::builder();
         header_builder.add("// License: MIT", ());
         let header = header_builder.build().unwrap();
 
-        let mut b = CodeBlock::<TypeScript>::builder();
+        let mut b = CodeBlock::builder();
         b.add_statement("const x = 1", ());
         let block = b.build().unwrap();
 
-        let mut fb = FileSpec::<TypeScript>::builder("test.ts");
-        fb.header(header);
-        fb.add_code(block);
-        let file = fb.build().unwrap();
+        let file = FileSpec::builder("test.ts")
+            .header(header)
+            .add_code(block)
+            .build()
+            .unwrap();
 
         let output = file.render(80).unwrap();
         assert!(output.starts_with("// License: MIT"));
@@ -436,17 +458,18 @@ mod tests {
 
     #[test]
     fn test_dedup_same_import() {
-        let user1 = TypeName::<TypeScript>::importable_type("./models", "User");
-        let user2 = TypeName::<TypeScript>::importable_type("./models", "User");
+        let user1 = TypeName::importable_type("./models", "User");
+        let user2 = TypeName::importable_type("./models", "User");
 
-        let mut b = CodeBlock::<TypeScript>::builder();
+        let mut b = CodeBlock::builder();
         b.add_statement("const u1: %T = get1()", (user1,));
         b.add_statement("const u2: %T = get2()", (user2,));
         let block = b.build().unwrap();
 
-        let mut fb = FileSpec::<TypeScript>::builder("user.ts");
-        fb.add_code(block);
-        let file = fb.build().unwrap();
+        let file = FileSpec::builder("user.ts")
+            .add_code(block)
+            .build()
+            .unwrap();
 
         let output = file.render(80).unwrap();
         // Should appear only once.
@@ -456,7 +479,7 @@ mod tests {
 
     #[test]
     fn test_build_empty_filename_errors() {
-        let result = FileSpec::<TypeScript>::builder("").build();
+        let result = FileSpec::builder("").build();
         assert!(result.is_err());
         assert!(
             result
@@ -468,15 +491,16 @@ mod tests {
 
     #[test]
     fn test_aliased_type_in_codeblock() {
-        let user = TypeName::<TypeScript>::importable("./models", "User").with_alias("UserModel");
+        let user = TypeName::importable("./models", "User").with_alias("UserModel");
 
-        let mut b = CodeBlock::<TypeScript>::builder();
+        let mut b = CodeBlock::builder();
         b.add_statement("const u: %T = getUser()", (user,));
         let block = b.build().unwrap();
 
-        let mut fb = FileSpec::<TypeScript>::builder("user.ts");
-        fb.add_code(block);
-        let file = fb.build().unwrap();
+        let file = FileSpec::builder("user.ts")
+            .add_code(block)
+            .build()
+            .unwrap();
 
         let output = file.render(80).unwrap();
         // Import should use the alias.
@@ -495,18 +519,18 @@ mod tests {
     fn test_aliased_type_with_auto_alias_conflict() {
         // Two types named "User" from different modules.
         // First one has a preferred alias; second should still get auto-aliased.
-        let user1 =
-            TypeName::<TypeScript>::importable_type("./models", "User").with_alias("ModelUser");
-        let user2 = TypeName::<TypeScript>::importable_type("./other", "User");
+        let user1 = TypeName::importable_type("./models", "User").with_alias("ModelUser");
+        let user2 = TypeName::importable_type("./other", "User");
 
-        let mut b = CodeBlock::<TypeScript>::builder();
+        let mut b = CodeBlock::builder();
         b.add_statement("const u1: %T = get1()", (user1,));
         b.add_statement("const u2: %T = get2()", (user2,));
         let block = b.build().unwrap();
 
-        let mut fb = FileSpec::<TypeScript>::builder("user.ts");
-        fb.add_code(block);
-        let file = fb.build().unwrap();
+        let file = FileSpec::builder("user.ts")
+            .add_code(block)
+            .build()
+            .unwrap();
 
         let output = file.render(80).unwrap();
         // First uses its preferred alias.

--- a/src/spec/file_spec.rs
+++ b/src/spec/file_spec.rs
@@ -112,9 +112,10 @@ impl FileSpec {
     ///
     /// `width` controls the target line width for pretty-printing.
     pub fn render(&self, width: usize) -> Result<String, SigilStitchError> {
-        let lang: &dyn CodeLang = self.lang.as_deref().expect(
-            "FileSpec requires a language — use builder_with() or set lang via deserialization",
-        );
+        let lang: &dyn CodeLang = self
+            .lang
+            .as_deref()
+            .expect("FileSpec requires a language — use builder_with() to set one");
 
         // Phase 0: Materialize specs into CodeBlocks.
         enum Materialized {

--- a/src/spec/fun_spec.rs
+++ b/src/spec/fun_spec.rs
@@ -1,6 +1,6 @@
 //! Function/method specification.
 
-use crate::code_block::{Arg, CodeBlock, FormatPart};
+use crate::code_block::{Arg, CodeBlock};
 use crate::lang::CodeLang;
 use crate::spec::annotation_spec::AnnotationSpec;
 use crate::spec::modifiers::{
@@ -439,11 +439,7 @@ impl FunSpec {
                 cb.add_statement("%L", deleg.clone());
             }
             cb.add_code(body.clone());
-            let body_ends_with_newline = body
-                .parts
-                .last()
-                .is_some_and(|p| matches!(p, FormatPart::Newline | FormatPart::BlockClose));
-            if !body_ends_with_newline {
+            if !body.ends_with_newline_or_block_close() {
                 cb.add_line();
             }
             cb.add("%<", ());
@@ -578,11 +574,7 @@ impl FunSpec {
             cb.add_line();
             cb.add("%>", ());
             cb.add_code(body.clone());
-            let body_ends_with_newline = body
-                .parts
-                .last()
-                .is_some_and(|p| matches!(p, FormatPart::Newline | FormatPart::BlockClose));
-            if !body_ends_with_newline {
+            if !body.ends_with_newline_or_block_close() {
                 cb.add_line();
             }
             cb.add("%<", ());

--- a/src/spec/fun_spec.rs
+++ b/src/spec/fun_spec.rs
@@ -144,10 +144,11 @@ pub fn render_type_params(
         return String::new();
     }
 
-    let constraint_kw = lang.generic_constraint_keyword();
-    let constraint_sep = lang.generic_constraint_separator();
+    let generic = lang.generic_syntax();
+    let constraint_kw = generic.constraint_keyword;
+    let constraint_sep = generic.constraint_separator;
 
-    let mut fmt = String::from(lang.generic_open());
+    let mut fmt = String::from(generic.open);
     let mut first = true;
 
     // Lifetimes first (Rust convention: `<'a, 'b, T, U>`).
@@ -188,7 +189,7 @@ pub fn render_type_params(
                 args.push(Arg::TypeName(bound.clone()));
             }
         }
-        let ctx_kw = lang.context_bound_keyword();
+        let ctx_kw = generic.context_bound_keyword;
         for ctx_bound in &tp.context_bounds {
             fmt.push_str(ctx_kw);
             fmt.push_str("%T");
@@ -197,7 +198,7 @@ pub fn render_type_params(
         first = false;
     }
 
-    fmt.push_str(lang.generic_close());
+    fmt.push_str(generic.close);
     fmt
 }
 
@@ -317,12 +318,12 @@ impl FunSpec {
         }
 
         // Build signature.
-        if lang.function_signature_style() == FunctionSignatureStyle::Split {
+        if lang.function_syntax().function_signature_style == FunctionSignatureStyle::Split {
             return self.emit_split_signature(cb, lang);
         }
         let vis = lang.render_visibility(self.modifiers.visibility, ctx);
         let fn_kw = if self.modifiers.is_constructor {
-            lang.constructor_keyword()
+            lang.function_syntax().constructor_keyword
         } else {
             lang.function_keyword(ctx)
         };
@@ -332,7 +333,7 @@ impl FunSpec {
 
         sig.push_str(vis);
         if self.modifiers.is_abstract {
-            sig.push_str(lang.abstract_keyword());
+            sig.push_str(lang.function_syntax().abstract_keyword);
         }
         if self.modifiers.is_static {
             sig.push_str("static ");
@@ -341,11 +342,11 @@ impl FunSpec {
             sig.push_str("override ");
         }
         if self.modifiers.is_async {
-            sig.push_str(lang.async_keyword());
+            sig.push_str(lang.function_syntax().async_keyword);
         }
 
         // Return type as prefix (C-style: `int add(...)`).
-        if lang.return_type_is_prefix()
+        if lang.type_decl_syntax().return_type_is_prefix
             && let Some(ret) = &self.return_type
         {
             sig.push_str("%T");
@@ -362,7 +363,7 @@ impl FunSpec {
         if let Some(recv) = &self.receiver {
             sig.push('(');
             sig.push_str(&lang.escape_reserved(&recv.name));
-            sig.push_str(lang.type_annotation_separator());
+            sig.push_str(lang.type_decl_syntax().type_annotation_separator);
             sig.push_str("%T");
             sig_args.push(Arg::TypeName(recv.param_type.clone()));
             sig.push_str(") ");
@@ -375,7 +376,7 @@ impl FunSpec {
         sig.push_str(&tp_str);
 
         // Parameters — build as a sub-block for %W support.
-        if lang.param_list_style() == ParamListStyle::Curried {
+        if lang.function_syntax().param_list_style == ParamListStyle::Curried {
             if !self.params.is_empty() {
                 sig.push(' ');
                 sig.push_str("%L");
@@ -397,17 +398,19 @@ impl FunSpec {
         }
 
         // Return type as suffix (TS/Rust/Go-style: `fn add(...) -> int`).
-        if !lang.return_type_is_prefix()
+        if !lang.type_decl_syntax().return_type_is_prefix
             && let Some(ret) = &self.return_type
         {
-            sig.push_str(lang.return_type_separator());
+            sig.push_str(lang.function_syntax().return_type_separator);
             sig.push_str("%T");
             sig_args.push(Arg::TypeName(ret.clone()));
         }
 
         // Constructor delegation — signature style (Kotlin: `constructor(x: Int) : this(x, 0)`).
         let delegation_in_body = if let Some(deleg) = &self.delegation {
-            if lang.constructor_delegation_style() == ConstructorDelegationStyle::Signature {
+            if lang.function_syntax().constructor_delegation_style
+                == ConstructorDelegationStyle::Signature
+            {
                 sig.push_str(" : %L");
                 sig_args.push(Arg::Code(deleg.clone()));
                 false
@@ -444,13 +447,13 @@ impl FunSpec {
                 cb.add_line();
             }
             cb.add("%<", ());
-            let close = lang.block_close();
+            let close = lang.block_syntax().block_close;
             if !close.is_empty() {
                 cb.add(close, ());
                 cb.add_line();
             }
         } else {
-            let empty = lang.empty_body();
+            let empty = lang.function_syntax().empty_body;
             if !empty.is_empty() {
                 // Language requires a body placeholder (e.g., Python `...`).
                 self.emit_where_and_open(&mut sig, &mut sig_args, lang);
@@ -470,13 +473,13 @@ impl FunSpec {
                 }
                 cb.add_statement(empty, ());
                 cb.add("%<", ());
-                let close = lang.block_close();
+                let close = lang.block_syntax().block_close;
                 if !close.is_empty() {
                     cb.add(close, ());
                     cb.add_line();
                 }
             } else {
-                if lang.uses_semicolons() {
+                if lang.block_syntax().uses_semicolons {
                     sig.push(';');
                 }
                 cb.add(&sig, sig_args);
@@ -519,7 +522,7 @@ impl FunSpec {
 
     fn emit_where_and_open(&self, sig: &mut String, sig_args: &mut Vec<Arg>, lang: &dyn CodeLang) {
         if !self.where_constraints.is_empty()
-            && lang.where_clause_style() == WhereClauseStyle::WhereBlock
+            && lang.function_syntax().where_clause_style == WhereClauseStyle::WhereBlock
         {
             emit_where_block(sig, sig_args, &self.where_constraints, lang);
         }
@@ -568,7 +571,7 @@ impl FunSpec {
             def.push(' ');
             def.push_str(&lang.escape_reserved(&param.name));
         }
-        def.push_str(lang.block_open());
+        def.push_str(lang.block_syntax().block_open);
 
         if let Some(body) = &self.body {
             cb.add(&def, ());
@@ -583,20 +586,20 @@ impl FunSpec {
                 cb.add_line();
             }
             cb.add("%<", ());
-            let close = lang.block_close();
+            let close = lang.block_syntax().block_close;
             if !close.is_empty() {
                 cb.add(close, ());
                 cb.add_line();
             }
         } else {
-            let empty = lang.empty_body();
+            let empty = lang.function_syntax().empty_body;
             if !empty.is_empty() {
                 cb.add(&def, ());
                 cb.add_line();
                 cb.add("%>", ());
                 cb.add_statement(empty, ());
                 cb.add("%<", ());
-                let close = lang.block_close();
+                let close = lang.block_syntax().block_close;
                 if !close.is_empty() {
                     cb.add(close, ());
                     cb.add_line();
@@ -622,8 +625,9 @@ pub(crate) fn emit_where_block(
     constraints: &[WhereConstraint],
     lang: &dyn CodeLang,
 ) {
-    let constraint_sep = lang.generic_constraint_separator();
-    let indent = lang.indent_unit();
+    let generic = lang.generic_syntax();
+    let constraint_sep = generic.constraint_separator;
+    let indent = lang.block_syntax().indent_unit;
     fmt.push_str("\nwhere\n");
     for (i, wc) in constraints.iter().enumerate() {
         if i > 0 {
@@ -632,7 +636,7 @@ pub(crate) fn emit_where_block(
         fmt.push_str(indent);
         fmt.push_str("%T");
         args.push(Arg::TypeName(wc.subject.clone()));
-        fmt.push_str(lang.generic_constraint_keyword());
+        fmt.push_str(lang.generic_syntax().constraint_keyword);
         for (j, bound) in wc.bounds.iter().enumerate() {
             if j > 0 {
                 fmt.push_str(constraint_sep);

--- a/src/spec/fun_spec.rs
+++ b/src/spec/fun_spec.rs
@@ -13,10 +13,9 @@ use crate::type_name::TypeName;
 ///
 /// Represents `Subject: Bound1 + Bound2` in Rust's `where` block.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-#[serde(bound = "")]
-pub struct WhereConstraint<L: CodeLang> {
-    pub(crate) subject: TypeName<L>,
-    pub(crate) bounds: Vec<TypeName<L>>,
+pub struct WhereConstraint {
+    pub(crate) subject: TypeName,
+    pub(crate) bounds: Vec<TypeName>,
 }
 
 /// How where-clause constraints are rendered.
@@ -73,25 +72,24 @@ pub enum TypeParamKind {
 /// use sigil_stitch::prelude::*;
 /// use sigil_stitch::lang::typescript::TypeScript;
 ///
-/// let tp = TypeParamSpec::<TypeScript>::new("T")
+/// let tp = TypeParamSpec::new("T")
 ///     .with_bound(TypeName::primitive("Serializable"));
-/// let mut fb = FunSpec::<TypeScript>::builder("serialize");
-/// fb.add_type_param(tp);
+/// let fb = FunSpec::builder("serialize")
+///     .add_type_param(tp);
 /// ```
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-#[serde(bound = "")]
-pub struct TypeParamSpec<L: CodeLang> {
+pub struct TypeParamSpec {
     pub(crate) name: String,
-    pub(crate) bounds: Vec<TypeName<L>>,
+    pub(crate) bounds: Vec<TypeName>,
     #[serde(default)]
     pub(crate) kind: Option<TypeParamKind>,
     #[serde(default)]
     pub(crate) is_lifetime: bool,
     #[serde(default)]
-    pub(crate) context_bounds: Vec<TypeName<L>>,
+    pub(crate) context_bounds: Vec<TypeName>,
 }
 
-impl<L: CodeLang> TypeParamSpec<L> {
+impl TypeParamSpec {
     /// Create a new type parameter with the given name and no bounds.
     pub fn new(name: &str) -> Self {
         Self {
@@ -117,7 +115,7 @@ impl<L: CodeLang> TypeParamSpec<L> {
     }
 
     /// Add a trait/interface bound to this type parameter.
-    pub fn with_bound(mut self, bound: TypeName<L>) -> Self {
+    pub fn with_bound(mut self, bound: TypeName) -> Self {
         self.bounds.push(bound);
         self
     }
@@ -129,7 +127,7 @@ impl<L: CodeLang> TypeParamSpec<L> {
     }
 
     /// Add a context bound (e.g., Scala `[T : Ordering]`).
-    pub fn with_context_bound(mut self, bound: TypeName<L>) -> Self {
+    pub fn with_context_bound(mut self, bound: TypeName) -> Self {
         self.context_bounds.push(bound);
         self
     }
@@ -137,10 +135,10 @@ impl<L: CodeLang> TypeParamSpec<L> {
 
 /// Render type parameters into `<T: Bound, U>` form, appending to a format string and args vec.
 /// Returns the format string fragment (empty string if no type params).
-pub fn render_type_params<L: CodeLang>(
-    params: &[TypeParamSpec<L>],
-    lang: &L,
-    args: &mut Vec<Arg<L>>,
+pub fn render_type_params(
+    params: &[TypeParamSpec],
+    lang: &dyn CodeLang,
+    args: &mut Vec<Arg>,
 ) -> String {
     if params.is_empty() {
         return String::new();
@@ -220,27 +218,26 @@ pub fn render_type_params<L: CodeLang>(
 /// use sigil_stitch::prelude::*;
 /// use sigil_stitch::lang::typescript::TypeScript;
 ///
-/// let body = CodeBlock::<TypeScript>::of("return this.name", ()).unwrap();
+/// let body = CodeBlock::of("return this.name", ()).unwrap();
 ///
-/// let mut fb = FunSpec::<TypeScript>::builder("getName");
-/// fb.returns(TypeName::primitive("string"));
-/// fb.body(body);
-/// let fun = fb.build().unwrap();
+/// let fun = FunSpec::builder("getName")
+///     .returns(TypeName::primitive("string"))
+///     .body(body)
+///     .build().unwrap();
 /// ```
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-#[serde(bound = "")]
-pub struct FunSpec<L: CodeLang> {
+pub struct FunSpec {
     pub(crate) name: String,
-    pub(crate) params: Vec<ParameterSpec<L>>,
-    pub(crate) return_type: Option<TypeName<L>>,
-    pub(crate) body: Option<CodeBlock<L>>,
+    pub(crate) params: Vec<ParameterSpec>,
+    pub(crate) return_type: Option<TypeName>,
+    pub(crate) body: Option<CodeBlock>,
     pub(crate) modifiers: Modifiers,
     pub(crate) doc: Vec<String>,
-    pub(crate) type_params: Vec<TypeParamSpec<L>>,
-    pub(crate) annotations: Vec<CodeBlock<L>>,
-    pub(crate) annotation_specs: Vec<AnnotationSpec<L>>,
+    pub(crate) type_params: Vec<TypeParamSpec>,
+    pub(crate) annotations: Vec<CodeBlock>,
+    pub(crate) annotation_specs: Vec<AnnotationSpec>,
     /// Receiver parameter (e.g., Go: `func (s *Server) Handle()`).
-    pub(crate) receiver: Option<ParameterSpec<L>>,
+    pub(crate) receiver: Option<ParameterSpec>,
     /// Suffixes appended after the parameter list (e.g., C++: `const`, `override`, `= 0`).
     pub(crate) suffixes: Vec<String>,
     /// Constructor delegation call (e.g., `super(arg1, arg2)` or `this(arg1)`).
@@ -249,15 +246,15 @@ pub struct FunSpec<L: CodeLang> {
     /// statement in the constructor body.
     /// For signature-style languages (Kotlin): emitted after the parameter list
     /// as ` : super(...)` / ` : this(...)`.
-    pub(crate) delegation: Option<CodeBlock<L>>,
+    pub(crate) delegation: Option<CodeBlock>,
     /// Where-clause constraints (e.g., Rust `where T: Clone + Send`).
     #[serde(default)]
-    pub(crate) where_constraints: Vec<WhereConstraint<L>>,
+    pub(crate) where_constraints: Vec<WhereConstraint>,
 }
 
-impl<L: CodeLang> FunSpec<L> {
+impl FunSpec {
     /// Create a new builder for a function with the given name.
-    pub fn builder(name: &str) -> FunSpecBuilder<L> {
+    pub fn builder(name: &str) -> FunSpecBuilder {
         FunSpecBuilder {
             name: name.to_string(),
             params: Vec::new(),
@@ -283,10 +280,10 @@ impl<L: CodeLang> FunSpec<L> {
     /// Emit this function as a CodeBlock.
     pub fn emit(
         &self,
-        lang: &L,
+        lang: &dyn CodeLang,
         ctx: DeclarationContext,
-    ) -> Result<CodeBlock<L>, crate::error::SigilStitchError> {
-        let mut cb = CodeBlock::<L>::builder();
+    ) -> Result<CodeBlock, crate::error::SigilStitchError> {
+        let mut cb = CodeBlock::builder();
 
         let emit_doc = || -> Option<String> {
             if self.doc.is_empty() || lang.doc_comment_inside_body() {
@@ -331,7 +328,7 @@ impl<L: CodeLang> FunSpec<L> {
         };
 
         let mut sig = String::new();
-        let mut sig_args: Vec<Arg<L>> = Vec::new();
+        let mut sig_args: Vec<Arg> = Vec::new();
 
         sig.push_str(vis);
         if self.modifiers.is_abstract {
@@ -490,8 +487,11 @@ impl<L: CodeLang> FunSpec<L> {
         cb.build()
     }
 
-    fn build_params_block(&self, lang: &L) -> Result<CodeBlock<L>, crate::error::SigilStitchError> {
-        let mut pb = CodeBlock::<L>::builder();
+    fn build_params_block(
+        &self,
+        lang: &dyn CodeLang,
+    ) -> Result<CodeBlock, crate::error::SigilStitchError> {
+        let mut pb = CodeBlock::builder();
         for (i, param) in self.params.iter().enumerate() {
             if i > 0 {
                 pb.add(",%W", ());
@@ -503,9 +503,9 @@ impl<L: CodeLang> FunSpec<L> {
 
     fn build_curried_params_block(
         &self,
-        lang: &L,
-    ) -> Result<CodeBlock<L>, crate::error::SigilStitchError> {
-        let mut pb = CodeBlock::<L>::builder();
+        lang: &dyn CodeLang,
+    ) -> Result<CodeBlock, crate::error::SigilStitchError> {
+        let mut pb = CodeBlock::builder();
         for (i, param) in self.params.iter().enumerate() {
             if i > 0 {
                 pb.add(" ", ());
@@ -517,7 +517,7 @@ impl<L: CodeLang> FunSpec<L> {
         pb.build()
     }
 
-    fn emit_where_and_open(&self, sig: &mut String, sig_args: &mut Vec<Arg<L>>, lang: &L) {
+    fn emit_where_and_open(&self, sig: &mut String, sig_args: &mut Vec<Arg>, lang: &dyn CodeLang) {
         if !self.where_constraints.is_empty()
             && lang.where_clause_style() == WhereClauseStyle::WhereBlock
         {
@@ -536,9 +536,9 @@ impl<L: CodeLang> FunSpec<L> {
     /// ```
     fn emit_split_signature(
         &self,
-        mut cb: crate::code_block::CodeBlockBuilder<L>,
-        lang: &L,
-    ) -> Result<CodeBlock<L>, crate::error::SigilStitchError> {
+        mut cb: crate::code_block::CodeBlockBuilder,
+        lang: &dyn CodeLang,
+    ) -> Result<CodeBlock, crate::error::SigilStitchError> {
         let resolve = |_module: &str, name: &str| name.to_string();
 
         // Type context (e.g., "(Show a) => ").
@@ -616,11 +616,11 @@ impl<L: CodeLang> FunSpec<L> {
 /// ```text
 /// \nwhere\n    T: Clone + Send,\n    U: Debug,
 /// ```
-pub(crate) fn emit_where_block<L: CodeLang>(
+pub(crate) fn emit_where_block(
     fmt: &mut String,
-    args: &mut Vec<Arg<L>>,
-    constraints: &[WhereConstraint<L>],
-    lang: &L,
+    args: &mut Vec<Arg>,
+    constraints: &[WhereConstraint],
+    lang: &dyn CodeLang,
 ) {
     let constraint_sep = lang.generic_constraint_separator();
     let indent = lang.indent_unit();
@@ -646,109 +646,109 @@ pub(crate) fn emit_where_block<L: CodeLang>(
 
 /// Builder for [`FunSpec`].
 #[derive(Debug)]
-pub struct FunSpecBuilder<L: CodeLang> {
+pub struct FunSpecBuilder {
     name: String,
-    params: Vec<ParameterSpec<L>>,
-    return_type: Option<TypeName<L>>,
-    body: Option<CodeBlock<L>>,
+    params: Vec<ParameterSpec>,
+    return_type: Option<TypeName>,
+    body: Option<CodeBlock>,
     modifiers: Modifiers,
     doc: Vec<String>,
-    type_params: Vec<TypeParamSpec<L>>,
-    annotations: Vec<CodeBlock<L>>,
-    annotation_specs: Vec<AnnotationSpec<L>>,
-    receiver: Option<ParameterSpec<L>>,
+    type_params: Vec<TypeParamSpec>,
+    annotations: Vec<CodeBlock>,
+    annotation_specs: Vec<AnnotationSpec>,
+    receiver: Option<ParameterSpec>,
     suffixes: Vec<String>,
-    delegation: Option<CodeBlock<L>>,
-    where_constraints: Vec<WhereConstraint<L>>,
+    delegation: Option<CodeBlock>,
+    where_constraints: Vec<WhereConstraint>,
 }
 
-impl<L: CodeLang> FunSpecBuilder<L> {
+impl FunSpecBuilder {
     /// Add a parameter to the function signature.
-    pub fn add_param(&mut self, param: ParameterSpec<L>) -> &mut Self {
+    pub fn add_param(mut self, param: ParameterSpec) -> Self {
         self.params.push(param);
         self
     }
 
     /// Set the return type.
-    pub fn returns(&mut self, ret: TypeName<L>) -> &mut Self {
+    pub fn returns(mut self, ret: TypeName) -> Self {
         self.return_type = Some(ret);
         self
     }
 
     /// Set the function body.
-    pub fn body(&mut self, body: CodeBlock<L>) -> &mut Self {
+    pub fn body(mut self, body: CodeBlock) -> Self {
         self.body = Some(body);
         self
     }
 
     /// Set the visibility modifier.
-    pub fn visibility(&mut self, vis: Visibility) -> &mut Self {
+    pub fn visibility(mut self, vis: Visibility) -> Self {
         self.modifiers.visibility = vis;
         self
     }
 
     /// Mark this function as async.
-    pub fn is_async(&mut self) -> &mut Self {
+    pub fn is_async(mut self) -> Self {
         self.modifiers.is_async = true;
         self
     }
 
     /// Mark this function as static.
-    pub fn is_static(&mut self) -> &mut Self {
+    pub fn is_static(mut self) -> Self {
         self.modifiers.is_static = true;
         self
     }
 
     /// Mark this function as abstract.
-    pub fn is_abstract(&mut self) -> &mut Self {
+    pub fn is_abstract(mut self) -> Self {
         self.modifiers.is_abstract = true;
         self
     }
 
     /// Mark this function as an override.
-    pub fn is_override(&mut self) -> &mut Self {
+    pub fn is_override(mut self) -> Self {
         self.modifiers.is_override = true;
         self
     }
 
     /// Mark this function as a constructor.
-    pub fn is_constructor(&mut self) -> &mut Self {
+    pub fn is_constructor(mut self) -> Self {
         self.modifiers.is_constructor = true;
         self
     }
 
     /// Add a documentation comment line.
-    pub fn doc(&mut self, line: &str) -> &mut Self {
+    pub fn doc(mut self, line: &str) -> Self {
         self.doc.push(line.to_string());
         self
     }
 
     /// Add a generic type parameter.
-    pub fn add_type_param(&mut self, tp: TypeParamSpec<L>) -> &mut Self {
+    pub fn add_type_param(mut self, tp: TypeParamSpec) -> Self {
         self.type_params.push(tp);
         self
     }
 
     /// Add a raw annotation CodeBlock.
-    pub fn annotation(&mut self, ann: CodeBlock<L>) -> &mut Self {
+    pub fn annotation(mut self, ann: CodeBlock) -> Self {
         self.annotations.push(ann);
         self
     }
 
     /// Add a structured annotation spec.
-    pub fn annotate(&mut self, spec: AnnotationSpec<L>) -> &mut Self {
+    pub fn annotate(mut self, spec: AnnotationSpec) -> Self {
         self.annotation_specs.push(spec);
         self
     }
 
     /// Set the receiver parameter (e.g., Go's `(s *Server)`).
-    pub fn receiver(&mut self, recv: ParameterSpec<L>) -> &mut Self {
+    pub fn receiver(mut self, recv: ParameterSpec) -> Self {
         self.receiver = Some(recv);
         self
     }
 
     /// Append a suffix after the parameter list (e.g., C++ `const`, `override`).
-    pub fn suffix(&mut self, s: &str) -> &mut Self {
+    pub fn suffix(mut self, s: &str) -> Self {
         self.suffixes.push(s.to_string());
         self
     }
@@ -759,17 +759,13 @@ impl<L: CodeLang> FunSpecBuilder<L> {
     /// the first statement in the constructor body.
     /// For signature-style languages (Kotlin), this appears after the parameter
     /// list: `constructor(x: Int) : this(x, 0) { ... }`.
-    pub fn delegation(&mut self, call: CodeBlock<L>) -> &mut Self {
+    pub fn delegation(mut self, call: CodeBlock) -> Self {
         self.delegation = Some(call);
         self
     }
 
     /// Add a where-clause constraint (e.g., `T: Clone + Send`).
-    pub fn add_where_constraint(
-        &mut self,
-        subject: TypeName<L>,
-        bounds: Vec<TypeName<L>>,
-    ) -> &mut Self {
+    pub fn add_where_constraint(mut self, subject: TypeName, bounds: Vec<TypeName>) -> Self {
         self.where_constraints
             .push(WhereConstraint { subject, bounds });
         self
@@ -777,7 +773,7 @@ impl<L: CodeLang> FunSpecBuilder<L> {
 
     /// Convenience: add a single bound to an existing or new where constraint for
     /// the named type parameter.
-    pub fn where_bound(&mut self, param_name: &str, bound: TypeName<L>) -> &mut Self {
+    pub fn where_bound(mut self, param_name: &str, bound: TypeName) -> Self {
         if let Some(wc) = self
             .where_constraints
             .iter_mut()
@@ -798,7 +794,7 @@ impl<L: CodeLang> FunSpecBuilder<L> {
     /// # Errors
     ///
     /// Returns [`SigilStitchError::EmptyName`](crate::error::SigilStitchError::EmptyName) if `name` is empty.
-    pub fn build(self) -> Result<FunSpec<L>, crate::error::SigilStitchError> {
+    pub fn build(self) -> Result<FunSpec, crate::error::SigilStitchError> {
         snafu::ensure!(
             !self.name.is_empty(),
             crate::error::EmptyNameSnafu {
@@ -829,7 +825,7 @@ mod tests {
     use crate::lang::rust_lang::RustLang;
     use crate::lang::typescript::TypeScript;
 
-    fn emit_fun_ts(spec: &FunSpec<TypeScript>, ctx: DeclarationContext) -> String {
+    fn emit_fun_ts(spec: &FunSpec, ctx: DeclarationContext) -> String {
         let lang = TypeScript::new();
         let block = spec.emit(&lang, ctx).unwrap();
         let imports = crate::import::ImportGroup::new();
@@ -837,7 +833,7 @@ mod tests {
         renderer.render(&block).unwrap()
     }
 
-    fn emit_fun_rs(spec: &FunSpec<RustLang>, ctx: DeclarationContext) -> String {
+    fn emit_fun_rs(spec: &FunSpec, ctx: DeclarationContext) -> String {
         let lang = RustLang::new();
         let block = spec.emit(&lang, ctx).unwrap();
         let imports = crate::import::ImportGroup::new();
@@ -847,12 +843,13 @@ mod tests {
 
     #[test]
     fn test_ts_simple_function() {
-        let mut fb = FunSpec::<TypeScript>::builder("greet");
-        fb.add_param(ParameterSpec::new("name", TypeName::primitive("string")).unwrap());
-        fb.returns(TypeName::primitive("void"));
-        let body = CodeBlock::<TypeScript>::of("console.log(name)", ()).unwrap();
-        fb.body(body);
-        let fun = fb.build().unwrap();
+        let body = CodeBlock::of("console.log(name)", ()).unwrap();
+        let fun = FunSpec::builder("greet")
+            .add_param(ParameterSpec::new("name", TypeName::primitive("string")).unwrap())
+            .returns(TypeName::primitive("void"))
+            .body(body)
+            .build()
+            .unwrap();
         let output = emit_fun_ts(&fun, DeclarationContext::TopLevel);
         assert!(output.contains("function greet(name: string): void {"));
         assert!(output.contains("console.log(name)"));
@@ -861,41 +858,44 @@ mod tests {
 
     #[test]
     fn test_ts_async_method() {
-        let mut fb = FunSpec::<TypeScript>::builder("getUser");
-        fb.add_param(ParameterSpec::new("id", TypeName::primitive("string")).unwrap());
-        fb.returns(TypeName::generic(
-            TypeName::primitive("Promise"),
-            vec![TypeName::primitive("User")],
-        ));
-        fb.is_async();
-        fb.visibility(Visibility::Public);
-        let body = CodeBlock::<TypeScript>::of("return db.find(id)", ()).unwrap();
-        fb.body(body);
-        let fun = fb.build().unwrap();
+        let body = CodeBlock::of("return db.find(id)", ()).unwrap();
+        let fun = FunSpec::builder("getUser")
+            .add_param(ParameterSpec::new("id", TypeName::primitive("string")).unwrap())
+            .returns(TypeName::generic(
+                TypeName::primitive("Promise"),
+                vec![TypeName::primitive("User")],
+            ))
+            .is_async()
+            .visibility(Visibility::Public)
+            .body(body)
+            .build()
+            .unwrap();
         let output = emit_fun_ts(&fun, DeclarationContext::Member);
         assert!(output.contains("public async getUser(id: string): Promise<User> {"));
     }
 
     #[test]
     fn test_ts_abstract_method() {
-        let mut fb = FunSpec::<TypeScript>::builder("validate");
-        fb.is_abstract();
-        fb.returns(TypeName::primitive("boolean"));
-        let fun = fb.build().unwrap();
+        let fun = FunSpec::builder("validate")
+            .is_abstract()
+            .returns(TypeName::primitive("boolean"))
+            .build()
+            .unwrap();
         let output = emit_fun_ts(&fun, DeclarationContext::Member);
         assert!(output.contains("abstract validate(): boolean;"));
     }
 
     #[test]
     fn test_rust_simple_function() {
-        let mut fb = FunSpec::<RustLang>::builder("add");
-        fb.visibility(Visibility::Public);
-        fb.add_param(ParameterSpec::new("a", TypeName::primitive("i32")).unwrap());
-        fb.add_param(ParameterSpec::new("b", TypeName::primitive("i32")).unwrap());
-        fb.returns(TypeName::primitive("i32"));
-        let body = CodeBlock::<RustLang>::of("a + b", ()).unwrap();
-        fb.body(body);
-        let fun = fb.build().unwrap();
+        let body = CodeBlock::of("a + b", ()).unwrap();
+        let fun = FunSpec::builder("add")
+            .visibility(Visibility::Public)
+            .add_param(ParameterSpec::new("a", TypeName::primitive("i32")).unwrap())
+            .add_param(ParameterSpec::new("b", TypeName::primitive("i32")).unwrap())
+            .returns(TypeName::primitive("i32"))
+            .body(body)
+            .build()
+            .unwrap();
         let output = emit_fun_rs(&fun, DeclarationContext::TopLevel);
         assert!(output.contains("pub fn add(a: i32, b: i32) -> i32 {"));
         assert!(output.contains("a + b"));
@@ -903,22 +903,22 @@ mod tests {
 
     #[test]
     fn test_fun_with_type_params() {
-        let tp =
-            TypeParamSpec::<TypeScript>::new("T").with_bound(TypeName::primitive("Serializable"));
-        let mut fb = FunSpec::<TypeScript>::builder("serialize");
-        fb.add_type_param(tp);
-        fb.add_param(ParameterSpec::new("value", TypeName::primitive("T")).unwrap());
-        fb.returns(TypeName::primitive("string"));
-        let body = CodeBlock::<TypeScript>::of("return JSON.stringify(value)", ()).unwrap();
-        fb.body(body);
-        let fun = fb.build().unwrap();
+        let tp = TypeParamSpec::new("T").with_bound(TypeName::primitive("Serializable"));
+        let body = CodeBlock::of("return JSON.stringify(value)", ()).unwrap();
+        let fun = FunSpec::builder("serialize")
+            .add_type_param(tp)
+            .add_param(ParameterSpec::new("value", TypeName::primitive("T")).unwrap())
+            .returns(TypeName::primitive("string"))
+            .body(body)
+            .build()
+            .unwrap();
         let output = emit_fun_ts(&fun, DeclarationContext::TopLevel);
         assert!(output.contains("function serialize<T extends Serializable>(value: T): string {"));
     }
 
     #[test]
     fn test_build_empty_name_errors() {
-        let result = FunSpec::<TypeScript>::builder("").build();
+        let result = FunSpec::builder("").build();
         assert!(result.is_err());
         assert!(
             result
@@ -930,18 +930,19 @@ mod tests {
 
     #[test]
     fn test_where_clause_rust_function() {
-        let mut fb = FunSpec::<RustLang>::builder("process");
-        fb.add_type_param(TypeParamSpec::new("T"));
-        fb.add_type_param(TypeParamSpec::new("U"));
-        fb.add_where_constraint(
-            TypeName::primitive("T"),
-            vec![TypeName::primitive("Clone"), TypeName::primitive("Send")],
-        );
-        fb.add_where_constraint(TypeName::primitive("U"), vec![TypeName::primitive("Debug")]);
-        fb.add_param(ParameterSpec::new("a", TypeName::primitive("T")).unwrap());
-        fb.add_param(ParameterSpec::new("b", TypeName::primitive("U")).unwrap());
-        fb.body(CodeBlock::<RustLang>::of("todo!()", ()).unwrap());
-        let fun = fb.build().unwrap();
+        let fun = FunSpec::builder("process")
+            .add_type_param(TypeParamSpec::new("T"))
+            .add_type_param(TypeParamSpec::new("U"))
+            .add_where_constraint(
+                TypeName::primitive("T"),
+                vec![TypeName::primitive("Clone"), TypeName::primitive("Send")],
+            )
+            .add_where_constraint(TypeName::primitive("U"), vec![TypeName::primitive("Debug")])
+            .add_param(ParameterSpec::new("a", TypeName::primitive("T")).unwrap())
+            .add_param(ParameterSpec::new("b", TypeName::primitive("U")).unwrap())
+            .body(CodeBlock::of("todo!()", ()).unwrap())
+            .build()
+            .unwrap();
         let output = emit_fun_rs(&fun, DeclarationContext::TopLevel);
         assert!(
             output.contains("fn process<T, U>(a: T, b: U)"),
@@ -956,14 +957,15 @@ mod tests {
 
     #[test]
     fn test_where_clause_ts_inline_ignored() {
-        let mut fb = FunSpec::<TypeScript>::builder("process");
-        fb.add_type_param(TypeParamSpec::new("T"));
-        fb.add_where_constraint(
-            TypeName::primitive("T"),
-            vec![TypeName::primitive("Serializable")],
-        );
-        fb.body(CodeBlock::<TypeScript>::of("return value", ()).unwrap());
-        let fun = fb.build().unwrap();
+        let fun = FunSpec::builder("process")
+            .add_type_param(TypeParamSpec::new("T"))
+            .add_where_constraint(
+                TypeName::primitive("T"),
+                vec![TypeName::primitive("Serializable")],
+            )
+            .body(CodeBlock::of("return value", ()).unwrap())
+            .build()
+            .unwrap();
         let output = emit_fun_ts(&fun, DeclarationContext::TopLevel);
         assert!(
             !output.contains("where"),
@@ -974,12 +976,13 @@ mod tests {
 
     #[test]
     fn test_where_bound_convenience() {
-        let mut fb = FunSpec::<RustLang>::builder("example");
-        fb.add_type_param(TypeParamSpec::new("T"));
-        fb.where_bound("T", TypeName::primitive("Clone"));
-        fb.where_bound("T", TypeName::primitive("Send"));
-        fb.body(CodeBlock::<RustLang>::of("todo!()", ()).unwrap());
-        let fun = fb.build().unwrap();
+        let fun = FunSpec::builder("example")
+            .add_type_param(TypeParamSpec::new("T"))
+            .where_bound("T", TypeName::primitive("Clone"))
+            .where_bound("T", TypeName::primitive("Send"))
+            .body(CodeBlock::of("todo!()", ()).unwrap())
+            .build()
+            .unwrap();
         let output = emit_fun_rs(&fun, DeclarationContext::TopLevel);
         assert!(
             output.contains("where\n    T: Clone + Send,"),
@@ -989,20 +992,22 @@ mod tests {
 
     #[test]
     fn test_type_param_kind_none_unchanged() {
-        let mut fb = FunSpec::<TypeScript>::builder("foo");
-        fb.add_type_param(TypeParamSpec::new("T"));
-        fb.body(CodeBlock::<TypeScript>::of("return null", ()).unwrap());
-        let fun = fb.build().unwrap();
+        let fun = FunSpec::builder("foo")
+            .add_type_param(TypeParamSpec::new("T"))
+            .body(CodeBlock::of("return null", ()).unwrap())
+            .build()
+            .unwrap();
         let output = emit_fun_ts(&fun, DeclarationContext::TopLevel);
         assert!(output.contains("function foo<T>()"), "unchanged: {output}");
     }
 
     #[test]
     fn test_type_param_with_kind_default_no_output() {
-        let mut fb = FunSpec::<RustLang>::builder("apply");
-        fb.add_type_param(TypeParamSpec::new("F").with_kind(TypeParamKind::Constructor1));
-        fb.body(CodeBlock::<RustLang>::of("todo!()", ()).unwrap());
-        let fun = fb.build().unwrap();
+        let fun = FunSpec::builder("apply")
+            .add_type_param(TypeParamSpec::new("F").with_kind(TypeParamKind::Constructor1))
+            .body(CodeBlock::of("todo!()", ()).unwrap())
+            .build()
+            .unwrap();
         let output = emit_fun_rs(&fun, DeclarationContext::TopLevel);
         assert!(
             output.contains("fn apply<F>()"),
@@ -1012,29 +1017,30 @@ mod tests {
 
     #[test]
     fn test_lifetime_params_before_type_params() {
-        let mut fb = FunSpec::<RustLang>::builder("longest");
-        fb.add_type_param(TypeParamSpec::new("T"));
-        fb.add_type_param(TypeParamSpec::lifetime("'a"));
-        fb.add_param(
-            ParameterSpec::new(
-                "x",
-                TypeName::reference_with_lifetime(TypeName::primitive("str"), "'a"),
+        let fun = FunSpec::builder("longest")
+            .add_type_param(TypeParamSpec::new("T"))
+            .add_type_param(TypeParamSpec::lifetime("'a"))
+            .add_param(
+                ParameterSpec::new(
+                    "x",
+                    TypeName::reference_with_lifetime(TypeName::primitive("str"), "'a"),
+                )
+                .unwrap(),
             )
-            .unwrap(),
-        );
-        fb.add_param(
-            ParameterSpec::new(
-                "y",
-                TypeName::reference_with_lifetime(TypeName::primitive("str"), "'a"),
+            .add_param(
+                ParameterSpec::new(
+                    "y",
+                    TypeName::reference_with_lifetime(TypeName::primitive("str"), "'a"),
+                )
+                .unwrap(),
             )
-            .unwrap(),
-        );
-        fb.returns(TypeName::reference_with_lifetime(
-            TypeName::primitive("str"),
-            "'a",
-        ));
-        fb.body(CodeBlock::<RustLang>::of("x", ()).unwrap());
-        let fun = fb.build().unwrap();
+            .returns(TypeName::reference_with_lifetime(
+                TypeName::primitive("str"),
+                "'a",
+            ))
+            .body(CodeBlock::of("x", ()).unwrap())
+            .build()
+            .unwrap();
         let output = emit_fun_rs(&fun, DeclarationContext::TopLevel);
         assert!(
             output.contains("fn longest<'a, T>("),

--- a/src/spec/import_spec.rs
+++ b/src/spec/import_spec.rs
@@ -1,7 +1,4 @@
-use std::marker::PhantomData;
-
 use crate::import::ImportEntry;
-use crate::lang::CodeLang;
 
 /// Explicit import specification for manual import control.
 ///
@@ -22,17 +19,16 @@ use crate::lang::CodeLang;
 /// use sigil_stitch::lang::typescript::TypeScript;
 ///
 /// // Forced named import:
-/// let spec = ImportSpec::<TypeScript>::named("./models", "User");
+/// let spec = ImportSpec::named("./models", "User");
 ///
 /// // Aliased import: import { User as MyUser } from './models'
-/// let spec = ImportSpec::<TypeScript>::named_as("./models", "User", "MyUser");
+/// let spec = ImportSpec::named_as("./models", "User", "MyUser");
 ///
 /// // Side-effect import: import './polyfill';
-/// let spec = ImportSpec::<TypeScript>::side_effect("./polyfill");
+/// let spec = ImportSpec::side_effect("./polyfill");
 /// ```
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-#[serde(bound = "")]
-pub enum ImportSpec<L: CodeLang> {
+pub enum ImportSpec {
     /// Import a specific named symbol from a module.
     Named {
         /// The module path to import from.
@@ -43,9 +39,6 @@ pub enum ImportSpec<L: CodeLang> {
         alias: Option<String>,
         /// Whether this is a type-only import (e.g., TypeScript `import type`).
         is_type_only: bool,
-        /// Language phantom data.
-        #[serde(skip)]
-        _phantom: PhantomData<L>,
     },
     /// Side-effect import: import a module for its side effects only.
     ///
@@ -58,9 +51,6 @@ pub enum ImportSpec<L: CodeLang> {
     SideEffect {
         /// The module path to import for side effects.
         module: String,
-        /// Language phantom data.
-        #[serde(skip)]
-        _phantom: PhantomData<L>,
     },
     /// Wildcard import: import all exports from a module.
     ///
@@ -72,13 +62,10 @@ pub enum ImportSpec<L: CodeLang> {
     Wildcard {
         /// The module path to wildcard-import from.
         module: String,
-        /// Language phantom data.
-        #[serde(skip)]
-        _phantom: PhantomData<L>,
     },
 }
 
-impl<L: CodeLang> ImportSpec<L> {
+impl ImportSpec {
     /// Create a named import.
     pub fn named(module: &str, name: &str) -> Self {
         ImportSpec::Named {
@@ -86,7 +73,6 @@ impl<L: CodeLang> ImportSpec<L> {
             name: name.to_string(),
             alias: None,
             is_type_only: false,
-            _phantom: PhantomData,
         }
     }
 
@@ -97,7 +83,6 @@ impl<L: CodeLang> ImportSpec<L> {
             name: name.to_string(),
             alias: Some(alias.to_string()),
             is_type_only: false,
-            _phantom: PhantomData,
         }
     }
 
@@ -108,7 +93,6 @@ impl<L: CodeLang> ImportSpec<L> {
             name: name.to_string(),
             alias: None,
             is_type_only: true,
-            _phantom: PhantomData,
         }
     }
 
@@ -116,7 +100,6 @@ impl<L: CodeLang> ImportSpec<L> {
     pub fn side_effect(module: &str) -> Self {
         ImportSpec::SideEffect {
             module: module.to_string(),
-            _phantom: PhantomData,
         }
     }
 
@@ -124,7 +107,6 @@ impl<L: CodeLang> ImportSpec<L> {
     pub fn wildcard(module: &str) -> Self {
         ImportSpec::Wildcard {
             module: module.to_string(),
-            _phantom: PhantomData,
         }
     }
 
@@ -168,11 +150,10 @@ impl<L: CodeLang> ImportSpec<L> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::lang::typescript::TypeScript;
 
     #[test]
     fn test_named_import() {
-        let spec = ImportSpec::<TypeScript>::named("./models", "User");
+        let spec = ImportSpec::named("./models", "User");
         let entry = spec.into_entry();
         assert_eq!(entry.module, "./models");
         assert_eq!(entry.name, "User");
@@ -184,7 +165,7 @@ mod tests {
 
     #[test]
     fn test_named_as_import() {
-        let spec = ImportSpec::<TypeScript>::named_as("./models", "User", "MyUser");
+        let spec = ImportSpec::named_as("./models", "User", "MyUser");
         let entry = spec.into_entry();
         assert_eq!(entry.name, "User");
         assert_eq!(entry.alias.as_deref(), Some("MyUser"));
@@ -192,14 +173,14 @@ mod tests {
 
     #[test]
     fn test_named_type_import() {
-        let spec = ImportSpec::<TypeScript>::named_type("./models", "User");
+        let spec = ImportSpec::named_type("./models", "User");
         let entry = spec.into_entry();
         assert!(entry.is_type_only);
     }
 
     #[test]
     fn test_side_effect_import() {
-        let spec = ImportSpec::<TypeScript>::side_effect("./polyfill");
+        let spec = ImportSpec::side_effect("./polyfill");
         let entry = spec.into_entry();
         assert!(entry.is_side_effect);
         assert!(entry.name.is_empty());
@@ -208,7 +189,7 @@ mod tests {
 
     #[test]
     fn test_wildcard_import() {
-        let spec = ImportSpec::<TypeScript>::wildcard("./utils");
+        let spec = ImportSpec::wildcard("./utils");
         let entry = spec.into_entry();
         assert!(entry.is_wildcard);
         assert!(entry.name.is_empty());

--- a/src/spec/parameter_spec.rs
+++ b/src/spec/parameter_spec.rs
@@ -74,7 +74,7 @@ impl ParameterSpec {
         let mut fmt = String::new();
         let mut args: Vec<Arg> = Vec::new();
 
-        if lang.type_before_name() {
+        if lang.type_decl_syntax().type_before_name {
             // C-style: type name
             if !self.param_type.is_empty() {
                 fmt.push_str("%T");
@@ -91,7 +91,7 @@ impl ParameterSpec {
 
             // Skip type annotation when the type is empty (e.g., Python's bare `self`).
             if !self.param_type.is_empty() {
-                let sep = lang.type_annotation_separator();
+                let sep = lang.type_decl_syntax().type_annotation_separator;
                 fmt.push_str(sep);
                 fmt.push_str("%T");
                 args.push(Arg::TypeName(self.param_type.clone()));

--- a/src/spec/parameter_spec.rs
+++ b/src/spec/parameter_spec.rs
@@ -18,26 +18,25 @@ use crate::type_name::TypeName;
 /// use sigil_stitch::lang::typescript::TypeScript;
 ///
 /// // Simple parameter:
-/// let param = ParameterSpec::<TypeScript>::new("id", TypeName::primitive("string")).unwrap();
+/// let param = ParameterSpec::new("id", TypeName::primitive("string")).unwrap();
 ///
 /// // Parameter with default value:
-/// let default_val = CodeBlock::<TypeScript>::of("0", ()).unwrap();
-/// let mut pb = ParameterSpec::builder("count", TypeName::<TypeScript>::primitive("number"));
-/// pb.default_value(default_val);
-/// let param = pb.build().unwrap();
+/// let default_val = CodeBlock::of("0", ()).unwrap();
+/// let param = ParameterSpec::builder("count", TypeName::primitive("number"))
+///     .default_value(default_val)
+///     .build().unwrap();
 /// ```
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-#[serde(bound = "")]
-pub struct ParameterSpec<L: CodeLang> {
+pub struct ParameterSpec {
     pub(crate) name: String,
-    pub(crate) param_type: TypeName<L>,
-    pub(crate) default_value: Option<crate::code_block::CodeBlock<L>>,
+    pub(crate) param_type: TypeName,
+    pub(crate) default_value: Option<crate::code_block::CodeBlock>,
     pub(crate) is_variadic: bool,
 }
 
-impl<L: CodeLang> ParameterSpec<L> {
+impl ParameterSpec {
     /// Create a new builder for a parameter with the given name and type.
-    pub fn builder(name: &str, param_type: TypeName<L>) -> ParameterSpecBuilder<L> {
+    pub fn builder(name: &str, param_type: TypeName) -> ParameterSpecBuilder {
         ParameterSpecBuilder {
             name: name.to_string(),
             param_type,
@@ -47,11 +46,17 @@ impl<L: CodeLang> ParameterSpec<L> {
     }
 
     /// Convenience constructor for a simple parameter (name + type, no frills).
-    pub fn new(
-        name: &str,
-        param_type: TypeName<L>,
-    ) -> Result<Self, crate::error::SigilStitchError> {
+    pub fn new(name: &str, param_type: TypeName) -> Result<Self, crate::error::SigilStitchError> {
         Self::builder(name, param_type).build()
+    }
+
+    /// Infallible convenience constructor for a simple parameter.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `name` is empty.
+    pub fn of(name: &str, param_type: TypeName) -> Self {
+        Self::new(name, param_type).expect("ParameterSpec name must not be empty")
     }
 
     /// Return the parameter name.
@@ -60,14 +65,14 @@ impl<L: CodeLang> ParameterSpec<L> {
     }
 
     /// Return the parameter type.
-    pub fn param_type(&self) -> &TypeName<L> {
+    pub fn param_type(&self) -> &TypeName {
         &self.param_type
     }
 
     /// Emit this parameter into a CodeBlockBuilder (appends format parts + args).
-    pub fn emit_into(&self, cb: &mut CodeBlockBuilder<L>, lang: &L) {
+    pub fn emit_into(&self, cb: &mut CodeBlockBuilder, lang: &dyn CodeLang) {
         let mut fmt = String::new();
-        let mut args: Vec<Arg<L>> = Vec::new();
+        let mut args: Vec<Arg> = Vec::new();
 
         if lang.type_before_name() {
             // C-style: type name
@@ -104,22 +109,22 @@ impl<L: CodeLang> ParameterSpec<L> {
 
 /// Builder for [`ParameterSpec`].
 #[derive(Debug)]
-pub struct ParameterSpecBuilder<L: CodeLang> {
+pub struct ParameterSpecBuilder {
     name: String,
-    param_type: TypeName<L>,
-    default_value: Option<crate::code_block::CodeBlock<L>>,
+    param_type: TypeName,
+    default_value: Option<crate::code_block::CodeBlock>,
     is_variadic: bool,
 }
 
-impl<L: CodeLang> ParameterSpecBuilder<L> {
+impl ParameterSpecBuilder {
     /// Set the default value for this parameter.
-    pub fn default_value(&mut self, value: crate::code_block::CodeBlock<L>) -> &mut Self {
+    pub fn default_value(mut self, value: crate::code_block::CodeBlock) -> Self {
         self.default_value = Some(value);
         self
     }
 
     /// Mark this parameter as variadic.
-    pub fn variadic(&mut self) -> &mut Self {
+    pub fn variadic(mut self) -> Self {
         self.is_variadic = true;
         self
     }
@@ -129,7 +134,7 @@ impl<L: CodeLang> ParameterSpecBuilder<L> {
     /// # Errors
     ///
     /// Returns [`SigilStitchError::EmptyName`](crate::error::SigilStitchError::EmptyName) if `name` is empty.
-    pub fn build(self) -> Result<ParameterSpec<L>, crate::error::SigilStitchError> {
+    pub fn build(self) -> Result<ParameterSpec, crate::error::SigilStitchError> {
         snafu::ensure!(
             !self.name.is_empty(),
             crate::error::EmptyNameSnafu {
@@ -151,9 +156,9 @@ mod tests {
     use crate::code_block::CodeBlock;
     use crate::lang::typescript::TypeScript;
 
-    fn emit_param(spec: &ParameterSpec<TypeScript>) -> String {
+    fn emit_param(spec: &ParameterSpec) -> String {
         let lang = TypeScript::new();
-        let mut cb = CodeBlock::<TypeScript>::builder();
+        let mut cb = CodeBlock::builder();
         spec.emit_into(&mut cb, &lang);
         // Build and render the parts to a simple string for testing.
         let block = cb.build().unwrap();
@@ -165,34 +170,35 @@ mod tests {
 
     #[test]
     fn test_simple_param() {
-        let param = ParameterSpec::<TypeScript>::new("id", TypeName::primitive("string")).unwrap();
+        let param = ParameterSpec::new("id", TypeName::primitive("string")).unwrap();
         let output = emit_param(&param);
         assert_eq!(output, "id: string");
     }
 
     #[test]
     fn test_variadic_param() {
-        let mut pb = ParameterSpec::builder("args", TypeName::<TypeScript>::primitive("string"));
-        pb.variadic();
-        let param = pb.build().unwrap();
+        let param = ParameterSpec::builder("args", TypeName::primitive("string"))
+            .variadic()
+            .build()
+            .unwrap();
         let output = emit_param(&param);
         assert_eq!(output, "...args: string");
     }
 
     #[test]
     fn test_param_with_default() {
-        let default = CodeBlock::<TypeScript>::of("0", ()).unwrap();
-        let mut pb = ParameterSpec::builder("count", TypeName::<TypeScript>::primitive("number"));
-        pb.default_value(default);
-        let param = pb.build().unwrap();
+        let default = CodeBlock::of("0", ()).unwrap();
+        let param = ParameterSpec::builder("count", TypeName::primitive("number"))
+            .default_value(default)
+            .build()
+            .unwrap();
         let output = emit_param(&param);
         assert_eq!(output, "count: number = 0");
     }
 
     #[test]
     fn test_build_empty_name_errors() {
-        let result =
-            ParameterSpec::builder("", TypeName::<TypeScript>::primitive("string")).build();
+        let result = ParameterSpec::builder("", TypeName::primitive("string")).build();
         assert!(result.is_err());
         assert!(
             result

--- a/src/spec/project_spec.rs
+++ b/src/spec/project_spec.rs
@@ -5,7 +5,6 @@
 //! to the filesystem.
 
 use crate::error::SigilStitchError;
-use crate::lang::CodeLang;
 use crate::spec::file_spec::FileSpec;
 
 /// A rendered file produced by [`ProjectSpec::render()`]: path and content pair.
@@ -29,31 +28,30 @@ pub struct RenderedFile {
 /// use sigil_stitch::prelude::*;
 /// use sigil_stitch::lang::typescript::TypeScript;
 ///
-/// let mut models_b = FileSpec::<TypeScript>::builder("src/models.ts");
-/// models_b.add_type(TypeSpec::builder("User", TypeKind::Interface).build().unwrap());
-/// let models = models_b.build().unwrap();
+/// let models = FileSpec::builder("src/models.ts")
+///     .add_type(TypeSpec::builder("User", TypeKind::Interface).build().unwrap())
+///     .build().unwrap();
 ///
-/// let mut index_b = FileSpec::<TypeScript>::builder("src/index.ts");
-/// index_b.add_code(CodeBlock::of("export {}", ()).unwrap());
-/// let index = index_b.build().unwrap();
+/// let index = FileSpec::builder("src/index.ts")
+///     .add_code(CodeBlock::of("export {}", ()).unwrap())
+///     .build().unwrap();
 ///
-/// let mut pb = ProjectSpec::<TypeScript>::builder();
-/// pb.add_file(models);
-/// pb.add_file(index);
-/// let project = pb.build();
+/// let project = ProjectSpec::builder()
+///     .add_file(models)
+///     .add_file(index)
+///     .build();
 ///
 /// let rendered = project.render(80).unwrap();
 /// assert_eq!(rendered.len(), 2);
 /// ```
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-#[serde(bound(serialize = "", deserialize = "L: Default"))]
-pub struct ProjectSpec<L: CodeLang> {
-    pub(crate) files: Vec<FileSpec<L>>,
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub struct ProjectSpec {
+    pub(crate) files: Vec<FileSpec>,
 }
 
-impl<L: CodeLang> ProjectSpec<L> {
+impl ProjectSpec {
     /// Create a new builder for a project specification.
-    pub fn builder() -> ProjectSpecBuilder<L> {
+    pub fn builder() -> ProjectSpecBuilder {
         ProjectSpecBuilder { files: Vec::new() }
     }
 
@@ -104,19 +102,19 @@ impl<L: CodeLang> ProjectSpec<L> {
 
 /// Builder for [`ProjectSpec`].
 #[derive(Debug)]
-pub struct ProjectSpecBuilder<L: CodeLang> {
-    files: Vec<FileSpec<L>>,
+pub struct ProjectSpecBuilder {
+    files: Vec<FileSpec>,
 }
 
-impl<L: CodeLang> ProjectSpecBuilder<L> {
+impl ProjectSpecBuilder {
     /// Add a file to the project.
-    pub fn add_file(&mut self, file: FileSpec<L>) -> &mut Self {
+    pub fn add_file(mut self, file: FileSpec) -> Self {
         self.files.push(file);
         self
     }
 
     /// Build the [`ProjectSpec`].
-    pub fn build(self) -> ProjectSpec<L> {
+    pub fn build(self) -> ProjectSpec {
         ProjectSpec { files: self.files }
     }
 }

--- a/src/spec/property_spec.rs
+++ b/src/spec/property_spec.rs
@@ -117,19 +117,19 @@ impl PropertySpec {
             sig.push_str("()");
 
             if !self.property_type.is_empty() {
-                sig.push_str(lang.return_type_separator());
+                sig.push_str(lang.function_syntax().return_type_separator);
                 sig.push_str("%T");
                 sig_args.push(Arg::TypeName(self.property_type.clone()));
             }
 
-            sig.push_str(lang.block_open());
+            sig.push_str(lang.block_syntax().block_open);
             cb.add(&sig, sig_args);
             cb.add_line();
             cb.add("%>", ());
             cb.add_code(getter_body.clone());
             cb.add_line();
             cb.add("%<", ());
-            let close = lang.block_close();
+            let close = lang.block_syntax().block_close;
             if !close.is_empty() {
                 cb.add(close, ());
                 cb.add_line();
@@ -156,20 +156,20 @@ impl PropertySpec {
             sig.push_str(&lang.escape_reserved(&setter.param_name));
 
             if !self.property_type.is_empty() {
-                sig.push_str(lang.type_annotation_separator());
+                sig.push_str(lang.type_decl_syntax().type_annotation_separator);
                 sig.push_str("%T");
                 sig_args.push(Arg::TypeName(self.property_type.clone()));
             }
 
             sig.push(')');
-            sig.push_str(lang.block_open());
+            sig.push_str(lang.block_syntax().block_open);
             cb.add(&sig, sig_args);
             cb.add_line();
             cb.add("%>", ());
             cb.add_code(setter.body.clone());
             cb.add_line();
             cb.add("%<", ());
-            let close = lang.block_close();
+            let close = lang.block_syntax().block_close;
             if !close.is_empty() {
                 cb.add(close, ());
                 cb.add_line();
@@ -205,20 +205,20 @@ impl PropertySpec {
         }
 
         if has_setter {
-            sig.push_str(lang.mutable_field_keyword());
+            sig.push_str(lang.enum_and_annotation().mutable_field_keyword);
         } else {
-            sig.push_str(lang.readonly_keyword());
+            sig.push_str(lang.enum_and_annotation().readonly_keyword);
         }
 
         sig.push_str(&lang.escape_reserved(&self.name));
 
         if !self.property_type.is_empty() {
-            sig.push_str(lang.type_annotation_separator());
+            sig.push_str(lang.type_decl_syntax().type_annotation_separator);
             sig.push_str("%T");
             sig_args.push(Arg::TypeName(self.property_type.clone()));
         }
 
-        sig.push_str(lang.block_open());
+        sig.push_str(lang.block_syntax().block_open);
         cb.add(&sig, sig_args);
         cb.add_line();
         cb.add("%>", ());
@@ -226,14 +226,14 @@ impl PropertySpec {
         // Getter block.
         if let Some(getter_body) = &self.getter {
             let getter_kw = lang.property_getter_keyword();
-            let getter_sig = format!("{getter_kw}{}", lang.block_open());
+            let getter_sig = format!("{getter_kw}{}", lang.block_syntax().block_open);
             cb.add(&getter_sig, ());
             cb.add_line();
             cb.add("%>", ());
             cb.add_code(getter_body.clone());
             cb.add_line();
             cb.add("%<", ());
-            let close = lang.block_close();
+            let close = lang.block_syntax().block_close;
             if !close.is_empty() {
                 cb.add(close, ());
                 cb.add_line();
@@ -242,14 +242,18 @@ impl PropertySpec {
 
         // Setter block.
         if let Some(setter) = &self.setter {
-            let setter_sig = format!("set({}){}", setter.param_name, lang.block_open());
+            let setter_sig = format!(
+                "set({}){}",
+                setter.param_name,
+                lang.block_syntax().block_open
+            );
             cb.add(&setter_sig, ());
             cb.add_line();
             cb.add("%>", ());
             cb.add_code(setter.body.clone());
             cb.add_line();
             cb.add("%<", ());
-            let close = lang.block_close();
+            let close = lang.block_syntax().block_close;
             if !close.is_empty() {
                 cb.add(close, ());
                 cb.add_line();
@@ -257,7 +261,7 @@ impl PropertySpec {
         }
 
         cb.add("%<", ());
-        let close = lang.block_close();
+        let close = lang.block_syntax().block_close;
         if !close.is_empty() {
             cb.add(close, ());
             cb.add_line();

--- a/src/spec/property_spec.rs
+++ b/src/spec/property_spec.rs
@@ -13,10 +13,9 @@ use crate::type_name::TypeName;
 
 /// A setter definition: parameter name + body.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-#[serde(bound = "")]
-pub struct SetterSpec<L: CodeLang> {
+pub struct SetterSpec {
     pub(crate) param_name: String,
-    pub(crate) body: CodeBlock<L>,
+    pub(crate) body: CodeBlock,
 }
 
 /// A computed property with optional getter and setter.
@@ -37,28 +36,27 @@ pub struct SetterSpec<L: CodeLang> {
 /// use sigil_stitch::spec::property_spec::PropertySpec;
 /// use sigil_stitch::lang::typescript::TypeScript;
 ///
-/// let getter_body = CodeBlock::<TypeScript>::of("return this._name", ()).unwrap();
+/// let getter_body = CodeBlock::of("return this._name", ()).unwrap();
 ///
-/// let mut pb = PropertySpec::builder("name", TypeName::<TypeScript>::primitive("string"));
-/// pb.getter(getter_body);
-/// let prop = pb.build().unwrap();
+/// let prop = PropertySpec::builder("name", TypeName::primitive("string"))
+///     .getter(getter_body)
+///     .build().unwrap();
 /// ```
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-#[serde(bound = "")]
-pub struct PropertySpec<L: CodeLang> {
+pub struct PropertySpec {
     pub(crate) name: String,
-    pub(crate) property_type: TypeName<L>,
+    pub(crate) property_type: TypeName,
     pub(crate) modifiers: Modifiers,
     pub(crate) doc: Vec<String>,
-    pub(crate) getter: Option<CodeBlock<L>>,
-    pub(crate) setter: Option<SetterSpec<L>>,
-    pub(crate) annotations: Vec<CodeBlock<L>>,
-    pub(crate) annotation_specs: Vec<AnnotationSpec<L>>,
+    pub(crate) getter: Option<CodeBlock>,
+    pub(crate) setter: Option<SetterSpec>,
+    pub(crate) annotations: Vec<CodeBlock>,
+    pub(crate) annotation_specs: Vec<AnnotationSpec>,
 }
 
-impl<L: CodeLang> PropertySpec<L> {
+impl PropertySpec {
     /// Create a new builder for a property with the given name and type.
-    pub fn builder(name: &str, property_type: TypeName<L>) -> PropertySpecBuilder<L> {
+    pub fn builder(name: &str, property_type: TypeName) -> PropertySpecBuilder {
         PropertySpecBuilder {
             name: name.to_string(),
             property_type,
@@ -82,9 +80,9 @@ impl<L: CodeLang> PropertySpec<L> {
     /// Field style returns 1 block (field with inline body).
     pub fn emit(
         &self,
-        lang: &L,
+        lang: &dyn CodeLang,
         ctx: DeclarationContext,
-    ) -> Result<Vec<CodeBlock<L>>, crate::error::SigilStitchError> {
+    ) -> Result<Vec<CodeBlock>, crate::error::SigilStitchError> {
         match lang.property_style() {
             PropertyStyle::Accessor => self.emit_accessor(lang, ctx),
             PropertyStyle::Field => self.emit_field(lang, ctx),
@@ -94,13 +92,13 @@ impl<L: CodeLang> PropertySpec<L> {
     /// Emit as accessor methods: `get name(): T { ... }` / `set name(v: T) { ... }`.
     fn emit_accessor(
         &self,
-        lang: &L,
+        lang: &dyn CodeLang,
         ctx: DeclarationContext,
-    ) -> Result<Vec<CodeBlock<L>>, crate::error::SigilStitchError> {
+    ) -> Result<Vec<CodeBlock>, crate::error::SigilStitchError> {
         let mut blocks = Vec::new();
 
         if let Some(getter_body) = &self.getter {
-            let mut cb = CodeBlock::<L>::builder();
+            let mut cb = CodeBlock::builder();
 
             // Annotations + doc on the getter.
             self.emit_preamble(&mut cb, lang)?;
@@ -108,7 +106,7 @@ impl<L: CodeLang> PropertySpec<L> {
             // Signature: [vis] get [name]()[return_type_sep][type][block_open]
             let vis = lang.render_visibility(self.modifiers.visibility, ctx);
             let mut sig = String::new();
-            let mut sig_args: Vec<Arg<L>> = Vec::new();
+            let mut sig_args: Vec<Arg> = Vec::new();
 
             sig.push_str(vis);
             if self.modifiers.is_static {
@@ -141,12 +139,12 @@ impl<L: CodeLang> PropertySpec<L> {
         }
 
         if let Some(setter) = &self.setter {
-            let mut cb = CodeBlock::<L>::builder();
+            let mut cb = CodeBlock::builder();
 
             // Setter signature: [vis] set [name]([param][sep][type])[block_open]
             let vis = lang.render_visibility(self.modifiers.visibility, ctx);
             let mut sig = String::new();
-            let mut sig_args: Vec<Arg<L>> = Vec::new();
+            let mut sig_args: Vec<Arg> = Vec::new();
 
             sig.push_str(vis);
             if self.modifiers.is_static {
@@ -186,10 +184,10 @@ impl<L: CodeLang> PropertySpec<L> {
     /// Emit as a field with inline getter/setter body (Swift/Kotlin).
     fn emit_field(
         &self,
-        lang: &L,
+        lang: &dyn CodeLang,
         ctx: DeclarationContext,
-    ) -> Result<Vec<CodeBlock<L>>, crate::error::SigilStitchError> {
-        let mut cb = CodeBlock::<L>::builder();
+    ) -> Result<Vec<CodeBlock>, crate::error::SigilStitchError> {
+        let mut cb = CodeBlock::builder();
 
         // Annotations + doc.
         self.emit_preamble(&mut cb, lang)?;
@@ -199,7 +197,7 @@ impl<L: CodeLang> PropertySpec<L> {
         let has_setter = self.setter.is_some();
 
         let mut sig = String::new();
-        let mut sig_args: Vec<Arg<L>> = Vec::new();
+        let mut sig_args: Vec<Arg> = Vec::new();
 
         sig.push_str(vis);
         if self.modifiers.is_static {
@@ -271,8 +269,8 @@ impl<L: CodeLang> PropertySpec<L> {
     /// Emit annotations and doc comment as a preamble.
     fn emit_preamble(
         &self,
-        cb: &mut crate::code_block::CodeBlockBuilder<L>,
-        lang: &L,
+        cb: &mut crate::code_block::CodeBlockBuilder,
+        lang: &dyn CodeLang,
     ) -> Result<(), crate::error::SigilStitchError> {
         let emit_doc = || -> Option<String> {
             if self.doc.is_empty() || lang.doc_comment_inside_body() {
@@ -311,26 +309,26 @@ impl<L: CodeLang> PropertySpec<L> {
 
 /// Builder for [`PropertySpec`].
 #[derive(Debug)]
-pub struct PropertySpecBuilder<L: CodeLang> {
+pub struct PropertySpecBuilder {
     name: String,
-    property_type: TypeName<L>,
+    property_type: TypeName,
     modifiers: Modifiers,
     doc: Vec<String>,
-    getter: Option<CodeBlock<L>>,
-    setter: Option<SetterSpec<L>>,
-    annotations: Vec<CodeBlock<L>>,
-    annotation_specs: Vec<AnnotationSpec<L>>,
+    getter: Option<CodeBlock>,
+    setter: Option<SetterSpec>,
+    annotations: Vec<CodeBlock>,
+    annotation_specs: Vec<AnnotationSpec>,
 }
 
-impl<L: CodeLang> PropertySpecBuilder<L> {
+impl PropertySpecBuilder {
     /// Set the getter body.
-    pub fn getter(&mut self, body: CodeBlock<L>) -> &mut Self {
+    pub fn getter(mut self, body: CodeBlock) -> Self {
         self.getter = Some(body);
         self
     }
 
     /// Set the setter parameter name and body.
-    pub fn setter(&mut self, param_name: &str, body: CodeBlock<L>) -> &mut Self {
+    pub fn setter(mut self, param_name: &str, body: CodeBlock) -> Self {
         self.setter = Some(SetterSpec {
             param_name: param_name.to_string(),
             body,
@@ -339,31 +337,31 @@ impl<L: CodeLang> PropertySpecBuilder<L> {
     }
 
     /// Set the visibility.
-    pub fn visibility(&mut self, vis: Visibility) -> &mut Self {
+    pub fn visibility(mut self, vis: Visibility) -> Self {
         self.modifiers.visibility = vis;
         self
     }
 
     /// Mark this property as static.
-    pub fn is_static(&mut self) -> &mut Self {
+    pub fn is_static(mut self) -> Self {
         self.modifiers.is_static = true;
         self
     }
 
     /// Add a doc comment line.
-    pub fn doc(&mut self, line: &str) -> &mut Self {
+    pub fn doc(mut self, line: &str) -> Self {
         self.doc.push(line.to_string());
         self
     }
 
     /// Add a raw annotation code block.
-    pub fn annotation(&mut self, ann: CodeBlock<L>) -> &mut Self {
+    pub fn annotation(mut self, ann: CodeBlock) -> Self {
         self.annotations.push(ann);
         self
     }
 
     /// Add a structured annotation.
-    pub fn annotate(&mut self, spec: AnnotationSpec<L>) -> &mut Self {
+    pub fn annotate(mut self, spec: AnnotationSpec) -> Self {
         self.annotation_specs.push(spec);
         self
     }
@@ -373,7 +371,7 @@ impl<L: CodeLang> PropertySpecBuilder<L> {
     /// # Errors
     ///
     /// Returns [`SigilStitchError::EmptyName`](crate::error::SigilStitchError::EmptyName) if `name` is empty.
-    pub fn build(self) -> Result<PropertySpec<L>, crate::error::SigilStitchError> {
+    pub fn build(self) -> Result<PropertySpec, crate::error::SigilStitchError> {
         snafu::ensure!(
             !self.name.is_empty(),
             crate::error::EmptyNameSnafu {
@@ -396,11 +394,10 @@ impl<L: CodeLang> PropertySpecBuilder<L> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::lang::typescript::TypeScript;
 
     #[test]
     fn test_build_empty_name_errors() {
-        let result = PropertySpec::builder("", TypeName::<TypeScript>::primitive("string")).build();
+        let result = PropertySpec::builder("", TypeName::primitive("string")).build();
         assert!(result.is_err());
         assert!(
             result

--- a/src/spec/type_spec.rs
+++ b/src/spec/type_spec.rs
@@ -198,10 +198,11 @@ impl TypeSpec {
             cb.add_line();
         }
         cb.add("%<", ());
-        let close = lang.block_close();
+        let block_syn = lang.block_syntax();
+        let close = block_syn.block_close;
         let type_close_suffix = self.render_impl_type_suffix(lang);
         if !close.is_empty() {
-            let term = lang.type_close_terminator();
+            let term = block_syn.type_close_terminator;
             cb.add(&format!("{close}{term}"), ());
             if !type_close_suffix.is_empty() {
                 cb.add("%L", type_close_suffix);
@@ -259,10 +260,11 @@ impl TypeSpec {
             cb.add_line();
         }
         cb.add("%<", ());
-        let close = lang.block_close();
+        let block_syn = lang.block_syntax();
+        let close = block_syn.block_close;
         let type_close_suffix = self.render_impl_type_suffix(lang);
         if !close.is_empty() {
-            let term = lang.type_close_terminator();
+            let term = block_syn.type_close_terminator;
             cb.add(&format!("{close}{term}"), ());
             if !type_close_suffix.is_empty() {
                 cb.add("%L", type_close_suffix);
@@ -286,23 +288,24 @@ impl TypeSpec {
             impl_fmt.push(' ');
             impl_fmt.push_str(&self.name);
             // Repeat bare type param names.
+            let gen_syn = lang.generic_syntax();
             if !self.type_params.is_empty() {
-                impl_fmt.push_str(lang.generic_open());
+                impl_fmt.push_str(gen_syn.open);
                 for (i, tp) in self.type_params.iter().enumerate() {
                     if i > 0 {
                         impl_fmt.push_str(", ");
                     }
                     impl_fmt.push_str(&tp.name);
                 }
-                impl_fmt.push_str(lang.generic_close());
+                impl_fmt.push_str(gen_syn.close);
             }
             // Where clause on impl block.
             if !self.where_constraints.is_empty()
-                && lang.where_clause_style() == WhereClauseStyle::WhereBlock
+                && lang.function_syntax().where_clause_style == WhereClauseStyle::WhereBlock
             {
                 emit_where_block(&mut impl_fmt, &mut impl_args, &self.where_constraints, lang);
             }
-            impl_fmt.push_str(lang.block_open());
+            impl_fmt.push_str(lang.block_syntax().block_open);
             impl_cb.add(&impl_fmt, impl_args);
             impl_cb.add_line();
 
@@ -326,7 +329,7 @@ impl TypeSpec {
                 impl_cb.add_code(method.emit(lang, DeclarationContext::Member)?);
             }
             impl_cb.add("%<", ());
-            let close = lang.block_close();
+            let close = lang.block_syntax().block_close;
             if !close.is_empty() {
                 impl_cb.add(close, ());
                 impl_cb.add_line();
@@ -358,9 +361,13 @@ impl TypeSpec {
             .cloned()
             .unwrap_or_else(|| TypeName::primitive(""));
 
-        let semi = if lang.uses_semicolons() { ";" } else { "" };
+        let semi = if lang.block_syntax().uses_semicolons {
+            ";"
+        } else {
+            ""
+        };
 
-        let fmt = if lang.type_alias_target_first() {
+        let fmt = if lang.type_decl_syntax().type_alias_target_first {
             // C typedef: `typedef target name;`
             args.push(Arg::TypeName(target));
             format!("{kw} %T {}{tp_str}{semi}", self.name)
@@ -417,10 +424,11 @@ impl TypeSpec {
         cb: &mut CodeBlockBuilder,
         lang: &dyn CodeLang,
     ) -> Result<(), crate::error::SigilStitchError> {
-        let sep = lang.enum_variant_separator();
-        let trailing = lang.enum_variant_trailing_separator();
+        let ea = lang.enum_and_annotation();
+        let sep = ea.variant_separator;
+        let trailing = ea.variant_trailing_separator;
         let count = self.variants.len();
-        let field_term = lang.field_terminator();
+        let field_term = lang.block_syntax().field_terminator;
 
         for (i, variant) in self.variants.iter().enumerate() {
             // Emit variant parts directly here rather than calling variant.emit(),
@@ -457,9 +465,9 @@ impl TypeSpec {
             }
 
             let prefix = if i == 0 {
-                lang.enum_variant_prefix_first()
+                ea.variant_prefix_first.unwrap_or(ea.variant_prefix)
             } else {
-                lang.enum_variant_prefix()
+                ea.variant_prefix
             };
             let mut fmt = String::new();
             let mut args: Vec<Arg> = Vec::new();
@@ -496,7 +504,8 @@ impl TypeSpec {
                     let mut f_fmt = String::new();
                     let mut f_args: Vec<Arg> = Vec::new();
                     f_fmt.push_str(vis);
-                    if lang.type_before_name() {
+                    let tds = lang.type_decl_syntax();
+                    if tds.type_before_name {
                         if !field.field_type.is_empty() {
                             f_fmt.push_str("%T");
                             f_args.push(Arg::TypeName(field.field_type.clone()));
@@ -506,7 +515,7 @@ impl TypeSpec {
                     } else {
                         f_fmt.push_str(&field.name);
                         if !field.field_type.is_empty() {
-                            let type_sep = lang.type_annotation_separator();
+                            let type_sep = tds.type_annotation_separator;
                             f_fmt.push_str(type_sep);
                             f_fmt.push_str("%T");
                             f_args.push(Arg::TypeName(field.field_type.clone()));
@@ -621,8 +630,10 @@ impl TypeSpec {
         let tp_str = render_type_params(&self.type_params, lang, &mut args);
         fmt.push_str(&tp_str);
 
+        let tds = lang.type_decl_syntax();
+
         // Primary constructor parameters (Kotlin: `class Foo(val x: Int, val y: String)`).
-        if !self.primary_constructor.is_empty() && lang.supports_primary_constructor() {
+        if !self.primary_constructor.is_empty() && tds.supports_primary_constructor {
             fmt.push('(');
             fmt.push_str("%L");
             let params_block = self.build_primary_constructor_block(lang)?;
@@ -632,11 +643,11 @@ impl TypeSpec {
 
         // Super types (extends).
         if !self.super_types.is_empty() {
-            let super_kw = lang.super_type_keyword();
+            let super_kw = tds.super_type_keyword;
             if !super_kw.is_empty() {
                 fmt.push_str(super_kw);
-                let sep = lang.super_type_separator();
-                let subsequent_sep = lang.super_type_subsequent_separator();
+                let sep = tds.super_type_separator;
+                let subsequent_sep = tds.super_type_subsequent_separator;
                 for (i, st) in self.super_types.iter().enumerate() {
                     if i > 0 {
                         fmt.push_str(subsequent_sep.unwrap_or(sep));
@@ -649,7 +660,7 @@ impl TypeSpec {
 
         // Implements.
         if !self.impl_types.is_empty() {
-            let impl_kw = lang.implements_keyword();
+            let impl_kw = tds.implements_keyword;
             if !impl_kw.is_empty() {
                 fmt.push_str(impl_kw);
                 for (i, it) in self.impl_types.iter().enumerate() {
@@ -671,7 +682,7 @@ impl TypeSpec {
 
         // Close bases list (e.g., Python: ")").
         if !self.super_types.is_empty() || !self.impl_types.is_empty() {
-            let bases_close = lang.bases_close();
+            let bases_close = lang.block_syntax().bases_close;
             if !bases_close.is_empty() {
                 fmt.push_str(bases_close);
             }
@@ -679,7 +690,7 @@ impl TypeSpec {
 
         // Where clause (Rust-style).
         if !self.where_constraints.is_empty()
-            && lang.where_clause_style() == WhereClauseStyle::WhereBlock
+            && lang.function_syntax().where_clause_style == WhereClauseStyle::WhereBlock
         {
             emit_where_block(&mut fmt, &mut args, &self.where_constraints, lang);
         }

--- a/src/spec/type_spec.rs
+++ b/src/spec/type_spec.rs
@@ -30,45 +30,46 @@ use crate::type_name::TypeName;
 /// use sigil_stitch::prelude::*;
 /// use sigil_stitch::lang::typescript::TypeScript;
 ///
-/// let mut tb = TypeSpec::<TypeScript>::builder("UserService", TypeKind::Class);
-/// tb.visibility(Visibility::Public);
-/// tb.add_field(
-///     FieldSpec::builder("name", TypeName::primitive("string")).build().unwrap(),
-/// );
-/// let body = CodeBlock::<TypeScript>::of("return this.name", ()).unwrap();
-/// let mut fb = FunSpec::builder("getName");
-/// fb.returns(TypeName::primitive("string"));
-/// fb.body(body);
-/// tb.add_method(fb.build().unwrap());
-/// let type_spec = tb.build().unwrap();
+/// let body = CodeBlock::of("return this.name", ()).unwrap();
+/// let type_spec = TypeSpec::builder("UserService", TypeKind::Class)
+///     .visibility(Visibility::Public)
+///     .add_field(
+///         FieldSpec::builder("name", TypeName::primitive("string")).build().unwrap(),
+///     )
+///     .add_method(
+///         FunSpec::builder("getName")
+///             .returns(TypeName::primitive("string"))
+///             .body(body)
+///             .build().unwrap(),
+///     )
+///     .build().unwrap();
 /// ```
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-#[serde(bound = "")]
-pub struct TypeSpec<L: CodeLang> {
+pub struct TypeSpec {
     pub(crate) name: String,
     pub(crate) kind: TypeKind,
     pub(crate) modifiers: Modifiers,
     pub(crate) doc: Vec<String>,
-    pub(crate) fields: Vec<FieldSpec<L>>,
-    pub(crate) properties: Vec<PropertySpec<L>>,
-    pub(crate) methods: Vec<FunSpec<L>>,
-    pub(crate) type_params: Vec<TypeParamSpec<L>>,
-    pub(crate) super_types: Vec<TypeName<L>>,
-    pub(crate) impl_types: Vec<TypeName<L>>,
-    pub(crate) annotations: Vec<CodeBlock<L>>,
-    pub(crate) annotation_specs: Vec<AnnotationSpec<L>>,
-    pub(crate) extra_members: Vec<CodeBlock<L>>,
-    pub(crate) variants: Vec<EnumVariantSpec<L>>,
+    pub(crate) fields: Vec<FieldSpec>,
+    pub(crate) properties: Vec<PropertySpec>,
+    pub(crate) methods: Vec<FunSpec>,
+    pub(crate) type_params: Vec<TypeParamSpec>,
+    pub(crate) super_types: Vec<TypeName>,
+    pub(crate) impl_types: Vec<TypeName>,
+    pub(crate) annotations: Vec<CodeBlock>,
+    pub(crate) annotation_specs: Vec<AnnotationSpec>,
+    pub(crate) extra_members: Vec<CodeBlock>,
+    pub(crate) variants: Vec<EnumVariantSpec>,
     /// Primary constructor parameters (Kotlin: `class Foo(val x: Int, val y: String)`).
-    pub(crate) primary_constructor: Vec<ParameterSpec<L>>,
+    pub(crate) primary_constructor: Vec<ParameterSpec>,
     /// Where-clause constraints (e.g., Rust `where T: Clone + Send`).
     #[serde(default)]
-    pub(crate) where_constraints: Vec<WhereConstraint<L>>,
+    pub(crate) where_constraints: Vec<WhereConstraint>,
 }
 
-impl<L: CodeLang> TypeSpec<L> {
+impl TypeSpec {
     /// Create a new builder for a type declaration with the given name and kind.
-    pub fn builder(name: &str, kind: TypeKind) -> TypeSpecBuilder<L> {
+    pub fn builder(name: &str, kind: TypeKind) -> TypeSpecBuilder {
         TypeSpecBuilder {
             name: name.to_string(),
             kind,
@@ -103,7 +104,10 @@ impl<L: CodeLang> TypeSpec<L> {
     ///
     /// Returns a `Vec` because Rust struct + impl = two separate blocks,
     /// while TypeScript class = one block.
-    pub fn emit(&self, lang: &L) -> Result<Vec<CodeBlock<L>>, crate::error::SigilStitchError> {
+    pub fn emit(
+        &self,
+        lang: &dyn CodeLang,
+    ) -> Result<Vec<CodeBlock>, crate::error::SigilStitchError> {
         match self.kind {
             TypeKind::TypeAlias => return Ok(vec![self.emit_type_alias(lang)?]),
             TypeKind::Newtype => return Ok(vec![self.emit_newtype(lang)?]),
@@ -117,8 +121,11 @@ impl<L: CodeLang> TypeSpec<L> {
     }
 
     /// Emit as a single block with methods inside the body (TypeScript class/interface, Rust trait).
-    fn emit_inline(&self, lang: &L) -> Result<CodeBlock<L>, crate::error::SigilStitchError> {
-        let mut cb = CodeBlock::<L>::builder();
+    fn emit_inline(
+        &self,
+        lang: &dyn CodeLang,
+    ) -> Result<CodeBlock, crate::error::SigilStitchError> {
+        let mut cb = CodeBlock::builder();
 
         self.emit_preamble(&mut cb, lang)?;
         self.emit_header(&mut cb, lang)?;
@@ -209,11 +216,14 @@ impl<L: CodeLang> TypeSpec<L> {
     }
 
     /// Emit as separate struct + impl blocks (Rust struct/enum).
-    fn emit_split(&self, lang: &L) -> Result<Vec<CodeBlock<L>>, crate::error::SigilStitchError> {
+    fn emit_split(
+        &self,
+        lang: &dyn CodeLang,
+    ) -> Result<Vec<CodeBlock>, crate::error::SigilStitchError> {
         let mut blocks = Vec::new();
 
         // Block 1: struct/enum definition.
-        let mut cb = CodeBlock::<L>::builder();
+        let mut cb = CodeBlock::builder();
         self.emit_preamble(&mut cb, lang)?;
         self.emit_header(&mut cb, lang)?;
 
@@ -266,9 +276,9 @@ impl<L: CodeLang> TypeSpec<L> {
 
         // Block 2: impl block (only if methods or properties are non-empty).
         if !self.methods.is_empty() || !self.properties.is_empty() {
-            let mut impl_cb = CodeBlock::<L>::builder();
+            let mut impl_cb = CodeBlock::builder();
             let mut impl_fmt = String::from("impl");
-            let mut impl_args: Vec<Arg<L>> = Vec::new();
+            let mut impl_args: Vec<Arg> = Vec::new();
 
             // Type params on impl.
             let tp_str = render_type_params(&self.type_params, lang, &mut impl_args);
@@ -329,9 +339,12 @@ impl<L: CodeLang> TypeSpec<L> {
     }
 
     /// Emit a type alias declaration: `type Name = Target;`.
-    fn emit_type_alias(&self, lang: &L) -> Result<CodeBlock<L>, crate::error::SigilStitchError> {
-        let mut cb = CodeBlock::<L>::builder();
-        let mut args: Vec<Arg<L>> = Vec::new();
+    fn emit_type_alias(
+        &self,
+        lang: &dyn CodeLang,
+    ) -> Result<CodeBlock, crate::error::SigilStitchError> {
+        let mut cb = CodeBlock::builder();
+        let mut args: Vec<Arg> = Vec::new();
 
         self.emit_preamble(&mut cb, lang)?;
 
@@ -363,8 +376,11 @@ impl<L: CodeLang> TypeSpec<L> {
     }
 
     /// Emit a newtype wrapper declaration.
-    fn emit_newtype(&self, lang: &L) -> Result<CodeBlock<L>, crate::error::SigilStitchError> {
-        let mut cb = CodeBlock::<L>::builder();
+    fn emit_newtype(
+        &self,
+        lang: &dyn CodeLang,
+    ) -> Result<CodeBlock, crate::error::SigilStitchError> {
+        let mut cb = CodeBlock::builder();
 
         self.emit_preamble(&mut cb, lang)?;
 
@@ -378,7 +394,7 @@ impl<L: CodeLang> TypeSpec<L> {
         let resolve = |_module: &str, name: &str| name.to_string();
         let inner_str = target.render(80, &resolve).unwrap_or_default();
 
-        let mut tp_args: Vec<Arg<L>> = Vec::new();
+        let mut tp_args: Vec<Arg> = Vec::new();
         let tp_str = render_type_params(&self.type_params, lang, &mut tp_args);
         let name_with_params = format!("{}{tp_str}", self.name);
 
@@ -398,8 +414,8 @@ impl<L: CodeLang> TypeSpec<L> {
     /// Emit enum variants with language-aware separators.
     fn emit_variants(
         &self,
-        cb: &mut CodeBlockBuilder<L>,
-        lang: &L,
+        cb: &mut CodeBlockBuilder,
+        lang: &dyn CodeLang,
     ) -> Result<(), crate::error::SigilStitchError> {
         let sep = lang.enum_variant_separator();
         let trailing = lang.enum_variant_trailing_separator();
@@ -446,7 +462,7 @@ impl<L: CodeLang> TypeSpec<L> {
                 lang.enum_variant_prefix()
             };
             let mut fmt = String::new();
-            let mut args: Vec<Arg<L>> = Vec::new();
+            let mut args: Vec<Arg> = Vec::new();
             fmt.push_str(prefix);
             fmt.push_str(&variant.name);
 
@@ -478,7 +494,7 @@ impl<L: CodeLang> TypeSpec<L> {
                         crate::spec::modifiers::DeclarationContext::Member,
                     );
                     let mut f_fmt = String::new();
-                    let mut f_args: Vec<Arg<L>> = Vec::new();
+                    let mut f_args: Vec<Arg> = Vec::new();
                     f_fmt.push_str(vis);
                     if lang.type_before_name() {
                         if !field.field_type.is_empty() {
@@ -527,7 +543,7 @@ impl<L: CodeLang> TypeSpec<L> {
     }
 
     /// Render impl_types to strings and pass them to `lang.render_type_close_suffix()`.
-    fn render_impl_type_suffix(&self, lang: &L) -> String {
+    fn render_impl_type_suffix(&self, lang: &dyn CodeLang) -> String {
         if self.impl_types.is_empty() {
             let empty: Vec<String> = Vec::new();
             return lang.render_type_close_suffix(self.kind, &empty);
@@ -544,8 +560,8 @@ impl<L: CodeLang> TypeSpec<L> {
     /// Emit annotations and doc comment.
     fn emit_preamble(
         &self,
-        cb: &mut CodeBlockBuilder<L>,
-        lang: &L,
+        cb: &mut CodeBlockBuilder,
+        lang: &dyn CodeLang,
     ) -> Result<(), crate::error::SigilStitchError> {
         let emit_doc = || -> Option<String> {
             if self.doc.is_empty() || lang.doc_comment_inside_body() {
@@ -584,14 +600,14 @@ impl<L: CodeLang> TypeSpec<L> {
     /// Emit the type header line: `{vis}{keyword} {name}<params>(primary ctor){extends}{implements} {`.
     fn emit_header(
         &self,
-        cb: &mut CodeBlockBuilder<L>,
-        lang: &L,
+        cb: &mut CodeBlockBuilder,
+        lang: &dyn CodeLang,
     ) -> Result<(), crate::error::SigilStitchError> {
         let vis = lang.render_visibility(self.modifiers.visibility, DeclarationContext::TopLevel);
         let kw = lang.type_keyword(self.kind);
 
         let mut fmt = String::new();
-        let mut args: Vec<Arg<L>> = Vec::new();
+        let mut args: Vec<Arg> = Vec::new();
 
         fmt.push_str(vis);
         if self.modifiers.is_abstract {
@@ -677,9 +693,9 @@ impl<L: CodeLang> TypeSpec<L> {
     /// Build a CodeBlock for primary constructor parameters.
     fn build_primary_constructor_block(
         &self,
-        lang: &L,
-    ) -> Result<CodeBlock<L>, crate::error::SigilStitchError> {
-        let mut pb = CodeBlock::<L>::builder();
+        lang: &dyn CodeLang,
+    ) -> Result<CodeBlock, crate::error::SigilStitchError> {
+        let mut pb = CodeBlock::builder();
         for (i, param) in self.primary_constructor.iter().enumerate() {
             if i > 0 {
                 pb.add(",%W", ());
@@ -692,100 +708,100 @@ impl<L: CodeLang> TypeSpec<L> {
 
 /// Builder for [`TypeSpec`].
 #[derive(Debug)]
-pub struct TypeSpecBuilder<L: CodeLang> {
+pub struct TypeSpecBuilder {
     name: String,
     kind: TypeKind,
     modifiers: Modifiers,
     doc: Vec<String>,
-    fields: Vec<FieldSpec<L>>,
-    properties: Vec<PropertySpec<L>>,
-    methods: Vec<FunSpec<L>>,
-    type_params: Vec<TypeParamSpec<L>>,
-    super_types: Vec<TypeName<L>>,
-    impl_types: Vec<TypeName<L>>,
-    annotations: Vec<CodeBlock<L>>,
-    annotation_specs: Vec<AnnotationSpec<L>>,
-    extra_members: Vec<CodeBlock<L>>,
-    variants: Vec<EnumVariantSpec<L>>,
-    primary_constructor: Vec<ParameterSpec<L>>,
-    where_constraints: Vec<WhereConstraint<L>>,
+    fields: Vec<FieldSpec>,
+    properties: Vec<PropertySpec>,
+    methods: Vec<FunSpec>,
+    type_params: Vec<TypeParamSpec>,
+    super_types: Vec<TypeName>,
+    impl_types: Vec<TypeName>,
+    annotations: Vec<CodeBlock>,
+    annotation_specs: Vec<AnnotationSpec>,
+    extra_members: Vec<CodeBlock>,
+    variants: Vec<EnumVariantSpec>,
+    primary_constructor: Vec<ParameterSpec>,
+    where_constraints: Vec<WhereConstraint>,
 }
 
-impl<L: CodeLang> TypeSpecBuilder<L> {
+impl TypeSpecBuilder {
     /// Set the visibility modifier.
-    pub fn visibility(&mut self, vis: Visibility) -> &mut Self {
+    pub fn visibility(mut self, vis: Visibility) -> Self {
         self.modifiers.visibility = vis;
         self
     }
 
     /// Mark this type as abstract.
-    pub fn is_abstract(&mut self) -> &mut Self {
+    pub fn is_abstract(mut self) -> Self {
         self.modifiers.is_abstract = true;
         self
     }
 
     /// Add a documentation comment line.
-    pub fn doc(&mut self, line: &str) -> &mut Self {
+    pub fn doc(mut self, line: &str) -> Self {
         self.doc.push(line.to_string());
         self
     }
 
     /// Add a field to this type.
-    pub fn add_field(&mut self, field: FieldSpec<L>) -> &mut Self {
+    pub fn add_field(mut self, field: FieldSpec) -> Self {
         self.fields.push(field);
         self
     }
 
     /// Add a computed property to this type.
-    pub fn add_property(&mut self, prop: PropertySpec<L>) -> &mut Self {
+    pub fn add_property(mut self, prop: PropertySpec) -> Self {
         self.properties.push(prop);
         self
     }
 
     /// Add a method to this type.
-    pub fn add_method(&mut self, method: FunSpec<L>) -> &mut Self {
+    pub fn add_method(mut self, method: FunSpec) -> Self {
         self.methods.push(method);
         self
     }
 
     /// Add a type parameter (generic).
-    pub fn add_type_param(&mut self, tp: TypeParamSpec<L>) -> &mut Self {
+    pub fn add_type_param(mut self, tp: TypeParamSpec) -> Self {
         self.type_params.push(tp);
         self
     }
 
     /// Add a super type (extends / inherits from).
-    pub fn extends(&mut self, super_type: TypeName<L>) -> &mut Self {
+    pub fn extends(mut self, super_type: TypeName) -> Self {
         self.super_types.push(super_type);
         self
     }
 
     /// Add an implemented interface.
-    pub fn implements(&mut self, iface: TypeName<L>) -> &mut Self {
+    pub fn implements(mut self, iface: TypeName) -> Self {
         self.impl_types.push(iface);
         self
     }
 
     /// Add a raw annotation code block.
-    pub fn annotation(&mut self, ann: CodeBlock<L>) -> &mut Self {
+    pub fn annotation(mut self, ann: CodeBlock) -> Self {
         self.annotations.push(ann);
         self
     }
 
     /// Add a structured annotation.
-    pub fn annotate(&mut self, spec: AnnotationSpec<L>) -> &mut Self {
+    pub fn annotate(mut self, spec: AnnotationSpec) -> Self {
         self.annotation_specs.push(spec);
         self
     }
 
     /// Add an extra code block to the type body.
-    pub fn extra_member(&mut self, block: CodeBlock<L>) -> &mut Self {
+    pub fn extra_member(mut self, block: CodeBlock) -> Self {
         self.extra_members.push(block);
         self
     }
 
     /// Add an enum variant. Only meaningful when `kind` is `TypeKind::Enum`.
-    pub fn add_variant(&mut self, variant: EnumVariantSpec<L>) -> &mut Self {
+    pub fn add_variant(mut self, variant: EnumVariantSpec) -> Self {
         self.variants.push(variant);
         self
     }
@@ -797,17 +813,13 @@ impl<L: CodeLang> TypeSpecBuilder<L> {
     /// `class Foo(val x: Int, val y: String)`.
     ///
     /// For languages that don't support primary constructors, these are ignored.
-    pub fn add_primary_constructor_param(&mut self, param: ParameterSpec<L>) -> &mut Self {
+    pub fn add_primary_constructor_param(mut self, param: ParameterSpec) -> Self {
         self.primary_constructor.push(param);
         self
     }
 
     /// Add a where-clause constraint (e.g., `T: Clone + Send`).
-    pub fn add_where_constraint(
-        &mut self,
-        subject: TypeName<L>,
-        bounds: Vec<TypeName<L>>,
-    ) -> &mut Self {
+    pub fn add_where_constraint(mut self, subject: TypeName, bounds: Vec<TypeName>) -> Self {
         self.where_constraints
             .push(WhereConstraint { subject, bounds });
         self
@@ -819,7 +831,7 @@ impl<L: CodeLang> TypeSpecBuilder<L> {
     ///
     /// Returns [`SigilStitchError::EmptyName`](crate::error::SigilStitchError::EmptyName) if `name` is empty.
     /// Returns [`SigilStitchError::DuplicateFieldName`](crate::error::SigilStitchError::DuplicateFieldName) if any two fields share the same name.
-    pub fn build(self) -> Result<TypeSpec<L>, crate::error::SigilStitchError> {
+    pub fn build(self) -> Result<TypeSpec, crate::error::SigilStitchError> {
         snafu::ensure!(
             !self.name.is_empty(),
             crate::error::EmptyNameSnafu {
@@ -896,7 +908,7 @@ mod tests {
     use crate::lang::typescript::TypeScript;
     use crate::spec::parameter_spec::ParameterSpec;
 
-    fn render_blocks_ts(blocks: &[CodeBlock<TypeScript>]) -> String {
+    fn render_blocks_ts(blocks: &[CodeBlock]) -> String {
         let lang = TypeScript::new();
         let imports = crate::import::ImportGroup::new();
         let mut output = String::new();
@@ -910,7 +922,7 @@ mod tests {
         output
     }
 
-    fn render_blocks_rs(blocks: &[CodeBlock<RustLang>]) -> String {
+    fn render_blocks_rs(blocks: &[CodeBlock]) -> String {
         let lang = RustLang::new();
         let imports = crate::import::ImportGroup::new();
         let mut output = String::new();
@@ -926,17 +938,24 @@ mod tests {
 
     #[test]
     fn test_ts_class() {
-        let mut tb = TypeSpec::<TypeScript>::builder("UserService", TypeKind::Class);
-        tb.visibility(Visibility::Public);
-        let mut field_b = FieldSpec::builder("name", TypeName::primitive("string"));
-        field_b.visibility(Visibility::Private);
-        tb.add_field(field_b.build().unwrap());
-        let body = CodeBlock::<TypeScript>::of("return this.name", ()).unwrap();
-        let mut fb = FunSpec::builder("getName");
-        fb.returns(TypeName::primitive("string"));
-        fb.body(body);
-        tb.add_method(fb.build().unwrap());
-        let ts = tb.build().unwrap();
+        let body = CodeBlock::of("return this.name", ()).unwrap();
+        let ts = TypeSpec::builder("UserService", TypeKind::Class)
+            .visibility(Visibility::Public)
+            .add_field(
+                FieldSpec::builder("name", TypeName::primitive("string"))
+                    .visibility(Visibility::Private)
+                    .build()
+                    .unwrap(),
+            )
+            .add_method(
+                FunSpec::builder("getName")
+                    .returns(TypeName::primitive("string"))
+                    .body(body)
+                    .build()
+                    .unwrap(),
+            )
+            .build()
+            .unwrap();
 
         let blocks = ts.emit(&TypeScript::new()).unwrap();
         let output = render_blocks_ts(&blocks);
@@ -948,18 +967,20 @@ mod tests {
 
     #[test]
     fn test_ts_interface() {
-        let mut tb = TypeSpec::<TypeScript>::builder("Repository", TypeKind::Interface);
-        tb.visibility(Visibility::Public);
-        tb.add_method({
-            let mut fb = FunSpec::builder("findById");
-            fb.add_param(ParameterSpec::new("id", TypeName::primitive("string")).unwrap());
-            fb.returns(TypeName::generic(
-                TypeName::primitive("Promise"),
-                vec![TypeName::primitive("Entity")],
-            ));
-            fb.build().unwrap()
-        });
-        let ts = tb.build().unwrap();
+        let ts = TypeSpec::builder("Repository", TypeKind::Interface)
+            .visibility(Visibility::Public)
+            .add_method(
+                FunSpec::builder("findById")
+                    .add_param(ParameterSpec::new("id", TypeName::primitive("string")).unwrap())
+                    .returns(TypeName::generic(
+                        TypeName::primitive("Promise"),
+                        vec![TypeName::primitive("Entity")],
+                    ))
+                    .build()
+                    .unwrap(),
+            )
+            .build()
+            .unwrap();
 
         let blocks = ts.emit(&TypeScript::new()).unwrap();
         let output = render_blocks_ts(&blocks);
@@ -969,21 +990,26 @@ mod tests {
 
     #[test]
     fn test_rust_struct_with_impl() {
-        let mut tb = TypeSpec::<RustLang>::builder("Config", TypeKind::Struct);
-        tb.visibility(Visibility::Public);
-        tb.add_field({
-            let mut fb = FieldSpec::builder("name", TypeName::primitive("String"));
-            fb.visibility(Visibility::Public);
-            fb.build().unwrap()
-        });
-        let body = CodeBlock::<RustLang>::of("Self { name: name.to_string() }", ()).unwrap();
-        let mut fb = FunSpec::<RustLang>::builder("new");
-        fb.visibility(Visibility::Public);
-        fb.add_param(ParameterSpec::new("name", TypeName::primitive("&str")).unwrap());
-        fb.returns(TypeName::primitive("Self"));
-        fb.body(body);
-        tb.add_method(fb.build().unwrap());
-        let ts = tb.build().unwrap();
+        let body = CodeBlock::of("Self { name: name.to_string() }", ()).unwrap();
+        let ts = TypeSpec::builder("Config", TypeKind::Struct)
+            .visibility(Visibility::Public)
+            .add_field(
+                FieldSpec::builder("name", TypeName::primitive("String"))
+                    .visibility(Visibility::Public)
+                    .build()
+                    .unwrap(),
+            )
+            .add_method(
+                FunSpec::builder("new")
+                    .visibility(Visibility::Public)
+                    .add_param(ParameterSpec::new("name", TypeName::primitive("&str")).unwrap())
+                    .returns(TypeName::primitive("Self"))
+                    .body(body)
+                    .build()
+                    .unwrap(),
+            )
+            .build()
+            .unwrap();
 
         let blocks = ts.emit(&RustLang::new()).unwrap();
         let output = render_blocks_rs(&blocks);
@@ -996,11 +1022,12 @@ mod tests {
 
     #[test]
     fn test_ts_class_extends_implements() {
-        let mut tb = TypeSpec::<TypeScript>::builder("AdminService", TypeKind::Class);
-        tb.visibility(Visibility::Public);
-        tb.extends(TypeName::primitive("BaseService"));
-        tb.implements(TypeName::primitive("Serializable"));
-        let ts = tb.build().unwrap();
+        let ts = TypeSpec::builder("AdminService", TypeKind::Class)
+            .visibility(Visibility::Public)
+            .extends(TypeName::primitive("BaseService"))
+            .implements(TypeName::primitive("Serializable"))
+            .build()
+            .unwrap();
 
         let blocks = ts.emit(&TypeScript::new()).unwrap();
         let output = render_blocks_ts(&blocks);
@@ -1013,7 +1040,7 @@ mod tests {
 
     #[test]
     fn test_build_empty_name_errors() {
-        let result = TypeSpec::<TypeScript>::builder("", TypeKind::Class).build();
+        let result = TypeSpec::builder("", TypeKind::Class).build();
         assert!(result.is_err());
         assert!(
             result
@@ -1025,23 +1052,23 @@ mod tests {
 
     #[test]
     fn test_build_duplicate_field_name_errors() {
-        let mut tb = TypeSpec::<TypeScript>::builder("MyClass", TypeKind::Class);
-        tb.add_field(
-            FieldSpec::builder("name", TypeName::primitive("string"))
-                .build()
-                .unwrap(),
-        );
-        tb.add_field(
-            FieldSpec::builder("age", TypeName::primitive("number"))
-                .build()
-                .unwrap(),
-        );
-        tb.add_field(
-            FieldSpec::builder("name", TypeName::primitive("string"))
-                .build()
-                .unwrap(),
-        );
-        let result = tb.build();
+        let result = TypeSpec::builder("MyClass", TypeKind::Class)
+            .add_field(
+                FieldSpec::builder("name", TypeName::primitive("string"))
+                    .build()
+                    .unwrap(),
+            )
+            .add_field(
+                FieldSpec::builder("age", TypeName::primitive("number"))
+                    .build()
+                    .unwrap(),
+            )
+            .add_field(
+                FieldSpec::builder("name", TypeName::primitive("string"))
+                    .build()
+                    .unwrap(),
+            )
+            .build();
         assert!(result.is_err());
         let err_msg = result.unwrap_err().to_string();
         assert!(err_msg.contains("duplicate field name"));
@@ -1051,26 +1078,27 @@ mod tests {
 
     #[test]
     fn test_build_no_duplicate_fields_ok() {
-        let mut tb = TypeSpec::<TypeScript>::builder("MyClass", TypeKind::Class);
-        tb.add_field(
-            FieldSpec::builder("name", TypeName::primitive("string"))
-                .build()
-                .unwrap(),
-        );
-        tb.add_field(
-            FieldSpec::builder("age", TypeName::primitive("number"))
-                .build()
-                .unwrap(),
-        );
-        let result = tb.build();
+        let result = TypeSpec::builder("MyClass", TypeKind::Class)
+            .add_field(
+                FieldSpec::builder("name", TypeName::primitive("string"))
+                    .build()
+                    .unwrap(),
+            )
+            .add_field(
+                FieldSpec::builder("age", TypeName::primitive("number"))
+                    .build()
+                    .unwrap(),
+            )
+            .build();
         assert!(result.is_ok());
     }
 
     #[test]
     fn test_type_alias_rust() {
-        let mut tb = TypeSpec::<RustLang>::builder("Meters", TypeKind::TypeAlias);
-        tb.extends(TypeName::primitive("f64"));
-        let spec = tb.build().unwrap();
+        let spec = TypeSpec::builder("Meters", TypeKind::TypeAlias)
+            .extends(TypeName::primitive("f64"))
+            .build()
+            .unwrap();
         let lang = RustLang::new();
         let blocks = spec.emit(&lang).unwrap();
         let output = render_blocks_rs(&blocks);
@@ -1079,10 +1107,11 @@ mod tests {
 
     #[test]
     fn test_type_alias_rust_pub() {
-        let mut tb = TypeSpec::<RustLang>::builder("Meters", TypeKind::TypeAlias);
-        tb.visibility(Visibility::Public);
-        tb.extends(TypeName::primitive("f64"));
-        let spec = tb.build().unwrap();
+        let spec = TypeSpec::builder("Meters", TypeKind::TypeAlias)
+            .visibility(Visibility::Public)
+            .extends(TypeName::primitive("f64"))
+            .build()
+            .unwrap();
         let lang = RustLang::new();
         let blocks = spec.emit(&lang).unwrap();
         let output = render_blocks_rs(&blocks);
@@ -1091,10 +1120,11 @@ mod tests {
 
     #[test]
     fn test_type_alias_ts() {
-        let mut tb = TypeSpec::<TypeScript>::builder("UserId", TypeKind::TypeAlias);
-        tb.visibility(Visibility::Public);
-        tb.extends(TypeName::primitive("string"));
-        let spec = tb.build().unwrap();
+        let spec = TypeSpec::builder("UserId", TypeKind::TypeAlias)
+            .visibility(Visibility::Public)
+            .extends(TypeName::primitive("string"))
+            .build()
+            .unwrap();
         let blocks = spec.emit(&TypeScript::new()).unwrap();
         let output = render_blocks_ts(&blocks);
         assert_eq!(output.trim(), "export type UserId = string;");
@@ -1103,9 +1133,10 @@ mod tests {
     #[test]
     fn test_type_alias_cpp() {
         use crate::lang::cpp_lang::CppLang;
-        let mut tb = TypeSpec::<CppLang>::builder("Meters", TypeKind::TypeAlias);
-        tb.extends(TypeName::primitive("double"));
-        let spec = tb.build().unwrap();
+        let spec = TypeSpec::builder("Meters", TypeKind::TypeAlias)
+            .extends(TypeName::primitive("double"))
+            .build()
+            .unwrap();
         let lang = CppLang::new();
         let imports = crate::import::ImportGroup::new();
         let blocks = spec.emit(&lang).unwrap();
@@ -1117,9 +1148,10 @@ mod tests {
     #[test]
     fn test_type_alias_c() {
         use crate::lang::c_lang::CLang;
-        let mut tb = TypeSpec::<CLang>::builder("Meters", TypeKind::TypeAlias);
-        tb.extends(TypeName::primitive("double"));
-        let spec = tb.build().unwrap();
+        let spec = TypeSpec::builder("Meters", TypeKind::TypeAlias)
+            .extends(TypeName::primitive("double"))
+            .build()
+            .unwrap();
         let lang = CLang::new();
         let imports = crate::import::ImportGroup::new();
         let blocks = spec.emit(&lang).unwrap();
@@ -1131,9 +1163,10 @@ mod tests {
     #[test]
     fn test_type_alias_go() {
         use crate::lang::go_lang::GoLang;
-        let mut tb = TypeSpec::<GoLang>::builder("Meters", TypeKind::TypeAlias);
-        tb.extends(TypeName::primitive("float64"));
-        let spec = tb.build().unwrap();
+        let spec = TypeSpec::builder("Meters", TypeKind::TypeAlias)
+            .extends(TypeName::primitive("float64"))
+            .build()
+            .unwrap();
         let lang = GoLang::new();
         let imports = crate::import::ImportGroup::new();
         let blocks = spec.emit(&lang).unwrap();
@@ -1145,9 +1178,10 @@ mod tests {
     #[test]
     fn test_type_alias_python() {
         use crate::lang::python::Python;
-        let mut tb = TypeSpec::<Python>::builder("UserId", TypeKind::TypeAlias);
-        tb.extends(TypeName::primitive("str"));
-        let spec = tb.build().unwrap();
+        let spec = TypeSpec::builder("UserId", TypeKind::TypeAlias)
+            .extends(TypeName::primitive("str"))
+            .build()
+            .unwrap();
         let lang = Python::new();
         let imports = crate::import::ImportGroup::new();
         let blocks = spec.emit(&lang).unwrap();
@@ -1159,10 +1193,11 @@ mod tests {
     #[test]
     fn test_type_alias_kotlin() {
         use crate::lang::kotlin::Kotlin;
-        let mut tb = TypeSpec::<Kotlin>::builder("Name", TypeKind::TypeAlias);
-        tb.visibility(Visibility::Public);
-        tb.extends(TypeName::primitive("String"));
-        let spec = tb.build().unwrap();
+        let spec = TypeSpec::builder("Name", TypeKind::TypeAlias)
+            .visibility(Visibility::Public)
+            .extends(TypeName::primitive("String"))
+            .build()
+            .unwrap();
         let lang = Kotlin::new();
         let imports = crate::import::ImportGroup::new();
         let blocks = spec.emit(&lang).unwrap();
@@ -1173,10 +1208,11 @@ mod tests {
 
     #[test]
     fn test_newtype_rust() {
-        let mut tb = TypeSpec::<RustLang>::builder("Meters", TypeKind::Newtype);
-        tb.visibility(Visibility::Public);
-        tb.extends(TypeName::primitive("f64"));
-        let spec = tb.build().unwrap();
+        let spec = TypeSpec::builder("Meters", TypeKind::Newtype)
+            .visibility(Visibility::Public)
+            .extends(TypeName::primitive("f64"))
+            .build()
+            .unwrap();
         let lang = RustLang::new();
         let blocks = spec.emit(&lang).unwrap();
         let output = render_blocks_rs(&blocks);
@@ -1186,9 +1222,10 @@ mod tests {
     #[test]
     fn test_newtype_go() {
         use crate::lang::go_lang::GoLang;
-        let mut tb = TypeSpec::<GoLang>::builder("Meters", TypeKind::Newtype);
-        tb.extends(TypeName::primitive("float64"));
-        let spec = tb.build().unwrap();
+        let spec = TypeSpec::builder("Meters", TypeKind::Newtype)
+            .extends(TypeName::primitive("float64"))
+            .build()
+            .unwrap();
         let lang = GoLang::new();
         let imports = crate::import::ImportGroup::new();
         let blocks = spec.emit(&lang).unwrap();
@@ -1200,10 +1237,11 @@ mod tests {
     #[test]
     fn test_newtype_kotlin() {
         use crate::lang::kotlin::Kotlin;
-        let mut tb = TypeSpec::<Kotlin>::builder("Meters", TypeKind::Newtype);
-        tb.visibility(Visibility::Public);
-        tb.extends(TypeName::primitive("Double"));
-        let spec = tb.build().unwrap();
+        let spec = TypeSpec::builder("Meters", TypeKind::Newtype)
+            .visibility(Visibility::Public)
+            .extends(TypeName::primitive("Double"))
+            .build()
+            .unwrap();
         let lang = Kotlin::new();
         let imports = crate::import::ImportGroup::new();
         let blocks = spec.emit(&lang).unwrap();
@@ -1215,9 +1253,10 @@ mod tests {
     #[test]
     fn test_newtype_python() {
         use crate::lang::python::Python;
-        let mut tb = TypeSpec::<Python>::builder("UserId", TypeKind::Newtype);
-        tb.extends(TypeName::primitive("str"));
-        let spec = tb.build().unwrap();
+        let spec = TypeSpec::builder("UserId", TypeKind::Newtype)
+            .extends(TypeName::primitive("str"))
+            .build()
+            .unwrap();
         let lang = Python::new();
         let imports = crate::import::ImportGroup::new();
         let blocks = spec.emit(&lang).unwrap();
@@ -1228,7 +1267,7 @@ mod tests {
 
     #[test]
     fn test_type_alias_validation_no_super_type() {
-        let tb = TypeSpec::<TypeScript>::builder("Foo", TypeKind::TypeAlias);
+        let tb = TypeSpec::builder("Foo", TypeKind::TypeAlias);
         let result = tb.build();
         assert!(result.is_err());
         assert!(
@@ -1241,14 +1280,14 @@ mod tests {
 
     #[test]
     fn test_type_alias_validation_has_fields() {
-        let mut tb = TypeSpec::<TypeScript>::builder("Foo", TypeKind::TypeAlias);
-        tb.extends(TypeName::primitive("string"));
-        tb.add_field(
-            FieldSpec::builder("x", TypeName::primitive("number"))
-                .build()
-                .unwrap(),
-        );
-        let result = tb.build();
+        let result = TypeSpec::builder("Foo", TypeKind::TypeAlias)
+            .extends(TypeName::primitive("string"))
+            .add_field(
+                FieldSpec::builder("x", TypeName::primitive("number"))
+                    .build()
+                    .unwrap(),
+            )
+            .build();
         assert!(result.is_err());
         assert!(
             result
@@ -1260,24 +1299,31 @@ mod tests {
 
     #[test]
     fn test_where_clause_rust_struct() {
-        let mut tb = TypeSpec::<RustLang>::builder("Container", TypeKind::Struct);
-        tb.visibility(Visibility::Public);
-        tb.add_type_param(TypeParamSpec::new("T"));
-        tb.add_where_constraint(
-            TypeName::primitive("T"),
-            vec![TypeName::primitive("Clone"), TypeName::primitive("Send")],
-        );
-        let mut fb = FieldSpec::builder("value", TypeName::primitive("T"));
-        fb.visibility(Visibility::Public);
-        tb.add_field(fb.build().unwrap());
-        let body = CodeBlock::<RustLang>::of("Self { value }", ()).unwrap();
-        let mut mb = FunSpec::<RustLang>::builder("new");
-        mb.visibility(Visibility::Public);
-        mb.add_param(ParameterSpec::new("value", TypeName::primitive("T")).unwrap());
-        mb.returns(TypeName::primitive("Self"));
-        mb.body(body);
-        tb.add_method(mb.build().unwrap());
-        let type_spec = tb.build().unwrap();
+        let body = CodeBlock::of("Self { value }", ()).unwrap();
+        let type_spec = TypeSpec::builder("Container", TypeKind::Struct)
+            .visibility(Visibility::Public)
+            .add_type_param(TypeParamSpec::new("T"))
+            .add_where_constraint(
+                TypeName::primitive("T"),
+                vec![TypeName::primitive("Clone"), TypeName::primitive("Send")],
+            )
+            .add_field(
+                FieldSpec::builder("value", TypeName::primitive("T"))
+                    .visibility(Visibility::Public)
+                    .build()
+                    .unwrap(),
+            )
+            .add_method(
+                FunSpec::builder("new")
+                    .visibility(Visibility::Public)
+                    .add_param(ParameterSpec::new("value", TypeName::primitive("T")).unwrap())
+                    .returns(TypeName::primitive("Self"))
+                    .body(body)
+                    .build()
+                    .unwrap(),
+            )
+            .build()
+            .unwrap();
         let blocks = type_spec.emit(&RustLang::new()).unwrap();
         let output = render_blocks_rs(&blocks);
         assert!(

--- a/src/type_name.rs
+++ b/src/type_name.rs
@@ -8,7 +8,7 @@ use crate::lang::CodeLang;
 /// Each variant describes a structural pattern for assembling already-rendered
 /// inner type docs into the output. The rendering engine in `type_name.rs`
 /// interprets these patterns — language implementations never build `BoxDoc`.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TypePresentation<'a> {
     /// `name<P1, P2>` — delimiters from `generic_open()`/`generic_close()`.
     GenericWrap {
@@ -61,7 +61,7 @@ pub enum GenericApplicationStyle {
 }
 
 /// Syntactic pattern for rendering a function type expression.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct FunctionPresentation<'a> {
     /// Keyword before the param list (e.g., `"fn"`, `"func"`, `""`).
     pub keyword: &'a str,
@@ -83,8 +83,24 @@ pub struct FunctionPresentation<'a> {
     pub wrapper_close: &'a str,
 }
 
+impl Default for FunctionPresentation<'_> {
+    fn default() -> Self {
+        Self {
+            keyword: "",
+            params_open: "(",
+            params_sep: ", ",
+            params_close: ")",
+            arrow: " => ",
+            return_first: false,
+            curried: false,
+            wrapper_open: "",
+            wrapper_close: "",
+        }
+    }
+}
+
 /// How `TypeName::AssociatedType` renders across languages.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AssociatedTypeStyle<'a> {
     /// Rust-style: `<Base as Qual>::Member` or `Base::Member`.
     QualifiedPath {
@@ -111,7 +127,7 @@ pub enum AssociatedTypeStyle<'a> {
 }
 
 /// How `impl Trait` / `dyn Trait` bounds render.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct BoundsPresentation<'a> {
     /// Keyword prefix (e.g., `"impl "`, `"dyn "`).
     pub keyword: &'a str,
@@ -120,7 +136,7 @@ pub struct BoundsPresentation<'a> {
 }
 
 /// How wildcard types render.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct WildcardPresentation<'a> {
     /// Unbounded wildcard (e.g., `"?"`, `"*"`, `"_"`, `"any"`).
     pub unbounded: &'a str,
@@ -258,16 +274,16 @@ pub enum TypeName {
 fn render_presentation(
     pres: &TypePresentation<'_>,
     inner_docs: Vec<BoxDoc<'static, ()>>,
-    lang: &dyn CodeLang,
+    gs: &crate::lang::config::GenericSyntaxConfig<'_>,
 ) -> BoxDoc<'static, ()> {
     match pres {
         TypePresentation::GenericWrap { name } => {
             let sep = BoxDoc::text(",").append(BoxDoc::softline());
             let params = BoxDoc::intersperse(inner_docs, sep);
             BoxDoc::text(name.to_string())
-                .append(BoxDoc::text(lang.generic_open().to_string()))
+                .append(BoxDoc::text(gs.open.to_string()))
                 .append(params.nest(2).group())
-                .append(BoxDoc::text(lang.generic_close().to_string()))
+                .append(BoxDoc::text(gs.close.to_string()))
         }
         TypePresentation::Prefix { prefix } => {
             debug_assert_eq!(inner_docs.len(), 1);
@@ -843,6 +859,9 @@ impl TypeName {
     where
         F: Fn(&str, &str) -> String,
     {
+        let tp = lang.type_presentation();
+        let gs = lang.generic_syntax();
+
         match self {
             TypeName::Generic { base, params } => {
                 let base_doc = base.to_doc_with_lang(resolve, lang);
@@ -850,14 +869,14 @@ impl TypeName {
                     .iter()
                     .map(|p| p.to_doc_with_lang(resolve, lang))
                     .collect();
-                match lang.generic_application_style() {
+                match gs.application_style {
                     GenericApplicationStyle::Delimited => {
                         let sep = BoxDoc::text(",").append(BoxDoc::softline());
                         let params_doc = BoxDoc::intersperse(params_docs, sep);
                         base_doc
-                            .append(BoxDoc::text(lang.generic_open().to_string()))
+                            .append(BoxDoc::text(gs.open.to_string()))
                             .append(params_doc.nest(2).group())
-                            .append(BoxDoc::text(lang.generic_close().to_string()))
+                            .append(BoxDoc::text(gs.close.to_string()))
                     }
                     GenericApplicationStyle::PrefixJuxtaposition => {
                         let mut doc = base_doc;
@@ -895,16 +914,14 @@ impl TypeName {
             }
             TypeName::Array(inner) => {
                 let inner_doc = inner.to_doc_with_lang(resolve, lang);
-                render_presentation(&lang.present_array(), vec![inner_doc], lang)
+                render_presentation(&tp.array, vec![inner_doc], &gs)
             }
             TypeName::ReadonlyArray(inner) => {
                 let inner_doc = inner.to_doc_with_lang(resolve, lang);
-                if let Some(pres) = lang.present_readonly_array() {
-                    render_presentation(&pres, vec![inner_doc], lang)
+                if let Some(pres) = tp.readonly_array {
+                    render_presentation(&pres, vec![inner_doc], &gs)
                 } else {
-                    // Default: "readonly " + array rendering
-                    let array_doc =
-                        render_presentation(&lang.present_array(), vec![inner_doc], lang);
+                    let array_doc = render_presentation(&tp.array, vec![inner_doc], &gs);
                     BoxDoc::text("readonly ").append(array_doc)
                 }
             }
@@ -913,37 +930,36 @@ impl TypeName {
                     .iter()
                     .map(|m| m.to_doc_with_lang(resolve, lang))
                     .collect();
-                render_presentation(&lang.present_union(), docs, lang)
+                render_presentation(&tp.union, docs, &gs)
             }
             TypeName::Intersection(members) => {
                 let docs: Vec<_> = members
                     .iter()
                     .map(|m| m.to_doc_with_lang(resolve, lang))
                     .collect();
-                render_presentation(&lang.present_intersection(), docs, lang)
+                render_presentation(&tp.intersection, docs, &gs)
             }
             TypeName::Pointer(inner) => {
                 let inner_doc = inner.to_doc_with_lang(resolve, lang);
-                render_presentation(&lang.present_pointer(), vec![inner_doc], lang)
+                render_presentation(&tp.pointer, vec![inner_doc], &gs)
             }
             TypeName::Slice(inner) => {
                 let inner_doc = inner.to_doc_with_lang(resolve, lang);
-                render_presentation(&lang.present_slice(), vec![inner_doc], lang)
+                render_presentation(&tp.slice, vec![inner_doc], &gs)
             }
             TypeName::Map { key, value } => {
                 let key_doc = key.to_doc_with_lang(resolve, lang);
                 let value_doc = value.to_doc_with_lang(resolve, lang);
-                render_presentation(&lang.present_map(), vec![key_doc, value_doc], lang)
+                render_presentation(&tp.map, vec![key_doc, value_doc], &gs)
             }
             TypeName::Optional(inner) => {
                 let inner_doc = inner.to_doc_with_lang(resolve, lang);
-                let pres = lang.present_optional();
-                match &pres {
+                match &tp.optional {
                     TypePresentation::Infix { .. } => {
-                        let null_doc = BoxDoc::text(lang.optional_absent_literal().to_string());
-                        render_presentation(&pres, vec![inner_doc, null_doc], lang)
+                        let null_doc = BoxDoc::text(tp.optional_absent_literal.to_string());
+                        render_presentation(&tp.optional, vec![inner_doc, null_doc], &gs)
                     }
-                    _ => render_presentation(&pres, vec![inner_doc], lang),
+                    _ => render_presentation(&tp.optional, vec![inner_doc], &gs),
                 }
             }
             TypeName::Tuple(elements) => {
@@ -951,7 +967,7 @@ impl TypeName {
                     .iter()
                     .map(|e| e.to_doc_with_lang(resolve, lang))
                     .collect();
-                render_presentation(&lang.present_tuple(), docs, lang)
+                render_presentation(&tp.tuple, docs, &gs)
             }
             TypeName::Reference {
                 inner,
@@ -969,11 +985,11 @@ impl TypeName {
                     BoxDoc::text(prefix).append(inner_doc)
                 } else {
                     let pres = if *mutable {
-                        lang.present_reference_mut()
+                        tp.reference_mut
                     } else {
-                        lang.present_reference()
+                        tp.reference
                     };
-                    render_presentation(&pres, vec![inner_doc], lang)
+                    render_presentation(&pres, vec![inner_doc], &gs)
                 }
             }
             TypeName::Function {
@@ -985,7 +1001,7 @@ impl TypeName {
                     .map(|p| p.to_doc_with_lang(resolve, lang))
                     .collect();
                 let return_doc = return_type.to_doc_with_lang(resolve, lang);
-                render_function_presentation(&lang.present_function(), param_docs, return_doc)
+                render_function_presentation(&tp.function, param_docs, return_doc)
             }
             TypeName::AssociatedType {
                 base,
@@ -993,8 +1009,7 @@ impl TypeName {
                 member,
             } => {
                 let base_doc = base.to_doc_with_lang(resolve, lang);
-                let style = lang.present_associated_type();
-                match style {
+                match tp.associated_type {
                     AssociatedTypeStyle::QualifiedPath {
                         open,
                         as_kw,
@@ -1029,18 +1044,18 @@ impl TypeName {
                     .iter()
                     .map(|b| b.to_doc_with_lang(resolve, lang))
                     .collect();
-                let pres = lang.present_impl_trait();
-                let sep = BoxDoc::text(pres.separator.to_string());
-                BoxDoc::text(pres.keyword.to_string()).append(BoxDoc::intersperse(docs, sep))
+                let sep = BoxDoc::text(tp.impl_trait.separator.to_string());
+                BoxDoc::text(tp.impl_trait.keyword.to_string())
+                    .append(BoxDoc::intersperse(docs, sep))
             }
             TypeName::DynTrait { bounds } => {
                 let docs: Vec<_> = bounds
                     .iter()
                     .map(|b| b.to_doc_with_lang(resolve, lang))
                     .collect();
-                let pres = lang.present_dyn_trait();
-                let sep = BoxDoc::text(pres.separator.to_string());
-                BoxDoc::text(pres.keyword.to_string()).append(BoxDoc::intersperse(docs, sep))
+                let sep = BoxDoc::text(tp.dyn_trait.separator.to_string());
+                BoxDoc::text(tp.dyn_trait.keyword.to_string())
+                    .append(BoxDoc::intersperse(docs, sep))
             }
             TypeName::Wildcard {
                 upper_bound,
@@ -1050,15 +1065,14 @@ impl TypeName {
                     upper_bound.is_none() || lower_bound.is_none(),
                     "Wildcard cannot have both upper and lower bounds"
                 );
-                let pres = lang.present_wildcard();
                 if let Some(ub) = upper_bound {
                     let ub_doc = ub.to_doc_with_lang(resolve, lang);
-                    BoxDoc::text(pres.upper_keyword.to_string()).append(ub_doc)
+                    BoxDoc::text(tp.wildcard.upper_keyword.to_string()).append(ub_doc)
                 } else if let Some(lb) = lower_bound {
                     let lb_doc = lb.to_doc_with_lang(resolve, lang);
-                    BoxDoc::text(pres.lower_keyword.to_string()).append(lb_doc)
+                    BoxDoc::text(tp.wildcard.lower_keyword.to_string()).append(lb_doc)
                 } else {
-                    BoxDoc::text(pres.unbounded.to_string())
+                    BoxDoc::text(tp.wildcard.unbounded.to_string())
                 }
             }
             // Leaf variants delegate to to_doc (no recursion needed).
@@ -1091,32 +1105,35 @@ mod tests {
                 fn render_string_literal(&self, s: &str) -> String { self.0.render_string_literal(s) }
                 fn render_doc_comment(&self, lines: &[&str]) -> String { self.0.render_doc_comment(lines) }
                 fn line_comment_prefix(&self) -> &str { self.0.line_comment_prefix() }
-                fn indent_unit(&self) -> &str { self.0.indent_unit() }
-                fn uses_semicolons(&self) -> bool { self.0.uses_semicolons() }
                 fn render_visibility(&self, vis: crate::spec::modifiers::Visibility, ctx: crate::spec::modifiers::DeclarationContext) -> &str { self.0.render_visibility(vis, ctx) }
                 fn function_keyword(&self, ctx: crate::spec::modifiers::DeclarationContext) -> &str { self.0.function_keyword(ctx) }
-                fn return_type_separator(&self) -> &str { self.0.return_type_separator() }
                 fn type_keyword(&self, kind: crate::spec::modifiers::TypeKind) -> &str { self.0.type_keyword(kind) }
-                fn field_terminator(&self) -> &str { self.0.field_terminator() }
                 fn methods_inside_type_body(&self, kind: crate::spec::modifiers::TypeKind) -> bool { self.0.methods_inside_type_body(kind) }
-                fn generic_constraint_keyword(&self) -> &str { self.0.generic_constraint_keyword() }
-                fn generic_constraint_separator(&self) -> &str { self.0.generic_constraint_separator() }
-                fn super_type_keyword(&self) -> &str { self.0.super_type_keyword() }
-                fn implements_keyword(&self) -> &str { self.0.implements_keyword() }
+                fn type_presentation(&self) -> crate::lang::config::TypePresentationConfig<'_> { self.0.type_presentation() }
+                fn block_syntax(&self) -> crate::lang::config::BlockSyntaxConfig<'_> { self.0.block_syntax() }
+                fn function_syntax(&self) -> crate::lang::config::FunctionSyntaxConfig<'_> { self.0.function_syntax() }
+                fn type_decl_syntax(&self) -> crate::lang::config::TypeDeclSyntaxConfig<'_> { self.0.type_decl_syntax() }
+                fn enum_and_annotation(&self) -> crate::lang::config::EnumAndAnnotationConfig<'_> { self.0.enum_and_annotation() }
                 $($override)*
             }
         };
     }
 
     test_lang!(PrefixLang, TypeScript {
-        fn generic_application_style(&self) -> GenericApplicationStyle {
-            GenericApplicationStyle::PrefixJuxtaposition
+        fn generic_syntax(&self) -> crate::lang::config::GenericSyntaxConfig<'_> {
+            crate::lang::config::GenericSyntaxConfig {
+                application_style: GenericApplicationStyle::PrefixJuxtaposition,
+                ..self.0.generic_syntax()
+            }
         }
     });
 
     test_lang!(PostfixLang, TypeScript {
-        fn generic_application_style(&self) -> GenericApplicationStyle {
-            GenericApplicationStyle::PostfixJuxtaposition
+        fn generic_syntax(&self) -> crate::lang::config::GenericSyntaxConfig<'_> {
+            crate::lang::config::GenericSyntaxConfig {
+                application_style: GenericApplicationStyle::PostfixJuxtaposition,
+                ..self.0.generic_syntax()
+            }
         }
     });
 

--- a/src/type_name.rs
+++ b/src/type_name.rs
@@ -10,7 +10,7 @@ use crate::lang::CodeLang;
 /// interprets these patterns — language implementations never build `BoxDoc`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TypePresentation<'a> {
-    /// `name<P1, P2>` — delimiters from `generic_open()`/`generic_close()`.
+    /// `name<P1, P2>` — delimiters from `generic_syntax().open`/`.close`.
     GenericWrap {
         /// The wrapper type name (e.g., `"Vec"`, `"Option"`, `"HashMap"`).
         name: &'a str,
@@ -51,7 +51,7 @@ pub enum TypePresentation<'a> {
 /// Controls how `TypeName::Generic { base, params }` renders.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum GenericApplicationStyle {
-    /// `Base<P1, P2>` or `Base[P1, P2]` — uses `generic_open()`/`generic_close()`.
+    /// `Base<P1, P2>` or `Base[P1, P2]` — uses `generic_syntax().open`/`.close`.
     Delimited,
     /// `Base P1 P2` — Haskell-style prefix juxtaposition.
     /// Compound params are parenthesized: `Either String (Maybe Int)`.

--- a/src/type_name.rs
+++ b/src/type_name.rs
@@ -148,23 +148,22 @@ pub struct WildcardPresentation<'a> {
 /// use sigil_stitch::lang::typescript::TypeScript;
 ///
 /// // Importable type (generates `import { User } from './models'`):
-/// let user = TypeName::<TypeScript>::importable("./models", "User");
+/// let user = TypeName::importable("./models", "User");
 ///
 /// // Primitive (no import needed):
-/// let num = TypeName::<TypeScript>::primitive("number");
+/// let num = TypeName::primitive("number");
 ///
 /// // Generic: Promise<User>
-/// let promise = TypeName::<TypeScript>::generic(
+/// let promise = TypeName::generic(
 ///     TypeName::primitive("Promise"),
 ///     vec![user],
 /// );
 ///
 /// // Optional: string | null
-/// let maybe_str = TypeName::<TypeScript>::optional(TypeName::primitive("string"));
+/// let maybe_str = TypeName::optional(TypeName::primitive("string"));
 /// ```
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-#[serde(bound = "")]
-pub enum TypeName<L: CodeLang> {
+pub enum TypeName {
     /// A type that requires an import statement.
     Importable {
         /// The module path to import from.
@@ -179,40 +178,40 @@ pub enum TypeName<L: CodeLang> {
     /// A primitive/built-in type (no import needed).
     Primitive(String),
     /// Array type. TS: `T[]`, Go: `[]T`, Rust: `Vec<T>`.
-    Array(Box<TypeName<L>>),
+    Array(Box<TypeName>),
     /// Readonly array type. TS: `readonly T[]`. Other languages fall back to
     /// their `Array` rendering since they lack a direct readonly-array form.
-    ReadonlyArray(Box<TypeName<L>>),
+    ReadonlyArray(Box<TypeName>),
     /// Generic type. e.g., `Promise<User>`, `HashMap<String, User>`.
     Generic {
         /// The base type (e.g., `Promise`, `HashMap`).
-        base: Box<TypeName<L>>,
+        base: Box<TypeName>,
         /// The type parameters.
-        params: Vec<TypeName<L>>,
+        params: Vec<TypeName>,
     },
     /// Union type. TS: `A | B | C`.
-    Union(Vec<TypeName<L>>),
+    Union(Vec<TypeName>),
     /// Intersection type. TS: `A & B`.
-    Intersection(Vec<TypeName<L>>),
+    Intersection(Vec<TypeName>),
     /// Pointer type. Go: `*T`.
-    Pointer(Box<TypeName<L>>),
+    Pointer(Box<TypeName>),
     /// Slice type. Go: `[]T`.
-    Slice(Box<TypeName<L>>),
+    Slice(Box<TypeName>),
     /// Map type. Go: `map[K]V`, TS: `Record<K, V>`.
     Map {
         /// The key type.
-        key: Box<TypeName<L>>,
+        key: Box<TypeName>,
         /// The value type.
-        value: Box<TypeName<L>>,
+        value: Box<TypeName>,
     },
     /// Optional type. TS: `T | null`, Rust: `Option<T>`.
-    Optional(Box<TypeName<L>>),
+    Optional(Box<TypeName>),
     /// Tuple type. Rust: `(A, B)`, TS: `[A, B]`, Python: `tuple[A, B]`.
-    Tuple(Vec<TypeName<L>>),
+    Tuple(Vec<TypeName>),
     /// Reference type. Rust: `&T` / `&mut T` / `&'a T`, C++: `const T&` / `T&`.
     Reference {
         /// The referenced type.
-        inner: Box<TypeName<L>>,
+        inner: Box<TypeName>,
         /// Whether the reference is mutable.
         mutable: bool,
         /// Optional lifetime (Rust only, e.g., `'a`).
@@ -222,48 +221,44 @@ pub enum TypeName<L: CodeLang> {
     /// Associated/path-dependent type. Rust: `<T as Iterator>::Item`, TS: `T["key"]`.
     AssociatedType {
         /// The base type (e.g., `T`, `Vec<i32>`).
-        base: Box<TypeName<L>>,
+        base: Box<TypeName>,
         /// Optional qualifier trait (Rust: `Iterator` in `<T as Iterator>::Item`).
-        qualifier: Option<Box<TypeName<L>>>,
+        qualifier: Option<Box<TypeName>>,
         /// The projected member name (e.g., `"Item"`, `"key"`).
         member: String,
     },
     /// `impl Trait` bounds. Rust: `impl Display + Debug`.
     ImplTrait {
         /// The trait bounds.
-        bounds: Vec<TypeName<L>>,
+        bounds: Vec<TypeName>,
     },
     /// `dyn Trait` bounds. Rust: `dyn Error + Send`.
     DynTrait {
         /// The trait bounds.
-        bounds: Vec<TypeName<L>>,
+        bounds: Vec<TypeName>,
     },
     /// Wildcard type. Java: `?`, `? extends T`, `? super T`. Kotlin: `*`, `out T`, `in T`.
     Wildcard {
         /// Upper bound (Java: `? extends T`, Kotlin: `out T`).
-        upper_bound: Option<Box<TypeName<L>>>,
+        upper_bound: Option<Box<TypeName>>,
         /// Lower bound (Java: `? super T`, Kotlin: `in T`).
-        lower_bound: Option<Box<TypeName<L>>>,
+        lower_bound: Option<Box<TypeName>>,
     },
     /// Function type. TS: `(a: A, b: B) => R`.
     Function {
         /// The parameter types.
-        params: Vec<TypeName<L>>,
+        params: Vec<TypeName>,
         /// The return type.
-        return_type: Box<TypeName<L>>,
+        return_type: Box<TypeName>,
     },
     /// Raw string escape hatch. No import tracking.
     Raw(String),
-
-    /// Phantom data to carry L without requiring it in all variants.
-    #[doc(hidden)]
-    _Phantom(std::marker::PhantomData<L>),
 }
 
 fn render_presentation(
     pres: &TypePresentation<'_>,
     inner_docs: Vec<BoxDoc<'static, ()>>,
-    lang: &impl CodeLang,
+    lang: &dyn CodeLang,
 ) -> BoxDoc<'static, ()> {
     match pres {
         TypePresentation::GenericWrap { name } => {
@@ -351,7 +346,7 @@ fn render_function_presentation(
     }
 }
 
-fn is_compound_type<L: CodeLang>(t: &TypeName<L>) -> bool {
+fn is_compound_type(t: &TypeName) -> bool {
     matches!(
         t,
         TypeName::Generic { .. }
@@ -362,7 +357,7 @@ fn is_compound_type<L: CodeLang>(t: &TypeName<L>) -> bool {
     )
 }
 
-impl<L: CodeLang> TypeName<L> {
+impl TypeName {
     /// Create an importable type name.
     pub fn importable(module: &str, name: &str) -> Self {
         TypeName::Importable {
@@ -413,7 +408,7 @@ impl<L: CodeLang> TypeName<L> {
     }
 
     /// Create an array type.
-    pub fn array(inner: TypeName<L>) -> Self {
+    pub fn array(inner: TypeName) -> Self {
         TypeName::Array(Box::new(inner))
     }
 
@@ -423,12 +418,12 @@ impl<L: CodeLang> TypeName<L> {
     /// this renders identically to [`TypeName::array`]. Use this variant only
     /// when the readonly distinction carries information the output should
     /// preserve (e.g. TypeScript interface fields).
-    pub fn readonly_array(inner: TypeName<L>) -> Self {
+    pub fn readonly_array(inner: TypeName) -> Self {
         TypeName::ReadonlyArray(Box::new(inner))
     }
 
     /// Create a generic type (e.g., `Promise<User>`).
-    pub fn generic(base: TypeName<L>, params: Vec<TypeName<L>>) -> Self {
+    pub fn generic(base: TypeName, params: Vec<TypeName>) -> Self {
         TypeName::Generic {
             base: Box::new(base),
             params,
@@ -436,27 +431,27 @@ impl<L: CodeLang> TypeName<L> {
     }
 
     /// Create a union type (e.g., `A | B | C`).
-    pub fn union(members: Vec<TypeName<L>>) -> Self {
+    pub fn union(members: Vec<TypeName>) -> Self {
         TypeName::Union(members)
     }
 
     /// Create an intersection type (e.g., `A & B`).
-    pub fn intersection(members: Vec<TypeName<L>>) -> Self {
+    pub fn intersection(members: Vec<TypeName>) -> Self {
         TypeName::Intersection(members)
     }
 
     /// Create a pointer type (e.g., Go `*T`).
-    pub fn pointer(inner: TypeName<L>) -> Self {
+    pub fn pointer(inner: TypeName) -> Self {
         TypeName::Pointer(Box::new(inner))
     }
 
     /// Create a slice type (e.g., Go `[]T`).
-    pub fn slice(inner: TypeName<L>) -> Self {
+    pub fn slice(inner: TypeName) -> Self {
         TypeName::Slice(Box::new(inner))
     }
 
     /// Create a map type (e.g., `map[K]V`).
-    pub fn map(key: TypeName<L>, value: TypeName<L>) -> Self {
+    pub fn map(key: TypeName, value: TypeName) -> Self {
         TypeName::Map {
             key: Box::new(key),
             value: Box::new(value),
@@ -464,12 +459,12 @@ impl<L: CodeLang> TypeName<L> {
     }
 
     /// Create an optional type.
-    pub fn optional(inner: TypeName<L>) -> Self {
+    pub fn optional(inner: TypeName) -> Self {
         TypeName::Optional(Box::new(inner))
     }
 
     /// Create a tuple type (e.g., Rust `(A, B)`, TS `[A, B]`).
-    pub fn tuple(elements: Vec<TypeName<L>>) -> Self {
+    pub fn tuple(elements: Vec<TypeName>) -> Self {
         TypeName::Tuple(elements)
     }
 
@@ -479,7 +474,7 @@ impl<L: CodeLang> TypeName<L> {
     }
 
     /// Create a shared reference type (Rust `&T`, C++ `const T&`).
-    pub fn reference(inner: TypeName<L>) -> Self {
+    pub fn reference(inner: TypeName) -> Self {
         TypeName::Reference {
             inner: Box::new(inner),
             mutable: false,
@@ -488,7 +483,7 @@ impl<L: CodeLang> TypeName<L> {
     }
 
     /// Create a mutable reference type (Rust `&mut T`, C++ `T&`).
-    pub fn reference_mut(inner: TypeName<L>) -> Self {
+    pub fn reference_mut(inner: TypeName) -> Self {
         TypeName::Reference {
             inner: Box::new(inner),
             mutable: true,
@@ -497,7 +492,7 @@ impl<L: CodeLang> TypeName<L> {
     }
 
     /// Create a shared reference with a lifetime (Rust `&'a T`).
-    pub fn reference_with_lifetime(inner: TypeName<L>, lifetime: &str) -> Self {
+    pub fn reference_with_lifetime(inner: TypeName, lifetime: &str) -> Self {
         TypeName::Reference {
             inner: Box::new(inner),
             mutable: false,
@@ -506,7 +501,7 @@ impl<L: CodeLang> TypeName<L> {
     }
 
     /// Create a mutable reference with a lifetime (Rust `&'a mut T`).
-    pub fn reference_mut_with_lifetime(inner: TypeName<L>, lifetime: &str) -> Self {
+    pub fn reference_mut_with_lifetime(inner: TypeName, lifetime: &str) -> Self {
         TypeName::Reference {
             inner: Box::new(inner),
             mutable: true,
@@ -515,7 +510,7 @@ impl<L: CodeLang> TypeName<L> {
     }
 
     /// Create a function type.
-    pub fn function(params: Vec<TypeName<L>>, return_type: TypeName<L>) -> Self {
+    pub fn function(params: Vec<TypeName>, return_type: TypeName) -> Self {
         TypeName::Function {
             params,
             return_type: Box::new(return_type),
@@ -530,11 +525,7 @@ impl<L: CodeLang> TypeName<L> {
     /// Create an associated/path-dependent type with a qualifier.
     ///
     /// Rust: `<base as qualifier>::member` (e.g., `<T as Iterator>::Item`).
-    pub fn associated_type(
-        base: TypeName<L>,
-        qualifier: Option<TypeName<L>>,
-        member: &str,
-    ) -> Self {
+    pub fn associated_type(base: TypeName, qualifier: Option<TypeName>, member: &str) -> Self {
         TypeName::AssociatedType {
             base: Box::new(base),
             qualifier: qualifier.map(Box::new),
@@ -545,7 +536,7 @@ impl<L: CodeLang> TypeName<L> {
     /// Create a simple member type (no qualifier).
     ///
     /// Rust: `base::member` (e.g., `Self::Output`).
-    pub fn member_type(base: TypeName<L>, member: &str) -> Self {
+    pub fn member_type(base: TypeName, member: &str) -> Self {
         TypeName::AssociatedType {
             base: Box::new(base),
             qualifier: None,
@@ -554,12 +545,12 @@ impl<L: CodeLang> TypeName<L> {
     }
 
     /// Create an `impl Trait` type (Rust: `impl Display + Debug`).
-    pub fn impl_trait(bounds: Vec<TypeName<L>>) -> Self {
+    pub fn impl_trait(bounds: Vec<TypeName>) -> Self {
         TypeName::ImplTrait { bounds }
     }
 
     /// Create a `dyn Trait` type (Rust: `dyn Error + Send`).
-    pub fn dyn_trait(bounds: Vec<TypeName<L>>) -> Self {
+    pub fn dyn_trait(bounds: Vec<TypeName>) -> Self {
         TypeName::DynTrait { bounds }
     }
 
@@ -572,7 +563,7 @@ impl<L: CodeLang> TypeName<L> {
     }
 
     /// Create a wildcard with an upper bound (Java: `? extends T`, Kotlin: `out T`).
-    pub fn wildcard_extends(bound: TypeName<L>) -> Self {
+    pub fn wildcard_extends(bound: TypeName) -> Self {
         TypeName::Wildcard {
             upper_bound: Some(Box::new(bound)),
             lower_bound: None,
@@ -580,7 +571,7 @@ impl<L: CodeLang> TypeName<L> {
     }
 
     /// Create a wildcard with a lower bound (Java: `? super T`, Kotlin: `in T`).
-    pub fn wildcard_super(bound: TypeName<L>) -> Self {
+    pub fn wildcard_super(bound: TypeName) -> Self {
         TypeName::Wildcard {
             upper_bound: None,
             lower_bound: Some(Box::new(bound)),
@@ -674,7 +665,7 @@ impl<L: CodeLang> TypeName<L> {
                     lb.collect_imports(out);
                 }
             }
-            TypeName::Primitive(_) | TypeName::Raw(_) | TypeName::_Phantom(_) => {}
+            TypeName::Primitive(_) | TypeName::Raw(_) => {}
         }
     }
 
@@ -821,7 +812,6 @@ impl<L: CodeLang> TypeName<L> {
                     BoxDoc::text("?")
                 }
             }
-            TypeName::_Phantom(_) => BoxDoc::nil(),
         }
     }
 
@@ -849,7 +839,7 @@ impl<L: CodeLang> TypeName<L> {
 
     /// Language-aware variant of [`TypeName::to_doc`] that consults the lang for
     /// syntax differences (e.g., generic delimiters `<>` vs `[]`).
-    pub fn to_doc_with_lang<F>(&self, resolve: &F, lang: &L) -> BoxDoc<'static, ()>
+    pub fn to_doc_with_lang<F>(&self, resolve: &F, lang: &dyn CodeLang) -> BoxDoc<'static, ()>
     where
         F: Fn(&str, &str) -> String,
     {
@@ -1132,19 +1122,19 @@ mod tests {
 
     #[test]
     fn test_primitive() {
-        let t = TypeName::<TypeScript>::primitive("number");
+        let t = TypeName::primitive("number");
         assert_eq!(t.render(80, &identity_resolve).unwrap(), "number");
     }
 
     #[test]
     fn test_importable() {
-        let t = TypeName::<TypeScript>::importable("./models", "User");
+        let t = TypeName::importable("./models", "User");
         assert_eq!(t.render(80, &identity_resolve).unwrap(), "User");
     }
 
     #[test]
     fn test_importable_with_alias() {
-        let t = TypeName::<TypeScript>::importable("./other", "User");
+        let t = TypeName::importable("./other", "User");
         let resolve = |module: &str, name: &str| {
             if module == "./other" && name == "User" {
                 "OtherUser".to_string()
@@ -1157,13 +1147,13 @@ mod tests {
 
     #[test]
     fn test_array() {
-        let t = TypeName::<TypeScript>::array(TypeName::primitive("string"));
+        let t = TypeName::array(TypeName::primitive("string"));
         assert_eq!(t.render(80, &identity_resolve).unwrap(), "string[]");
     }
 
     #[test]
     fn test_generic() {
-        let t = TypeName::<TypeScript>::generic(
+        let t = TypeName::generic(
             TypeName::primitive("Promise"),
             vec![TypeName::importable("./models", "User")],
         );
@@ -1172,7 +1162,7 @@ mod tests {
 
     #[test]
     fn test_generic_multiline() {
-        let t = TypeName::<TypeScript>::generic(
+        let t = TypeName::generic(
             TypeName::primitive("Map"),
             vec![
                 TypeName::primitive("VeryLongKeyTypeName"),
@@ -1188,7 +1178,7 @@ mod tests {
 
     #[test]
     fn test_union() {
-        let t = TypeName::<TypeScript>::union(vec![
+        let t = TypeName::union(vec![
             TypeName::primitive("string"),
             TypeName::primitive("number"),
             TypeName::primitive("boolean"),
@@ -1201,7 +1191,7 @@ mod tests {
 
     #[test]
     fn test_union_multiline() {
-        let t = TypeName::<TypeScript>::union(vec![
+        let t = TypeName::union(vec![
             TypeName::primitive("VeryLongTypeName1"),
             TypeName::primitive("VeryLongTypeName2"),
             TypeName::primitive("VeryLongTypeName3"),
@@ -1212,32 +1202,31 @@ mod tests {
 
     #[test]
     fn test_pointer() {
-        let t = TypeName::<TypeScript>::pointer(TypeName::primitive("User"));
+        let t = TypeName::pointer(TypeName::primitive("User"));
         assert_eq!(t.render(80, &identity_resolve).unwrap(), "*User");
     }
 
     #[test]
     fn test_slice() {
-        let t = TypeName::<TypeScript>::slice(TypeName::primitive("User"));
+        let t = TypeName::slice(TypeName::primitive("User"));
         assert_eq!(t.render(80, &identity_resolve).unwrap(), "[]User");
     }
 
     #[test]
     fn test_map() {
-        let t =
-            TypeName::<TypeScript>::map(TypeName::primitive("string"), TypeName::primitive("User"));
+        let t = TypeName::map(TypeName::primitive("string"), TypeName::primitive("User"));
         assert_eq!(t.render(80, &identity_resolve).unwrap(), "map[string]User");
     }
 
     #[test]
     fn test_optional() {
-        let t = TypeName::<TypeScript>::optional(TypeName::primitive("string"));
+        let t = TypeName::optional(TypeName::primitive("string"));
         assert_eq!(t.render(80, &identity_resolve).unwrap(), "string | null");
     }
 
     #[test]
     fn test_function_type() {
-        let t = TypeName::<TypeScript>::function(
+        let t = TypeName::function(
             vec![TypeName::primitive("string"), TypeName::primitive("number")],
             TypeName::primitive("boolean"),
         );
@@ -1249,7 +1238,7 @@ mod tests {
 
     #[test]
     fn test_deeply_nested() {
-        let inner = TypeName::<TypeScript>::generic(
+        let inner = TypeName::generic(
             TypeName::primitive("Array"),
             vec![TypeName::importable("./models", "User")],
         );
@@ -1262,7 +1251,7 @@ mod tests {
 
     #[test]
     fn test_collect_imports() {
-        let t = TypeName::<TypeScript>::generic(
+        let t = TypeName::generic(
             TypeName::importable("./base", "Base"),
             vec![
                 TypeName::importable("./models", "User"),
@@ -1279,7 +1268,7 @@ mod tests {
 
     #[test]
     fn test_raw_no_imports() {
-        let t = TypeName::<TypeScript>::raw("any");
+        let t = TypeName::raw("any");
         let mut imports = Vec::new();
         t.collect_imports(&mut imports);
         assert!(imports.is_empty());
@@ -1288,7 +1277,7 @@ mod tests {
 
     #[test]
     fn test_with_alias_on_importable() {
-        let t = TypeName::<TypeScript>::importable("./models", "User").with_alias("MyUser");
+        let t = TypeName::importable("./models", "User").with_alias("MyUser");
         // Verify the alias is stored correctly.
         if let TypeName::Importable { alias, .. } = &t {
             assert_eq!(alias.as_deref(), Some("MyUser"));
@@ -1299,7 +1288,7 @@ mod tests {
 
     #[test]
     fn test_with_alias_propagates_to_import_ref() {
-        let t = TypeName::<TypeScript>::importable("./models", "User").with_alias("MyUser");
+        let t = TypeName::importable("./models", "User").with_alias("MyUser");
         let mut imports = Vec::new();
         t.collect_imports(&mut imports);
         assert_eq!(imports.len(), 1);
@@ -1310,13 +1299,13 @@ mod tests {
     #[test]
     fn test_with_alias_noop_on_primitive() {
         // with_alias on a non-Importable variant should be a no-op.
-        let t = TypeName::<TypeScript>::primitive("number").with_alias("MyNumber");
+        let t = TypeName::primitive("number").with_alias("MyNumber");
         assert_eq!(t.render(80, &identity_resolve).unwrap(), "number");
     }
 
     #[test]
     fn test_with_alias_renders_alias_name() {
-        let t = TypeName::<TypeScript>::importable("./models", "User").with_alias("MyUser");
+        let t = TypeName::importable("./models", "User").with_alias("MyUser");
         // The resolve function should map to the alias.
         let resolve = |_module: &str, _name: &str| "MyUser".to_string();
         assert_eq!(t.render(80, &resolve).unwrap(), "MyUser");
@@ -1324,7 +1313,7 @@ mod tests {
 
     #[test]
     fn test_tuple() {
-        let t = TypeName::<TypeScript>::tuple(vec![
+        let t = TypeName::tuple(vec![
             TypeName::primitive("string"),
             TypeName::primitive("number"),
         ]);
@@ -1333,13 +1322,13 @@ mod tests {
 
     #[test]
     fn test_unit_tuple() {
-        let t = TypeName::<TypeScript>::unit();
+        let t = TypeName::unit();
         assert_eq!(t.render(80, &identity_resolve).unwrap(), "()");
     }
 
     #[test]
     fn test_tuple_collect_imports() {
-        let t = TypeName::<TypeScript>::tuple(vec![
+        let t = TypeName::tuple(vec![
             TypeName::importable("./models", "User"),
             TypeName::importable("./models", "Tag"),
         ]);
@@ -1353,7 +1342,7 @@ mod tests {
     #[test]
     fn test_tuple_with_lang_ts() {
         let lang = TypeScript::new();
-        let t = TypeName::<TypeScript>::tuple(vec![
+        let t = TypeName::tuple(vec![
             TypeName::primitive("string"),
             TypeName::primitive("number"),
         ]);
@@ -1367,7 +1356,7 @@ mod tests {
     fn test_tuple_with_lang_rust() {
         use crate::lang::rust_lang::RustLang;
         let lang = RustLang::new();
-        let t = TypeName::<RustLang>::tuple(vec![
+        let t = TypeName::tuple(vec![
             TypeName::primitive("String"),
             TypeName::primitive("i32"),
         ]);
@@ -1381,8 +1370,7 @@ mod tests {
     fn test_tuple_with_lang_python() {
         use crate::lang::python::Python;
         let lang = Python::new();
-        let t =
-            TypeName::<Python>::tuple(vec![TypeName::primitive("str"), TypeName::primitive("int")]);
+        let t = TypeName::tuple(vec![TypeName::primitive("str"), TypeName::primitive("int")]);
         let doc = t.to_doc_with_lang(&identity_resolve, &lang);
         let mut buf = Vec::new();
         doc.render(80, &mut buf).unwrap();
@@ -1393,7 +1381,7 @@ mod tests {
     fn test_tuple_with_lang_cpp() {
         use crate::lang::cpp_lang::CppLang;
         let lang = CppLang::new();
-        let t = TypeName::<CppLang>::tuple(vec![
+        let t = TypeName::tuple(vec![
             TypeName::primitive("int"),
             TypeName::primitive("std::string"),
         ]);
@@ -1410,7 +1398,7 @@ mod tests {
     fn test_unit_tuple_with_lang_rust() {
         use crate::lang::rust_lang::RustLang;
         let lang = RustLang::new();
-        let t = TypeName::<RustLang>::unit();
+        let t = TypeName::unit();
         let doc = t.to_doc_with_lang(&identity_resolve, &lang);
         let mut buf = Vec::new();
         doc.render(80, &mut buf).unwrap();
@@ -1419,19 +1407,19 @@ mod tests {
 
     #[test]
     fn test_reference() {
-        let t = TypeName::<TypeScript>::reference(TypeName::primitive("str"));
+        let t = TypeName::reference(TypeName::primitive("str"));
         assert_eq!(t.render(80, &identity_resolve).unwrap(), "&str");
     }
 
     #[test]
     fn test_reference_mut() {
-        let t = TypeName::<TypeScript>::reference_mut(TypeName::primitive("Vec<i32>"));
+        let t = TypeName::reference_mut(TypeName::primitive("Vec<i32>"));
         assert_eq!(t.render(80, &identity_resolve).unwrap(), "&mut Vec<i32>");
     }
 
     #[test]
     fn test_reference_collect_imports() {
-        let t = TypeName::<TypeScript>::reference(TypeName::importable("./models", "User"));
+        let t = TypeName::reference(TypeName::importable("./models", "User"));
         let mut imports = Vec::new();
         t.collect_imports(&mut imports);
         assert_eq!(imports.len(), 1);
@@ -1442,7 +1430,7 @@ mod tests {
     fn test_reference_with_lang_rust() {
         use crate::lang::rust_lang::RustLang;
         let lang = RustLang::new();
-        let t = TypeName::<RustLang>::reference(TypeName::primitive("String"));
+        let t = TypeName::reference(TypeName::primitive("String"));
         let doc = t.to_doc_with_lang(&identity_resolve, &lang);
         let mut buf = Vec::new();
         doc.render(80, &mut buf).unwrap();
@@ -1453,7 +1441,7 @@ mod tests {
     fn test_reference_mut_with_lang_rust() {
         use crate::lang::rust_lang::RustLang;
         let lang = RustLang::new();
-        let t = TypeName::<RustLang>::reference_mut(TypeName::primitive("String"));
+        let t = TypeName::reference_mut(TypeName::primitive("String"));
         let doc = t.to_doc_with_lang(&identity_resolve, &lang);
         let mut buf = Vec::new();
         doc.render(80, &mut buf).unwrap();
@@ -1464,7 +1452,7 @@ mod tests {
     fn test_reference_with_lang_cpp() {
         use crate::lang::cpp_lang::CppLang;
         let lang = CppLang::new();
-        let t = TypeName::<CppLang>::reference(TypeName::primitive("std::string"));
+        let t = TypeName::reference(TypeName::primitive("std::string"));
         let doc = t.to_doc_with_lang(&identity_resolve, &lang);
         let mut buf = Vec::new();
         doc.render(80, &mut buf).unwrap();
@@ -1475,7 +1463,7 @@ mod tests {
     fn test_reference_mut_with_lang_cpp() {
         use crate::lang::cpp_lang::CppLang;
         let lang = CppLang::new();
-        let t = TypeName::<CppLang>::reference_mut(TypeName::primitive("std::string"));
+        let t = TypeName::reference_mut(TypeName::primitive("std::string"));
         let doc = t.to_doc_with_lang(&identity_resolve, &lang);
         let mut buf = Vec::new();
         doc.render(80, &mut buf).unwrap();
@@ -1485,7 +1473,7 @@ mod tests {
     #[test]
     fn test_reference_with_lang_ts() {
         let lang = TypeScript::new();
-        let t = TypeName::<TypeScript>::reference(TypeName::primitive("string"));
+        let t = TypeName::reference(TypeName::primitive("string"));
         let doc = t.to_doc_with_lang(&identity_resolve, &lang);
         let mut buf = Vec::new();
         doc.render(80, &mut buf).unwrap();
@@ -1496,7 +1484,7 @@ mod tests {
     fn test_reference_mut_with_lang_go() {
         use crate::lang::go_lang::GoLang;
         let lang = GoLang::new();
-        let t = TypeName::<GoLang>::reference_mut(TypeName::primitive("int"));
+        let t = TypeName::reference_mut(TypeName::primitive("int"));
         let doc = t.to_doc_with_lang(&identity_resolve, &lang);
         let mut buf = Vec::new();
         doc.render(80, &mut buf).unwrap();
@@ -1507,7 +1495,7 @@ mod tests {
     fn test_reference_with_lang_go() {
         use crate::lang::go_lang::GoLang;
         let lang = GoLang::new();
-        let t = TypeName::<GoLang>::reference(TypeName::primitive("int"));
+        let t = TypeName::reference(TypeName::primitive("int"));
         let doc = t.to_doc_with_lang(&identity_resolve, &lang);
         let mut buf = Vec::new();
         doc.render(80, &mut buf).unwrap();
@@ -1518,7 +1506,7 @@ mod tests {
     fn test_reference_with_lang_c() {
         use crate::lang::c_lang::CLang;
         let lang = CLang::new();
-        let t = TypeName::<CLang>::reference(TypeName::primitive("int"));
+        let t = TypeName::reference(TypeName::primitive("int"));
         let doc = t.to_doc_with_lang(&identity_resolve, &lang);
         let mut buf = Vec::new();
         doc.render(80, &mut buf).unwrap();
@@ -1529,7 +1517,7 @@ mod tests {
     fn test_reference_mut_with_lang_c() {
         use crate::lang::c_lang::CLang;
         let lang = CLang::new();
-        let t = TypeName::<CLang>::reference_mut(TypeName::primitive("int"));
+        let t = TypeName::reference_mut(TypeName::primitive("int"));
         let doc = t.to_doc_with_lang(&identity_resolve, &lang);
         let mut buf = Vec::new();
         doc.render(80, &mut buf).unwrap();
@@ -1539,7 +1527,7 @@ mod tests {
     #[test]
     fn test_generic_prefix_juxtaposition() {
         let lang = PrefixLang::new();
-        let t = TypeName::<PrefixLang>::generic(
+        let t = TypeName::generic(
             TypeName::primitive("Maybe"),
             vec![TypeName::primitive("Int")],
         );
@@ -1552,11 +1540,11 @@ mod tests {
     #[test]
     fn test_generic_prefix_juxtaposition_compound_param() {
         let lang = PrefixLang::new();
-        let inner = TypeName::<PrefixLang>::generic(
+        let inner = TypeName::generic(
             TypeName::primitive("Maybe"),
             vec![TypeName::primitive("Int")],
         );
-        let t = TypeName::<PrefixLang>::generic(
+        let t = TypeName::generic(
             TypeName::primitive("Either"),
             vec![TypeName::primitive("String"), inner],
         );
@@ -1569,7 +1557,7 @@ mod tests {
     #[test]
     fn test_generic_postfix_juxtaposition_single() {
         let lang = PostfixLang::new();
-        let t = TypeName::<PostfixLang>::generic(
+        let t = TypeName::generic(
             TypeName::primitive("option"),
             vec![TypeName::primitive("int")],
         );
@@ -1582,7 +1570,7 @@ mod tests {
     #[test]
     fn test_generic_postfix_juxtaposition_multi() {
         let lang = PostfixLang::new();
-        let t = TypeName::<PostfixLang>::generic(
+        let t = TypeName::generic(
             TypeName::primitive("result"),
             vec![TypeName::primitive("int"), TypeName::primitive("string")],
         );
@@ -1594,29 +1582,30 @@ mod tests {
 
     #[test]
     fn test_is_compound_type() {
-        assert!(is_compound_type(&TypeName::<TypeScript>::generic(
+        assert!(is_compound_type(&TypeName::generic(
             TypeName::primitive("A"),
             vec![TypeName::primitive("B")],
         )));
-        assert!(is_compound_type(&TypeName::<TypeScript>::union(vec![
+        assert!(is_compound_type(&TypeName::union(vec![
             TypeName::primitive("A"),
             TypeName::primitive("B"),
         ])));
-        assert!(is_compound_type(&TypeName::<TypeScript>::intersection(
-            vec![TypeName::primitive("A"), TypeName::primitive("B"),]
-        )));
-        assert!(is_compound_type(&TypeName::<TypeScript>::function(
+        assert!(is_compound_type(&TypeName::intersection(vec![
+            TypeName::primitive("A"),
+            TypeName::primitive("B"),
+        ])));
+        assert!(is_compound_type(&TypeName::function(
             vec![TypeName::primitive("A")],
             TypeName::primitive("B"),
         )));
-        assert!(is_compound_type(&TypeName::<TypeScript>::tuple(vec![
+        assert!(is_compound_type(&TypeName::tuple(vec![
             TypeName::primitive("A"),
             TypeName::primitive("B"),
         ])));
-        assert!(!is_compound_type(&TypeName::<TypeScript>::primitive("Int")));
-        assert!(!is_compound_type(&TypeName::<TypeScript>::array(
-            TypeName::primitive("Int"),
-        )));
+        assert!(!is_compound_type(&TypeName::primitive("Int")));
+        assert!(!is_compound_type(&TypeName::array(TypeName::primitive(
+            "Int"
+        ),)));
     }
 
     // --- Feature 07: Associated Types ---
@@ -1625,7 +1614,7 @@ mod tests {
     fn test_associated_type_rust_qualified() {
         use crate::lang::rust_lang::RustLang;
         let lang = RustLang::new();
-        let t = TypeName::<RustLang>::associated_type(
+        let t = TypeName::associated_type(
             TypeName::primitive("T"),
             Some(TypeName::primitive("Iterator")),
             "Item",
@@ -1640,7 +1629,7 @@ mod tests {
     fn test_associated_type_rust_simple() {
         use crate::lang::rust_lang::RustLang;
         let lang = RustLang::new();
-        let t = TypeName::<RustLang>::member_type(TypeName::primitive("Self"), "Output");
+        let t = TypeName::member_type(TypeName::primitive("Self"), "Output");
         let doc = t.to_doc_with_lang(&identity_resolve, &lang);
         let mut buf = Vec::new();
         doc.render(80, &mut buf).unwrap();
@@ -1650,7 +1639,7 @@ mod tests {
     #[test]
     fn test_associated_type_ts_index_access() {
         let lang = TypeScript::new();
-        let t = TypeName::<TypeScript>::associated_type(
+        let t = TypeName::associated_type(
             TypeName::primitive("T"),
             Some(TypeName::primitive("Qual")),
             "key",
@@ -1665,7 +1654,7 @@ mod tests {
     fn test_associated_type_java_dot() {
         use crate::lang::java_lang::JavaLang;
         let lang = JavaLang::new();
-        let t = TypeName::<JavaLang>::member_type(TypeName::primitive("Map"), "Entry");
+        let t = TypeName::member_type(TypeName::primitive("Map"), "Entry");
         let doc = t.to_doc_with_lang(&identity_resolve, &lang);
         let mut buf = Vec::new();
         doc.render(80, &mut buf).unwrap();
@@ -1674,7 +1663,7 @@ mod tests {
 
     #[test]
     fn test_associated_type_collect_imports() {
-        let t = TypeName::<TypeScript>::associated_type(
+        let t = TypeName::associated_type(
             TypeName::importable("./models", "User"),
             Some(TypeName::importable("./traits", "Serializable")),
             "Output",
@@ -1690,7 +1679,7 @@ mod tests {
     fn test_impl_trait_rust() {
         use crate::lang::rust_lang::RustLang;
         let lang = RustLang::new();
-        let t = TypeName::<RustLang>::impl_trait(vec![
+        let t = TypeName::impl_trait(vec![
             TypeName::primitive("Display"),
             TypeName::primitive("Debug"),
         ]);
@@ -1704,7 +1693,7 @@ mod tests {
     fn test_dyn_trait_rust() {
         use crate::lang::rust_lang::RustLang;
         let lang = RustLang::new();
-        let t = TypeName::<RustLang>::dyn_trait(vec![TypeName::primitive("Error")]);
+        let t = TypeName::dyn_trait(vec![TypeName::primitive("Error")]);
         let doc = t.to_doc_with_lang(&identity_resolve, &lang);
         let mut buf = Vec::new();
         doc.render(80, &mut buf).unwrap();
@@ -1714,7 +1703,7 @@ mod tests {
     #[test]
     fn test_impl_trait_ts_intersection() {
         let lang = TypeScript::new();
-        let t = TypeName::<TypeScript>::impl_trait(vec![
+        let t = TypeName::impl_trait(vec![
             TypeName::primitive("Serializable"),
             TypeName::primitive("Loggable"),
         ]);
@@ -1728,7 +1717,7 @@ mod tests {
     fn test_wildcard_java_unbounded() {
         use crate::lang::java_lang::JavaLang;
         let lang = JavaLang::new();
-        let t = TypeName::<JavaLang>::wildcard();
+        let t = TypeName::wildcard();
         let doc = t.to_doc_with_lang(&identity_resolve, &lang);
         let mut buf = Vec::new();
         doc.render(80, &mut buf).unwrap();
@@ -1739,7 +1728,7 @@ mod tests {
     fn test_wildcard_java_extends() {
         use crate::lang::java_lang::JavaLang;
         let lang = JavaLang::new();
-        let t = TypeName::<JavaLang>::wildcard_extends(TypeName::primitive("Comparable"));
+        let t = TypeName::wildcard_extends(TypeName::primitive("Comparable"));
         let doc = t.to_doc_with_lang(&identity_resolve, &lang);
         let mut buf = Vec::new();
         doc.render(80, &mut buf).unwrap();
@@ -1750,7 +1739,7 @@ mod tests {
     fn test_wildcard_java_super() {
         use crate::lang::java_lang::JavaLang;
         let lang = JavaLang::new();
-        let t = TypeName::<JavaLang>::wildcard_super(TypeName::primitive("Number"));
+        let t = TypeName::wildcard_super(TypeName::primitive("Number"));
         let doc = t.to_doc_with_lang(&identity_resolve, &lang);
         let mut buf = Vec::new();
         doc.render(80, &mut buf).unwrap();
@@ -1761,7 +1750,7 @@ mod tests {
     fn test_wildcard_kotlin() {
         use crate::lang::kotlin::Kotlin;
         let lang = Kotlin::new();
-        let t = TypeName::<Kotlin>::wildcard();
+        let t = TypeName::wildcard();
         let doc = t.to_doc_with_lang(&identity_resolve, &lang);
         let mut buf = Vec::new();
         doc.render(80, &mut buf).unwrap();
@@ -1772,7 +1761,7 @@ mod tests {
     fn test_wildcard_kotlin_out() {
         use crate::lang::kotlin::Kotlin;
         let lang = Kotlin::new();
-        let t = TypeName::<Kotlin>::wildcard_extends(TypeName::primitive("Number"));
+        let t = TypeName::wildcard_extends(TypeName::primitive("Number"));
         let doc = t.to_doc_with_lang(&identity_resolve, &lang);
         let mut buf = Vec::new();
         doc.render(80, &mut buf).unwrap();
@@ -1783,7 +1772,7 @@ mod tests {
     fn test_wildcard_kotlin_in() {
         use crate::lang::kotlin::Kotlin;
         let lang = Kotlin::new();
-        let t = TypeName::<Kotlin>::wildcard_super(TypeName::primitive("Number"));
+        let t = TypeName::wildcard_super(TypeName::primitive("Number"));
         let doc = t.to_doc_with_lang(&identity_resolve, &lang);
         let mut buf = Vec::new();
         doc.render(80, &mut buf).unwrap();
@@ -1794,7 +1783,7 @@ mod tests {
     fn test_wildcard_go() {
         use crate::lang::go_lang::GoLang;
         let lang = GoLang::new();
-        let t = TypeName::<GoLang>::wildcard();
+        let t = TypeName::wildcard();
         let doc = t.to_doc_with_lang(&identity_resolve, &lang);
         let mut buf = Vec::new();
         doc.render(80, &mut buf).unwrap();
@@ -1805,7 +1794,7 @@ mod tests {
     fn test_wildcard_rust() {
         use crate::lang::rust_lang::RustLang;
         let lang = RustLang::new();
-        let t = TypeName::<RustLang>::wildcard();
+        let t = TypeName::wildcard();
         let doc = t.to_doc_with_lang(&identity_resolve, &lang);
         let mut buf = Vec::new();
         doc.render(80, &mut buf).unwrap();
@@ -1814,7 +1803,7 @@ mod tests {
 
     #[test]
     fn test_impl_trait_collect_imports() {
-        let t = TypeName::<TypeScript>::impl_trait(vec![
+        let t = TypeName::impl_trait(vec![
             TypeName::importable("./traits", "Serializable"),
             TypeName::primitive("Debug"),
         ]);
@@ -1825,8 +1814,7 @@ mod tests {
 
     #[test]
     fn test_dyn_trait_collect_imports() {
-        let t =
-            TypeName::<TypeScript>::dyn_trait(vec![TypeName::importable("./errors", "AppError")]);
+        let t = TypeName::dyn_trait(vec![TypeName::importable("./errors", "AppError")]);
         let mut imports = Vec::new();
         t.collect_imports(&mut imports);
         assert_eq!(imports.len(), 1);
@@ -1834,7 +1822,7 @@ mod tests {
 
     #[test]
     fn test_wildcard_collect_imports() {
-        let t = TypeName::<TypeScript>::wildcard_extends(TypeName::importable("./models", "User"));
+        let t = TypeName::wildcard_extends(TypeName::importable("./models", "User"));
         let mut imports = Vec::new();
         t.collect_imports(&mut imports);
         assert_eq!(imports.len(), 1);
@@ -1842,7 +1830,7 @@ mod tests {
 
     #[test]
     fn test_associated_type_default_rendering() {
-        let t = TypeName::<TypeScript>::associated_type(
+        let t = TypeName::associated_type(
             TypeName::primitive("T"),
             Some(TypeName::primitive("Iter")),
             "Item",
@@ -1855,19 +1843,19 @@ mod tests {
 
     #[test]
     fn test_member_type_default_rendering() {
-        let t = TypeName::<TypeScript>::member_type(TypeName::primitive("Self"), "Output");
+        let t = TypeName::member_type(TypeName::primitive("Self"), "Output");
         assert_eq!(t.render(80, &identity_resolve).unwrap(), "Self::Output");
     }
 
     #[test]
     fn test_impl_trait_default_rendering() {
-        let t = TypeName::<TypeScript>::impl_trait(vec![TypeName::primitive("Display")]);
+        let t = TypeName::impl_trait(vec![TypeName::primitive("Display")]);
         assert_eq!(t.render(80, &identity_resolve).unwrap(), "impl Display");
     }
 
     #[test]
     fn test_dyn_trait_default_rendering() {
-        let t = TypeName::<TypeScript>::dyn_trait(vec![
+        let t = TypeName::dyn_trait(vec![
             TypeName::primitive("Error"),
             TypeName::primitive("Send"),
         ]);
@@ -1877,19 +1865,17 @@ mod tests {
     #[test]
     fn test_wildcard_default_rendering() {
         assert_eq!(
-            TypeName::<TypeScript>::wildcard()
-                .render(80, &identity_resolve)
-                .unwrap(),
+            TypeName::wildcard().render(80, &identity_resolve).unwrap(),
             "?"
         );
         assert_eq!(
-            TypeName::<TypeScript>::wildcard_extends(TypeName::primitive("T"))
+            TypeName::wildcard_extends(TypeName::primitive("T"))
                 .render(80, &identity_resolve)
                 .unwrap(),
             "? extends T"
         );
         assert_eq!(
-            TypeName::<TypeScript>::wildcard_super(TypeName::primitive("T"))
+            TypeName::wildcard_super(TypeName::primitive("T"))
                 .render(80, &identity_resolve)
                 .unwrap(),
             "? super T"
@@ -1902,7 +1888,7 @@ mod tests {
     fn test_reference_with_lifetime_rust() {
         use crate::lang::rust_lang::RustLang;
         let lang = RustLang::new();
-        let t = TypeName::<RustLang>::reference_with_lifetime(TypeName::primitive("str"), "'a");
+        let t = TypeName::reference_with_lifetime(TypeName::primitive("str"), "'a");
         let doc = t.to_doc_with_lang(&identity_resolve, &lang);
         let mut buf = Vec::new();
         doc.render(80, &mut buf).unwrap();
@@ -1913,8 +1899,7 @@ mod tests {
     fn test_reference_mut_with_lifetime_rust() {
         use crate::lang::rust_lang::RustLang;
         let lang = RustLang::new();
-        let t =
-            TypeName::<RustLang>::reference_mut_with_lifetime(TypeName::primitive("String"), "'a");
+        let t = TypeName::reference_mut_with_lifetime(TypeName::primitive("String"), "'a");
         let doc = t.to_doc_with_lang(&identity_resolve, &lang);
         let mut buf = Vec::new();
         doc.render(80, &mut buf).unwrap();
@@ -1923,7 +1908,7 @@ mod tests {
 
     #[test]
     fn test_reference_with_lifetime_default_rendering() {
-        let t = TypeName::<TypeScript>::reference_with_lifetime(TypeName::primitive("str"), "'a");
+        let t = TypeName::reference_with_lifetime(TypeName::primitive("str"), "'a");
         assert_eq!(t.render(80, &identity_resolve).unwrap(), "&'a str");
     }
 
@@ -1931,7 +1916,7 @@ mod tests {
     fn test_reference_without_lifetime_unchanged() {
         use crate::lang::rust_lang::RustLang;
         let lang = RustLang::new();
-        let t = TypeName::<RustLang>::reference(TypeName::primitive("String"));
+        let t = TypeName::reference(TypeName::primitive("String"));
         let doc = t.to_doc_with_lang(&identity_resolve, &lang);
         let mut buf = Vec::new();
         doc.render(80, &mut buf).unwrap();

--- a/tests/annotation_spec_tests.rs
+++ b/tests/annotation_spec_tests.rs
@@ -17,9 +17,9 @@ use sigil_stitch::type_name::TypeName;
 
 // ── Helpers ──────────────────────────────────────────────
 
-fn render_fun<L: sigil_stitch::lang::CodeLang>(
-    spec: &FunSpec<L>,
-    lang: &L,
+fn render_fun(
+    spec: &FunSpec,
+    lang: &dyn sigil_stitch::lang::CodeLang,
     ctx: DeclarationContext,
 ) -> String {
     let block = spec.emit(lang, ctx).unwrap();
@@ -28,7 +28,7 @@ fn render_fun<L: sigil_stitch::lang::CodeLang>(
     renderer.render(&block).unwrap()
 }
 
-fn render_type<L: sigil_stitch::lang::CodeLang>(spec: &TypeSpec<L>, lang: &L) -> String {
+fn render_type(spec: &TypeSpec, lang: &dyn sigil_stitch::lang::CodeLang) -> String {
     let blocks = spec.emit(lang).unwrap();
     let imports = sigil_stitch::import::ImportGroup::new();
     let mut output = String::new();
@@ -42,9 +42,9 @@ fn render_type<L: sigil_stitch::lang::CodeLang>(spec: &TypeSpec<L>, lang: &L) ->
     output
 }
 
-fn render_field<L: sigil_stitch::lang::CodeLang>(
-    spec: &FieldSpec<L>,
-    lang: &L,
+fn render_field(
+    spec: &FieldSpec,
+    lang: &dyn sigil_stitch::lang::CodeLang,
     ctx: DeclarationContext,
 ) -> String {
     let block = spec.emit(lang, ctx).unwrap();
@@ -58,11 +58,16 @@ fn render_field<L: sigil_stitch::lang::CodeLang>(
 #[test]
 fn test_ts_simple_annotation_on_fun() {
     let ts = TypeScript::new();
-    let mut fb = FunSpec::<TypeScript>::builder("handleRequest");
-    fb.annotate(AnnotationSpec::new("deprecated"));
-    fb.returns(TypeName::primitive("void"));
-    fb.body(CodeBlock::of("// todo", ()).unwrap());
-    let output = render_fun(&fb.build().unwrap(), &ts, DeclarationContext::TopLevel);
+    let output = render_fun(
+        &FunSpec::builder("handleRequest")
+            .annotate(AnnotationSpec::new("deprecated"))
+            .returns(TypeName::primitive("void"))
+            .body(CodeBlock::of("// todo", ()).unwrap())
+            .build()
+            .unwrap(),
+        &ts,
+        DeclarationContext::TopLevel,
+    );
     assert!(output.contains("@deprecated\n"));
     assert!(output.contains("function handleRequest(): void {"));
 }
@@ -70,20 +75,29 @@ fn test_ts_simple_annotation_on_fun() {
 #[test]
 fn test_ts_annotation_with_args() {
     let ts = TypeScript::new();
-    let mut fb = FunSpec::<TypeScript>::builder("myMethod");
-    fb.annotate(AnnotationSpec::new("Component").arg("selector: 'app-root'"));
-    fb.body(CodeBlock::of("// body", ()).unwrap());
-    let output = render_fun(&fb.build().unwrap(), &ts, DeclarationContext::Member);
+    let output = render_fun(
+        &FunSpec::builder("myMethod")
+            .annotate(AnnotationSpec::new("Component").arg("selector: 'app-root'"))
+            .body(CodeBlock::of("// body", ()).unwrap())
+            .build()
+            .unwrap(),
+        &ts,
+        DeclarationContext::Member,
+    );
     assert!(output.contains("@Component(selector: 'app-root')\n"));
 }
 
 #[test]
 fn test_ts_annotation_on_class() {
     let ts = TypeScript::new();
-    let mut tb = TypeSpec::<TypeScript>::builder("AppComponent", TypeKind::Class);
-    tb.annotate(AnnotationSpec::new("Component").arg("{ selector: 'app-root' }"));
-    tb.visibility(Visibility::Public);
-    let output = render_type(&tb.build().unwrap(), &ts);
+    let output = render_type(
+        &TypeSpec::builder("AppComponent", TypeKind::Class)
+            .annotate(AnnotationSpec::new("Component").arg("{ selector: 'app-root' }"))
+            .visibility(Visibility::Public)
+            .build()
+            .unwrap(),
+        &ts,
+    );
     assert!(output.contains("@Component({ selector: 'app-root' })\n"));
     assert!(output.contains("export class AppComponent {"));
 }
@@ -91,9 +105,14 @@ fn test_ts_annotation_on_class() {
 #[test]
 fn test_ts_annotation_on_field() {
     let ts = TypeScript::new();
-    let mut fb = FieldSpec::builder("name", TypeName::<TypeScript>::primitive("string"));
-    fb.annotate(AnnotationSpec::new("Required"));
-    let output = render_field(&fb.build().unwrap(), &ts, DeclarationContext::Member);
+    let output = render_field(
+        &FieldSpec::builder("name", TypeName::primitive("string"))
+            .annotate(AnnotationSpec::new("Required"))
+            .build()
+            .unwrap(),
+        &ts,
+        DeclarationContext::Member,
+    );
     assert!(output.contains("@Required\n"));
     assert!(output.contains("name: string;"));
 }
@@ -103,10 +122,14 @@ fn test_ts_annotation_on_field() {
 #[test]
 fn test_rust_derive_annotation() {
     let rs = RustLang::new();
-    let mut tb = TypeSpec::<RustLang>::builder("Config", TypeKind::Struct);
-    tb.annotate(AnnotationSpec::new("derive").arg("Debug, Clone, Serialize"));
-    tb.visibility(Visibility::Public);
-    let output = render_type(&tb.build().unwrap(), &rs);
+    let output = render_type(
+        &TypeSpec::builder("Config", TypeKind::Struct)
+            .annotate(AnnotationSpec::new("derive").arg("Debug, Clone, Serialize"))
+            .visibility(Visibility::Public)
+            .build()
+            .unwrap(),
+        &rs,
+    );
     assert!(output.contains("#[derive(Debug, Clone, Serialize)]"));
     assert!(output.contains("pub struct Config {"));
 }
@@ -114,10 +137,15 @@ fn test_rust_derive_annotation() {
 #[test]
 fn test_rust_allow_annotation() {
     let rs = RustLang::new();
-    let mut fb = FunSpec::<RustLang>::builder("old_func");
-    fb.annotate(AnnotationSpec::new("allow").arg("dead_code"));
-    fb.body(CodeBlock::of("// noop", ()).unwrap());
-    let output = render_fun(&fb.build().unwrap(), &rs, DeclarationContext::TopLevel);
+    let output = render_fun(
+        &FunSpec::builder("old_func")
+            .annotate(AnnotationSpec::new("allow").arg("dead_code"))
+            .body(CodeBlock::of("// noop", ()).unwrap())
+            .build()
+            .unwrap(),
+        &rs,
+        DeclarationContext::TopLevel,
+    );
     assert!(output.contains("#[allow(dead_code)]"));
     assert!(output.contains("fn old_func()"));
 }
@@ -125,20 +153,30 @@ fn test_rust_allow_annotation() {
 #[test]
 fn test_rust_no_args_annotation() {
     let rs = RustLang::new();
-    let mut fb = FunSpec::<RustLang>::builder("my_test");
-    fb.annotate(AnnotationSpec::new("test"));
-    fb.body(CodeBlock::of("assert!(true)", ()).unwrap());
-    let output = render_fun(&fb.build().unwrap(), &rs, DeclarationContext::TopLevel);
+    let output = render_fun(
+        &FunSpec::builder("my_test")
+            .annotate(AnnotationSpec::new("test"))
+            .body(CodeBlock::of("assert!(true)", ()).unwrap())
+            .build()
+            .unwrap(),
+        &rs,
+        DeclarationContext::TopLevel,
+    );
     assert!(output.contains("#[test]"));
 }
 
 #[test]
 fn test_rust_annotation_on_field() {
     let rs = RustLang::new();
-    let mut fb = FieldSpec::builder("name", TypeName::<RustLang>::primitive("String"));
-    fb.annotate(AnnotationSpec::new("serde").arg("rename = \"user_name\""));
-    fb.visibility(Visibility::Public);
-    let output = render_field(&fb.build().unwrap(), &rs, DeclarationContext::Member);
+    let output = render_field(
+        &FieldSpec::builder("name", TypeName::primitive("String"))
+            .annotate(AnnotationSpec::new("serde").arg("rename = \"user_name\""))
+            .visibility(Visibility::Public)
+            .build()
+            .unwrap(),
+        &rs,
+        DeclarationContext::Member,
+    );
     assert!(output.contains("#[serde(rename = \"user_name\")]"));
     assert!(output.contains("pub name: String,"));
 }
@@ -146,12 +184,19 @@ fn test_rust_annotation_on_field() {
 #[test]
 fn test_rust_annotation_on_enum_variant() {
     let rs = RustLang::new();
-    let mut tb = TypeSpec::<RustLang>::builder("Color", TypeKind::Enum);
-    let mut v = EnumVariantSpec::builder("Default");
-    v.annotate(AnnotationSpec::new("default"));
-    tb.add_variant(v.build().unwrap());
-    tb.add_variant(EnumVariantSpec::new("Custom").unwrap());
-    let output = render_type(&tb.build().unwrap(), &rs);
+    let output = render_type(
+        &TypeSpec::builder("Color", TypeKind::Enum)
+            .add_variant(
+                EnumVariantSpec::builder("Default")
+                    .annotate(AnnotationSpec::new("default"))
+                    .build()
+                    .unwrap(),
+            )
+            .add_variant(EnumVariantSpec::new("Custom").unwrap())
+            .build()
+            .unwrap(),
+        &rs,
+    );
     assert!(output.contains("#[default]"));
     assert!(output.contains("Default,"));
     assert!(output.contains("Custom,"));
@@ -162,22 +207,32 @@ fn test_rust_annotation_on_enum_variant() {
 #[test]
 fn test_cpp_nodiscard_annotation() {
     let cpp = CppLang::new();
-    let mut fb = FunSpec::<CppLang>::builder("compute");
-    fb.annotate(AnnotationSpec::new("nodiscard"));
-    fb.returns(TypeName::primitive("int"));
-    fb.body(CodeBlock::of("return 42;", ()).unwrap());
-    let output = render_fun(&fb.build().unwrap(), &cpp, DeclarationContext::TopLevel);
+    let output = render_fun(
+        &FunSpec::builder("compute")
+            .annotate(AnnotationSpec::new("nodiscard"))
+            .returns(TypeName::primitive("int"))
+            .body(CodeBlock::of("return 42;", ()).unwrap())
+            .build()
+            .unwrap(),
+        &cpp,
+        DeclarationContext::TopLevel,
+    );
     assert!(output.contains("[[nodiscard]]"));
 }
 
 #[test]
 fn test_cpp_deprecated_with_reason() {
     let cpp = CppLang::new();
-    let mut fb = FunSpec::<CppLang>::builder("oldFunc");
-    fb.annotate(AnnotationSpec::new("deprecated").arg("\"use newFunc instead\""));
-    fb.returns(TypeName::primitive("void"));
-    fb.body(CodeBlock::of("// noop", ()).unwrap());
-    let output = render_fun(&fb.build().unwrap(), &cpp, DeclarationContext::TopLevel);
+    let output = render_fun(
+        &FunSpec::builder("oldFunc")
+            .annotate(AnnotationSpec::new("deprecated").arg("\"use newFunc instead\""))
+            .returns(TypeName::primitive("void"))
+            .body(CodeBlock::of("// noop", ()).unwrap())
+            .build()
+            .unwrap(),
+        &cpp,
+        DeclarationContext::TopLevel,
+    );
     assert!(output.contains("[[deprecated(\"use newFunc instead\")]]"));
 }
 
@@ -186,22 +241,32 @@ fn test_cpp_deprecated_with_reason() {
 #[test]
 fn test_c_attribute_annotation() {
     let c = CLang::new();
-    let mut fb = FunSpec::<CLang>::builder("init");
-    fb.annotate(AnnotationSpec::new("constructor"));
-    fb.returns(TypeName::primitive("void"));
-    fb.body(CodeBlock::of("// startup", ()).unwrap());
-    let output = render_fun(&fb.build().unwrap(), &c, DeclarationContext::TopLevel);
+    let output = render_fun(
+        &FunSpec::builder("init")
+            .annotate(AnnotationSpec::new("constructor"))
+            .returns(TypeName::primitive("void"))
+            .body(CodeBlock::of("// startup", ()).unwrap())
+            .build()
+            .unwrap(),
+        &c,
+        DeclarationContext::TopLevel,
+    );
     assert!(output.contains("__attribute__((constructor))"));
 }
 
 #[test]
 fn test_c_attribute_with_args() {
     let c = CLang::new();
-    let mut fb = FunSpec::<CLang>::builder("alloc");
-    fb.annotate(AnnotationSpec::new("malloc").arg("free, 1"));
-    fb.returns(TypeName::primitive("void*"));
-    fb.body(CodeBlock::of("return malloc(size);", ()).unwrap());
-    let output = render_fun(&fb.build().unwrap(), &c, DeclarationContext::TopLevel);
+    let output = render_fun(
+        &FunSpec::builder("alloc")
+            .annotate(AnnotationSpec::new("malloc").arg("free, 1"))
+            .returns(TypeName::primitive("void*"))
+            .body(CodeBlock::of("return malloc(size);", ()).unwrap())
+            .build()
+            .unwrap(),
+        &c,
+        DeclarationContext::TopLevel,
+    );
     assert!(output.contains("__attribute__((malloc(free, 1)))"));
 }
 
@@ -210,12 +275,17 @@ fn test_c_attribute_with_args() {
 #[test]
 fn test_java_override_annotation() {
     let java = JavaLang::new();
-    let mut fb = FunSpec::<JavaLang>::builder("toString");
-    fb.annotate(AnnotationSpec::new("Override"));
-    fb.visibility(Visibility::Public);
-    fb.returns(TypeName::primitive("String"));
-    fb.body(CodeBlock::of("return \"\";", ()).unwrap());
-    let output = render_fun(&fb.build().unwrap(), &java, DeclarationContext::Member);
+    let output = render_fun(
+        &FunSpec::builder("toString")
+            .annotate(AnnotationSpec::new("Override"))
+            .visibility(Visibility::Public)
+            .returns(TypeName::primitive("String"))
+            .body(CodeBlock::of("return \"\";", ()).unwrap())
+            .build()
+            .unwrap(),
+        &java,
+        DeclarationContext::Member,
+    );
     assert!(output.contains("@Override\n"));
     assert!(output.contains("public String toString()"));
 }
@@ -223,10 +293,15 @@ fn test_java_override_annotation() {
 #[test]
 fn test_java_suppress_warnings() {
     let java = JavaLang::new();
-    let mut fb = FunSpec::<JavaLang>::builder("process");
-    fb.annotate(AnnotationSpec::new("SuppressWarnings").arg("\"unchecked\""));
-    fb.body(CodeBlock::of("// raw types", ()).unwrap());
-    let output = render_fun(&fb.build().unwrap(), &java, DeclarationContext::TopLevel);
+    let output = render_fun(
+        &FunSpec::builder("process")
+            .annotate(AnnotationSpec::new("SuppressWarnings").arg("\"unchecked\""))
+            .body(CodeBlock::of("// raw types", ()).unwrap())
+            .build()
+            .unwrap(),
+        &java,
+        DeclarationContext::TopLevel,
+    );
     assert!(output.contains("@SuppressWarnings(\"unchecked\")"));
 }
 
@@ -235,11 +310,16 @@ fn test_java_suppress_warnings() {
 #[test]
 fn test_kotlin_jvm_static() {
     let kt = Kotlin::new();
-    let mut fb = FunSpec::<Kotlin>::builder("getInstance");
-    fb.annotate(AnnotationSpec::new("JvmStatic"));
-    fb.returns(TypeName::primitive("Singleton"));
-    fb.body(CodeBlock::of("return INSTANCE", ()).unwrap());
-    let output = render_fun(&fb.build().unwrap(), &kt, DeclarationContext::Member);
+    let output = render_fun(
+        &FunSpec::builder("getInstance")
+            .annotate(AnnotationSpec::new("JvmStatic"))
+            .returns(TypeName::primitive("Singleton"))
+            .body(CodeBlock::of("return INSTANCE", ()).unwrap())
+            .build()
+            .unwrap(),
+        &kt,
+        DeclarationContext::Member,
+    );
     assert!(output.contains("@JvmStatic\n"));
 }
 
@@ -248,19 +328,28 @@ fn test_kotlin_jvm_static() {
 #[test]
 fn test_python_decorator() {
     let py = Python::new();
-    let mut fb = FunSpec::<Python>::builder("my_method");
-    fb.annotate(AnnotationSpec::new("staticmethod"));
-    fb.body(CodeBlock::of("pass", ()).unwrap());
-    let output = render_fun(&fb.build().unwrap(), &py, DeclarationContext::Member);
+    let output = render_fun(
+        &FunSpec::builder("my_method")
+            .annotate(AnnotationSpec::new("staticmethod"))
+            .body(CodeBlock::of("pass", ()).unwrap())
+            .build()
+            .unwrap(),
+        &py,
+        DeclarationContext::Member,
+    );
     assert!(output.contains("@staticmethod\n"));
 }
 
 #[test]
 fn test_python_dataclass_decorator() {
     let py = Python::new();
-    let mut tb = TypeSpec::<Python>::builder("Config", TypeKind::Class);
-    tb.annotate(AnnotationSpec::new("dataclass").arg("frozen=True"));
-    let output = render_type(&tb.build().unwrap(), &py);
+    let output = render_type(
+        &TypeSpec::builder("Config", TypeKind::Class)
+            .annotate(AnnotationSpec::new("dataclass").arg("frozen=True"))
+            .build()
+            .unwrap(),
+        &py,
+    );
     assert!(output.contains("@dataclass(frozen=True)\n"));
     assert!(output.contains("class Config:"));
 }
@@ -270,12 +359,10 @@ fn test_python_dataclass_decorator() {
 #[test]
 fn test_mixed_annotation_and_codeblock() {
     let rs = RustLang::new();
-    let mut fb = FunSpec::<RustLang>::builder("test_it");
-    // Structured annotation first.
-    fb.annotate(AnnotationSpec::new("cfg").arg("test"));
-    // Raw CodeBlock annotation second.
-    fb.annotation(CodeBlock::of("#[ignore]", ()).unwrap());
-    fb.body(CodeBlock::of("// test body", ()).unwrap());
+    let fb = FunSpec::builder("test_it")
+        .annotate(AnnotationSpec::new("cfg").arg("test"))
+        .annotation(CodeBlock::of("#[ignore]", ()).unwrap())
+        .body(CodeBlock::of("// test body", ()).unwrap());
     let output = render_fun(&fb.build().unwrap(), &rs, DeclarationContext::TopLevel);
     // Structured specs appear before raw CodeBlock annotations.
     let cfg_pos = output
@@ -289,13 +376,19 @@ fn test_mixed_annotation_and_codeblock() {
 
 #[test]
 fn test_importable_annotation_ts() {
-    let mut fb = FileSpec::<TypeScript>::builder("app.ts");
-    let decorator_type = TypeName::<TypeScript>::importable("./decorators", "Component");
-    let mut fun_b = FunSpec::<TypeScript>::builder("init");
-    fun_b.annotate(AnnotationSpec::importable(decorator_type).arg("{ selector: 'app' }"));
-    fun_b.body(CodeBlock::of("// init", ()).unwrap());
-    fb.add_function(fun_b.build().unwrap());
-    let output = fb.build().unwrap().render(80).unwrap();
+    let decorator_type = TypeName::importable("./decorators", "Component");
+    let output = FileSpec::builder("app.ts")
+        .add_function(
+            FunSpec::builder("init")
+                .annotate(AnnotationSpec::importable(decorator_type).arg("{ selector: 'app' }"))
+                .body(CodeBlock::of("// init", ()).unwrap())
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap();
     // The import should be tracked.
     assert!(output.contains("import { Component } from './decorators'"));
     // The annotation should use the resolved name.
@@ -304,14 +397,20 @@ fn test_importable_annotation_ts() {
 
 #[test]
 fn test_importable_annotation_java() {
-    let mut fb = FileSpec::<JavaLang>::builder("App.java");
-    let nullable = TypeName::<JavaLang>::importable("javax.annotation", "Nullable");
-    let mut fun_b = FunSpec::<JavaLang>::builder("getUser");
-    fun_b.annotate(AnnotationSpec::importable(nullable));
-    fun_b.returns(TypeName::primitive("User"));
-    fun_b.body(CodeBlock::of("return null;", ()).unwrap());
-    fb.add_function(fun_b.build().unwrap());
-    let output = fb.build().unwrap().render(80).unwrap();
+    let nullable = TypeName::importable("javax.annotation", "Nullable");
+    let output = FileSpec::builder("App.java")
+        .add_function(
+            FunSpec::builder("getUser")
+                .annotate(AnnotationSpec::importable(nullable))
+                .returns(TypeName::primitive("User"))
+                .body(CodeBlock::of("return null;", ()).unwrap())
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap();
     assert!(output.contains("import javax.annotation.Nullable;"));
     assert!(output.contains("@Nullable"));
 }
@@ -321,11 +420,16 @@ fn test_importable_annotation_java() {
 #[test]
 fn test_multiple_annotations_on_fun() {
     let rs = RustLang::new();
-    let mut fb = FunSpec::<RustLang>::builder("bench_it");
-    fb.annotate(AnnotationSpec::new("cfg").arg("test"));
-    fb.annotate(AnnotationSpec::new("bench"));
-    fb.body(CodeBlock::of("// benchmark", ()).unwrap());
-    let output = render_fun(&fb.build().unwrap(), &rs, DeclarationContext::TopLevel);
+    let output = render_fun(
+        &FunSpec::builder("bench_it")
+            .annotate(AnnotationSpec::new("cfg").arg("test"))
+            .annotate(AnnotationSpec::new("bench"))
+            .body(CodeBlock::of("// benchmark", ()).unwrap())
+            .build()
+            .unwrap(),
+        &rs,
+        DeclarationContext::TopLevel,
+    );
     assert!(output.contains("#[cfg(test)]"));
     assert!(output.contains("#[bench]"));
     let cfg_pos = output.find("#[cfg(test)]").unwrap();
@@ -336,13 +440,18 @@ fn test_multiple_annotations_on_fun() {
 #[test]
 fn test_multiple_args() {
     let rs = RustLang::new();
-    let mut fb = FunSpec::<RustLang>::builder("handler");
-    fb.annotate(
-        AnnotationSpec::new("cfg")
-            .arg("feature = \"web\"")
-            .arg("not(test)"),
+    let output = render_fun(
+        &FunSpec::builder("handler")
+            .annotate(
+                AnnotationSpec::new("cfg")
+                    .arg("feature = \"web\"")
+                    .arg("not(test)"),
+            )
+            .body(CodeBlock::of("// handler", ()).unwrap())
+            .build()
+            .unwrap(),
+        &rs,
+        DeclarationContext::TopLevel,
     );
-    fb.body(CodeBlock::of("// handler", ()).unwrap());
-    let output = render_fun(&fb.build().unwrap(), &rs, DeclarationContext::TopLevel);
     assert!(output.contains("#[cfg(feature = \"web\", not(test))]"));
 }

--- a/tests/bash/builder_control_flow.rs
+++ b/tests/bash/builder_control_flow.rs
@@ -1,12 +1,11 @@
 use sigil_stitch::code_block::CodeBlock;
-use sigil_stitch::lang::bash::Bash;
 use sigil_stitch::spec::file_spec::FileSpec;
 
 use super::golden;
 
 #[test]
 fn test_if_then_fi() {
-    let mut b = CodeBlock::<Bash>::builder();
+    let mut b = CodeBlock::builder();
     b.add("if [ -f \"$1\" ]; then\n", ());
     b.add("%>", ());
     b.add_statement("echo \"file exists\"", ());
@@ -18,9 +17,10 @@ fn test_if_then_fi() {
     b.add("fi\n", ());
     let block = b.build().unwrap();
 
-    let mut fb = FileSpec::<Bash>::builder("check.bash");
-    fb.add_code(block);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder("check.bash")
+        .add_code(block)
+        .build()
+        .unwrap();
 
     let output = file.render(80).unwrap();
     golden::assert_golden("bash/if_then_fi.bash", &output);
@@ -28,7 +28,7 @@ fn test_if_then_fi() {
 
 #[test]
 fn test_for_loop() {
-    let mut b = CodeBlock::<Bash>::builder();
+    let mut b = CodeBlock::builder();
     b.add("for f in *.txt; do\n", ());
     b.add("%>", ());
     b.add_statement("echo \"Processing $f\"", ());
@@ -36,9 +36,10 @@ fn test_for_loop() {
     b.add("done\n", ());
     let block = b.build().unwrap();
 
-    let mut fb = FileSpec::<Bash>::builder("loop.bash");
-    fb.add_code(block);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder("loop.bash")
+        .add_code(block)
+        .build()
+        .unwrap();
 
     let output = file.render(80).unwrap();
     golden::assert_golden("bash/for_loop.bash", &output);
@@ -46,7 +47,7 @@ fn test_for_loop() {
 
 #[test]
 fn test_while_loop() {
-    let mut b = CodeBlock::<Bash>::builder();
+    let mut b = CodeBlock::builder();
     b.add("while read -r line; do\n", ());
     b.add("%>", ());
     b.add_statement("echo \"$line\"", ());
@@ -54,9 +55,10 @@ fn test_while_loop() {
     b.add("done\n", ());
     let block = b.build().unwrap();
 
-    let mut fb = FileSpec::<Bash>::builder("reader.bash");
-    fb.add_code(block);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder("reader.bash")
+        .add_code(block)
+        .build()
+        .unwrap();
 
     let output = file.render(80).unwrap();
     golden::assert_golden("bash/while_loop.bash", &output);
@@ -64,7 +66,7 @@ fn test_while_loop() {
 
 #[test]
 fn test_case_esac() {
-    let mut b = CodeBlock::<Bash>::builder();
+    let mut b = CodeBlock::builder();
     b.add("case \"$1\" in\n", ());
     b.add("%>", ());
     b.add("start)\n", ());
@@ -86,9 +88,10 @@ fn test_case_esac() {
     b.add("esac\n", ());
     let block = b.build().unwrap();
 
-    let mut fb = FileSpec::<Bash>::builder("service.bash");
-    fb.add_code(block);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder("service.bash")
+        .add_code(block)
+        .build()
+        .unwrap();
 
     let output = file.render(80).unwrap();
     golden::assert_golden("bash/case_esac.bash", &output);
@@ -96,7 +99,7 @@ fn test_case_esac() {
 
 #[test]
 fn test_nested_control_flow() {
-    let mut b = CodeBlock::<Bash>::builder();
+    let mut b = CodeBlock::builder();
     b.add("if [ -d \"$1\" ]; then\n", ());
     b.add("%>", ());
     b.add("for f in \"$1\"/*; do\n", ());
@@ -112,9 +115,10 @@ fn test_nested_control_flow() {
     b.add("fi\n", ());
     let block = b.build().unwrap();
 
-    let mut fb = FileSpec::<Bash>::builder("nested.bash");
-    fb.add_code(block);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder("nested.bash")
+        .add_code(block)
+        .build()
+        .unwrap();
 
     let output = file.render(80).unwrap();
     golden::assert_golden("bash/nested_control_flow.bash", &output);

--- a/tests/bash/builder_edge_cases.rs
+++ b/tests/bash/builder_edge_cases.rs
@@ -1,20 +1,20 @@
 use sigil_stitch::code_block::{CodeBlock, StringLitArg};
-use sigil_stitch::lang::bash::Bash;
 use sigil_stitch::spec::file_spec::FileSpec;
 
 use super::golden;
 
 #[test]
 fn test_variable_assignment() {
-    let mut b = CodeBlock::<Bash>::builder();
+    let mut b = CodeBlock::builder();
     b.add("NAME=%S\n", (StringLitArg("world".into()),));
     b.add("COUNT=42\n", ());
     b.add("READONLY_VAR=%S\n", (StringLitArg("constant".into()),));
     let block = b.build().unwrap();
 
-    let mut fb = FileSpec::<Bash>::builder("vars.bash");
-    fb.add_code(block);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder("vars.bash")
+        .add_code(block)
+        .build()
+        .unwrap();
 
     let output = file.render(80).unwrap();
     golden::assert_golden("bash/variable_assignment.bash", &output);
@@ -22,19 +22,20 @@ fn test_variable_assignment() {
 
 #[test]
 fn test_shebang() {
-    let mut header_b = CodeBlock::<Bash>::builder();
+    let mut header_b = CodeBlock::builder();
     header_b.add("#!/usr/bin/env bash\n", ());
     header_b.add("set -euo pipefail", ());
     let header = header_b.build().unwrap();
 
-    let mut body = CodeBlock::<Bash>::builder();
+    let mut body = CodeBlock::builder();
     body.add_statement("echo \"hello\"", ());
     let block = body.build().unwrap();
 
-    let mut fb = FileSpec::<Bash>::builder("script.bash");
-    fb.header(header);
-    fb.add_code(block);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder("script.bash")
+        .header(header)
+        .add_code(block)
+        .build()
+        .unwrap();
 
     let output = file.render(80).unwrap();
     golden::assert_golden("bash/shebang.bash", &output);
@@ -42,16 +43,17 @@ fn test_shebang() {
 
 #[test]
 fn test_string_escaping() {
-    let mut b = CodeBlock::<Bash>::builder();
+    let mut b = CodeBlock::builder();
     b.add("MSG=%S\n", (StringLitArg("hello \"world\"".into()),));
     b.add("PATH_VAR=%S\n", (StringLitArg("$HOME/bin".into()),));
     b.add("CMD=%S\n", (StringLitArg("`whoami`".into()),));
     b.add("BANG=%S\n", (StringLitArg("wow!".into()),));
     let block = b.build().unwrap();
 
-    let mut fb = FileSpec::<Bash>::builder("escape.bash");
-    fb.add_code(block);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder("escape.bash")
+        .add_code(block)
+        .build()
+        .unwrap();
 
     let output = file.render(80).unwrap();
     golden::assert_golden("bash/string_escaping.bash", &output);

--- a/tests/bash/builder_functions.rs
+++ b/tests/bash/builder_functions.rs
@@ -1,5 +1,4 @@
 use sigil_stitch::code_block::CodeBlock;
-use sigil_stitch::lang::bash::Bash;
 use sigil_stitch::spec::file_spec::FileSpec;
 use sigil_stitch::spec::fun_spec::FunSpec;
 use sigil_stitch::type_name::TypeName;
@@ -8,18 +7,17 @@ use super::golden;
 
 #[test]
 fn test_function_spec() {
-    let mut body_b = CodeBlock::<Bash>::builder();
+    let mut body_b = CodeBlock::builder();
     body_b.add("local name=$1\n", ());
     body_b.add_statement("echo \"Hello, $name\"", ());
     let body = body_b.build().unwrap();
 
-    let mut fb = FunSpec::<Bash>::builder("greet");
-    fb.body(body);
-    let fun = fb.build().unwrap();
+    let fun = FunSpec::builder("greet").body(body).build().unwrap();
 
-    let mut file_b = FileSpec::<Bash>::builder("funcs.bash");
-    file_b.add_function(fun);
-    let file = file_b.build().unwrap();
+    let file = FileSpec::builder("funcs.bash")
+        .add_function(fun)
+        .build()
+        .unwrap();
 
     let output = file.render(80).unwrap();
     golden::assert_golden("bash/function_spec.bash", &output);
@@ -27,15 +25,15 @@ fn test_function_spec() {
 
 #[test]
 fn test_complete_script() {
-    let utils_fn = TypeName::<Bash>::importable("./lib/utils.sh", "log_info");
+    let utils_fn = TypeName::importable("./lib/utils.sh", "log_info");
 
-    let mut header_b = CodeBlock::<Bash>::builder();
+    let mut header_b = CodeBlock::builder();
     header_b.add("#!/usr/bin/env bash\n", ());
     header_b.add("set -euo pipefail", ());
     let header = header_b.build().unwrap();
 
     // Function
-    let mut fun_body = CodeBlock::<Bash>::builder();
+    let mut fun_body = CodeBlock::builder();
     fun_body.add("local target=$1\n", ());
     fun_body.add("if [ -z \"$target\" ]; then\n", ());
     fun_body.add("%>", ());
@@ -46,20 +44,19 @@ fn test_complete_script() {
     fun_body.add_statement("%T \"deploying to $target\"", (utils_fn,));
     let fun_body = fun_body.build().unwrap();
 
-    let mut fun = FunSpec::<Bash>::builder("deploy");
-    fun.body(fun_body);
-    let fun = fun.build().unwrap();
+    let fun = FunSpec::builder("deploy").body(fun_body).build().unwrap();
 
     // Main body
-    let mut main = CodeBlock::<Bash>::builder();
+    let mut main = CodeBlock::builder();
     main.add_statement("deploy \"$@\"", ());
     let main = main.build().unwrap();
 
-    let mut fb = FileSpec::<Bash>::builder("deploy.bash");
-    fb.header(header);
-    fb.add_function(fun);
-    fb.add_code(main);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder("deploy.bash")
+        .header(header)
+        .add_function(fun)
+        .add_code(main)
+        .build()
+        .unwrap();
 
     let output = file.render(80).unwrap();
     golden::assert_golden("bash/complete_script.bash", &output);
@@ -67,15 +64,17 @@ fn test_complete_script() {
 
 #[test]
 fn test_function_with_doc() {
-    let body = CodeBlock::<Bash>::of("echo \"Hello, $1!\"", ()).unwrap();
-    let mut fb = FunSpec::<Bash>::builder("greet");
-    fb.doc("Greet the user by name.");
-    fb.body(body);
-    let fun = fb.build().unwrap();
+    let body = CodeBlock::of("echo \"Hello, $1!\"", ()).unwrap();
+    let fun = FunSpec::builder("greet")
+        .doc("Greet the user by name.")
+        .body(body)
+        .build()
+        .unwrap();
 
-    let mut file_b = FileSpec::<Bash>::builder("greet.bash");
-    file_b.add_function(fun);
-    let file = file_b.build().unwrap();
+    let file = FileSpec::builder("greet.bash")
+        .add_function(fun)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("bash/function_with_doc.bash", &output);

--- a/tests/bash/builder_imports.rs
+++ b/tests/bash/builder_imports.rs
@@ -1,5 +1,4 @@
 use sigil_stitch::code_block::CodeBlock;
-use sigil_stitch::lang::bash::Bash;
 use sigil_stitch::spec::file_spec::FileSpec;
 use sigil_stitch::type_name::TypeName;
 
@@ -7,17 +6,18 @@ use super::golden;
 
 #[test]
 fn test_source_imports() {
-    let utils_fn = TypeName::<Bash>::importable("./lib/utils.sh", "log_info");
-    let config_fn = TypeName::<Bash>::importable("./lib/config.sh", "load_config");
+    let utils_fn = TypeName::importable("./lib/utils.sh", "log_info");
+    let config_fn = TypeName::importable("./lib/config.sh", "load_config");
 
-    let mut b = CodeBlock::<Bash>::builder();
+    let mut b = CodeBlock::builder();
     b.add_statement("%T", (config_fn,));
     b.add_statement("%T \"starting up\"", (utils_fn,));
     let block = b.build().unwrap();
 
-    let mut fb = FileSpec::<Bash>::builder("main.bash");
-    fb.add_code(block);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder("main.bash")
+        .add_code(block)
+        .build()
+        .unwrap();
 
     let output = file.render(80).unwrap();
     golden::assert_golden("bash/source_imports.bash", &output);

--- a/tests/bash/quote_basic.rs
+++ b/tests/bash/quote_basic.rs
@@ -1,14 +1,16 @@
 use sigil_stitch::code_block::CodeBlock;
-use sigil_stitch::lang::bash::Bash;
 use sigil_stitch::prelude::*;
 use sigil_stitch::spec::file_spec::FileSpec;
 
 use super::golden;
 
-fn render(block: &CodeBlock<Bash>) -> String {
-    let mut fb = FileSpec::<Bash>::builder("test.bash");
-    fb.add_code(block.clone());
-    fb.build().unwrap().render(80).unwrap()
+fn render(block: &CodeBlock) -> String {
+    FileSpec::builder("test.bash")
+        .add_code(block.clone())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap()
 }
 
 #[test]

--- a/tests/bash/quote_control_flow.rs
+++ b/tests/bash/quote_control_flow.rs
@@ -1,14 +1,16 @@
 use sigil_stitch::code_block::CodeBlock;
-use sigil_stitch::lang::bash::Bash;
 use sigil_stitch::prelude::*;
 use sigil_stitch::spec::file_spec::FileSpec;
 
 use super::golden;
 
-fn render(block: &CodeBlock<Bash>) -> String {
-    let mut fb = FileSpec::<Bash>::builder("test.bash");
-    fb.add_code(block.clone());
-    fb.build().unwrap().render(80).unwrap()
+fn render(block: &CodeBlock) -> String {
+    FileSpec::builder("test.bash")
+        .add_code(block.clone())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap()
 }
 
 #[test]

--- a/tests/c/builder_control_flow.rs
+++ b/tests/c/builder_control_flow.rs
@@ -6,7 +6,7 @@ use super::golden;
 
 #[test]
 fn test_control_flow() {
-    let mut b = CodeBlock::<CLang>::builder();
+    let mut b = CodeBlock::builder();
     b.begin_control_flow("if (x > 0)", ());
     b.add_statement("return 1", ());
     b.next_control_flow("else if (x < 0)", ());
@@ -16,9 +16,10 @@ fn test_control_flow() {
     b.end_control_flow();
     let block = b.build().unwrap();
 
-    let mut fb = FileSpec::builder_with("flow.c", CLang::new());
-    fb.add_code(block);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("flow.c", CLang::new())
+        .add_code(block)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("c/control_flow.c", &output);

--- a/tests/c/builder_edge_cases.rs
+++ b/tests/c/builder_edge_cases.rs
@@ -13,7 +13,7 @@ use super::golden;
 
 #[test]
 fn test_struct_basic() {
-    let mut b = CodeBlock::<CLang>::builder();
+    let mut b = CodeBlock::builder();
     b.add("struct Point", ());
     b.add(" {", ());
     b.add_line();
@@ -25,9 +25,10 @@ fn test_struct_basic() {
     b.add_line();
     let block = b.build().unwrap();
 
-    let mut fb = FileSpec::builder_with("point.c", CLang::new());
-    fb.add_code(block);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("point.c", CLang::new())
+        .add_code(block)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("c/struct_basic.c", &output);
@@ -36,30 +37,33 @@ fn test_struct_basic() {
 #[test]
 fn test_struct_with_function() {
     // Struct definition + a separate function that uses it.
-    let mut tb = TypeSpec::<CLang>::builder("Point", TypeKind::Struct);
-    tb.add_field(
-        FieldSpec::builder("x", TypeName::primitive("int"))
-            .build()
-            .unwrap(),
-    );
-    tb.add_field(
-        FieldSpec::builder("y", TypeName::primitive("int"))
-            .build()
-            .unwrap(),
-    );
-    let ts = tb.build().unwrap();
+    let ts = TypeSpec::builder("Point", TypeKind::Struct)
+        .add_field(
+            FieldSpec::builder("x", TypeName::primitive("int"))
+                .build()
+                .unwrap(),
+        )
+        .add_field(
+            FieldSpec::builder("y", TypeName::primitive("int"))
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
 
-    let body = CodeBlock::<CLang>::of("return p.x + p.y;", ()).unwrap();
-    let mut fb = FunSpec::<CLang>::builder("point_sum");
-    fb.add_param(ParameterSpec::new("p", TypeName::primitive("struct Point")).unwrap());
-    fb.returns(TypeName::primitive("int"));
-    fb.body(body);
-    let fun = fb.build().unwrap();
+    let body = CodeBlock::of("return p.x + p.y;", ()).unwrap();
+    let fun = FunSpec::builder("point_sum")
+        .add_param(ParameterSpec::new("p", TypeName::primitive("struct Point")).unwrap())
+        .returns(TypeName::primitive("int"))
+        .body(body)
+        .build()
+        .unwrap();
 
-    let mut file_b = FileSpec::builder_with("point.c", CLang::new());
-    file_b.add_type(ts);
-    file_b.add_function(fun);
-    let file = file_b.build().unwrap();
+    let file = FileSpec::builder_with("point.c", CLang::new())
+        .add_type(ts)
+        .add_function(fun)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("c/struct_with_function.c", &output);
@@ -68,25 +72,26 @@ fn test_struct_with_function() {
 #[test]
 fn test_top_level_with_includes() {
     // Full file with #pragma once, includes, struct, function declarations.
-    let stdio = TypeName::<CLang>::importable("stdio.h", "printf");
-    let config = TypeName::<CLang>::importable("./config.h", "Config");
+    let stdio = TypeName::importable("stdio.h", "printf");
+    let config = TypeName::importable("./config.h", "Config");
 
-    let mut tb = TypeSpec::<CLang>::builder("Server", TypeKind::Struct);
-    tb.doc("HTTP server configuration.");
-    tb.add_field(
-        FieldSpec::builder("port", TypeName::primitive("int"))
-            .build()
-            .unwrap(),
-    );
-    tb.add_field(
-        FieldSpec::builder("host", TypeName::primitive("const char*"))
-            .build()
-            .unwrap(),
-    );
-    let ts = tb.build().unwrap();
+    let ts = TypeSpec::builder("Server", TypeKind::Struct)
+        .doc("HTTP server configuration.")
+        .add_field(
+            FieldSpec::builder("port", TypeName::primitive("int"))
+                .build()
+                .unwrap(),
+        )
+        .add_field(
+            FieldSpec::builder("host", TypeName::primitive("const char*"))
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
 
     // Function that uses imports.
-    let body = CodeBlock::<CLang>::of(
+    let body = CodeBlock::of(
         "%T(%S, srv.host, srv.port, %T());",
         (
             stdio,
@@ -95,17 +100,19 @@ fn test_top_level_with_includes() {
         ),
     )
     .unwrap();
-    let mut fb = FunSpec::<CLang>::builder("server_start");
-    fb.add_param(ParameterSpec::new("srv", TypeName::primitive("struct Server")).unwrap());
-    fb.returns(TypeName::primitive("void"));
-    fb.body(body);
-    let fun = fb.build().unwrap();
+    let fun = FunSpec::builder("server_start")
+        .add_param(ParameterSpec::new("srv", TypeName::primitive("struct Server")).unwrap())
+        .returns(TypeName::primitive("void"))
+        .body(body)
+        .build()
+        .unwrap();
 
-    let mut file_b = FileSpec::builder_with("server.h", CLang::header());
-    file_b.header(CodeBlock::<CLang>::of("#pragma once", ()).unwrap());
-    file_b.add_type(ts);
-    file_b.add_function(fun);
-    let file = file_b.build().unwrap();
+    let file = FileSpec::builder_with("server.h", CLang::header())
+        .header(CodeBlock::of("#pragma once", ()).unwrap())
+        .add_type(ts)
+        .add_function(fun)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("c/top_level_with_includes.c", &output);
@@ -113,23 +120,25 @@ fn test_top_level_with_includes() {
 
 #[test]
 fn test_annotation_attribute() {
-    let mut tb = TypeSpec::<CLang>::builder("PackedData", TypeKind::Struct);
-    tb.annotate(AnnotationSpec::new("packed"));
-    tb.add_field(
-        FieldSpec::builder("flags", TypeName::primitive("uint8_t"))
-            .build()
-            .unwrap(),
-    );
-    tb.add_field(
-        FieldSpec::builder("value", TypeName::primitive("uint32_t"))
-            .build()
-            .unwrap(),
-    );
-    let ts = tb.build().unwrap();
+    let ts = TypeSpec::builder("PackedData", TypeKind::Struct)
+        .annotate(AnnotationSpec::new("packed"))
+        .add_field(
+            FieldSpec::builder("flags", TypeName::primitive("uint8_t"))
+                .build()
+                .unwrap(),
+        )
+        .add_field(
+            FieldSpec::builder("value", TypeName::primitive("uint32_t"))
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
 
-    let mut file_b = FileSpec::builder_with("packed.h", CLang::header());
-    file_b.add_type(ts);
-    let file = file_b.build().unwrap();
+    let file = FileSpec::builder_with("packed.h", CLang::header())
+        .add_type(ts)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("c/annotation_attribute.c", &output);

--- a/tests/c/builder_functions.rs
+++ b/tests/c/builder_functions.rs
@@ -10,17 +10,19 @@ use super::golden;
 
 #[test]
 fn test_function_with_params() {
-    let body = CodeBlock::<CLang>::of("return a + b;", ()).unwrap();
-    let mut fb = FunSpec::<CLang>::builder("add");
-    fb.add_param(ParameterSpec::new("a", TypeName::primitive("int")).unwrap());
-    fb.add_param(ParameterSpec::new("b", TypeName::primitive("int")).unwrap());
-    fb.returns(TypeName::primitive("int"));
-    fb.body(body);
-    let fun = fb.build().unwrap();
+    let body = CodeBlock::of("return a + b;", ()).unwrap();
+    let fun = FunSpec::builder("add")
+        .add_param(ParameterSpec::new("a", TypeName::primitive("int")).unwrap())
+        .add_param(ParameterSpec::new("b", TypeName::primitive("int")).unwrap())
+        .returns(TypeName::primitive("int"))
+        .body(body)
+        .build()
+        .unwrap();
 
-    let mut file_b = FileSpec::builder_with("math.c", CLang::new());
-    file_b.add_function(fun);
-    let file = file_b.build().unwrap();
+    let file = FileSpec::builder_with("math.c", CLang::new())
+        .add_function(fun)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("c/function_with_params.c", &output);
@@ -28,21 +30,23 @@ fn test_function_with_params() {
 
 #[test]
 fn test_void_function() {
-    let printf_type = TypeName::<CLang>::importable("stdio.h", "printf");
-    let body = CodeBlock::<CLang>::of(
+    let printf_type = TypeName::importable("stdio.h", "printf");
+    let body = CodeBlock::of(
         "%T(%S, name);",
         (printf_type, StringLitArg("Hello, %s!\\n".to_string())),
     )
     .unwrap();
-    let mut fb = FunSpec::<CLang>::builder("greet");
-    fb.add_param(ParameterSpec::new("name", TypeName::primitive("const char*")).unwrap());
-    fb.returns(TypeName::primitive("void"));
-    fb.body(body);
-    let fun = fb.build().unwrap();
+    let fun = FunSpec::builder("greet")
+        .add_param(ParameterSpec::new("name", TypeName::primitive("const char*")).unwrap())
+        .returns(TypeName::primitive("void"))
+        .body(body)
+        .build()
+        .unwrap();
 
-    let mut file_b = FileSpec::builder_with("greet.c", CLang::new());
-    file_b.add_function(fun);
-    let file = file_b.build().unwrap();
+    let file = FileSpec::builder_with("greet.c", CLang::new())
+        .add_function(fun)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("c/void_function.c", &output);
@@ -50,18 +54,20 @@ fn test_void_function() {
 
 #[test]
 fn test_static_function() {
-    let body = CodeBlock::<CLang>::of("return x * x;", ()).unwrap();
-    let mut fb = FunSpec::<CLang>::builder("square");
-    fb.visibility(Visibility::Private);
-    fb.is_static();
-    fb.add_param(ParameterSpec::new("x", TypeName::primitive("int")).unwrap());
-    fb.returns(TypeName::primitive("int"));
-    fb.body(body);
-    let fun = fb.build().unwrap();
+    let body = CodeBlock::of("return x * x;", ()).unwrap();
+    let fun = FunSpec::builder("square")
+        .visibility(Visibility::Private)
+        .is_static()
+        .add_param(ParameterSpec::new("x", TypeName::primitive("int")).unwrap())
+        .returns(TypeName::primitive("int"))
+        .body(body)
+        .build()
+        .unwrap();
 
-    let mut file_b = FileSpec::builder_with("helpers.c", CLang::new());
-    file_b.add_function(fun);
-    let file = file_b.build().unwrap();
+    let file = FileSpec::builder_with("helpers.c", CLang::new())
+        .add_function(fun)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("c/static_function.c", &output);
@@ -70,15 +76,17 @@ fn test_static_function() {
 #[test]
 fn test_function_declaration() {
     // Forward declaration — no body, should end with semicolon.
-    let mut fb = FunSpec::<CLang>::builder("process");
-    fb.add_param(ParameterSpec::new("data", TypeName::primitive("const char*")).unwrap());
-    fb.add_param(ParameterSpec::new("len", TypeName::primitive("size_t")).unwrap());
-    fb.returns(TypeName::primitive("int"));
-    let fun = fb.build().unwrap();
+    let fun = FunSpec::builder("process")
+        .add_param(ParameterSpec::new("data", TypeName::primitive("const char*")).unwrap())
+        .add_param(ParameterSpec::new("len", TypeName::primitive("size_t")).unwrap())
+        .returns(TypeName::primitive("int"))
+        .build()
+        .unwrap();
 
-    let mut file_b = FileSpec::builder_with("api.h", CLang::header());
-    file_b.add_function(fun);
-    let file = file_b.build().unwrap();
+    let file = FileSpec::builder_with("api.h", CLang::header())
+        .add_function(fun)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("c/function_declaration.c", &output);
@@ -86,18 +94,20 @@ fn test_function_declaration() {
 
 #[test]
 fn test_function_with_doc() {
-    let body = CodeBlock::<CLang>::of("return a + b;", ()).unwrap();
-    let mut fb = FunSpec::<CLang>::builder("add");
-    fb.doc("Add two integers.");
-    fb.add_param(ParameterSpec::new("a", TypeName::primitive("int")).unwrap());
-    fb.add_param(ParameterSpec::new("b", TypeName::primitive("int")).unwrap());
-    fb.returns(TypeName::primitive("int"));
-    fb.body(body);
-    let fun = fb.build().unwrap();
+    let body = CodeBlock::of("return a + b;", ()).unwrap();
+    let fun = FunSpec::builder("add")
+        .doc("Add two integers.")
+        .add_param(ParameterSpec::new("a", TypeName::primitive("int")).unwrap())
+        .add_param(ParameterSpec::new("b", TypeName::primitive("int")).unwrap())
+        .returns(TypeName::primitive("int"))
+        .body(body)
+        .build()
+        .unwrap();
 
-    let mut file_b = FileSpec::builder_with("math_doc.c", CLang::new());
-    file_b.add_function(fun);
-    let file = file_b.build().unwrap();
+    let file = FileSpec::builder_with("math_doc.c", CLang::new())
+        .add_function(fun)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("c/function_with_doc.c", &output);

--- a/tests/c/builder_imports.rs
+++ b/tests/c/builder_imports.rs
@@ -7,10 +7,10 @@ use super::golden;
 
 #[test]
 fn test_function_with_includes() {
-    let printf_type = TypeName::<CLang>::importable("stdio.h", "printf");
-    let config_type = TypeName::<CLang>::importable("./config.h", "Config");
+    let printf_type = TypeName::importable("stdio.h", "printf");
+    let config_type = TypeName::importable("./config.h", "Config");
 
-    let mut b = CodeBlock::<CLang>::builder();
+    let mut b = CodeBlock::builder();
     b.add("int main(void) {", ());
     b.add_line();
     b.add("%>", ());
@@ -26,9 +26,10 @@ fn test_function_with_includes() {
     b.add_line();
     let block = b.build().unwrap();
 
-    let mut fb = FileSpec::builder_with("main.c", CLang::new());
-    fb.add_code(block);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("main.c", CLang::new())
+        .add_code(block)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("c/function_with_includes.c", &output);
@@ -36,13 +37,13 @@ fn test_function_with_includes() {
 
 #[test]
 fn test_include_grouping() {
-    let stdio = TypeName::<CLang>::importable("stdio.h", "printf");
-    let stdlib = TypeName::<CLang>::importable("stdlib.h", "malloc");
-    let string = TypeName::<CLang>::importable("string.h", "strlen");
-    let config = TypeName::<CLang>::importable("./config.h", "Config");
-    let utils = TypeName::<CLang>::importable("./utils.h", "helper");
+    let stdio = TypeName::importable("stdio.h", "printf");
+    let stdlib = TypeName::importable("stdlib.h", "malloc");
+    let string = TypeName::importable("string.h", "strlen");
+    let config = TypeName::importable("./config.h", "Config");
+    let utils = TypeName::importable("./utils.h", "helper");
 
-    let mut b = CodeBlock::<CLang>::builder();
+    let mut b = CodeBlock::builder();
     b.add_statement(
         "int x = %T(%S)",
         (stdio.clone(), StringLitArg("hello".to_string())),
@@ -56,9 +57,10 @@ fn test_include_grouping() {
     b.add_statement("%T()", (utils,));
     let block = b.build().unwrap();
 
-    let mut fb = FileSpec::builder_with("test.c", CLang::new());
-    fb.add_code(block);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("test.c", CLang::new())
+        .add_code(block)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("c/include_grouping.c", &output);

--- a/tests/c/builder_types.rs
+++ b/tests/c/builder_types.rs
@@ -11,29 +11,31 @@ use super::golden;
 
 #[test]
 fn test_struct_with_fields() {
-    let mut tb = TypeSpec::<CLang>::builder("Config", TypeKind::Struct);
-    tb.doc("Application configuration.");
-    tb.add_field(
-        FieldSpec::builder("timeout", TypeName::primitive("int"))
-            .build()
-            .unwrap(),
-    );
-    tb.add_field(
-        FieldSpec::builder("name", TypeName::primitive("char*"))
-            .build()
-            .unwrap(),
-    );
-    tb.add_field(
-        FieldSpec::builder("verbose", TypeName::primitive("int"))
-            .build()
-            .unwrap(),
-    );
-    let ts = tb.build().unwrap();
+    let ts = TypeSpec::builder("Config", TypeKind::Struct)
+        .doc("Application configuration.")
+        .add_field(
+            FieldSpec::builder("timeout", TypeName::primitive("int"))
+                .build()
+                .unwrap(),
+        )
+        .add_field(
+            FieldSpec::builder("name", TypeName::primitive("char*"))
+                .build()
+                .unwrap(),
+        )
+        .add_field(
+            FieldSpec::builder("verbose", TypeName::primitive("int"))
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
 
-    let mut fb = FileSpec::builder_with("config.h", CLang::header());
-    fb.header(CodeBlock::<CLang>::of("#pragma once", ()).unwrap());
-    fb.add_type(ts);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("config.h", CLang::header())
+        .header(CodeBlock::of("#pragma once", ()).unwrap())
+        .add_type(ts)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("c/struct_with_fields.c", &output);
@@ -41,17 +43,19 @@ fn test_struct_with_fields() {
 
 #[test]
 fn test_enum() {
-    let mut tb = TypeSpec::<CLang>::builder("Direction", TypeKind::Enum);
-    tb.doc("Cardinal directions.");
-    tb.add_variant(EnumVariantSpec::new("UP").unwrap());
-    tb.add_variant(EnumVariantSpec::new("DOWN").unwrap());
-    tb.add_variant(EnumVariantSpec::new("LEFT").unwrap());
-    tb.add_variant(EnumVariantSpec::new("RIGHT").unwrap());
-    let ts = tb.build().unwrap();
+    let ts = TypeSpec::builder("Direction", TypeKind::Enum)
+        .doc("Cardinal directions.")
+        .add_variant(EnumVariantSpec::new("UP").unwrap())
+        .add_variant(EnumVariantSpec::new("DOWN").unwrap())
+        .add_variant(EnumVariantSpec::new("LEFT").unwrap())
+        .add_variant(EnumVariantSpec::new("RIGHT").unwrap())
+        .build()
+        .unwrap();
 
-    let mut fb = FileSpec::builder_with("direction.h", CLang::header());
-    fb.add_type(ts);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("direction.h", CLang::header())
+        .add_type(ts)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("c/enum.c", &output);

--- a/tests/c/quote_basic.rs
+++ b/tests/c/quote_basic.rs
@@ -5,10 +5,13 @@ use sigil_stitch::spec::file_spec::FileSpec;
 
 use super::golden;
 
-fn render(block: &CodeBlock<CLang>) -> String {
-    let mut fb = FileSpec::builder_with("test.c", CLang::new());
-    fb.add_code(block.clone());
-    fb.build().unwrap().render(80).unwrap()
+fn render(block: &CodeBlock) -> String {
+    FileSpec::builder_with("test.c", CLang::new())
+        .add_code(block.clone())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap()
 }
 
 #[test]

--- a/tests/c/quote_control_flow.rs
+++ b/tests/c/quote_control_flow.rs
@@ -5,10 +5,13 @@ use sigil_stitch::spec::file_spec::FileSpec;
 
 use super::golden;
 
-fn render(block: &CodeBlock<CLang>) -> String {
-    let mut fb = FileSpec::builder_with("test.c", CLang::new());
-    fb.add_code(block.clone());
-    fb.build().unwrap().render(80).unwrap()
+fn render(block: &CodeBlock) -> String {
+    FileSpec::builder_with("test.c", CLang::new())
+        .add_code(block.clone())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap()
 }
 
 #[test]

--- a/tests/c/quote_imports.rs
+++ b/tests/c/quote_imports.rs
@@ -6,16 +6,19 @@ use sigil_stitch::type_name::TypeName;
 
 use super::golden;
 
-fn render(block: &CodeBlock<CLang>) -> String {
-    let mut fb = FileSpec::builder_with("test.c", CLang::new());
-    fb.add_code(block.clone());
-    fb.build().unwrap().render(80).unwrap()
+fn render(block: &CodeBlock) -> String {
+    FileSpec::builder_with("test.c", CLang::new())
+        .add_code(block.clone())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap()
 }
 
 #[test]
 fn test_imports() {
-    let stdio = TypeName::<CLang>::importable("stdio.h", "printf");
-    let stdlib = TypeName::<CLang>::importable("stdlib.h", "malloc");
+    let stdio = TypeName::importable("stdio.h", "printf");
+    let stdlib = TypeName::importable("stdlib.h", "malloc");
     let block = sigil_quote!(CLang {
         $T(stdio)($S("hello"));
         void* p = $T(stdlib)(sizeof(int));

--- a/tests/constructor_spec_tests.rs
+++ b/tests/constructor_spec_tests.rs
@@ -16,9 +16,9 @@ use sigil_stitch::type_name::TypeName;
 
 // ── Helpers ──────────────────────────────────────────────
 
-fn render_fun<L: sigil_stitch::lang::CodeLang>(
-    spec: &FunSpec<L>,
-    lang: &L,
+fn render_fun(
+    spec: &FunSpec,
+    lang: &dyn sigil_stitch::lang::CodeLang,
     ctx: DeclarationContext,
 ) -> String {
     let block = spec.emit(lang, ctx).unwrap();
@@ -27,7 +27,7 @@ fn render_fun<L: sigil_stitch::lang::CodeLang>(
     renderer.render(&block).unwrap()
 }
 
-fn render_type<L: sigil_stitch::lang::CodeLang>(spec: &TypeSpec<L>, lang: &L) -> String {
+fn render_type(spec: &TypeSpec, lang: &dyn sigil_stitch::lang::CodeLang) -> String {
     let blocks = spec.emit(lang).unwrap();
     let imports = sigil_stitch::import::ImportGroup::new();
     let mut output = String::new();
@@ -46,11 +46,16 @@ fn render_type<L: sigil_stitch::lang::CodeLang>(spec: &TypeSpec<L>, lang: &L) ->
 #[test]
 fn test_ts_constructor() {
     let ts = TypeScript::new();
-    let mut fb = FunSpec::<TypeScript>::builder("constructor");
-    fb.is_constructor();
-    fb.add_param(ParameterSpec::new("name", TypeName::primitive("string")).unwrap());
-    fb.body(CodeBlock::of("this.name = name", ()).unwrap());
-    let output = render_fun(&fb.build().unwrap(), &ts, DeclarationContext::Member);
+    let output = render_fun(
+        &FunSpec::builder("constructor")
+            .is_constructor()
+            .add_param(ParameterSpec::new("name", TypeName::primitive("string")).unwrap())
+            .body(CodeBlock::of("this.name = name", ()).unwrap())
+            .build()
+            .unwrap(),
+        &ts,
+        DeclarationContext::Member,
+    );
     assert!(output.contains("constructor(name: string) {"));
     assert!(output.contains("this.name = name"));
     // Must NOT have "function" keyword.
@@ -60,14 +65,21 @@ fn test_ts_constructor() {
 #[test]
 fn test_ts_constructor_in_class() {
     let ts = TypeScript::new();
-    let mut tb = TypeSpec::<TypeScript>::builder("User", TypeKind::Class);
-    tb.visibility(Visibility::Public);
-    let mut ctor = FunSpec::builder("constructor");
-    ctor.is_constructor();
-    ctor.add_param(ParameterSpec::new("name", TypeName::primitive("string")).unwrap());
-    ctor.body(CodeBlock::of("this.name = name", ()).unwrap());
-    tb.add_method(ctor.build().unwrap());
-    let output = render_type(&tb.build().unwrap(), &ts);
+    let output = render_type(
+        &TypeSpec::builder("User", TypeKind::Class)
+            .visibility(Visibility::Public)
+            .add_method(
+                FunSpec::builder("constructor")
+                    .is_constructor()
+                    .add_param(ParameterSpec::new("name", TypeName::primitive("string")).unwrap())
+                    .body(CodeBlock::of("this.name = name", ()).unwrap())
+                    .build()
+                    .unwrap(),
+            )
+            .build()
+            .unwrap(),
+        &ts,
+    );
     assert!(output.contains("export class User {"));
     assert!(output.contains("constructor(name: string) {"));
 }
@@ -77,11 +89,16 @@ fn test_ts_constructor_in_class() {
 #[test]
 fn test_js_constructor() {
     let js = JavaScript::new();
-    let mut fb = FunSpec::<JavaScript>::builder("constructor");
-    fb.is_constructor();
-    fb.add_param(ParameterSpec::new("name", TypeName::primitive("")).unwrap());
-    fb.body(CodeBlock::of("this.name = name", ()).unwrap());
-    let output = render_fun(&fb.build().unwrap(), &js, DeclarationContext::Member);
+    let output = render_fun(
+        &FunSpec::builder("constructor")
+            .is_constructor()
+            .add_param(ParameterSpec::new("name", TypeName::primitive("")).unwrap())
+            .body(CodeBlock::of("this.name = name", ()).unwrap())
+            .build()
+            .unwrap(),
+        &js,
+        DeclarationContext::Member,
+    );
     assert!(output.contains("constructor(name) {"));
     assert!(!output.contains("function"));
 }
@@ -91,12 +108,17 @@ fn test_js_constructor() {
 #[test]
 fn test_java_constructor() {
     let java = JavaLang::new();
-    let mut fb = FunSpec::<JavaLang>::builder("UserService");
-    fb.is_constructor();
-    fb.visibility(Visibility::Public);
-    fb.add_param(ParameterSpec::new("repo", TypeName::primitive("UserRepository")).unwrap());
-    fb.body(CodeBlock::of("this.repo = repo;", ()).unwrap());
-    let output = render_fun(&fb.build().unwrap(), &java, DeclarationContext::Member);
+    let output = render_fun(
+        &FunSpec::builder("UserService")
+            .is_constructor()
+            .visibility(Visibility::Public)
+            .add_param(ParameterSpec::new("repo", TypeName::primitive("UserRepository")).unwrap())
+            .body(CodeBlock::of("this.repo = repo;", ()).unwrap())
+            .build()
+            .unwrap(),
+        &java,
+        DeclarationContext::Member,
+    );
     assert!(output.contains("public UserService(UserRepository repo) {"));
     // No return type.
     assert!(!output.contains("void"));
@@ -107,10 +129,15 @@ fn test_java_constructor() {
 #[test]
 fn test_cpp_constructor() {
     let cpp = CppLang::new();
-    let mut fb = FunSpec::<CppLang>::builder("Counter");
-    fb.is_constructor();
-    fb.body(CodeBlock::of("count_ = 0;", ()).unwrap());
-    let output = render_fun(&fb.build().unwrap(), &cpp, DeclarationContext::Member);
+    let output = render_fun(
+        &FunSpec::builder("Counter")
+            .is_constructor()
+            .body(CodeBlock::of("count_ = 0;", ()).unwrap())
+            .build()
+            .unwrap(),
+        &cpp,
+        DeclarationContext::Member,
+    );
     assert!(output.contains("Counter() {"));
     // No return type prefix.
     assert!(!output.contains("void"));
@@ -121,11 +148,16 @@ fn test_cpp_constructor() {
 #[test]
 fn test_dart_constructor() {
     let dart = DartLang::new();
-    let mut fb = FunSpec::<DartLang>::builder("Task");
-    fb.is_constructor();
-    fb.add_param(ParameterSpec::new("title", TypeName::primitive("String")).unwrap());
-    fb.body(CodeBlock::of("this.title = title;", ()).unwrap());
-    let output = render_fun(&fb.build().unwrap(), &dart, DeclarationContext::Member);
+    let output = render_fun(
+        &FunSpec::builder("Task")
+            .is_constructor()
+            .add_param(ParameterSpec::new("title", TypeName::primitive("String")).unwrap())
+            .body(CodeBlock::of("this.title = title;", ()).unwrap())
+            .build()
+            .unwrap(),
+        &dart,
+        DeclarationContext::Member,
+    );
     assert!(output.contains("Task(String title) {"));
 }
 
@@ -134,11 +166,16 @@ fn test_dart_constructor() {
 #[test]
 fn test_swift_constructor() {
     let swift = Swift::new();
-    let mut fb = FunSpec::<Swift>::builder("init");
-    fb.is_constructor();
-    fb.add_param(ParameterSpec::new("name", TypeName::primitive("String")).unwrap());
-    fb.body(CodeBlock::of("self.name = name", ()).unwrap());
-    let output = render_fun(&fb.build().unwrap(), &swift, DeclarationContext::Member);
+    let output = render_fun(
+        &FunSpec::builder("init")
+            .is_constructor()
+            .add_param(ParameterSpec::new("name", TypeName::primitive("String")).unwrap())
+            .body(CodeBlock::of("self.name = name", ()).unwrap())
+            .build()
+            .unwrap(),
+        &swift,
+        DeclarationContext::Member,
+    );
     // Must be `init(name: String)` NOT `func init(name: String)`.
     assert!(output.contains("init(name: String) {"));
     assert!(!output.contains("func init"));
@@ -147,13 +184,20 @@ fn test_swift_constructor() {
 #[test]
 fn test_swift_constructor_in_class() {
     let swift = Swift::new();
-    let mut tb = TypeSpec::<Swift>::builder("Person", TypeKind::Class);
-    let mut ctor = FunSpec::builder("init");
-    ctor.is_constructor();
-    ctor.add_param(ParameterSpec::new("name", TypeName::primitive("String")).unwrap());
-    ctor.body(CodeBlock::of("self.name = name", ()).unwrap());
-    tb.add_method(ctor.build().unwrap());
-    let output = render_type(&tb.build().unwrap(), &swift);
+    let output = render_type(
+        &TypeSpec::builder("Person", TypeKind::Class)
+            .add_method(
+                FunSpec::builder("init")
+                    .is_constructor()
+                    .add_param(ParameterSpec::new("name", TypeName::primitive("String")).unwrap())
+                    .body(CodeBlock::of("self.name = name", ()).unwrap())
+                    .build()
+                    .unwrap(),
+            )
+            .build()
+            .unwrap(),
+        &swift,
+    );
     assert!(output.contains("class Person {"));
     assert!(output.contains("init(name: String) {"));
     assert!(!output.contains("func init"));
@@ -164,11 +208,16 @@ fn test_swift_constructor_in_class() {
 #[test]
 fn test_kotlin_secondary_constructor() {
     let kt = Kotlin::new();
-    let mut fb = FunSpec::<Kotlin>::builder("constructor");
-    fb.is_constructor();
-    fb.add_param(ParameterSpec::new("name", TypeName::primitive("String")).unwrap());
-    fb.body(CodeBlock::of("this.name = name", ()).unwrap());
-    let output = render_fun(&fb.build().unwrap(), &kt, DeclarationContext::Member);
+    let output = render_fun(
+        &FunSpec::builder("constructor")
+            .is_constructor()
+            .add_param(ParameterSpec::new("name", TypeName::primitive("String")).unwrap())
+            .body(CodeBlock::of("this.name = name", ()).unwrap())
+            .build()
+            .unwrap(),
+        &kt,
+        DeclarationContext::Member,
+    );
     // Must be `constructor(name: String)` NOT `fun constructor(name: String)`.
     assert!(output.contains("constructor(name: String)"));
     assert!(!output.contains("fun constructor"));
@@ -177,13 +226,20 @@ fn test_kotlin_secondary_constructor() {
 #[test]
 fn test_kotlin_constructor_in_class() {
     let kt = Kotlin::new();
-    let mut tb = TypeSpec::<Kotlin>::builder("Person", TypeKind::Class);
-    let mut ctor = FunSpec::builder("constructor");
-    ctor.is_constructor();
-    ctor.add_param(ParameterSpec::new("name", TypeName::primitive("String")).unwrap());
-    ctor.body(CodeBlock::of("this.name = name", ()).unwrap());
-    tb.add_method(ctor.build().unwrap());
-    let output = render_type(&tb.build().unwrap(), &kt);
+    let output = render_type(
+        &TypeSpec::builder("Person", TypeKind::Class)
+            .add_method(
+                FunSpec::builder("constructor")
+                    .is_constructor()
+                    .add_param(ParameterSpec::new("name", TypeName::primitive("String")).unwrap())
+                    .body(CodeBlock::of("this.name = name", ()).unwrap())
+                    .build()
+                    .unwrap(),
+            )
+            .build()
+            .unwrap(),
+        &kt,
+    );
     assert!(output.contains("class Person {"));
     assert!(output.contains("constructor(name: String)"));
     assert!(!output.contains("fun constructor"));
@@ -194,12 +250,17 @@ fn test_kotlin_constructor_in_class() {
 #[test]
 fn test_python_constructor() {
     let py = Python::new();
-    let mut fb = FunSpec::<Python>::builder("__init__");
-    fb.is_constructor();
-    fb.add_param(ParameterSpec::new("self", TypeName::primitive("")).unwrap());
-    fb.add_param(ParameterSpec::new("name", TypeName::primitive("str")).unwrap());
-    fb.body(CodeBlock::of("self.name = name", ()).unwrap());
-    let output = render_fun(&fb.build().unwrap(), &py, DeclarationContext::Member);
+    let output = render_fun(
+        &FunSpec::builder("__init__")
+            .is_constructor()
+            .add_param(ParameterSpec::new("self", TypeName::primitive("")).unwrap())
+            .add_param(ParameterSpec::new("name", TypeName::primitive("str")).unwrap())
+            .body(CodeBlock::of("self.name = name", ()).unwrap())
+            .build()
+            .unwrap(),
+        &py,
+        DeclarationContext::Member,
+    );
     // Must keep "def" keyword: `def __init__(self, name: str):`
     assert!(output.contains("def __init__(self, name: str):"));
 }
@@ -209,13 +270,18 @@ fn test_python_constructor() {
 #[test]
 fn test_rust_constructor() {
     let rs = RustLang::new();
-    let mut fb = FunSpec::<RustLang>::builder("new");
-    fb.is_constructor();
-    fb.visibility(Visibility::Public);
-    fb.add_param(ParameterSpec::new("name", TypeName::primitive("&str")).unwrap());
-    fb.returns(TypeName::primitive("Self"));
-    fb.body(CodeBlock::of("Self { name: name.to_string() }", ()).unwrap());
-    let output = render_fun(&fb.build().unwrap(), &rs, DeclarationContext::TopLevel);
+    let output = render_fun(
+        &FunSpec::builder("new")
+            .is_constructor()
+            .visibility(Visibility::Public)
+            .add_param(ParameterSpec::new("name", TypeName::primitive("&str")).unwrap())
+            .returns(TypeName::primitive("Self"))
+            .body(CodeBlock::of("Self { name: name.to_string() }", ()).unwrap())
+            .build()
+            .unwrap(),
+        &rs,
+        DeclarationContext::TopLevel,
+    );
     // Must keep "fn" keyword: `pub fn new(name: &str) -> Self {`
     assert!(output.contains("pub fn new(name: &str) -> Self {"));
 }
@@ -225,12 +291,17 @@ fn test_rust_constructor() {
 #[test]
 fn test_js_constructor_with_super() {
     let js = JavaScript::new();
-    let mut fb = FunSpec::<JavaScript>::builder("constructor");
-    fb.is_constructor();
-    fb.add_param(ParameterSpec::new("name", TypeName::primitive("")).unwrap());
-    fb.add_param(ParameterSpec::new("breed", TypeName::primitive("")).unwrap());
-    fb.body(CodeBlock::of("super(name);\nthis.breed = breed;", ()).unwrap());
-    let output = render_fun(&fb.build().unwrap(), &js, DeclarationContext::Member);
+    let output = render_fun(
+        &FunSpec::builder("constructor")
+            .is_constructor()
+            .add_param(ParameterSpec::new("name", TypeName::primitive("")).unwrap())
+            .add_param(ParameterSpec::new("breed", TypeName::primitive("")).unwrap())
+            .body(CodeBlock::of("super(name);\nthis.breed = breed;", ()).unwrap())
+            .build()
+            .unwrap(),
+        &js,
+        DeclarationContext::Member,
+    );
     assert!(output.contains("constructor(name, breed) {"));
     assert!(output.contains("super(name);"));
     assert!(output.contains("this.breed = breed;"));
@@ -239,12 +310,17 @@ fn test_js_constructor_with_super() {
 #[test]
 fn test_java_constructor_with_super() {
     let java = JavaLang::new();
-    let mut fb = FunSpec::<JavaLang>::builder("Dog");
-    fb.is_constructor();
-    fb.visibility(Visibility::Public);
-    fb.add_param(ParameterSpec::new("name", TypeName::primitive("String")).unwrap());
-    fb.body(CodeBlock::of("super(name);", ()).unwrap());
-    let output = render_fun(&fb.build().unwrap(), &java, DeclarationContext::Member);
+    let output = render_fun(
+        &FunSpec::builder("Dog")
+            .is_constructor()
+            .visibility(Visibility::Public)
+            .add_param(ParameterSpec::new("name", TypeName::primitive("String")).unwrap())
+            .body(CodeBlock::of("super(name);", ()).unwrap())
+            .build()
+            .unwrap(),
+        &java,
+        DeclarationContext::Member,
+    );
     assert!(output.contains("public Dog(String name) {"));
     assert!(output.contains("super(name);"));
 }
@@ -256,10 +332,15 @@ fn test_backward_compat_ts_constructor_without_flag() {
     // Existing pattern: FunSpec with name "constructor" and no is_constructor flag
     // should still work because TS function_keyword(Member) already returns "".
     let ts = TypeScript::new();
-    let mut fb = FunSpec::<TypeScript>::builder("constructor");
-    fb.add_param(ParameterSpec::new("name", TypeName::primitive("string")).unwrap());
-    fb.body(CodeBlock::of("this.name = name", ()).unwrap());
-    let output = render_fun(&fb.build().unwrap(), &ts, DeclarationContext::Member);
+    let output = render_fun(
+        &FunSpec::builder("constructor")
+            .add_param(ParameterSpec::new("name", TypeName::primitive("string")).unwrap())
+            .body(CodeBlock::of("this.name = name", ()).unwrap())
+            .build()
+            .unwrap(),
+        &ts,
+        DeclarationContext::Member,
+    );
     assert!(output.contains("constructor(name: string) {"));
 }
 
@@ -267,11 +348,16 @@ fn test_backward_compat_ts_constructor_without_flag() {
 fn test_backward_compat_java_constructor_without_flag() {
     // Existing pattern: FunSpec with class name and no is_constructor flag.
     let java = JavaLang::new();
-    let mut fb = FunSpec::<JavaLang>::builder("UserService");
-    fb.visibility(Visibility::Public);
-    fb.add_param(ParameterSpec::new("repo", TypeName::primitive("UserRepository")).unwrap());
-    fb.body(CodeBlock::of("this.repo = repo;", ()).unwrap());
-    let output = render_fun(&fb.build().unwrap(), &java, DeclarationContext::Member);
+    let output = render_fun(
+        &FunSpec::builder("UserService")
+            .visibility(Visibility::Public)
+            .add_param(ParameterSpec::new("repo", TypeName::primitive("UserRepository")).unwrap())
+            .body(CodeBlock::of("this.repo = repo;", ()).unwrap())
+            .build()
+            .unwrap(),
+        &java,
+        DeclarationContext::Member,
+    );
     assert!(output.contains("public UserService(UserRepository repo) {"));
 }
 
@@ -280,13 +366,18 @@ fn test_backward_compat_java_constructor_without_flag() {
 #[test]
 fn test_ts_constructor_with_super_delegation() {
     let ts = TypeScript::new();
-    let mut fb = FunSpec::<TypeScript>::builder("constructor");
-    fb.is_constructor();
-    fb.add_param(ParameterSpec::new("name", TypeName::primitive("string")).unwrap());
-    fb.add_param(ParameterSpec::new("age", TypeName::primitive("number")).unwrap());
-    fb.delegation(CodeBlock::of("super(name)", ()).unwrap());
-    fb.body(CodeBlock::of("this.age = age", ()).unwrap());
-    let output = render_fun(&fb.build().unwrap(), &ts, DeclarationContext::Member);
+    let output = render_fun(
+        &FunSpec::builder("constructor")
+            .is_constructor()
+            .add_param(ParameterSpec::new("name", TypeName::primitive("string")).unwrap())
+            .add_param(ParameterSpec::new("age", TypeName::primitive("number")).unwrap())
+            .delegation(CodeBlock::of("super(name)", ()).unwrap())
+            .body(CodeBlock::of("this.age = age", ()).unwrap())
+            .build()
+            .unwrap(),
+        &ts,
+        DeclarationContext::Member,
+    );
     assert!(output.contains("constructor(name: string, age: number) {"));
     assert!(output.contains("super(name);"));
     assert!(output.contains("this.age = age"));
@@ -299,26 +390,36 @@ fn test_ts_constructor_with_super_delegation() {
 #[test]
 fn test_ts_constructor_with_this_delegation() {
     let ts = TypeScript::new();
-    let mut fb = FunSpec::<TypeScript>::builder("constructor");
-    fb.is_constructor();
-    fb.add_param(ParameterSpec::new("name", TypeName::primitive("string")).unwrap());
-    fb.delegation(CodeBlock::of("this(name, 0)", ()).unwrap());
-    fb.body(CodeBlock::of("// additional init", ()).unwrap());
-    let output = render_fun(&fb.build().unwrap(), &ts, DeclarationContext::Member);
+    let output = render_fun(
+        &FunSpec::builder("constructor")
+            .is_constructor()
+            .add_param(ParameterSpec::new("name", TypeName::primitive("string")).unwrap())
+            .delegation(CodeBlock::of("this(name, 0)", ()).unwrap())
+            .body(CodeBlock::of("// additional init", ()).unwrap())
+            .build()
+            .unwrap(),
+        &ts,
+        DeclarationContext::Member,
+    );
     assert!(output.contains("this(name, 0);"));
 }
 
 #[test]
 fn test_java_constructor_with_super_delegation() {
     let java = JavaLang::new();
-    let mut fb = FunSpec::<JavaLang>::builder("Dog");
-    fb.is_constructor();
-    fb.visibility(Visibility::Public);
-    fb.add_param(ParameterSpec::new("name", TypeName::primitive("String")).unwrap());
-    fb.add_param(ParameterSpec::new("breed", TypeName::primitive("String")).unwrap());
-    fb.delegation(CodeBlock::of("super(name)", ()).unwrap());
-    fb.body(CodeBlock::of("this.breed = breed;", ()).unwrap());
-    let output = render_fun(&fb.build().unwrap(), &java, DeclarationContext::Member);
+    let output = render_fun(
+        &FunSpec::builder("Dog")
+            .is_constructor()
+            .visibility(Visibility::Public)
+            .add_param(ParameterSpec::new("name", TypeName::primitive("String")).unwrap())
+            .add_param(ParameterSpec::new("breed", TypeName::primitive("String")).unwrap())
+            .delegation(CodeBlock::of("super(name)", ()).unwrap())
+            .body(CodeBlock::of("this.breed = breed;", ()).unwrap())
+            .build()
+            .unwrap(),
+        &java,
+        DeclarationContext::Member,
+    );
     assert!(output.contains("public Dog(String name, String breed) {"));
     assert!(output.contains("super(name);"));
     assert!(output.contains("this.breed = breed;"));
@@ -330,25 +431,35 @@ fn test_java_constructor_with_super_delegation() {
 #[test]
 fn test_java_constructor_with_this_delegation() {
     let java = JavaLang::new();
-    let mut fb = FunSpec::<JavaLang>::builder("Config");
-    fb.is_constructor();
-    fb.visibility(Visibility::Public);
-    fb.add_param(ParameterSpec::new("name", TypeName::primitive("String")).unwrap());
-    fb.delegation(CodeBlock::of("this(name, \"default\")", ()).unwrap());
-    fb.body(CodeBlock::of("// chained", ()).unwrap());
-    let output = render_fun(&fb.build().unwrap(), &java, DeclarationContext::Member);
+    let output = render_fun(
+        &FunSpec::builder("Config")
+            .is_constructor()
+            .visibility(Visibility::Public)
+            .add_param(ParameterSpec::new("name", TypeName::primitive("String")).unwrap())
+            .delegation(CodeBlock::of("this(name, \"default\")", ()).unwrap())
+            .body(CodeBlock::of("// chained", ()).unwrap())
+            .build()
+            .unwrap(),
+        &java,
+        DeclarationContext::Member,
+    );
     assert!(output.contains("this(name, \"default\");"));
 }
 
 #[test]
 fn test_kotlin_constructor_with_super_delegation_signature_style() {
     let kt = Kotlin::new();
-    let mut fb = FunSpec::<Kotlin>::builder("constructor");
-    fb.is_constructor();
-    fb.add_param(ParameterSpec::new("name", TypeName::primitive("String")).unwrap());
-    fb.delegation(CodeBlock::of("super(name)", ()).unwrap());
-    fb.body(CodeBlock::of("this.name = name", ()).unwrap());
-    let output = render_fun(&fb.build().unwrap(), &kt, DeclarationContext::Member);
+    let output = render_fun(
+        &FunSpec::builder("constructor")
+            .is_constructor()
+            .add_param(ParameterSpec::new("name", TypeName::primitive("String")).unwrap())
+            .delegation(CodeBlock::of("super(name)", ()).unwrap())
+            .body(CodeBlock::of("this.name = name", ()).unwrap())
+            .build()
+            .unwrap(),
+        &kt,
+        DeclarationContext::Member,
+    );
     // Kotlin places delegation in the signature, not the body
     assert!(output.contains("constructor(name: String) : super(name) {"));
     assert!(output.contains("this.name = name"));
@@ -364,24 +475,34 @@ fn test_kotlin_constructor_with_super_delegation_signature_style() {
 #[test]
 fn test_kotlin_constructor_with_this_delegation_signature_style() {
     let kt = Kotlin::new();
-    let mut fb = FunSpec::<Kotlin>::builder("constructor");
-    fb.is_constructor();
-    fb.add_param(ParameterSpec::new("name", TypeName::primitive("String")).unwrap());
-    fb.delegation(CodeBlock::of("this(name, 0)", ()).unwrap());
-    fb.body(CodeBlock::of("// chained", ()).unwrap());
-    let output = render_fun(&fb.build().unwrap(), &kt, DeclarationContext::Member);
+    let output = render_fun(
+        &FunSpec::builder("constructor")
+            .is_constructor()
+            .add_param(ParameterSpec::new("name", TypeName::primitive("String")).unwrap())
+            .delegation(CodeBlock::of("this(name, 0)", ()).unwrap())
+            .body(CodeBlock::of("// chained", ()).unwrap())
+            .build()
+            .unwrap(),
+        &kt,
+        DeclarationContext::Member,
+    );
     assert!(output.contains("constructor(name: String) : this(name, 0) {"));
 }
 
 #[test]
 fn test_swift_constructor_with_super_delegation() {
     let swift = Swift::new();
-    let mut fb = FunSpec::<Swift>::builder("init");
-    fb.is_constructor();
-    fb.add_param(ParameterSpec::new("name", TypeName::primitive("String")).unwrap());
-    fb.delegation(CodeBlock::of("super.init()", ()).unwrap());
-    fb.body(CodeBlock::of("self.name = name", ()).unwrap());
-    let output = render_fun(&fb.build().unwrap(), &swift, DeclarationContext::Member);
+    let output = render_fun(
+        &FunSpec::builder("init")
+            .is_constructor()
+            .add_param(ParameterSpec::new("name", TypeName::primitive("String")).unwrap())
+            .delegation(CodeBlock::of("super.init()", ()).unwrap())
+            .body(CodeBlock::of("self.name = name", ()).unwrap())
+            .build()
+            .unwrap(),
+        &swift,
+        DeclarationContext::Member,
+    );
     assert!(output.contains("init(name: String) {"));
     assert!(output.contains("super.init()"));
     assert!(output.contains("self.name = name"));
@@ -390,12 +511,17 @@ fn test_swift_constructor_with_super_delegation() {
 #[test]
 fn test_dart_constructor_with_super_delegation() {
     let dart = DartLang::new();
-    let mut fb = FunSpec::<DartLang>::builder("Dog");
-    fb.is_constructor();
-    fb.add_param(ParameterSpec::new("name", TypeName::primitive("String")).unwrap());
-    fb.delegation(CodeBlock::of("super(name)", ()).unwrap());
-    fb.body(CodeBlock::of("print('Dog created');", ()).unwrap());
-    let output = render_fun(&fb.build().unwrap(), &dart, DeclarationContext::Member);
+    let output = render_fun(
+        &FunSpec::builder("Dog")
+            .is_constructor()
+            .add_param(ParameterSpec::new("name", TypeName::primitive("String")).unwrap())
+            .delegation(CodeBlock::of("super(name)", ()).unwrap())
+            .body(CodeBlock::of("print('Dog created');", ()).unwrap())
+            .build()
+            .unwrap(),
+        &dart,
+        DeclarationContext::Member,
+    );
     assert!(output.contains("Dog(String name) {"));
     assert!(output.contains("super(name);"));
     assert!(output.contains("print('Dog created');"));
@@ -404,13 +530,18 @@ fn test_dart_constructor_with_super_delegation() {
 #[test]
 fn test_python_constructor_with_super_delegation() {
     let py = Python::new();
-    let mut fb = FunSpec::<Python>::builder("__init__");
-    fb.is_constructor();
-    fb.add_param(ParameterSpec::new("self", TypeName::primitive("")).unwrap());
-    fb.add_param(ParameterSpec::new("name", TypeName::primitive("str")).unwrap());
-    fb.delegation(CodeBlock::of("super().__init__(name)", ()).unwrap());
-    fb.body(CodeBlock::of("self.extra = True", ()).unwrap());
-    let output = render_fun(&fb.build().unwrap(), &py, DeclarationContext::Member);
+    let output = render_fun(
+        &FunSpec::builder("__init__")
+            .is_constructor()
+            .add_param(ParameterSpec::new("self", TypeName::primitive("")).unwrap())
+            .add_param(ParameterSpec::new("name", TypeName::primitive("str")).unwrap())
+            .delegation(CodeBlock::of("super().__init__(name)", ()).unwrap())
+            .body(CodeBlock::of("self.extra = True", ()).unwrap())
+            .build()
+            .unwrap(),
+        &py,
+        DeclarationContext::Member,
+    );
     assert!(output.contains("def __init__(self, name: str):"));
     assert!(output.contains("super().__init__(name)"));
     assert!(output.contains("self.extra = True"));
@@ -419,12 +550,17 @@ fn test_python_constructor_with_super_delegation() {
 #[test]
 fn test_cpp_constructor_with_super_delegation() {
     let cpp = CppLang::new();
-    let mut fb = FunSpec::<CppLang>::builder("Dog");
-    fb.is_constructor();
-    fb.add_param(ParameterSpec::new("name", TypeName::primitive("std::string")).unwrap());
-    fb.delegation(CodeBlock::of("Animal(name)", ()).unwrap());
-    fb.body(CodeBlock::of("// extra init", ()).unwrap());
-    let output = render_fun(&fb.build().unwrap(), &cpp, DeclarationContext::Member);
+    let output = render_fun(
+        &FunSpec::builder("Dog")
+            .is_constructor()
+            .add_param(ParameterSpec::new("name", TypeName::primitive("std::string")).unwrap())
+            .delegation(CodeBlock::of("Animal(name)", ()).unwrap())
+            .body(CodeBlock::of("// extra init", ()).unwrap())
+            .build()
+            .unwrap(),
+        &cpp,
+        DeclarationContext::Member,
+    );
     // C++ uses body-style delegation (in this simplified model)
     assert!(output.contains("Dog(std::string name) {"));
     assert!(output.contains("Animal(name);"));
@@ -435,19 +571,24 @@ fn test_cpp_constructor_with_super_delegation() {
 #[test]
 fn test_ts_class_with_super_constructor_delegation() {
     let ts = TypeScript::new();
-    let mut tb = TypeSpec::<TypeScript>::builder("Dog", TypeKind::Class);
-    tb.visibility(Visibility::Public);
-    tb.extends(TypeName::primitive("Animal"));
-
-    let mut ctor = FunSpec::builder("constructor");
-    ctor.is_constructor();
-    ctor.add_param(ParameterSpec::new("name", TypeName::primitive("string")).unwrap());
-    ctor.add_param(ParameterSpec::new("breed", TypeName::primitive("string")).unwrap());
-    ctor.delegation(CodeBlock::of("super(name)", ()).unwrap());
-    ctor.body(CodeBlock::of("this.breed = breed", ()).unwrap());
-    tb.add_method(ctor.build().unwrap());
-
-    let output = render_type(&tb.build().unwrap(), &ts);
+    let output = render_type(
+        &TypeSpec::builder("Dog", TypeKind::Class)
+            .visibility(Visibility::Public)
+            .extends(TypeName::primitive("Animal"))
+            .add_method(
+                FunSpec::builder("constructor")
+                    .is_constructor()
+                    .add_param(ParameterSpec::new("name", TypeName::primitive("string")).unwrap())
+                    .add_param(ParameterSpec::new("breed", TypeName::primitive("string")).unwrap())
+                    .delegation(CodeBlock::of("super(name)", ()).unwrap())
+                    .body(CodeBlock::of("this.breed = breed", ()).unwrap())
+                    .build()
+                    .unwrap(),
+            )
+            .build()
+            .unwrap(),
+        &ts,
+    );
     assert!(output.contains("export class Dog extends Animal {"));
     assert!(output.contains("constructor(name: string, breed: string) {"));
     assert!(output.contains("super(name);"));
@@ -457,17 +598,22 @@ fn test_ts_class_with_super_constructor_delegation() {
 #[test]
 fn test_kotlin_class_with_super_constructor_delegation() {
     let kt = Kotlin::new();
-    let mut tb = TypeSpec::<Kotlin>::builder("Dog", TypeKind::Class);
-    tb.extends(TypeName::primitive("Animal"));
-
-    let mut ctor = FunSpec::builder("constructor");
-    ctor.is_constructor();
-    ctor.add_param(ParameterSpec::new("name", TypeName::primitive("String")).unwrap());
-    ctor.delegation(CodeBlock::of("super(name)", ()).unwrap());
-    ctor.body(CodeBlock::of("this.name = name", ()).unwrap());
-    tb.add_method(ctor.build().unwrap());
-
-    let output = render_type(&tb.build().unwrap(), &kt);
+    let output = render_type(
+        &TypeSpec::builder("Dog", TypeKind::Class)
+            .extends(TypeName::primitive("Animal"))
+            .add_method(
+                FunSpec::builder("constructor")
+                    .is_constructor()
+                    .add_param(ParameterSpec::new("name", TypeName::primitive("String")).unwrap())
+                    .delegation(CodeBlock::of("super(name)", ()).unwrap())
+                    .body(CodeBlock::of("this.name = name", ()).unwrap())
+                    .build()
+                    .unwrap(),
+            )
+            .build()
+            .unwrap(),
+        &kt,
+    );
     assert!(output.contains("class Dog : Animal {"));
     assert!(output.contains("constructor(name: String) : super(name) {"));
 }
@@ -477,67 +623,78 @@ fn test_kotlin_class_with_super_constructor_delegation() {
 #[test]
 fn test_kotlin_primary_constructor() {
     let kt = Kotlin::new();
-    let mut tb = TypeSpec::<Kotlin>::builder("Person", TypeKind::Class);
-    tb.add_primary_constructor_param(
-        ParameterSpec::new("val name", TypeName::primitive("String")).unwrap(),
+    let output = render_type(
+        &TypeSpec::builder("Person", TypeKind::Class)
+            .add_primary_constructor_param(
+                ParameterSpec::new("val name", TypeName::primitive("String")).unwrap(),
+            )
+            .add_primary_constructor_param(
+                ParameterSpec::new("val age", TypeName::primitive("Int")).unwrap(),
+            )
+            .build()
+            .unwrap(),
+        &kt,
     );
-    tb.add_primary_constructor_param(
-        ParameterSpec::new("val age", TypeName::primitive("Int")).unwrap(),
-    );
-
-    let output = render_type(&tb.build().unwrap(), &kt);
     assert!(output.contains("class Person(val name: String, val age: Int) {"));
 }
 
 #[test]
 fn test_kotlin_primary_constructor_with_super() {
     let kt = Kotlin::new();
-    let mut tb = TypeSpec::<Kotlin>::builder("Student", TypeKind::Class);
-    tb.add_primary_constructor_param(
-        ParameterSpec::new("val name", TypeName::primitive("String")).unwrap(),
+    let output = render_type(
+        &TypeSpec::builder("Student", TypeKind::Class)
+            .add_primary_constructor_param(
+                ParameterSpec::new("val name", TypeName::primitive("String")).unwrap(),
+            )
+            .add_primary_constructor_param(
+                ParameterSpec::new("val grade", TypeName::primitive("Int")).unwrap(),
+            )
+            .extends(TypeName::primitive("Person"))
+            .build()
+            .unwrap(),
+        &kt,
     );
-    tb.add_primary_constructor_param(
-        ParameterSpec::new("val grade", TypeName::primitive("Int")).unwrap(),
-    );
-    tb.extends(TypeName::primitive("Person"));
-
-    let output = render_type(&tb.build().unwrap(), &kt);
     assert!(output.contains("class Student(val name: String, val grade: Int) : Person {"));
 }
 
 #[test]
 fn test_kotlin_data_class_primary_constructor() {
     let kt = Kotlin::new();
-    let mut tb = TypeSpec::<Kotlin>::builder("Point", TypeKind::Struct);
-    tb.add_primary_constructor_param(
-        ParameterSpec::new("val x", TypeName::primitive("Int")).unwrap(),
+    let output = render_type(
+        &TypeSpec::builder("Point", TypeKind::Struct)
+            .add_primary_constructor_param(
+                ParameterSpec::new("val x", TypeName::primitive("Int")).unwrap(),
+            )
+            .add_primary_constructor_param(
+                ParameterSpec::new("val y", TypeName::primitive("Int")).unwrap(),
+            )
+            .build()
+            .unwrap(),
+        &kt,
     );
-    tb.add_primary_constructor_param(
-        ParameterSpec::new("val y", TypeName::primitive("Int")).unwrap(),
-    );
-
-    let output = render_type(&tb.build().unwrap(), &kt);
     assert!(output.contains("data class Point(val x: Int, val y: Int) {"));
 }
 
 #[test]
 fn test_kotlin_primary_constructor_with_secondary() {
     let kt = Kotlin::new();
-    let mut tb = TypeSpec::<Kotlin>::builder("Config", TypeKind::Class);
-    tb.add_primary_constructor_param(
-        ParameterSpec::new("val name", TypeName::primitive("String")).unwrap(),
-    );
-    tb.add_primary_constructor_param(
-        ParameterSpec::new("val value", TypeName::primitive("Int")).unwrap(),
-    );
-
     // Secondary constructor delegates to primary
-    let mut ctor = FunSpec::builder("constructor");
-    ctor.is_constructor();
-    ctor.add_param(ParameterSpec::new("name", TypeName::primitive("String")).unwrap());
-    ctor.delegation(CodeBlock::of("this(name, 0)", ()).unwrap());
-    ctor.body(CodeBlock::of("// secondary", ()).unwrap());
-    tb.add_method(ctor.build().unwrap());
+    let tb = TypeSpec::builder("Config", TypeKind::Class)
+        .add_primary_constructor_param(
+            ParameterSpec::new("val name", TypeName::primitive("String")).unwrap(),
+        )
+        .add_primary_constructor_param(
+            ParameterSpec::new("val value", TypeName::primitive("Int")).unwrap(),
+        )
+        .add_method(
+            FunSpec::builder("constructor")
+                .is_constructor()
+                .add_param(ParameterSpec::new("name", TypeName::primitive("String")).unwrap())
+                .delegation(CodeBlock::of("this(name, 0)", ()).unwrap())
+                .body(CodeBlock::of("// secondary", ()).unwrap())
+                .build()
+                .unwrap(),
+        );
 
     let output = render_type(&tb.build().unwrap(), &kt);
     assert!(output.contains("class Config(val name: String, val value: Int) {"));
@@ -549,12 +706,15 @@ fn test_kotlin_primary_constructor_with_secondary() {
 #[test]
 fn test_ts_ignores_primary_constructor() {
     let ts = TypeScript::new();
-    let mut tb = TypeSpec::<TypeScript>::builder("Foo", TypeKind::Class);
-    tb.add_primary_constructor_param(
-        ParameterSpec::new("x", TypeName::primitive("number")).unwrap(),
+    let output = render_type(
+        &TypeSpec::builder("Foo", TypeKind::Class)
+            .add_primary_constructor_param(
+                ParameterSpec::new("x", TypeName::primitive("number")).unwrap(),
+            )
+            .build()
+            .unwrap(),
+        &ts,
     );
-
-    let output = render_type(&tb.build().unwrap(), &ts);
     // TypeScript doesn't support primary constructors — params should be ignored
     assert!(output.contains("class Foo {"));
     assert!(!output.contains("(x: number)"));

--- a/tests/cpp/builder_control_flow.rs
+++ b/tests/cpp/builder_control_flow.rs
@@ -6,7 +6,7 @@ use super::golden;
 
 #[test]
 fn test_control_flow() {
-    let mut b = CodeBlock::<CppLang>::builder();
+    let mut b = CodeBlock::builder();
     b.begin_control_flow("if (x > 0)", ());
     b.add_statement("return 1", ());
     b.next_control_flow("else if (x < 0)", ());
@@ -16,9 +16,10 @@ fn test_control_flow() {
     b.end_control_flow();
     let block = b.build().unwrap();
 
-    let mut fb = FileSpec::builder_with("flow.cpp", CppLang::new());
-    fb.add_code(block);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("flow.cpp", CppLang::new())
+        .add_code(block)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("cpp/control_flow.cpp", &output);

--- a/tests/cpp/builder_edge_cases.rs
+++ b/tests/cpp/builder_edge_cases.rs
@@ -11,20 +11,20 @@ use sigil_stitch::type_name::TypeName;
 use super::golden;
 
 /// Helper: emit a FunSpec as a CodeBlock for embedding in extra_member.
-fn emit_fun(fun: &FunSpec<CppLang>) -> CodeBlock<CppLang> {
+fn emit_fun(fun: &FunSpec) -> CodeBlock {
     let lang = CppLang::new();
     fun.emit(&lang, DeclarationContext::Member).unwrap()
 }
 
 /// Helper: emit a FieldSpec as a CodeBlock for embedding in extra_member.
-fn emit_field(field: &FieldSpec<CppLang>) -> CodeBlock<CppLang> {
+fn emit_field(field: &FieldSpec) -> CodeBlock {
     let lang = CppLang::new();
     field.emit(&lang, DeclarationContext::Member).unwrap()
 }
 
 #[test]
 fn test_namespace_wrapping() {
-    let mut b = CodeBlock::<CppLang>::builder();
+    let mut b = CodeBlock::builder();
     b.add("int square(int x) {", ());
     b.add_line();
     b.add("%>", ());
@@ -35,12 +35,13 @@ fn test_namespace_wrapping() {
     b.add_line();
     let block = b.build().unwrap();
 
-    let mut fb = FileSpec::builder_with("math.hpp", CppLang::header());
-    fb.header(CodeBlock::<CppLang>::of("#pragma once", ()).unwrap());
-    fb.add_raw("namespace math {\n");
-    fb.add_code(block);
-    fb.add_raw("\n} // namespace math\n");
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("math.hpp", CppLang::header())
+        .header(CodeBlock::of("#pragma once", ()).unwrap())
+        .add_raw("namespace math {\n")
+        .add_code(block)
+        .add_raw("\n} // namespace math\n")
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("cpp/namespace_wrapping.cpp", &output);
@@ -48,19 +49,19 @@ fn test_namespace_wrapping() {
 
 #[test]
 fn test_full_header() {
-    let iostream = TypeName::<CppLang>::importable("iostream", "std::cout");
-    let string_h = TypeName::<CppLang>::importable("string", "std::string");
+    let iostream = TypeName::importable("iostream", "std::cout");
+    let string_h = TypeName::importable("string", "std::string");
 
     // Logger class inheriting from Base.
-    let mut tb = sigil_stitch::spec::type_spec::TypeSpec::<CppLang>::builder(
+    let tb = sigil_stitch::spec::type_spec::TypeSpec::builder(
         "Logger",
         sigil_stitch::spec::modifiers::TypeKind::Class,
-    );
-    tb.extends(TypeName::primitive("Base"));
-    tb.doc("Application logger.");
+    )
+    .extends(TypeName::primitive("Base"))
+    .doc("Application logger.");
 
     // private: section
-    let mut priv_section = CodeBlock::<CppLang>::builder();
+    let mut priv_section = CodeBlock::builder();
     priv_section.add("%<", ());
     priv_section.add("private:", ());
     priv_section.add_line();
@@ -69,10 +70,10 @@ fn test_full_header() {
         .build()
         .unwrap();
     priv_section.add_code(emit_field(&field));
-    tb.extra_member(priv_section.build().unwrap());
+    let tb = tb.extra_member(priv_section.build().unwrap());
 
     // public: section
-    let mut pub_section = CodeBlock::<CppLang>::builder();
+    let mut pub_section = CodeBlock::builder();
     pub_section.add_line();
     pub_section.add("%<", ());
     pub_section.add("public:", ());
@@ -80,50 +81,60 @@ fn test_full_header() {
     pub_section.add("%>", ());
 
     // Constructor
-    let ctor_body = CodeBlock::<CppLang>::of("name_ = name;", ()).unwrap();
-    let mut ctor = FunSpec::<CppLang>::builder("Logger");
-    ctor.add_param(ParameterSpec::new("name", TypeName::primitive("const std::string&")).unwrap());
-    ctor.body(ctor_body);
-    pub_section.add_code(emit_fun(&ctor.build().unwrap()));
+    let ctor_body = CodeBlock::of("name_ = name;", ()).unwrap();
+    pub_section.add_code(emit_fun(
+        &FunSpec::builder("Logger")
+            .add_param(
+                ParameterSpec::new("name", TypeName::primitive("const std::string&")).unwrap(),
+            )
+            .body(ctor_body)
+            .build()
+            .unwrap(),
+    ));
 
     // log method using imports
     pub_section.add_line();
-    let log_body = CodeBlock::<CppLang>::of(
+    let log_body = CodeBlock::of(
         "%T << name_ << \": \" << %T(msg) << std::endl;",
         (iostream, string_h),
     )
     .unwrap();
-    let mut log = FunSpec::<CppLang>::builder("log");
-    log.add_param(ParameterSpec::new("msg", TypeName::primitive("const char*")).unwrap());
-    log.returns(TypeName::primitive("void"));
-    log.body(log_body);
-    pub_section.add_code(emit_fun(&log.build().unwrap()));
+    pub_section.add_code(emit_fun(
+        &FunSpec::builder("log")
+            .add_param(ParameterSpec::new("msg", TypeName::primitive("const char*")).unwrap())
+            .returns(TypeName::primitive("void"))
+            .body(log_body)
+            .build()
+            .unwrap(),
+    ));
 
     // name getter — const
     pub_section.add_line();
-    let name_body = CodeBlock::<CppLang>::of("return name_;", ()).unwrap();
-    let mut name_fn = FunSpec::<CppLang>::builder("name");
-    name_fn.returns(TypeName::primitive("const std::string&"));
-    name_fn.suffix("const");
-    name_fn.body(name_body);
-    pub_section.add_code(emit_fun(&name_fn.build().unwrap()));
+    let name_body = CodeBlock::of("return name_;", ()).unwrap();
+    pub_section.add_code(emit_fun(
+        &FunSpec::builder("name")
+            .returns(TypeName::primitive("const std::string&"))
+            .suffix("const")
+            .body(name_body)
+            .build()
+            .unwrap(),
+    ));
 
-    tb.extra_member(pub_section.build().unwrap());
-
-    let ts = tb.build().unwrap();
+    let ts = tb
+        .extra_member(pub_section.build().unwrap())
+        .build()
+        .unwrap();
 
     // Trigger base.hpp import.
-    let import_trigger = CodeBlock::<CppLang>::of(
-        "// Uses %T",
-        (TypeName::<CppLang>::importable("./base.hpp", "Base"),),
-    )
-    .unwrap();
+    let import_trigger =
+        CodeBlock::of("// Uses %T", (TypeName::importable("./base.hpp", "Base"),)).unwrap();
 
-    let mut fb = FileSpec::builder_with("logger.hpp", CppLang::header());
-    fb.header(CodeBlock::<CppLang>::of("#pragma once", ()).unwrap());
-    fb.add_code(import_trigger);
-    fb.add_type(ts);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("logger.hpp", CppLang::header())
+        .header(CodeBlock::of("#pragma once", ()).unwrap())
+        .add_code(import_trigger)
+        .add_type(ts)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("cpp/full_header.cpp", &output);
@@ -131,16 +142,18 @@ fn test_full_header() {
 
 #[test]
 fn test_annotation_attribute() {
-    let mut fb = FunSpec::<CppLang>::builder("compute");
-    fb.annotate(AnnotationSpec::new("nodiscard"));
-    fb.returns(TypeName::primitive("int"));
-    fb.body(CodeBlock::of("return 42;", ()).unwrap());
-    let fun = fb.build().unwrap();
+    let fun = FunSpec::builder("compute")
+        .annotate(AnnotationSpec::new("nodiscard"))
+        .returns(TypeName::primitive("int"))
+        .body(CodeBlock::of("return 42;", ()).unwrap())
+        .build()
+        .unwrap();
 
     let rendered = emit_fun(&fun);
-    let mut file_b = FileSpec::builder_with("compute.hpp", CppLang::header());
-    file_b.add_code(rendered);
-    let file = file_b.build().unwrap();
+    let file = FileSpec::builder_with("compute.hpp", CppLang::header())
+        .add_code(rendered)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("cpp/annotation_attribute.cpp", &output);

--- a/tests/cpp/builder_functions.rs
+++ b/tests/cpp/builder_functions.rs
@@ -9,15 +9,17 @@ use super::golden;
 
 #[test]
 fn test_const_method() {
-    let mut fb = FunSpec::<CppLang>::builder("size");
-    fb.returns(TypeName::primitive("int"));
-    fb.suffix("const");
-    fb.suffix("noexcept");
-    let fun = fb.build().unwrap();
+    let fun = FunSpec::builder("size")
+        .returns(TypeName::primitive("int"))
+        .suffix("const")
+        .suffix("noexcept")
+        .build()
+        .unwrap();
 
-    let mut file_b = FileSpec::builder_with("api.hpp", CppLang::header());
-    file_b.add_function(fun);
-    let file = file_b.build().unwrap();
+    let file = FileSpec::builder_with("api.hpp", CppLang::header())
+        .add_function(fun)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("cpp/const_method.cpp", &output);
@@ -25,18 +27,20 @@ fn test_const_method() {
 
 #[test]
 fn test_template_function() {
-    let mut fb = FunSpec::<CppLang>::builder("max_of");
-    fb.annotation(CodeBlock::<CppLang>::of("template<typename T>", ()).unwrap());
-    fb.add_param(ParameterSpec::new("a", TypeName::primitive("const T&")).unwrap());
-    fb.add_param(ParameterSpec::new("b", TypeName::primitive("const T&")).unwrap());
-    fb.returns(TypeName::primitive("T"));
-    let body = CodeBlock::<CppLang>::of("return (a > b) ? a : b;", ()).unwrap();
-    fb.body(body);
-    let fun = fb.build().unwrap();
+    let body = CodeBlock::of("return (a > b) ? a : b;", ()).unwrap();
+    let fun = FunSpec::builder("max_of")
+        .annotation(CodeBlock::of("template<typename T>", ()).unwrap())
+        .add_param(ParameterSpec::new("a", TypeName::primitive("const T&")).unwrap())
+        .add_param(ParameterSpec::new("b", TypeName::primitive("const T&")).unwrap())
+        .returns(TypeName::primitive("T"))
+        .body(body)
+        .build()
+        .unwrap();
 
-    let mut file_b = FileSpec::builder_with("algo.hpp", CppLang::header());
-    file_b.add_function(fun);
-    let file = file_b.build().unwrap();
+    let file = FileSpec::builder_with("algo.hpp", CppLang::header())
+        .add_function(fun)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("cpp/template_function.cpp", &output);
@@ -44,16 +48,18 @@ fn test_template_function() {
 
 #[test]
 fn test_static_method() {
-    let body = CodeBlock::<CppLang>::of("return instance_count_;", ()).unwrap();
-    let mut fb = FunSpec::<CppLang>::builder("count");
-    fb.is_static();
-    fb.returns(TypeName::primitive("int"));
-    fb.body(body);
-    let fun = fb.build().unwrap();
+    let body = CodeBlock::of("return instance_count_;", ()).unwrap();
+    let fun = FunSpec::builder("count")
+        .is_static()
+        .returns(TypeName::primitive("int"))
+        .body(body)
+        .build()
+        .unwrap();
 
-    let mut file_b = FileSpec::builder_with("helpers.cpp", CppLang::new());
-    file_b.add_function(fun);
-    let file = file_b.build().unwrap();
+    let file = FileSpec::builder_with("helpers.cpp", CppLang::new())
+        .add_function(fun)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("cpp/static_method.cpp", &output);
@@ -61,18 +67,20 @@ fn test_static_method() {
 
 #[test]
 fn test_function_with_doc() {
-    let body = CodeBlock::<CppLang>::of("return (a > b) ? a : b;", ()).unwrap();
-    let mut fb = FunSpec::<CppLang>::builder("max_val");
-    fb.doc("Return the larger of two values.");
-    fb.add_param(ParameterSpec::new("a", TypeName::primitive("int")).unwrap());
-    fb.add_param(ParameterSpec::new("b", TypeName::primitive("int")).unwrap());
-    fb.returns(TypeName::primitive("int"));
-    fb.body(body);
-    let fun = fb.build().unwrap();
+    let body = CodeBlock::of("return (a > b) ? a : b;", ()).unwrap();
+    let fun = FunSpec::builder("max_val")
+        .doc("Return the larger of two values.")
+        .add_param(ParameterSpec::new("a", TypeName::primitive("int")).unwrap())
+        .add_param(ParameterSpec::new("b", TypeName::primitive("int")).unwrap())
+        .returns(TypeName::primitive("int"))
+        .body(body)
+        .build()
+        .unwrap();
 
-    let mut file_b = FileSpec::builder_with("math_doc.cpp", CppLang::new());
-    file_b.add_function(fun);
-    let file = file_b.build().unwrap();
+    let file = FileSpec::builder_with("math_doc.cpp", CppLang::new())
+        .add_function(fun)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("cpp/function_with_doc.cpp", &output);

--- a/tests/cpp/builder_imports.rs
+++ b/tests/cpp/builder_imports.rs
@@ -7,19 +7,20 @@ use super::golden;
 
 #[test]
 fn test_includes() {
-    let cout = TypeName::<CppLang>::importable("iostream", "std::cout");
-    let vector = TypeName::<CppLang>::importable("vector", "std::vector");
-    let myclass = TypeName::<CppLang>::importable("./myclass.hpp", "MyClass");
+    let cout = TypeName::importable("iostream", "std::cout");
+    let vector = TypeName::importable("vector", "std::vector");
+    let myclass = TypeName::importable("./myclass.hpp", "MyClass");
 
-    let mut b = CodeBlock::<CppLang>::builder();
+    let mut b = CodeBlock::builder();
     b.add_statement("%T << %S", (cout, StringLitArg("hello".to_string())));
     b.add_statement("%T v", (vector,));
     b.add_statement("%T obj", (myclass,));
     let block = b.build().unwrap();
 
-    let mut fb = FileSpec::builder_with("test.cpp", CppLang::new());
-    fb.add_code(block);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("test.cpp", CppLang::new())
+        .add_code(block)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("cpp/includes.cpp", &output);

--- a/tests/cpp/builder_types.rs
+++ b/tests/cpp/builder_types.rs
@@ -12,25 +12,24 @@ use sigil_stitch::type_name::TypeName;
 use super::golden;
 
 /// Helper: emit a FunSpec as a CodeBlock for embedding in extra_member.
-fn emit_fun(fun: &FunSpec<CppLang>) -> CodeBlock<CppLang> {
+fn emit_fun(fun: &FunSpec) -> CodeBlock {
     let lang = CppLang::new();
     fun.emit(&lang, DeclarationContext::Member).unwrap()
 }
 
 /// Helper: emit a FieldSpec as a CodeBlock for embedding in extra_member.
-fn emit_field(field: &FieldSpec<CppLang>) -> CodeBlock<CppLang> {
+fn emit_field(field: &FieldSpec) -> CodeBlock {
     let lang = CppLang::new();
     field.emit(&lang, DeclarationContext::Member).unwrap()
 }
 
 #[test]
 fn test_class_with_methods() {
-    let mut tb = TypeSpec::<CppLang>::builder("Counter", TypeKind::Class);
-    tb.doc("A simple counter class.");
+    let tb = TypeSpec::builder("Counter", TypeKind::Class).doc("A simple counter class.");
 
     // Build class body with access specifiers via extra_member.
     // private: section
-    let mut priv_section = CodeBlock::<CppLang>::builder();
+    let mut priv_section = CodeBlock::builder();
     priv_section.add("%<", ());
     priv_section.add("private:", ());
     priv_section.add_line();
@@ -39,10 +38,10 @@ fn test_class_with_methods() {
         .build()
         .unwrap();
     priv_section.add_code(emit_field(&field));
-    tb.extra_member(priv_section.build().unwrap());
+    let tb = tb.extra_member(priv_section.build().unwrap());
 
     // public: section
-    let mut pub_section = CodeBlock::<CppLang>::builder();
+    let mut pub_section = CodeBlock::builder();
     pub_section.add_line();
     pub_section.add("%<", ());
     pub_section.add("public:", ());
@@ -50,36 +49,44 @@ fn test_class_with_methods() {
     pub_section.add("%>", ());
 
     // Constructor
-    let ctor_body = CodeBlock::<CppLang>::of("count_ = 0;", ()).unwrap();
-    let mut ctor = FunSpec::<CppLang>::builder("Counter");
-    ctor.body(ctor_body);
-    pub_section.add_code(emit_fun(&ctor.build().unwrap()));
+    let ctor_body = CodeBlock::of("count_ = 0;", ()).unwrap();
+    pub_section.add_code(emit_fun(
+        &FunSpec::builder("Counter").body(ctor_body).build().unwrap(),
+    ));
 
     // increment method
     pub_section.add_line();
-    let inc_body = CodeBlock::<CppLang>::of("++count_;", ()).unwrap();
-    let mut inc = FunSpec::<CppLang>::builder("increment");
-    inc.returns(TypeName::primitive("void"));
-    inc.body(inc_body);
-    pub_section.add_code(emit_fun(&inc.build().unwrap()));
+    let inc_body = CodeBlock::of("++count_;", ()).unwrap();
+    pub_section.add_code(emit_fun(
+        &FunSpec::builder("increment")
+            .returns(TypeName::primitive("void"))
+            .body(inc_body)
+            .build()
+            .unwrap(),
+    ));
 
     // get_count — const method
     pub_section.add_line();
-    let get_body = CodeBlock::<CppLang>::of("return count_;", ()).unwrap();
-    let mut get = FunSpec::<CppLang>::builder("get_count");
-    get.returns(TypeName::primitive("int"));
-    get.suffix("const");
-    get.body(get_body);
-    pub_section.add_code(emit_fun(&get.build().unwrap()));
+    let get_body = CodeBlock::of("return count_;", ()).unwrap();
+    pub_section.add_code(emit_fun(
+        &FunSpec::builder("get_count")
+            .returns(TypeName::primitive("int"))
+            .suffix("const")
+            .body(get_body)
+            .build()
+            .unwrap(),
+    ));
 
-    tb.extra_member(pub_section.build().unwrap());
+    let ts = tb
+        .extra_member(pub_section.build().unwrap())
+        .build()
+        .unwrap();
 
-    let ts = tb.build().unwrap();
-
-    let mut fb = FileSpec::builder_with("counter.hpp", CppLang::header());
-    fb.header(CodeBlock::<CppLang>::of("#pragma once", ()).unwrap());
-    fb.add_type(ts);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("counter.hpp", CppLang::header())
+        .header(CodeBlock::of("#pragma once", ()).unwrap())
+        .add_type(ts)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("cpp/class_with_methods.cpp", &output);
@@ -88,27 +95,29 @@ fn test_class_with_methods() {
 #[test]
 fn test_struct_with_fields() {
     // Struct — data-only, uses emit_split (no methods_inside_type_body).
-    let mut tb = TypeSpec::<CppLang>::builder("Point", TypeKind::Struct);
-    tb.add_field(
-        FieldSpec::builder("x", TypeName::primitive("double"))
-            .build()
-            .unwrap(),
-    );
-    tb.add_field(
-        FieldSpec::builder("y", TypeName::primitive("double"))
-            .build()
-            .unwrap(),
-    );
-    tb.add_field(
-        FieldSpec::builder("z", TypeName::primitive("double"))
-            .build()
-            .unwrap(),
-    );
-    let ts = tb.build().unwrap();
+    let ts = TypeSpec::builder("Point", TypeKind::Struct)
+        .add_field(
+            FieldSpec::builder("x", TypeName::primitive("double"))
+                .build()
+                .unwrap(),
+        )
+        .add_field(
+            FieldSpec::builder("y", TypeName::primitive("double"))
+                .build()
+                .unwrap(),
+        )
+        .add_field(
+            FieldSpec::builder("z", TypeName::primitive("double"))
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
 
-    let mut fb = FileSpec::builder_with("point.hpp", CppLang::header());
-    fb.add_type(ts);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("point.hpp", CppLang::header())
+        .add_type(ts)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("cpp/struct_with_fields.cpp", &output);
@@ -116,16 +125,18 @@ fn test_struct_with_fields() {
 
 #[test]
 fn test_enum_class() {
-    let mut tb = TypeSpec::<CppLang>::builder("Color", TypeKind::Enum);
-    tb.doc("Available colors.");
-    tb.add_variant(EnumVariantSpec::new("Red").unwrap());
-    tb.add_variant(EnumVariantSpec::new("Green").unwrap());
-    tb.add_variant(EnumVariantSpec::new("Blue").unwrap());
-    let ts = tb.build().unwrap();
+    let ts = TypeSpec::builder("Color", TypeKind::Enum)
+        .doc("Available colors.")
+        .add_variant(EnumVariantSpec::new("Red").unwrap())
+        .add_variant(EnumVariantSpec::new("Green").unwrap())
+        .add_variant(EnumVariantSpec::new("Blue").unwrap())
+        .build()
+        .unwrap();
 
-    let mut fb = FileSpec::builder_with("color.hpp", CppLang::header());
-    fb.add_type(ts);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("color.hpp", CppLang::header())
+        .add_type(ts)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("cpp/enum_class.cpp", &output);
@@ -134,37 +145,44 @@ fn test_enum_class() {
 #[test]
 fn test_virtual_method() {
     // Abstract class with pure virtual methods.
-    let mut tb = TypeSpec::<CppLang>::builder("Shape", TypeKind::Class);
-    tb.doc("Abstract shape base class.");
+    let tb = TypeSpec::builder("Shape", TypeKind::Class).doc("Abstract shape base class.");
 
-    let mut pub_section = CodeBlock::<CppLang>::builder();
+    let mut pub_section = CodeBlock::builder();
     pub_section.add("%<", ());
     pub_section.add("public:", ());
     pub_section.add_line();
     pub_section.add("%>", ());
 
     // Pure virtual: virtual double area() const = 0;
-    let mut area = FunSpec::<CppLang>::builder("area");
-    area.is_abstract();
-    area.returns(TypeName::primitive("double"));
-    area.suffix("const");
-    area.suffix("= 0");
-    pub_section.add_code(emit_fun(&area.build().unwrap()));
+    pub_section.add_code(emit_fun(
+        &FunSpec::builder("area")
+            .is_abstract()
+            .returns(TypeName::primitive("double"))
+            .suffix("const")
+            .suffix("= 0")
+            .build()
+            .unwrap(),
+    ));
 
     // Virtual destructor: virtual ~Shape() = default;
     pub_section.add_line();
-    let mut dtor = FunSpec::<CppLang>::builder("~Shape");
-    dtor.is_abstract();
-    dtor.suffix("= default");
-    pub_section.add_code(emit_fun(&dtor.build().unwrap()));
+    pub_section.add_code(emit_fun(
+        &FunSpec::builder("~Shape")
+            .is_abstract()
+            .suffix("= default")
+            .build()
+            .unwrap(),
+    ));
 
-    tb.extra_member(pub_section.build().unwrap());
+    let ts = tb
+        .extra_member(pub_section.build().unwrap())
+        .build()
+        .unwrap();
 
-    let ts = tb.build().unwrap();
-
-    let mut fb = FileSpec::builder_with("shape.hpp", CppLang::header());
-    fb.add_type(ts);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("shape.hpp", CppLang::header())
+        .add_type(ts)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("cpp/virtual_method.cpp", &output);
@@ -172,12 +190,12 @@ fn test_virtual_method() {
 
 #[test]
 fn test_template_class() {
-    let mut tb = TypeSpec::<CppLang>::builder("Stack", TypeKind::Class);
-    tb.annotation(CodeBlock::<CppLang>::of("template<typename T>", ()).unwrap());
-    tb.doc("A simple stack container.");
+    let tb = TypeSpec::builder("Stack", TypeKind::Class)
+        .annotation(CodeBlock::of("template<typename T>", ()).unwrap())
+        .doc("A simple stack container.");
 
     // private: section
-    let mut priv_section = CodeBlock::<CppLang>::builder();
+    let mut priv_section = CodeBlock::builder();
     priv_section.add("%<", ());
     priv_section.add("private:", ());
     priv_section.add_line();
@@ -186,39 +204,47 @@ fn test_template_class() {
         .build()
         .unwrap();
     priv_section.add_code(emit_field(&field));
-    tb.extra_member(priv_section.build().unwrap());
+    let tb = tb.extra_member(priv_section.build().unwrap());
 
     // public: section
-    let mut pub_section = CodeBlock::<CppLang>::builder();
+    let mut pub_section = CodeBlock::builder();
     pub_section.add_line();
     pub_section.add("%<", ());
     pub_section.add("public:", ());
     pub_section.add_line();
     pub_section.add("%>", ());
 
-    let push_body = CodeBlock::<CppLang>::of("data_.push_back(value);", ()).unwrap();
-    let mut push = FunSpec::<CppLang>::builder("push");
-    push.add_param(ParameterSpec::new("value", TypeName::primitive("const T&")).unwrap());
-    push.returns(TypeName::primitive("void"));
-    push.body(push_body);
-    pub_section.add_code(emit_fun(&push.build().unwrap()));
+    let push_body = CodeBlock::of("data_.push_back(value);", ()).unwrap();
+    pub_section.add_code(emit_fun(
+        &FunSpec::builder("push")
+            .add_param(ParameterSpec::new("value", TypeName::primitive("const T&")).unwrap())
+            .returns(TypeName::primitive("void"))
+            .body(push_body)
+            .build()
+            .unwrap(),
+    ));
 
     pub_section.add_line();
-    let empty_body = CodeBlock::<CppLang>::of("return data_.empty();", ()).unwrap();
-    let mut empty = FunSpec::<CppLang>::builder("empty");
-    empty.returns(TypeName::primitive("bool"));
-    empty.suffix("const");
-    empty.body(empty_body);
-    pub_section.add_code(emit_fun(&empty.build().unwrap()));
+    let empty_body = CodeBlock::of("return data_.empty();", ()).unwrap();
+    pub_section.add_code(emit_fun(
+        &FunSpec::builder("empty")
+            .returns(TypeName::primitive("bool"))
+            .suffix("const")
+            .body(empty_body)
+            .build()
+            .unwrap(),
+    ));
 
-    tb.extra_member(pub_section.build().unwrap());
+    let ts = tb
+        .extra_member(pub_section.build().unwrap())
+        .build()
+        .unwrap();
 
-    let ts = tb.build().unwrap();
-
-    let mut fb = FileSpec::builder_with("stack.hpp", CppLang::header());
-    fb.header(CodeBlock::<CppLang>::of("#pragma once", ()).unwrap());
-    fb.add_type(ts);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("stack.hpp", CppLang::header())
+        .header(CodeBlock::of("#pragma once", ()).unwrap())
+        .add_type(ts)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("cpp/template_class.cpp", &output);
@@ -227,46 +253,53 @@ fn test_template_class() {
 #[test]
 fn test_inheritance() {
     // Base class.
-    let mut base_tb = TypeSpec::<CppLang>::builder("Animal", TypeKind::Class);
-
-    let mut pub_section = CodeBlock::<CppLang>::builder();
+    let mut pub_section = CodeBlock::builder();
     pub_section.add("%<", ());
     pub_section.add("public:", ());
     pub_section.add_line();
     pub_section.add("%>", ());
-    let mut speak = FunSpec::<CppLang>::builder("speak");
-    speak.is_abstract();
-    speak.returns(TypeName::primitive("void"));
-    speak.suffix("const");
-    speak.suffix("= 0");
-    pub_section.add_code(emit_fun(&speak.build().unwrap()));
-    base_tb.extra_member(pub_section.build().unwrap());
-    let base = base_tb.build().unwrap();
+    pub_section.add_code(emit_fun(
+        &FunSpec::builder("speak")
+            .is_abstract()
+            .returns(TypeName::primitive("void"))
+            .suffix("const")
+            .suffix("= 0")
+            .build()
+            .unwrap(),
+    ));
+    let base = TypeSpec::builder("Animal", TypeKind::Class)
+        .extra_member(pub_section.build().unwrap())
+        .build()
+        .unwrap();
 
     // Derived class with multiple inheritance.
-    let mut derived_tb = TypeSpec::<CppLang>::builder("Dog", TypeKind::Class);
-    derived_tb.extends(TypeName::primitive("Animal"));
-    derived_tb.extends(TypeName::primitive("Serializable"));
-
-    let mut pub_section2 = CodeBlock::<CppLang>::builder();
+    let mut pub_section2 = CodeBlock::builder();
     pub_section2.add("%<", ());
     pub_section2.add("public:", ());
     pub_section2.add_line();
     pub_section2.add("%>", ());
-    let body = CodeBlock::<CppLang>::of("// bark", ()).unwrap();
-    let mut speak_impl = FunSpec::<CppLang>::builder("speak");
-    speak_impl.returns(TypeName::primitive("void"));
-    speak_impl.suffix("const");
-    speak_impl.suffix("override");
-    speak_impl.body(body);
-    pub_section2.add_code(emit_fun(&speak_impl.build().unwrap()));
-    derived_tb.extra_member(pub_section2.build().unwrap());
-    let derived = derived_tb.build().unwrap();
+    let body = CodeBlock::of("// bark", ()).unwrap();
+    pub_section2.add_code(emit_fun(
+        &FunSpec::builder("speak")
+            .returns(TypeName::primitive("void"))
+            .suffix("const")
+            .suffix("override")
+            .body(body)
+            .build()
+            .unwrap(),
+    ));
+    let derived = TypeSpec::builder("Dog", TypeKind::Class)
+        .extends(TypeName::primitive("Animal"))
+        .extends(TypeName::primitive("Serializable"))
+        .extra_member(pub_section2.build().unwrap())
+        .build()
+        .unwrap();
 
-    let mut fb = FileSpec::builder_with("animals.hpp", CppLang::header());
-    fb.add_type(base);
-    fb.add_type(derived);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("animals.hpp", CppLang::header())
+        .add_type(base)
+        .add_type(derived)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("cpp/inheritance.cpp", &output);

--- a/tests/cpp/quote_basic.rs
+++ b/tests/cpp/quote_basic.rs
@@ -5,10 +5,13 @@ use sigil_stitch::spec::file_spec::FileSpec;
 
 use super::golden;
 
-fn render(block: &CodeBlock<CppLang>) -> String {
-    let mut fb = FileSpec::builder_with("test.cpp", CppLang::new());
-    fb.add_code(block.clone());
-    fb.build().unwrap().render(80).unwrap()
+fn render(block: &CodeBlock) -> String {
+    FileSpec::builder_with("test.cpp", CppLang::new())
+        .add_code(block.clone())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap()
 }
 
 #[test]

--- a/tests/cpp/quote_control_flow.rs
+++ b/tests/cpp/quote_control_flow.rs
@@ -5,10 +5,13 @@ use sigil_stitch::spec::file_spec::FileSpec;
 
 use super::golden;
 
-fn render(block: &CodeBlock<CppLang>) -> String {
-    let mut fb = FileSpec::builder_with("test.cpp", CppLang::new());
-    fb.add_code(block.clone());
-    fb.build().unwrap().render(80).unwrap()
+fn render(block: &CodeBlock) -> String {
+    FileSpec::builder_with("test.cpp", CppLang::new())
+        .add_code(block.clone())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap()
 }
 
 #[test]

--- a/tests/cpp/quote_edge_cases.rs
+++ b/tests/cpp/quote_edge_cases.rs
@@ -6,16 +6,19 @@ use sigil_stitch::type_name::TypeName;
 
 use super::golden;
 
-fn render(block: &CodeBlock<CppLang>) -> String {
-    let mut fb = FileSpec::builder_with("test.cpp", CppLang::new());
-    fb.add_code(block.clone());
-    fb.build().unwrap().render(80).unwrap()
+fn render(block: &CodeBlock) -> String {
+    FileSpec::builder_with("test.cpp", CppLang::new())
+        .add_code(block.clone())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap()
 }
 
 #[test]
 fn test_includes() {
-    let iostream = TypeName::<CppLang>::importable("iostream", "cout");
-    let memory = TypeName::<CppLang>::importable("memory", "unique_ptr");
+    let iostream = TypeName::importable("iostream", "cout");
+    let memory = TypeName::importable("memory", "unique_ptr");
     let block = sigil_quote!(CppLang {
         auto ptr = std::make_unique<int>(42);
         $T(iostream) << $T(memory)(ptr.get()) << std::endl;

--- a/tests/cpp/quote_imports.rs
+++ b/tests/cpp/quote_imports.rs
@@ -6,16 +6,19 @@ use sigil_stitch::type_name::TypeName;
 
 use super::golden;
 
-fn render(block: &CodeBlock<CppLang>) -> String {
-    let mut fb = FileSpec::builder_with("test.cpp", CppLang::new());
-    fb.add_code(block.clone());
-    fb.build().unwrap().render(80).unwrap()
+fn render(block: &CodeBlock) -> String {
+    FileSpec::builder_with("test.cpp", CppLang::new())
+        .add_code(block.clone())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap()
 }
 
 #[test]
 fn test_imports() {
-    let vector = TypeName::<CppLang>::importable("vector", "vector");
-    let string = TypeName::<CppLang>::importable("string", "string");
+    let vector = TypeName::importable("vector", "vector");
+    let string = TypeName::importable("string", "string");
     let block = sigil_quote!(CppLang {
         $T(vector) items;
         $T(string) name = $S("Alice");

--- a/tests/dart/builder_control_flow.rs
+++ b/tests/dart/builder_control_flow.rs
@@ -6,7 +6,7 @@ use super::golden;
 
 #[test]
 fn test_control_flow() {
-    let mut b = CodeBlock::<DartLang>::builder();
+    let mut b = CodeBlock::builder();
     b.begin_control_flow("if (x > 0)", ());
     b.add_statement("return 1", ());
     b.next_control_flow("else if (x < 0)", ());
@@ -16,9 +16,10 @@ fn test_control_flow() {
     b.end_control_flow();
     let block = b.build().unwrap();
 
-    let mut fb = FileSpec::builder_with("flow.dart", DartLang::new());
-    fb.add_code(block);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("flow.dart", DartLang::new())
+        .add_code(block)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("dart/control_flow.dart", &output);

--- a/tests/dart/builder_edge_cases.rs
+++ b/tests/dart/builder_edge_cases.rs
@@ -12,77 +12,92 @@ use super::golden;
 
 #[test]
 fn test_full_module() {
-    let future = TypeName::<DartLang>::importable("dart:async", "Future");
-    let convert = TypeName::<DartLang>::importable("dart:convert", "jsonDecode");
+    let future = TypeName::importable("dart:async", "Future");
+    let convert = TypeName::importable("dart:convert", "jsonDecode");
 
     // Abstract class (interface).
-    let mut iface = TypeSpec::<DartLang>::builder("UserRepository", TypeKind::Interface);
-
-    let mut find = FunSpec::<DartLang>::builder("findById");
-    find.returns(TypeName::primitive("User?"));
-    find.add_param(ParameterSpec::new("id", TypeName::primitive("String")).unwrap());
-    iface.add_method(find.build().unwrap());
-
-    let mut find_all = FunSpec::<DartLang>::builder("findAll");
-    find_all.returns(TypeName::primitive("List<User>"));
-    iface.add_method(find_all.build().unwrap());
-
-    let iface_spec = iface.build().unwrap();
+    let iface_spec = TypeSpec::builder("UserRepository", TypeKind::Interface)
+        .add_method(
+            FunSpec::builder("findById")
+                .returns(TypeName::primitive("User?"))
+                .add_param(ParameterSpec::new("id", TypeName::primitive("String")).unwrap())
+                .build()
+                .unwrap(),
+        )
+        .add_method(
+            FunSpec::builder("findAll")
+                .returns(TypeName::primitive("List<User>"))
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
 
     // Implementation class.
-    let mut cls = TypeSpec::<DartLang>::builder("InMemoryUserRepository", TypeKind::Class);
-    cls.implements(TypeName::primitive("UserRepository"));
-    cls.doc("In-memory implementation of UserRepository.");
+    let cls = TypeSpec::builder("InMemoryUserRepository", TypeKind::Class);
+    let cls = cls.implements(TypeName::primitive("UserRepository"));
+    let cls = cls.doc("In-memory implementation of UserRepository.");
 
-    let mut users_field = FieldSpec::builder("_users", TypeName::primitive("List<User>"));
-    users_field.is_readonly();
-    users_field.initializer(CodeBlock::<DartLang>::of("[]", ()).unwrap());
-    cls.add_field(users_field.build().unwrap());
+    let cls = cls.add_field(
+        FieldSpec::builder("_users", TypeName::primitive("List<User>"))
+            .is_readonly()
+            .initializer(CodeBlock::of("[]", ()).unwrap())
+            .build()
+            .unwrap(),
+    );
 
     // findById with @override.
-    let find_body = CodeBlock::<DartLang>::of(
+    let find_body = CodeBlock::of(
         "return _users.cast<User?>().firstWhere(\n  (u) => u?.id == id,\n  orElse: () => null,\n);",
         (),
     )
     .unwrap();
-    let mut find_impl = FunSpec::<DartLang>::builder("findById");
-    find_impl.returns(TypeName::primitive("User?"));
-    find_impl.add_param(ParameterSpec::new("id", TypeName::primitive("String")).unwrap());
-    find_impl.annotation(CodeBlock::<DartLang>::of("@override", ()).unwrap());
-    find_impl.body(find_body);
-    cls.add_method(find_impl.build().unwrap());
+    let cls = cls.add_method(
+        FunSpec::builder("findById")
+            .returns(TypeName::primitive("User?"))
+            .add_param(ParameterSpec::new("id", TypeName::primitive("String")).unwrap())
+            .annotation(CodeBlock::of("@override", ()).unwrap())
+            .body(find_body)
+            .build()
+            .unwrap(),
+    );
 
     // findAll with @override.
-    let find_all_body = CodeBlock::<DartLang>::of("return List.unmodifiable(_users);", ()).unwrap();
-    let mut find_all_impl = FunSpec::<DartLang>::builder("findAll");
-    find_all_impl.returns(TypeName::primitive("List<User>"));
-    find_all_impl.annotation(CodeBlock::<DartLang>::of("@override", ()).unwrap());
-    find_all_impl.body(find_all_body);
-    cls.add_method(find_all_impl.build().unwrap());
+    let find_all_body = CodeBlock::of("return List.unmodifiable(_users);", ()).unwrap();
+    let cls = cls.add_method(
+        FunSpec::builder("findAll")
+            .returns(TypeName::primitive("List<User>"))
+            .annotation(CodeBlock::of("@override", ()).unwrap())
+            .body(find_all_body)
+            .build()
+            .unwrap(),
+    );
 
     let cls_spec = cls.build().unwrap();
 
     // Standalone function using Future + convert imports.
-    let parse_body = CodeBlock::<DartLang>::of(
+    let parse_body = CodeBlock::of(
         "final data = %T(json);\nreturn User.fromMap(data);",
         (convert,),
     )
     .unwrap();
-    let mut parse_fn = FunSpec::<DartLang>::builder("parseUser");
-    parse_fn.returns(TypeName::primitive("User"));
-    parse_fn.add_param(ParameterSpec::new("json", TypeName::primitive("String")).unwrap());
-    parse_fn.body(parse_body);
-    let parse_user = parse_fn.build().unwrap();
+    let parse_user = FunSpec::builder("parseUser")
+        .returns(TypeName::primitive("User"))
+        .add_param(ParameterSpec::new("json", TypeName::primitive("String")).unwrap())
+        .body(parse_body)
+        .build()
+        .unwrap();
 
     // Trigger Future import.
-    let future_trigger = CodeBlock::<DartLang>::of("// %T", (future,)).unwrap();
+    let future_trigger = CodeBlock::of("// %T", (future,)).unwrap();
 
-    let mut fb = FileSpec::builder_with("user_repo.dart", DartLang::new());
-    fb.add_code(future_trigger);
-    fb.add_type(iface_spec);
-    fb.add_type(cls_spec);
-    fb.add_function(parse_user);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("user_repo.dart", DartLang::new())
+        .add_code(future_trigger)
+        .add_type(iface_spec)
+        .add_type(cls_spec)
+        .add_function(parse_user)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("dart/full_module.dart", &output);
@@ -90,7 +105,7 @@ fn test_full_module() {
 
 #[test]
 fn test_string_dollar_escape() {
-    let body = CodeBlock::<DartLang>::of(
+    let body = CodeBlock::of(
         "final greeting = %S;\nfinal template = %S;\nprint(greeting);",
         (
             StringLitArg("Hello ${name}!".into()),
@@ -98,14 +113,16 @@ fn test_string_dollar_escape() {
         ),
     )
     .unwrap();
-    let mut fb = FunSpec::<DartLang>::builder("greet");
-    fb.add_param(ParameterSpec::new("name", TypeName::primitive("String")).unwrap());
-    fb.body(body);
-    let fun = fb.build().unwrap();
+    let fun = FunSpec::builder("greet")
+        .add_param(ParameterSpec::new("name", TypeName::primitive("String")).unwrap())
+        .body(body)
+        .build()
+        .unwrap();
 
-    let mut file_b = FileSpec::builder_with("greet.dart", DartLang::new());
-    file_b.add_function(fun);
-    let file = file_b.build().unwrap();
+    let file = FileSpec::builder_with("greet.dart", DartLang::new())
+        .add_function(fun)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("dart/string_dollar_escape.dart", &output);

--- a/tests/dart/builder_functions.rs
+++ b/tests/dart/builder_functions.rs
@@ -11,22 +11,24 @@ use super::golden;
 
 #[test]
 fn test_async_function() {
-    let user = TypeName::<DartLang>::importable("package:myapp/models/user.dart", "User");
+    let user = TypeName::importable("package:myapp/models/user.dart", "User");
 
-    let body = CodeBlock::<DartLang>::of("return await api.fetchUser(id);", ()).unwrap();
-    let mut fb_fun = FunSpec::<DartLang>::builder("fetchUser");
-    fb_fun.returns(TypeName::primitive("Future<User>"));
-    fb_fun.add_param(ParameterSpec::new("id", TypeName::primitive("String")).unwrap());
-    fb_fun.body(body);
-    let fun = fb_fun.build().unwrap();
+    let body = CodeBlock::of("return await api.fetchUser(id);", ()).unwrap();
+    let fun = FunSpec::builder("fetchUser")
+        .returns(TypeName::primitive("Future<User>"))
+        .add_param(ParameterSpec::new("id", TypeName::primitive("String")).unwrap())
+        .body(body)
+        .build()
+        .unwrap();
 
     // Trigger User import.
-    let trigger = CodeBlock::<DartLang>::of("// %T", (user,)).unwrap();
+    let trigger = CodeBlock::of("// %T", (user,)).unwrap();
 
-    let mut fb = FileSpec::builder_with("api.dart", DartLang::new());
-    fb.add_code(trigger);
-    fb.add_function(fun);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("api.dart", DartLang::new())
+        .add_code(trigger)
+        .add_function(fun)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("dart/async_function.dart", &output);
@@ -34,25 +36,28 @@ fn test_async_function() {
 
 #[test]
 fn test_annotated_method() {
-    let mut tb = TypeSpec::<DartLang>::builder("Dog", TypeKind::Class);
-    tb.extends(TypeName::primitive("Animal"));
-
-    let body = CodeBlock::<DartLang>::of(
+    let body = CodeBlock::of(
         "return %S;",
         (sigil_stitch::code_block::StringLitArg("Woof!".to_string()),),
     )
     .unwrap();
-    let mut speak = FunSpec::<DartLang>::builder("speak");
-    speak.returns(TypeName::primitive("String"));
-    speak.annotation(CodeBlock::<DartLang>::of("@override", ()).unwrap());
-    speak.body(body);
-    tb.add_method(speak.build().unwrap());
+    let ts = TypeSpec::builder("Dog", TypeKind::Class)
+        .extends(TypeName::primitive("Animal"))
+        .add_method(
+            FunSpec::builder("speak")
+                .returns(TypeName::primitive("String"))
+                .annotation(CodeBlock::of("@override", ()).unwrap())
+                .body(body)
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
 
-    let ts = tb.build().unwrap();
-
-    let mut fb = FileSpec::builder_with("dog.dart", DartLang::new());
-    fb.add_type(ts);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("dog.dart", DartLang::new())
+        .add_type(ts)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("dart/annotated_method.dart", &output);
@@ -60,17 +65,19 @@ fn test_annotated_method() {
 
 #[test]
 fn test_function_with_doc() {
-    let body = CodeBlock::<DartLang>::of("return 'Hello, $name!';", ()).unwrap();
-    let mut fb = FunSpec::<DartLang>::builder("greet");
-    fb.doc("Greet the user by name.");
-    fb.add_param(ParameterSpec::new("name", TypeName::primitive("String")).unwrap());
-    fb.returns(TypeName::primitive("String"));
-    fb.body(body);
-    let fun = fb.build().unwrap();
+    let body = CodeBlock::of("return 'Hello, $name!';", ()).unwrap();
+    let fun = FunSpec::builder("greet")
+        .doc("Greet the user by name.")
+        .add_param(ParameterSpec::new("name", TypeName::primitive("String")).unwrap())
+        .returns(TypeName::primitive("String"))
+        .body(body)
+        .build()
+        .unwrap();
 
-    let mut file_b = FileSpec::<DartLang>::builder("greet.dart");
-    file_b.add_function(fun);
-    let file = file_b.build().unwrap();
+    let file = FileSpec::builder("greet.dart")
+        .add_function(fun)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("dart/function_with_doc.dart", &output);

--- a/tests/dart/builder_imports.rs
+++ b/tests/dart/builder_imports.rs
@@ -7,16 +7,17 @@ use super::golden;
 
 #[test]
 fn test_function_with_imports() {
-    let future = TypeName::<DartLang>::importable("dart:async", "Future");
-    let user = TypeName::<DartLang>::importable("package:myapp/models/user.dart", "User");
+    let future = TypeName::importable("dart:async", "Future");
+    let user = TypeName::importable("package:myapp/models/user.dart", "User");
 
-    let mut b = CodeBlock::<DartLang>::builder();
+    let mut b = CodeBlock::builder();
     b.add_statement("%T<%T> users = fetchAll()", (future, user));
     let block = b.build().unwrap();
 
-    let mut fb = FileSpec::builder_with("app.dart", DartLang::new());
-    fb.add_code(block);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("app.dart", DartLang::new())
+        .add_code(block)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("dart/function_with_imports.dart", &output);
@@ -24,14 +25,14 @@ fn test_function_with_imports() {
 
 #[test]
 fn test_import_grouping() {
-    let future = TypeName::<DartLang>::importable("dart:async", "Future");
-    let convert = TypeName::<DartLang>::importable("dart:convert", "json");
-    let http = TypeName::<DartLang>::importable("package:http/http.dart", "Client");
-    let provider = TypeName::<DartLang>::importable("package:provider/provider.dart", "Provider");
-    let user = TypeName::<DartLang>::importable("../models/user.dart", "User");
-    let config = TypeName::<DartLang>::importable("./config.dart", "Config");
+    let future = TypeName::importable("dart:async", "Future");
+    let convert = TypeName::importable("dart:convert", "json");
+    let http = TypeName::importable("package:http/http.dart", "Client");
+    let provider = TypeName::importable("package:provider/provider.dart", "Provider");
+    let user = TypeName::importable("../models/user.dart", "User");
+    let config = TypeName::importable("./config.dart", "Config");
 
-    let mut b = CodeBlock::<DartLang>::builder();
+    let mut b = CodeBlock::builder();
     b.add(
         "// %T %T %T %T %T %T",
         (future, convert, http, provider, user, config),
@@ -39,9 +40,10 @@ fn test_import_grouping() {
     b.add_line();
     let block = b.build().unwrap();
 
-    let mut fb = FileSpec::builder_with("imports.dart", DartLang::new());
-    fb.add_code(block);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("imports.dart", DartLang::new())
+        .add_code(block)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("dart/import_grouping.dart", &output);

--- a/tests/dart/builder_types.rs
+++ b/tests/dart/builder_types.rs
@@ -13,39 +13,50 @@ use super::golden;
 
 #[test]
 fn test_class_with_fields() {
-    let mut tb = TypeSpec::<DartLang>::builder("UserService", TypeKind::Class);
-    tb.doc("Service for managing users.");
-
-    // Fields.
-    let repo_field = FieldSpec::builder("repo", TypeName::primitive("UserRepository"));
-    tb.add_field(repo_field.build().unwrap());
-
-    let mut logger_field = FieldSpec::builder("logger", TypeName::primitive("Logger"));
-    logger_field.is_readonly();
-    tb.add_field(logger_field.build().unwrap());
-
     // Constructor.
-    let ctor_body =
-        CodeBlock::<DartLang>::of("this.repo = repo;\nthis.logger = logger;", ()).unwrap();
-    let mut ctor = FunSpec::<DartLang>::builder("UserService");
-    ctor.add_param(ParameterSpec::new("repo", TypeName::primitive("UserRepository")).unwrap());
-    ctor.add_param(ParameterSpec::new("logger", TypeName::primitive("Logger")).unwrap());
-    ctor.body(ctor_body);
-    tb.add_method(ctor.build().unwrap());
+    let ctor_body = CodeBlock::of("this.repo = repo;\nthis.logger = logger;", ()).unwrap();
 
     // Method.
-    let find_body = CodeBlock::<DartLang>::of("return repo.findById(id);", ()).unwrap();
-    let mut find = FunSpec::<DartLang>::builder("findUser");
-    find.returns(TypeName::primitive("User?"));
-    find.add_param(ParameterSpec::new("id", TypeName::primitive("String")).unwrap());
-    find.body(find_body);
-    tb.add_method(find.build().unwrap());
+    let find_body = CodeBlock::of("return repo.findById(id);", ()).unwrap();
 
-    let ts = tb.build().unwrap();
+    let ts = TypeSpec::builder("UserService", TypeKind::Class)
+        .doc("Service for managing users.")
+        .add_field(
+            FieldSpec::builder("repo", TypeName::primitive("UserRepository"))
+                .build()
+                .unwrap(),
+        )
+        .add_field(
+            FieldSpec::builder("logger", TypeName::primitive("Logger"))
+                .is_readonly()
+                .build()
+                .unwrap(),
+        )
+        .add_method(
+            FunSpec::builder("UserService")
+                .add_param(
+                    ParameterSpec::new("repo", TypeName::primitive("UserRepository")).unwrap(),
+                )
+                .add_param(ParameterSpec::new("logger", TypeName::primitive("Logger")).unwrap())
+                .body(ctor_body)
+                .build()
+                .unwrap(),
+        )
+        .add_method(
+            FunSpec::builder("findUser")
+                .returns(TypeName::primitive("User?"))
+                .add_param(ParameterSpec::new("id", TypeName::primitive("String")).unwrap())
+                .body(find_body)
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
 
-    let mut fb = FileSpec::builder_with("user_service.dart", DartLang::new());
-    fb.add_type(ts);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("user_service.dart", DartLang::new())
+        .add_type(ts)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("dart/class_with_fields.dart", &output);
@@ -53,28 +64,33 @@ fn test_class_with_fields() {
 
 #[test]
 fn test_abstract_class() {
-    let mut tb = TypeSpec::<DartLang>::builder("Shape", TypeKind::Class);
-    tb.doc("Abstract shape.");
-    tb.is_abstract();
-
     // Concrete method.
-    let desc_body = CodeBlock::<DartLang>::of("return runtimeType.toString();", ()).unwrap();
-    let mut desc = FunSpec::<DartLang>::builder("describe");
-    desc.returns(TypeName::primitive("String"));
-    desc.body(desc_body);
-    tb.add_method(desc.build().unwrap());
+    let desc_body = CodeBlock::of("return runtimeType.toString();", ()).unwrap();
 
-    // Abstract method.
-    let mut area = FunSpec::<DartLang>::builder("area");
-    area.is_abstract();
-    area.returns(TypeName::primitive("double"));
-    tb.add_method(area.build().unwrap());
+    let ts = TypeSpec::builder("Shape", TypeKind::Class)
+        .doc("Abstract shape.")
+        .is_abstract()
+        .add_method(
+            FunSpec::builder("describe")
+                .returns(TypeName::primitive("String"))
+                .body(desc_body)
+                .build()
+                .unwrap(),
+        )
+        .add_method(
+            FunSpec::builder("area")
+                .is_abstract()
+                .returns(TypeName::primitive("double"))
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
 
-    let ts = tb.build().unwrap();
-
-    let mut fb = FileSpec::builder_with("shape.dart", DartLang::new());
-    fb.add_type(ts);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("shape.dart", DartLang::new())
+        .add_type(ts)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("dart/abstract_class.dart", &output);
@@ -82,26 +98,29 @@ fn test_abstract_class() {
 
 #[test]
 fn test_class_extends_implements() {
-    let base = TypeName::<DartLang>::importable("package:myapp/base.dart", "BaseService");
-    let auth = TypeName::<DartLang>::importable("package:myapp/auth.dart", "Authenticatable");
-    let serial = TypeName::<DartLang>::importable("package:myapp/serial.dart", "Serializable");
+    let base = TypeName::importable("package:myapp/base.dart", "BaseService");
+    let auth = TypeName::importable("package:myapp/auth.dart", "Authenticatable");
+    let serial = TypeName::importable("package:myapp/serial.dart", "Serializable");
 
-    let mut tb = TypeSpec::<DartLang>::builder("AdminService", TypeKind::Class);
-    tb.extends(base);
-    tb.implements(auth);
-    tb.implements(serial);
+    let body = CodeBlock::of("return true;", ()).unwrap();
+    let ts = TypeSpec::builder("AdminService", TypeKind::Class)
+        .extends(base)
+        .implements(auth)
+        .implements(serial)
+        .add_method(
+            FunSpec::builder("isAdmin")
+                .returns(TypeName::primitive("bool"))
+                .body(body)
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
 
-    let body = CodeBlock::<DartLang>::of("return true;", ()).unwrap();
-    let mut is_admin = FunSpec::<DartLang>::builder("isAdmin");
-    is_admin.returns(TypeName::primitive("bool"));
-    is_admin.body(body);
-    tb.add_method(is_admin.build().unwrap());
-
-    let ts = tb.build().unwrap();
-
-    let mut fb = FileSpec::builder_with("admin_service.dart", DartLang::new());
-    fb.add_type(ts);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("admin_service.dart", DartLang::new())
+        .add_type(ts)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("dart/class_extends_implements.dart", &output);
@@ -109,18 +128,18 @@ fn test_class_extends_implements() {
 
 #[test]
 fn test_enum() {
-    let mut tb = TypeSpec::<DartLang>::builder("Color", TypeKind::Enum);
-    tb.doc("Supported colors.");
+    let ts = TypeSpec::builder("Color", TypeKind::Enum)
+        .doc("Supported colors.")
+        .add_variant(EnumVariantSpec::new("red").unwrap())
+        .add_variant(EnumVariantSpec::new("green").unwrap())
+        .add_variant(EnumVariantSpec::new("blue").unwrap())
+        .build()
+        .unwrap();
 
-    tb.add_variant(EnumVariantSpec::new("red").unwrap());
-    tb.add_variant(EnumVariantSpec::new("green").unwrap());
-    tb.add_variant(EnumVariantSpec::new("blue").unwrap());
-
-    let ts = tb.build().unwrap();
-
-    let mut fb = FileSpec::builder_with("color.dart", DartLang::new());
-    fb.add_type(ts);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("color.dart", DartLang::new())
+        .add_type(ts)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("dart/enum.dart", &output);
@@ -128,28 +147,33 @@ fn test_enum() {
 
 #[test]
 fn test_generic_class() {
-    let tp = TypeParamSpec::<DartLang>::new("T").with_bound(TypeName::primitive("Comparable"));
+    let tp = TypeParamSpec::new("T").with_bound(TypeName::primitive("Comparable"));
 
-    let mut tb = TypeSpec::<DartLang>::builder("SortedList", TypeKind::Class);
-    tb.add_type_param(tp);
-    tb.doc("A sorted list with bounded type parameter.");
+    let add_body = CodeBlock::of("items.add(item);\nitems.sort();", ()).unwrap();
+    let ts = TypeSpec::builder("SortedList", TypeKind::Class)
+        .add_type_param(tp)
+        .doc("A sorted list with bounded type parameter.")
+        .add_field(
+            FieldSpec::builder("items", TypeName::primitive("List<T>"))
+                .is_readonly()
+                .build()
+                .unwrap(),
+        )
+        .add_method(
+            FunSpec::builder("add")
+                .returns(TypeName::primitive("void"))
+                .add_param(ParameterSpec::new("item", TypeName::primitive("T")).unwrap())
+                .body(add_body)
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
 
-    let mut items_field = FieldSpec::builder("items", TypeName::primitive("List<T>"));
-    items_field.is_readonly();
-    tb.add_field(items_field.build().unwrap());
-
-    let add_body = CodeBlock::<DartLang>::of("items.add(item);\nitems.sort();", ()).unwrap();
-    let mut add = FunSpec::<DartLang>::builder("add");
-    add.returns(TypeName::primitive("void"));
-    add.add_param(ParameterSpec::new("item", TypeName::primitive("T")).unwrap());
-    add.body(add_body);
-    tb.add_method(add.build().unwrap());
-
-    let ts = tb.build().unwrap();
-
-    let mut fb = FileSpec::builder_with("sorted_list.dart", DartLang::new());
-    fb.add_type(ts);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("sorted_list.dart", DartLang::new())
+        .add_type(ts)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("dart/generic_class.dart", &output);
@@ -157,31 +181,36 @@ fn test_generic_class() {
 
 #[test]
 fn test_static_final() {
-    let mut tb = TypeSpec::<DartLang>::builder("Constants", TypeKind::Class);
-
-    let mut max_field = FieldSpec::builder("maxSize", TypeName::primitive("int"));
-    max_field.is_static();
-    max_field.is_readonly();
-    max_field.initializer(CodeBlock::<DartLang>::of("100", ()).unwrap());
-    tb.add_field(max_field.build().unwrap());
-
-    let mut name_field = FieldSpec::builder("appName", TypeName::primitive("String"));
-    name_field.is_static();
-    name_field.is_readonly();
-    name_field.initializer(
-        CodeBlock::<DartLang>::of(
-            "%S",
-            (sigil_stitch::code_block::StringLitArg("MyApp".to_string()),),
+    let ts = TypeSpec::builder("Constants", TypeKind::Class)
+        .add_field(
+            FieldSpec::builder("maxSize", TypeName::primitive("int"))
+                .is_static()
+                .is_readonly()
+                .initializer(CodeBlock::of("100", ()).unwrap())
+                .build()
+                .unwrap(),
         )
-        .unwrap(),
-    );
-    tb.add_field(name_field.build().unwrap());
+        .add_field(
+            FieldSpec::builder("appName", TypeName::primitive("String"))
+                .is_static()
+                .is_readonly()
+                .initializer(
+                    CodeBlock::of(
+                        "%S",
+                        (sigil_stitch::code_block::StringLitArg("MyApp".to_string()),),
+                    )
+                    .unwrap(),
+                )
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
 
-    let ts = tb.build().unwrap();
-
-    let mut fb = FileSpec::builder_with("constants.dart", DartLang::new());
-    fb.add_type(ts);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("constants.dart", DartLang::new())
+        .add_type(ts)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("dart/static_final.dart", &output);

--- a/tests/dart/quote_basic.rs
+++ b/tests/dart/quote_basic.rs
@@ -1,14 +1,16 @@
 use sigil_stitch::code_block::CodeBlock;
-use sigil_stitch::lang::dart::DartLang;
 use sigil_stitch::prelude::*;
 use sigil_stitch::spec::file_spec::FileSpec;
 
 use super::golden;
 
-fn render(block: &CodeBlock<DartLang>) -> String {
-    let mut fb = FileSpec::<DartLang>::builder("test.dart");
-    fb.add_code(block.clone());
-    fb.build().unwrap().render(80).unwrap()
+fn render(block: &CodeBlock) -> String {
+    FileSpec::builder("test.dart")
+        .add_code(block.clone())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap()
 }
 
 #[test]

--- a/tests/dart/quote_control_flow.rs
+++ b/tests/dart/quote_control_flow.rs
@@ -1,14 +1,16 @@
 use sigil_stitch::code_block::CodeBlock;
-use sigil_stitch::lang::dart::DartLang;
 use sigil_stitch::prelude::*;
 use sigil_stitch::spec::file_spec::FileSpec;
 
 use super::golden;
 
-fn render(block: &CodeBlock<DartLang>) -> String {
-    let mut fb = FileSpec::<DartLang>::builder("test.dart");
-    fb.add_code(block.clone());
-    fb.build().unwrap().render(80).unwrap()
+fn render(block: &CodeBlock) -> String {
+    FileSpec::builder("test.dart")
+        .add_code(block.clone())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap()
 }
 
 #[test]

--- a/tests/dart/quote_imports.rs
+++ b/tests/dart/quote_imports.rs
@@ -1,21 +1,23 @@
 use sigil_stitch::code_block::CodeBlock;
-use sigil_stitch::lang::dart::DartLang;
 use sigil_stitch::prelude::*;
 use sigil_stitch::spec::file_spec::FileSpec;
 use sigil_stitch::type_name::TypeName;
 
 use super::golden;
 
-fn render(block: &CodeBlock<DartLang>) -> String {
-    let mut fb = FileSpec::<DartLang>::builder("test.dart");
-    fb.add_code(block.clone());
-    fb.build().unwrap().render(80).unwrap()
+fn render(block: &CodeBlock) -> String {
+    FileSpec::builder("test.dart")
+        .add_code(block.clone())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap()
 }
 
 #[test]
 fn test_imports() {
-    let http = TypeName::<DartLang>::importable("package:http/http.dart", "Client");
-    let convert = TypeName::<DartLang>::importable("dart:convert", "jsonDecode");
+    let http = TypeName::importable("package:http/http.dart", "Client");
+    let convert = TypeName::importable("dart:convert", "jsonDecode");
     let block = sigil_quote!(DartLang {
         final client = $T(http)();
         final data = $T(convert)(response.body);

--- a/tests/go/builder_control_flow.rs
+++ b/tests/go/builder_control_flow.rs
@@ -6,7 +6,7 @@ use super::golden;
 
 #[test]
 fn test_control_flow() {
-    let mut b = CodeBlock::<GoLang>::builder();
+    let mut b = CodeBlock::builder();
     b.add("func classify(x int) string {", ());
     b.add_line();
     b.add("%>", ());
@@ -22,10 +22,11 @@ fn test_control_flow() {
     b.add_line();
     let block = b.build().unwrap();
 
-    let mut fb = FileSpec::builder_with("classify.go", GoLang::new());
-    fb.header(CodeBlock::<GoLang>::of("package main", ()).unwrap());
-    fb.add_code(block);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("classify.go", GoLang::new())
+        .header(CodeBlock::of("package main", ()).unwrap())
+        .add_code(block)
+        .build()
+        .unwrap();
 
     let output = file.render(80).unwrap();
     golden::assert_golden("go/control_flow.go", &output);

--- a/tests/go/builder_edge_cases.rs
+++ b/tests/go/builder_edge_cases.rs
@@ -14,7 +14,7 @@ fn test_enum() {
     // This doesn't fit TypeSpec, so we build it as a raw CodeBlock.
     let go = GoLang::new();
 
-    let mut cb = CodeBlock::<GoLang>::builder();
+    let mut cb = CodeBlock::builder();
     let doc = go.render_doc_comment(&["Direction represents a cardinal direction."]);
     cb.add("%L", doc);
     cb.add_line();
@@ -37,10 +37,11 @@ fn test_enum() {
     cb.add_line();
     let block = cb.build().unwrap();
 
-    let mut fb = FileSpec::builder_with("direction.go", GoLang::new());
-    fb.header(CodeBlock::<GoLang>::of("package direction", ()).unwrap());
-    fb.add_code(block);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("direction.go", GoLang::new())
+        .header(CodeBlock::of("package direction", ()).unwrap())
+        .add_code(block)
+        .build()
+        .unwrap();
 
     let output = file.render(80).unwrap();
     golden::assert_golden("go/enum.go", &output);

--- a/tests/go/builder_functions.rs
+++ b/tests/go/builder_functions.rs
@@ -10,17 +10,20 @@ use super::golden;
 
 #[test]
 fn test_top_level_function() {
-    let fmt_sprintf = TypeName::<GoLang>::importable("fmt", "Sprintf");
+    let fmt_sprintf = TypeName::importable("fmt", "Sprintf");
 
-    let mut fb = FunSpec::<GoLang>::builder("Greet");
-    fb.add_param(ParameterSpec::new("name", TypeName::primitive("string")).unwrap());
-    fb.returns(TypeName::primitive("string"));
-    fb.body(CodeBlock::<GoLang>::of("return %T(\"Hello, %%s!\", name)", (fmt_sprintf,)).unwrap());
-
-    let mut file_b = FileSpec::builder_with("greet.go", GoLang::new());
-    file_b.header(CodeBlock::<GoLang>::of("package greet", ()).unwrap());
-    file_b.add_function(fb.build().unwrap());
-    let file = file_b.build().unwrap();
+    let file = FileSpec::builder_with("greet.go", GoLang::new())
+        .header(CodeBlock::of("package greet", ()).unwrap())
+        .add_function(
+            FunSpec::builder("Greet")
+                .add_param(ParameterSpec::new("name", TypeName::primitive("string")).unwrap())
+                .returns(TypeName::primitive("string"))
+                .body(CodeBlock::of("return %T(\"Hello, %%s!\", name)", (fmt_sprintf,)).unwrap())
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
 
     let output = file.render(80).unwrap();
     golden::assert_golden("go/top_level_function.go", &output);
@@ -28,19 +31,21 @@ fn test_top_level_function() {
 
 #[test]
 fn test_function_with_doc() {
-    let body = CodeBlock::<GoLang>::of("return a + b", ()).unwrap();
-    let mut fb = FunSpec::<GoLang>::builder("Add");
-    fb.visibility(Visibility::Public);
-    fb.doc("Add returns the sum of two integers.");
-    fb.add_param(ParameterSpec::new("a", TypeName::primitive("int")).unwrap());
-    fb.add_param(ParameterSpec::new("b", TypeName::primitive("int")).unwrap());
-    fb.returns(TypeName::primitive("int"));
-    fb.body(body);
-    let fun = fb.build().unwrap();
+    let body = CodeBlock::of("return a + b", ()).unwrap();
+    let fun = FunSpec::builder("Add")
+        .visibility(Visibility::Public)
+        .doc("Add returns the sum of two integers.")
+        .add_param(ParameterSpec::new("a", TypeName::primitive("int")).unwrap())
+        .add_param(ParameterSpec::new("b", TypeName::primitive("int")).unwrap())
+        .returns(TypeName::primitive("int"))
+        .body(body)
+        .build()
+        .unwrap();
 
-    let mut file_b = FileSpec::builder_with("add.go", GoLang::new());
-    file_b.add_function(fun);
-    let file = file_b.build().unwrap();
+    let file = FileSpec::builder_with("add.go", GoLang::new())
+        .add_function(fun)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("go/function_with_doc.go", &output);

--- a/tests/go/builder_imports.rs
+++ b/tests/go/builder_imports.rs
@@ -7,10 +7,10 @@ use super::golden;
 
 #[test]
 fn test_function_with_imports() {
-    let http_server = TypeName::<GoLang>::importable("net/http", "Server");
-    let json_marshal = TypeName::<GoLang>::importable("encoding/json", "Marshal");
+    let http_server = TypeName::importable("net/http", "Server");
+    let json_marshal = TypeName::importable("encoding/json", "Marshal");
 
-    let mut b = CodeBlock::<GoLang>::builder();
+    let mut b = CodeBlock::builder();
     b.add("func startServer() {", ());
     b.add_line();
     b.add("%>", ());
@@ -22,10 +22,11 @@ fn test_function_with_imports() {
     b.add_line();
     let block = b.build().unwrap();
 
-    let mut fb = FileSpec::builder_with("server.go", GoLang::new());
-    fb.header(CodeBlock::<GoLang>::of("package main", ()).unwrap());
-    fb.add_code(block);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("server.go", GoLang::new())
+        .header(CodeBlock::of("package main", ()).unwrap())
+        .add_code(block)
+        .build()
+        .unwrap();
 
     let output = file.render(80).unwrap();
     golden::assert_golden("go/function_with_imports.go", &output);
@@ -33,20 +34,21 @@ fn test_function_with_imports() {
 
 #[test]
 fn test_import_grouping() {
-    let fmt_println = TypeName::<GoLang>::importable("fmt", "Println");
-    let http_server = TypeName::<GoLang>::importable("net/http", "Server");
-    let gin_ctx = TypeName::<GoLang>::importable("github.com/gin-gonic/gin", "Context");
+    let fmt_println = TypeName::importable("fmt", "Println");
+    let http_server = TypeName::importable("net/http", "Server");
+    let gin_ctx = TypeName::importable("github.com/gin-gonic/gin", "Context");
 
-    let mut b = CodeBlock::<GoLang>::builder();
+    let mut b = CodeBlock::builder();
     b.add_statement("%T(\"hello\")", (fmt_println,));
     b.add_statement("_ = %T{}", (http_server,));
     b.add_statement("_ = %T{}", (gin_ctx,));
     let block = b.build().unwrap();
 
-    let mut fb = FileSpec::builder_with("main.go", GoLang::new());
-    fb.header(CodeBlock::<GoLang>::of("package main", ()).unwrap());
-    fb.add_code(block);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("main.go", GoLang::new())
+        .header(CodeBlock::of("package main", ()).unwrap())
+        .add_code(block)
+        .build()
+        .unwrap();
 
     let output = file.render(80).unwrap();
     golden::assert_golden("go/import_grouping.go", &output);
@@ -54,20 +56,21 @@ fn test_import_grouping() {
 
 #[test]
 fn test_same_package_symbols() {
-    let handler = TypeName::<GoLang>::importable("net/http", "Handler");
-    let server = TypeName::<GoLang>::importable("net/http", "Server");
-    let listen = TypeName::<GoLang>::importable("net/http", "ListenAndServe");
+    let handler = TypeName::importable("net/http", "Handler");
+    let server = TypeName::importable("net/http", "Server");
+    let listen = TypeName::importable("net/http", "ListenAndServe");
 
-    let mut b = CodeBlock::<GoLang>::builder();
+    let mut b = CodeBlock::builder();
     b.add_statement("var _ %T", (handler,));
     b.add_statement("var _ %T", (server,));
     b.add_statement("_ = %T", (listen,));
     let block = b.build().unwrap();
 
-    let mut fb = FileSpec::builder_with("http.go", GoLang::new());
-    fb.header(CodeBlock::<GoLang>::of("package main", ()).unwrap());
-    fb.add_code(block);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("http.go", GoLang::new())
+        .header(CodeBlock::of("package main", ()).unwrap())
+        .add_code(block)
+        .build()
+        .unwrap();
 
     let output = file.render(80).unwrap();
     golden::assert_golden("go/same_package_symbols.go", &output);

--- a/tests/go/builder_types.rs
+++ b/tests/go/builder_types.rs
@@ -12,25 +12,34 @@ use super::golden;
 
 #[test]
 fn test_struct_with_tags() {
-    let mut tb = TypeSpec::<GoLang>::builder("Config", TypeKind::Struct);
-    tb.doc("Config holds application configuration.");
-
-    let mut f1 = FieldSpec::builder("Name", TypeName::primitive("string"));
-    f1.tag("json:\"name\"");
-    tb.add_field(f1.build().unwrap());
-
-    let mut f2 = FieldSpec::builder("Port", TypeName::primitive("int"));
-    f2.tag("json:\"port\" yaml:\"port\"");
-    tb.add_field(f2.build().unwrap());
-
-    let mut f3 = FieldSpec::builder("Debug", TypeName::primitive("bool"));
-    f3.tag("json:\"debug,omitempty\"");
-    tb.add_field(f3.build().unwrap());
-
-    let mut fb = FileSpec::builder_with("config.go", GoLang::new());
-    fb.header(CodeBlock::<GoLang>::of("package config", ()).unwrap());
-    fb.add_type(tb.build().unwrap());
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("config.go", GoLang::new())
+        .header(CodeBlock::of("package config", ()).unwrap())
+        .add_type(
+            TypeSpec::builder("Config", TypeKind::Struct)
+                .doc("Config holds application configuration.")
+                .add_field(
+                    FieldSpec::builder("Name", TypeName::primitive("string"))
+                        .tag("json:\"name\"")
+                        .build()
+                        .unwrap(),
+                )
+                .add_field(
+                    FieldSpec::builder("Port", TypeName::primitive("int"))
+                        .tag("json:\"port\" yaml:\"port\"")
+                        .build()
+                        .unwrap(),
+                )
+                .add_field(
+                    FieldSpec::builder("Debug", TypeName::primitive("bool"))
+                        .tag("json:\"debug,omitempty\"")
+                        .build()
+                        .unwrap(),
+                )
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
 
     let output = file.render(80).unwrap();
     golden::assert_golden("go/struct_with_tags.go", &output);
@@ -38,40 +47,48 @@ fn test_struct_with_tags() {
 
 #[test]
 fn test_struct_with_methods() {
-    let json_marshal = TypeName::<GoLang>::importable("encoding/json", "Marshal");
+    let json_marshal = TypeName::importable("encoding/json", "Marshal");
 
     // Struct definition.
-    let mut tb = TypeSpec::<GoLang>::builder("Server", TypeKind::Struct);
-    tb.doc("Server is an HTTP server.");
-    tb.add_field(
-        FieldSpec::builder("host", TypeName::primitive("string"))
-            .build()
-            .unwrap(),
-    );
-    tb.add_field(
-        FieldSpec::builder("port", TypeName::primitive("int"))
-            .build()
-            .unwrap(),
-    );
+    let tb = TypeSpec::builder("Server", TypeKind::Struct)
+        .doc("Server is an HTTP server.")
+        .add_field(
+            FieldSpec::builder("host", TypeName::primitive("string"))
+                .build()
+                .unwrap(),
+        )
+        .add_field(
+            FieldSpec::builder("port", TypeName::primitive("int"))
+                .build()
+                .unwrap(),
+        );
 
     // Method 1: Start.
-    let mut m1 = FunSpec::<GoLang>::builder("Start");
-    m1.receiver(ParameterSpec::new("s", TypeName::pointer(TypeName::primitive("Server"))).unwrap());
-    m1.returns(TypeName::primitive("error"));
-    m1.body(CodeBlock::<GoLang>::of("return nil", ()).unwrap());
+    let m1 = FunSpec::builder("Start")
+        .receiver(
+            ParameterSpec::new("s", TypeName::pointer(TypeName::primitive("Server"))).unwrap(),
+        )
+        .returns(TypeName::primitive("error"))
+        .body(CodeBlock::of("return nil", ()).unwrap());
 
     // Method 2: ToJSON.
-    let mut m2 = FunSpec::<GoLang>::builder("ToJSON");
-    m2.receiver(ParameterSpec::new("s", TypeName::pointer(TypeName::primitive("Server"))).unwrap());
-    m2.returns(TypeName::raw("([]byte, error)"));
-    m2.body(CodeBlock::<GoLang>::of("return %T(s)", (json_marshal,)).unwrap());
-
-    let mut fb = FileSpec::builder_with("server.go", GoLang::new());
-    fb.header(CodeBlock::<GoLang>::of("package server", ()).unwrap());
-    fb.add_type(tb.build().unwrap());
-    fb.add_function(m1.build().unwrap());
-    fb.add_function(m2.build().unwrap());
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("server.go", GoLang::new())
+        .header(CodeBlock::of("package server", ()).unwrap())
+        .add_type(tb.build().unwrap())
+        .add_function(m1.build().unwrap())
+        .add_function(
+            FunSpec::builder("ToJSON")
+                .receiver(
+                    ParameterSpec::new("s", TypeName::pointer(TypeName::primitive("Server")))
+                        .unwrap(),
+                )
+                .returns(TypeName::raw("([]byte, error)"))
+                .body(CodeBlock::of("return %T(s)", (json_marshal,)).unwrap())
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
 
     let output = file.render(80).unwrap();
     golden::assert_golden("go/struct_with_methods.go", &output);
@@ -79,23 +96,32 @@ fn test_struct_with_methods() {
 
 #[test]
 fn test_interface() {
-    let mut tb = TypeSpec::<GoLang>::builder("Repository", TypeKind::Interface);
-    tb.doc("Repository defines data access methods.");
-
-    let mut find = FunSpec::<GoLang>::builder("FindByID");
-    find.add_param(ParameterSpec::new("id", TypeName::primitive("string")).unwrap());
-    find.returns(TypeName::raw("(Entity, error)"));
-    tb.add_method(find.build().unwrap());
-
-    let mut save = FunSpec::<GoLang>::builder("Save");
-    save.add_param(ParameterSpec::new("entity", TypeName::primitive("Entity")).unwrap());
-    save.returns(TypeName::primitive("error"));
-    tb.add_method(save.build().unwrap());
-
-    let mut fb = FileSpec::builder_with("repo.go", GoLang::new());
-    fb.header(CodeBlock::<GoLang>::of("package repo", ()).unwrap());
-    fb.add_type(tb.build().unwrap());
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("repo.go", GoLang::new())
+        .header(CodeBlock::of("package repo", ()).unwrap())
+        .add_type(
+            TypeSpec::builder("Repository", TypeKind::Interface)
+                .doc("Repository defines data access methods.")
+                .add_method(
+                    FunSpec::builder("FindByID")
+                        .add_param(ParameterSpec::new("id", TypeName::primitive("string")).unwrap())
+                        .returns(TypeName::raw("(Entity, error)"))
+                        .build()
+                        .unwrap(),
+                )
+                .add_method(
+                    FunSpec::builder("Save")
+                        .add_param(
+                            ParameterSpec::new("entity", TypeName::primitive("Entity")).unwrap(),
+                        )
+                        .returns(TypeName::primitive("error"))
+                        .build()
+                        .unwrap(),
+                )
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
 
     let output = file.render(80).unwrap();
     golden::assert_golden("go/interface.go", &output);
@@ -103,24 +129,27 @@ fn test_interface() {
 
 #[test]
 fn test_generic_function() {
-    let tp = TypeParamSpec::<GoLang>::new("T").with_bound(TypeName::primitive("comparable"));
-    let mut fb = FunSpec::<GoLang>::builder("Max");
-    fb.add_type_param(tp);
-    fb.add_param(ParameterSpec::new("a", TypeName::primitive("T")).unwrap());
-    fb.add_param(ParameterSpec::new("b", TypeName::primitive("T")).unwrap());
-    fb.returns(TypeName::primitive("T"));
-    let mut body_b = CodeBlock::<GoLang>::builder();
+    let tp = TypeParamSpec::new("T").with_bound(TypeName::primitive("comparable"));
+
+    let mut body_b = CodeBlock::builder();
     body_b.begin_control_flow("if a > b", ());
     body_b.add_statement("return a", ());
     body_b.end_control_flow();
     body_b.add_statement("return b", ());
     let body = body_b.build().unwrap();
-    fb.body(body);
 
-    let mut file_b = FileSpec::builder_with("max.go", GoLang::new());
-    file_b.header(CodeBlock::<GoLang>::of("package main", ()).unwrap());
-    file_b.add_function(fb.build().unwrap());
-    let file = file_b.build().unwrap();
+    let fb = FunSpec::builder("Max")
+        .add_type_param(tp)
+        .add_param(ParameterSpec::new("a", TypeName::primitive("T")).unwrap())
+        .add_param(ParameterSpec::new("b", TypeName::primitive("T")).unwrap())
+        .returns(TypeName::primitive("T"))
+        .body(body);
+
+    let file = FileSpec::builder_with("max.go", GoLang::new())
+        .header(CodeBlock::of("package main", ()).unwrap())
+        .add_function(fb.build().unwrap())
+        .build()
+        .unwrap();
 
     let output = file.render(80).unwrap();
     golden::assert_golden("go/generic_function.go", &output);

--- a/tests/go/quote_basic.rs
+++ b/tests/go/quote_basic.rs
@@ -5,10 +5,13 @@ use sigil_stitch::spec::file_spec::FileSpec;
 
 use super::golden;
 
-fn render(block: &CodeBlock<GoLang>) -> String {
-    let mut fb = FileSpec::builder_with("test.go", GoLang::new());
-    fb.add_code(block.clone());
-    fb.build().unwrap().render(80).unwrap()
+fn render(block: &CodeBlock) -> String {
+    FileSpec::builder_with("test.go", GoLang::new())
+        .add_code(block.clone())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap()
 }
 
 #[test]

--- a/tests/go/quote_control_flow.rs
+++ b/tests/go/quote_control_flow.rs
@@ -5,10 +5,13 @@ use sigil_stitch::spec::file_spec::FileSpec;
 
 use super::golden;
 
-fn render(block: &CodeBlock<GoLang>) -> String {
-    let mut fb = FileSpec::builder_with("test.go", GoLang::new());
-    fb.add_code(block.clone());
-    fb.build().unwrap().render(80).unwrap()
+fn render(block: &CodeBlock) -> String {
+    FileSpec::builder_with("test.go", GoLang::new())
+        .add_code(block.clone())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap()
 }
 
 #[test]

--- a/tests/go/quote_edge_cases.rs
+++ b/tests/go/quote_edge_cases.rs
@@ -5,10 +5,13 @@ use sigil_stitch::spec::file_spec::FileSpec;
 
 use super::golden;
 
-fn render(block: &CodeBlock<GoLang>) -> String {
-    let mut fb = FileSpec::builder_with("test.go", GoLang::new());
-    fb.add_code(block.clone());
-    fb.build().unwrap().render(80).unwrap()
+fn render(block: &CodeBlock) -> String {
+    FileSpec::builder_with("test.go", GoLang::new())
+        .add_code(block.clone())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap()
 }
 
 #[test]

--- a/tests/haskell/builder_control_flow.rs
+++ b/tests/haskell/builder_control_flow.rs
@@ -6,15 +6,16 @@ use super::golden;
 
 #[test]
 fn test_where_block() {
-    let mut b = CodeBlock::<Haskell>::builder();
+    let mut b = CodeBlock::builder();
     b.begin_control_flow("circleArea r", ());
     b.add_statement("pi * r * r", ());
     b.end_control_flow();
     let block = b.build().unwrap();
 
-    let mut fb = FileSpec::builder_with("Circle.hs", Haskell::new());
-    fb.add_code(block);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("Circle.hs", Haskell::new())
+        .add_code(block)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("haskell/where_block.hs", &output);
@@ -22,15 +23,16 @@ fn test_where_block() {
 
 #[test]
 fn test_type_class_where() {
-    let mut b = CodeBlock::<Haskell>::builder();
+    let mut b = CodeBlock::builder();
     b.begin_control_flow_with_open("class Functor f", (), " where");
     b.add_statement("fmap :: (a -> b) -> f a -> f b", ());
     b.end_control_flow();
     let block = b.build().unwrap();
 
-    let mut fb = FileSpec::builder_with("Functor.hs", Haskell::new());
-    fb.add_code(block);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("Functor.hs", Haskell::new())
+        .add_code(block)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("haskell/type_class_where.hs", &output);

--- a/tests/haskell/builder_functions.rs
+++ b/tests/haskell/builder_functions.rs
@@ -9,17 +9,19 @@ use super::golden;
 
 #[test]
 fn test_function_with_params() {
-    let body = CodeBlock::<Haskell>::of("x + y", ()).unwrap();
-    let mut fb_fun = FunSpec::<Haskell>::builder("add");
-    fb_fun.returns(TypeName::primitive("Int"));
-    fb_fun.add_param(ParameterSpec::new("x", TypeName::primitive("Int")).unwrap());
-    fb_fun.add_param(ParameterSpec::new("y", TypeName::primitive("Int")).unwrap());
-    fb_fun.body(body);
-    let fun = fb_fun.build().unwrap();
+    let body = CodeBlock::of("x + y", ()).unwrap();
+    let fun = FunSpec::builder("add")
+        .returns(TypeName::primitive("Int"))
+        .add_param(ParameterSpec::new("x", TypeName::primitive("Int")).unwrap())
+        .add_param(ParameterSpec::new("y", TypeName::primitive("Int")).unwrap())
+        .body(body)
+        .build()
+        .unwrap();
 
-    let mut fb = FileSpec::builder_with("Add.hs", Haskell::new());
-    fb.add_function(fun);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("Add.hs", Haskell::new())
+        .add_function(fun)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("haskell/function_with_params.hs", &output);
@@ -27,17 +29,19 @@ fn test_function_with_params() {
 
 #[test]
 fn test_function_with_import() {
-    let map_type = TypeName::<Haskell>::importable("Data.Map", "Map");
+    let map_type = TypeName::importable("Data.Map", "Map");
 
-    let body = CodeBlock::<Haskell>::of("Data.Map.empty", ()).unwrap();
-    let mut fb_fun = FunSpec::<Haskell>::builder("emptyMap");
-    fb_fun.returns(map_type);
-    fb_fun.body(body);
-    let fun = fb_fun.build().unwrap();
+    let body = CodeBlock::of("Data.Map.empty", ()).unwrap();
+    let fun = FunSpec::builder("emptyMap")
+        .returns(map_type)
+        .body(body)
+        .build()
+        .unwrap();
 
-    let mut fb = FileSpec::builder_with("EmptyMap.hs", Haskell::new());
-    fb.add_function(fun);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("EmptyMap.hs", Haskell::new())
+        .add_function(fun)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("haskell/function_with_import.hs", &output);
@@ -45,20 +49,22 @@ fn test_function_with_import() {
 
 #[test]
 fn test_function_with_context() {
-    let body = CodeBlock::<Haskell>::of("show x", ()).unwrap();
-    let mut fb_fun = FunSpec::<Haskell>::builder("display");
-    fb_fun.add_type_param(
-        sigil_stitch::spec::fun_spec::TypeParamSpec::new("a")
-            .with_bound(TypeName::primitive("Show")),
-    );
-    fb_fun.add_param(ParameterSpec::new("x", TypeName::primitive("a")).unwrap());
-    fb_fun.returns(TypeName::primitive("String"));
-    fb_fun.body(body);
-    let fun = fb_fun.build().unwrap();
+    let body = CodeBlock::of("show x", ()).unwrap();
+    let fun = FunSpec::builder("display")
+        .add_type_param(
+            sigil_stitch::spec::fun_spec::TypeParamSpec::new("a")
+                .with_bound(TypeName::primitive("Show")),
+        )
+        .add_param(ParameterSpec::new("x", TypeName::primitive("a")).unwrap())
+        .returns(TypeName::primitive("String"))
+        .body(body)
+        .build()
+        .unwrap();
 
-    let mut fb = FileSpec::builder_with("Display.hs", Haskell::new());
-    fb.add_function(fun);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("Display.hs", Haskell::new())
+        .add_function(fun)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("haskell/function_with_context.hs", &output);
@@ -66,15 +72,17 @@ fn test_function_with_context() {
 
 #[test]
 fn test_function_no_body() {
-    let mut fb_fun = FunSpec::<Haskell>::builder("add");
-    fb_fun.returns(TypeName::primitive("Int"));
-    fb_fun.add_param(ParameterSpec::new("x", TypeName::primitive("Int")).unwrap());
-    fb_fun.add_param(ParameterSpec::new("y", TypeName::primitive("Int")).unwrap());
-    let fun = fb_fun.build().unwrap();
+    let fun = FunSpec::builder("add")
+        .returns(TypeName::primitive("Int"))
+        .add_param(ParameterSpec::new("x", TypeName::primitive("Int")).unwrap())
+        .add_param(ParameterSpec::new("y", TypeName::primitive("Int")).unwrap())
+        .build()
+        .unwrap();
 
-    let mut fb = FileSpec::builder_with("Add.hs", Haskell::new());
-    fb.add_function(fun);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("Add.hs", Haskell::new())
+        .add_function(fun)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("haskell/function_no_body.hs", &output);
@@ -82,17 +90,19 @@ fn test_function_no_body() {
 
 #[test]
 fn test_function_with_doc() {
-    let body = CodeBlock::<Haskell>::of("putStrLn (\"Hello, \" ++ name)", ()).unwrap();
-    let mut fb = FunSpec::<Haskell>::builder("greet");
-    fb.doc("Greet the user by name.");
-    fb.add_param(ParameterSpec::new("name", TypeName::primitive("String")).unwrap());
-    fb.returns(TypeName::primitive("IO ()"));
-    fb.body(body);
-    let fun = fb.build().unwrap();
+    let body = CodeBlock::of("putStrLn (\"Hello, \" ++ name)", ()).unwrap();
+    let fun = FunSpec::builder("greet")
+        .doc("Greet the user by name.")
+        .add_param(ParameterSpec::new("name", TypeName::primitive("String")).unwrap())
+        .returns(TypeName::primitive("IO ()"))
+        .body(body)
+        .build()
+        .unwrap();
 
-    let mut file_b = FileSpec::builder_with("greet.hs", Haskell::new());
-    file_b.add_function(fun);
-    let file = file_b.build().unwrap();
+    let file = FileSpec::builder_with("greet.hs", Haskell::new())
+        .add_function(fun)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("haskell/function_with_doc.hs", &output);
@@ -100,21 +110,23 @@ fn test_function_with_doc() {
 
 #[test]
 fn test_multi_constraint_context() {
-    let body = CodeBlock::<Haskell>::of("show x", ()).unwrap();
-    let mut fb_fun = FunSpec::<Haskell>::builder("display");
-    fb_fun.add_type_param(
-        sigil_stitch::spec::fun_spec::TypeParamSpec::new("a")
-            .with_bound(TypeName::primitive("Show"))
-            .with_bound(TypeName::primitive("Eq")),
-    );
-    fb_fun.add_param(ParameterSpec::new("x", TypeName::primitive("a")).unwrap());
-    fb_fun.returns(TypeName::primitive("String"));
-    fb_fun.body(body);
-    let fun = fb_fun.build().unwrap();
+    let body = CodeBlock::of("show x", ()).unwrap();
+    let fun = FunSpec::builder("display")
+        .add_type_param(
+            sigil_stitch::spec::fun_spec::TypeParamSpec::new("a")
+                .with_bound(TypeName::primitive("Show"))
+                .with_bound(TypeName::primitive("Eq")),
+        )
+        .add_param(ParameterSpec::new("x", TypeName::primitive("a")).unwrap())
+        .returns(TypeName::primitive("String"))
+        .body(body)
+        .build()
+        .unwrap();
 
-    let mut fb = FileSpec::builder_with("Display.hs", Haskell::new());
-    fb.add_function(fun);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("Display.hs", Haskell::new())
+        .add_function(fun)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("haskell/function_multi_context.hs", &output);

--- a/tests/haskell/builder_imports.rs
+++ b/tests/haskell/builder_imports.rs
@@ -7,19 +7,20 @@ use super::golden;
 
 #[test]
 fn test_function_with_imports() {
-    let map_type = TypeName::<Haskell>::importable("Data.Map", "Map");
-    let text_type = TypeName::<Haskell>::importable("Data.Text", "Text");
+    let map_type = TypeName::importable("Data.Map", "Map");
+    let text_type = TypeName::importable("Data.Text", "Text");
 
-    let mut b = CodeBlock::<Haskell>::builder();
+    let mut b = CodeBlock::builder();
     b.add_statement(
         "let users = %T.fromList [(%T.pack \"alice\", 1)]",
         (map_type, text_type),
     );
     let block = b.build().unwrap();
 
-    let mut fb = FileSpec::builder_with("App.hs", Haskell::new());
-    fb.add_code(block);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("App.hs", Haskell::new())
+        .add_code(block)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("haskell/function_with_imports.hs", &output);
@@ -27,13 +28,13 @@ fn test_function_with_imports() {
 
 #[test]
 fn test_import_grouping() {
-    let put_str_ln = TypeName::<Haskell>::importable("Prelude", "putStrLn");
-    let map_type = TypeName::<Haskell>::importable("Data.Map", "Map");
-    let from_list = TypeName::<Haskell>::importable("Data.Map", "fromList");
-    let when_fn = TypeName::<Haskell>::importable("Control.Monad", "when");
-    let user = TypeName::<Haskell>::importable("MyApp.Types", "User");
+    let put_str_ln = TypeName::importable("Prelude", "putStrLn");
+    let map_type = TypeName::importable("Data.Map", "Map");
+    let from_list = TypeName::importable("Data.Map", "fromList");
+    let when_fn = TypeName::importable("Control.Monad", "when");
+    let user = TypeName::importable("MyApp.Types", "User");
 
-    let mut b = CodeBlock::<Haskell>::builder();
+    let mut b = CodeBlock::builder();
     b.add(
         "-- %T %T %T %T %T",
         (put_str_ln, map_type, from_list, when_fn, user),
@@ -41,9 +42,10 @@ fn test_import_grouping() {
     b.add_line();
     let block = b.build().unwrap();
 
-    let mut fb = FileSpec::builder_with("Imports.hs", Haskell::new());
-    fb.add_code(block);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("Imports.hs", Haskell::new())
+        .add_code(block)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("haskell/import_grouping.hs", &output);

--- a/tests/haskell/builder_types.rs
+++ b/tests/haskell/builder_types.rs
@@ -12,30 +12,30 @@ use super::golden;
 
 #[test]
 fn test_data_type_with_record() {
-    let mut tb = TypeSpec::<Haskell>::builder("Person", TypeKind::Struct);
-    tb.doc("A person record type.");
+    let ts = TypeSpec::builder("Person", TypeKind::Struct)
+        .doc("A person record type.")
+        .add_field(
+            FieldSpec::builder("personName", TypeName::primitive("String"))
+                .build()
+                .unwrap(),
+        )
+        .add_field(
+            FieldSpec::builder("personAge", TypeName::primitive("Int"))
+                .build()
+                .unwrap(),
+        )
+        .add_field(
+            FieldSpec::builder("personEmail", TypeName::primitive("String"))
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
 
-    tb.add_field(
-        FieldSpec::builder("personName", TypeName::primitive("String"))
-            .build()
-            .unwrap(),
-    );
-    tb.add_field(
-        FieldSpec::builder("personAge", TypeName::primitive("Int"))
-            .build()
-            .unwrap(),
-    );
-    tb.add_field(
-        FieldSpec::builder("personEmail", TypeName::primitive("String"))
-            .build()
-            .unwrap(),
-    );
-
-    let ts = tb.build().unwrap();
-
-    let mut fb = FileSpec::builder_with("Person.hs", Haskell::new());
-    fb.add_type(ts);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("Person.hs", Haskell::new())
+        .add_type(ts)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("haskell/data_type_record.hs", &output);
@@ -43,18 +43,18 @@ fn test_data_type_with_record() {
 
 #[test]
 fn test_enum_type() {
-    let mut tb = TypeSpec::<Haskell>::builder("Color", TypeKind::Enum);
-    tb.doc("Supported colors.");
+    let ts = TypeSpec::builder("Color", TypeKind::Enum)
+        .doc("Supported colors.")
+        .add_variant(EnumVariantSpec::new("Red").unwrap())
+        .add_variant(EnumVariantSpec::new("Green").unwrap())
+        .add_variant(EnumVariantSpec::new("Blue").unwrap())
+        .build()
+        .unwrap();
 
-    tb.add_variant(EnumVariantSpec::new("Red").unwrap());
-    tb.add_variant(EnumVariantSpec::new("Green").unwrap());
-    tb.add_variant(EnumVariantSpec::new("Blue").unwrap());
-
-    let ts = tb.build().unwrap();
-
-    let mut fb = FileSpec::builder_with("Color.hs", Haskell::new());
-    fb.add_type(ts);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("Color.hs", Haskell::new())
+        .add_type(ts)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("haskell/enum_type.hs", &output);
@@ -62,14 +62,15 @@ fn test_enum_type() {
 
 #[test]
 fn test_type_alias() {
-    let mut tb = TypeSpec::<Haskell>::builder("Name", TypeKind::TypeAlias);
-    tb.extends(TypeName::primitive("String"));
+    let ts = TypeSpec::builder("Name", TypeKind::TypeAlias)
+        .extends(TypeName::primitive("String"))
+        .build()
+        .unwrap();
 
-    let ts = tb.build().unwrap();
-
-    let mut fb = FileSpec::builder_with("Name.hs", Haskell::new());
-    fb.add_type(ts);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("Name.hs", Haskell::new())
+        .add_type(ts)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("haskell/type_alias.hs", &output);
@@ -77,18 +78,19 @@ fn test_type_alias() {
 
 #[test]
 fn test_data_with_deriving() {
-    let mut tb = TypeSpec::<Haskell>::builder("Color", TypeKind::Enum);
-    tb.add_variant(EnumVariantSpec::new("Red").unwrap());
-    tb.add_variant(EnumVariantSpec::new("Green").unwrap());
-    tb.add_variant(EnumVariantSpec::new("Blue").unwrap());
-    tb.implements(TypeName::primitive("Show"));
-    tb.implements(TypeName::primitive("Eq"));
+    let ts = TypeSpec::builder("Color", TypeKind::Enum)
+        .add_variant(EnumVariantSpec::new("Red").unwrap())
+        .add_variant(EnumVariantSpec::new("Green").unwrap())
+        .add_variant(EnumVariantSpec::new("Blue").unwrap())
+        .implements(TypeName::primitive("Show"))
+        .implements(TypeName::primitive("Eq"))
+        .build()
+        .unwrap();
 
-    let ts = tb.build().unwrap();
-
-    let mut fb = FileSpec::builder_with("Color.hs", Haskell::new());
-    fb.add_type(ts);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("Color.hs", Haskell::new())
+        .add_type(ts)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("haskell/data_with_deriving.hs", &output);
@@ -96,14 +98,15 @@ fn test_data_with_deriving() {
 
 #[test]
 fn test_newtype() {
-    let mut tb = TypeSpec::<Haskell>::builder("Meters", TypeKind::Newtype);
-    tb.extends(TypeName::primitive("Int"));
+    let ts = TypeSpec::builder("Meters", TypeKind::Newtype)
+        .extends(TypeName::primitive("Int"))
+        .build()
+        .unwrap();
 
-    let ts = tb.build().unwrap();
-
-    let mut fb = FileSpec::builder_with("Meters.hs", Haskell::new());
-    fb.add_type(ts);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("Meters.hs", Haskell::new())
+        .add_type(ts)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("haskell/newtype.hs", &output);
@@ -111,19 +114,22 @@ fn test_newtype() {
 
 #[test]
 fn test_type_class_via_type_spec() {
-    let mut tb = TypeSpec::<Haskell>::builder("Printable", TypeKind::Trait);
-    tb.doc("Things that can be printed.");
+    let ts = TypeSpec::builder("Printable", TypeKind::Trait)
+        .doc("Things that can be printed.")
+        .add_method(
+            FunSpec::builder("prettyPrint")
+                .add_param(ParameterSpec::new("x", TypeName::primitive("a")).unwrap())
+                .returns(TypeName::primitive("String"))
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
 
-    let mut pretty = FunSpec::<Haskell>::builder("prettyPrint");
-    pretty.add_param(ParameterSpec::new("x", TypeName::primitive("a")).unwrap());
-    pretty.returns(TypeName::primitive("String"));
-    tb.add_method(pretty.build().unwrap());
-
-    let ts = tb.build().unwrap();
-
-    let mut fb = FileSpec::builder_with("Printable.hs", Haskell::new());
-    fb.add_type(ts);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("Printable.hs", Haskell::new())
+        .add_type(ts)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("haskell/type_class_spec.hs", &output);
@@ -131,25 +137,26 @@ fn test_type_class_via_type_spec() {
 
 #[test]
 fn test_data_with_deriving_record() {
-    let mut tb = TypeSpec::<Haskell>::builder("Person", TypeKind::Struct);
-    tb.add_field(
-        FieldSpec::builder("personName", TypeName::primitive("String"))
-            .build()
-            .unwrap(),
-    );
-    tb.add_field(
-        FieldSpec::builder("personAge", TypeName::primitive("Int"))
-            .build()
-            .unwrap(),
-    );
-    tb.implements(TypeName::primitive("Show"));
-    tb.implements(TypeName::primitive("Eq"));
+    let ts = TypeSpec::builder("Person", TypeKind::Struct)
+        .add_field(
+            FieldSpec::builder("personName", TypeName::primitive("String"))
+                .build()
+                .unwrap(),
+        )
+        .add_field(
+            FieldSpec::builder("personAge", TypeName::primitive("Int"))
+                .build()
+                .unwrap(),
+        )
+        .implements(TypeName::primitive("Show"))
+        .implements(TypeName::primitive("Eq"))
+        .build()
+        .unwrap();
 
-    let ts = tb.build().unwrap();
-
-    let mut fb = FileSpec::builder_with("Person.hs", Haskell::new());
-    fb.add_type(ts);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("Person.hs", Haskell::new())
+        .add_type(ts)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("haskell/data_deriving_record.hs", &output);

--- a/tests/haskell/quote_basic.rs
+++ b/tests/haskell/quote_basic.rs
@@ -5,10 +5,13 @@ use sigil_stitch::spec::file_spec::FileSpec;
 
 use super::golden;
 
-fn render(block: &CodeBlock<Haskell>) -> String {
-    let mut fb = FileSpec::builder_with("test.hs", Haskell::new());
-    fb.add_code(block.clone());
-    fb.build().unwrap().render(80).unwrap()
+fn render(block: &CodeBlock) -> String {
+    FileSpec::builder_with("test.hs", Haskell::new())
+        .add_code(block.clone())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap()
 }
 
 #[test]

--- a/tests/haskell/quote_control_flow.rs
+++ b/tests/haskell/quote_control_flow.rs
@@ -5,10 +5,13 @@ use sigil_stitch::spec::file_spec::FileSpec;
 
 use super::golden;
 
-fn render(block: &CodeBlock<Haskell>) -> String {
-    let mut fb = FileSpec::builder_with("test.hs", Haskell::new());
-    fb.add_code(block.clone());
-    fb.build().unwrap().render(80).unwrap()
+fn render(block: &CodeBlock) -> String {
+    FileSpec::builder_with("test.hs", Haskell::new())
+        .add_code(block.clone())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap()
 }
 
 #[test]

--- a/tests/haskell/quote_edge_cases.rs
+++ b/tests/haskell/quote_edge_cases.rs
@@ -5,10 +5,13 @@ use sigil_stitch::spec::file_spec::FileSpec;
 
 use super::golden;
 
-fn render(block: &CodeBlock<Haskell>) -> String {
-    let mut fb = FileSpec::builder_with("test.hs", Haskell::new());
-    fb.add_code(block.clone());
-    fb.build().unwrap().render(80).unwrap()
+fn render(block: &CodeBlock) -> String {
+    FileSpec::builder_with("test.hs", Haskell::new())
+        .add_code(block.clone())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap()
 }
 
 #[test]

--- a/tests/import_spec_tests.rs
+++ b/tests/import_spec_tests.rs
@@ -7,7 +7,6 @@ use sigil_stitch::lang::kotlin::Kotlin;
 use sigil_stitch::lang::python::Python;
 use sigil_stitch::lang::rust_lang::RustLang;
 use sigil_stitch::lang::swift::Swift;
-use sigil_stitch::lang::typescript::TypeScript;
 use sigil_stitch::spec::file_spec::FileSpec;
 use sigil_stitch::spec::import_spec::ImportSpec;
 use sigil_stitch::type_name::TypeName;
@@ -16,10 +15,13 @@ use sigil_stitch::type_name::TypeName;
 
 #[test]
 fn test_ts_forced_named_import() {
-    let mut fb = FileSpec::<TypeScript>::builder("app.ts");
-    fb.add_import(ImportSpec::named("./models", "User"));
-    fb.add_code(CodeBlock::<TypeScript>::of("console.log('hello')", ()).unwrap());
-    let output = fb.build().unwrap().render(80).unwrap();
+    let output = FileSpec::builder("app.ts")
+        .add_import(ImportSpec::named("./models", "User"))
+        .add_code(CodeBlock::of("console.log('hello')", ()).unwrap())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap();
 
     assert!(output.contains("import { User } from './models';"));
     assert!(output.contains("console.log('hello')"));
@@ -27,53 +29,68 @@ fn test_ts_forced_named_import() {
 
 #[test]
 fn test_ts_aliased_import() {
-    let mut fb = FileSpec::<TypeScript>::builder("app.ts");
-    fb.add_import(ImportSpec::named_as("./models", "User", "AppUser"));
-    fb.add_code(CodeBlock::<TypeScript>::of("const u: AppUser = get()", ()).unwrap());
-    let output = fb.build().unwrap().render(80).unwrap();
+    let output = FileSpec::builder("app.ts")
+        .add_import(ImportSpec::named_as("./models", "User", "AppUser"))
+        .add_code(CodeBlock::of("const u: AppUser = get()", ()).unwrap())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap();
 
     assert!(output.contains("User as AppUser"));
 }
 
 #[test]
 fn test_ts_type_only_import() {
-    let mut fb = FileSpec::<TypeScript>::builder("app.ts");
-    fb.add_import(ImportSpec::named_type("./models", "User"));
-    fb.add_code(CodeBlock::<TypeScript>::of("// no usage", ()).unwrap());
-    let output = fb.build().unwrap().render(80).unwrap();
+    let output = FileSpec::builder("app.ts")
+        .add_import(ImportSpec::named_type("./models", "User"))
+        .add_code(CodeBlock::of("// no usage", ()).unwrap())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap();
 
     assert!(output.contains("import type { User } from './models';"));
 }
 
 #[test]
 fn test_ts_side_effect_import() {
-    let mut fb = FileSpec::<TypeScript>::builder("app.ts");
-    fb.add_import(ImportSpec::side_effect("./polyfill"));
-    fb.add_code(CodeBlock::<TypeScript>::of("// app code", ()).unwrap());
-    let output = fb.build().unwrap().render(80).unwrap();
+    let output = FileSpec::builder("app.ts")
+        .add_import(ImportSpec::side_effect("./polyfill"))
+        .add_code(CodeBlock::of("// app code", ()).unwrap())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap();
 
     assert!(output.contains("import './polyfill';"));
 }
 
 #[test]
 fn test_ts_wildcard_import() {
-    let mut fb = FileSpec::<TypeScript>::builder("app.ts");
-    fb.add_import(ImportSpec::wildcard("./utils"));
-    fb.add_code(CodeBlock::<TypeScript>::of("// app code", ()).unwrap());
-    let output = fb.build().unwrap().render(80).unwrap();
+    let output = FileSpec::builder("app.ts")
+        .add_import(ImportSpec::wildcard("./utils"))
+        .add_code(CodeBlock::of("// app code", ()).unwrap())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap();
 
     assert!(output.contains("import * as Utils from './utils';"));
 }
 
 #[test]
 fn test_ts_mixed_explicit_and_auto() {
-    let user = TypeName::<TypeScript>::importable_type("./models", "User");
+    let user = TypeName::importable_type("./models", "User");
 
-    let mut fb = FileSpec::<TypeScript>::builder("app.ts");
-    fb.add_import(ImportSpec::side_effect("./polyfill"));
-    fb.add_import(ImportSpec::named("./helpers", "format"));
-    fb.add_code(CodeBlock::<TypeScript>::of("const u: %T = get()", (user,)).unwrap());
-    let output = fb.build().unwrap().render(80).unwrap();
+    let output = FileSpec::builder("app.ts")
+        .add_import(ImportSpec::side_effect("./polyfill"))
+        .add_import(ImportSpec::named("./helpers", "format"))
+        .add_code(CodeBlock::of("const u: %T = get()", (user,)).unwrap())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap();
 
     assert!(output.contains("import './polyfill';"));
     assert!(output.contains("import type { User } from './models';"));
@@ -83,17 +100,20 @@ fn test_ts_mixed_explicit_and_auto() {
 #[test]
 fn test_ts_explicit_alias_takes_precedence() {
     // Explicit alias should override auto-resolution.
-    let user1 = TypeName::<TypeScript>::importable("./models", "User");
-    let user2 = TypeName::<TypeScript>::importable("./other", "User");
+    let user1 = TypeName::importable("./models", "User");
+    let user2 = TypeName::importable("./other", "User");
 
-    let mut fb = FileSpec::<TypeScript>::builder("app.ts");
-    // Pre-claim ./other User as "OtherUser" explicitly.
-    fb.add_import(ImportSpec::named_as("./other", "User", "OtherUser"));
-    let mut code = CodeBlock::<TypeScript>::builder();
+    let mut code = CodeBlock::builder();
     code.add_statement("const u1: %T = get1()", (user1,));
     code.add_statement("const u2: %T = get2()", (user2,));
-    fb.add_code(code.build().unwrap());
-    let output = fb.build().unwrap().render(80).unwrap();
+    // Pre-claim ./other User as "OtherUser" explicitly.
+    let output = FileSpec::builder("app.ts")
+        .add_import(ImportSpec::named_as("./other", "User", "OtherUser"))
+        .add_code(code.build().unwrap())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap();
 
     assert!(output.contains("User as OtherUser"));
     assert!(output.contains("const u2: OtherUser = get2();"));
@@ -103,20 +123,26 @@ fn test_ts_explicit_alias_takes_precedence() {
 
 #[test]
 fn test_js_side_effect_import() {
-    let mut fb = FileSpec::builder_with("app.js", JavaScript::new());
-    fb.add_import(ImportSpec::side_effect("./polyfill"));
-    fb.add_code(CodeBlock::<JavaScript>::of("// app code", ()).unwrap());
-    let output = fb.build().unwrap().render(80).unwrap();
+    let output = FileSpec::builder_with("app.js", JavaScript::new())
+        .add_import(ImportSpec::side_effect("./polyfill"))
+        .add_code(CodeBlock::of("// app code", ()).unwrap())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap();
 
     assert!(output.contains("import './polyfill';"));
 }
 
 #[test]
 fn test_js_wildcard_import() {
-    let mut fb = FileSpec::builder_with("app.js", JavaScript::new());
-    fb.add_import(ImportSpec::wildcard("./utils"));
-    fb.add_code(CodeBlock::<JavaScript>::of("// app code", ()).unwrap());
-    let output = fb.build().unwrap().render(80).unwrap();
+    let output = FileSpec::builder_with("app.js", JavaScript::new())
+        .add_import(ImportSpec::wildcard("./utils"))
+        .add_code(CodeBlock::of("// app code", ()).unwrap())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap();
 
     assert!(output.contains("import * as Utils from './utils';"));
 }
@@ -125,20 +151,26 @@ fn test_js_wildcard_import() {
 
 #[test]
 fn test_rust_forced_named_import() {
-    let mut fb = FileSpec::builder_with("main.rs", RustLang::new());
-    fb.add_import(ImportSpec::named("std::collections", "HashMap"));
-    fb.add_code(CodeBlock::<RustLang>::of("// code", ()).unwrap());
-    let output = fb.build().unwrap().render(80).unwrap();
+    let output = FileSpec::builder_with("main.rs", RustLang::new())
+        .add_import(ImportSpec::named("std::collections", "HashMap"))
+        .add_code(CodeBlock::of("// code", ()).unwrap())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap();
 
     assert!(output.contains("use std::collections::HashMap;"));
 }
 
 #[test]
 fn test_rust_wildcard_import() {
-    let mut fb = FileSpec::builder_with("main.rs", RustLang::new());
-    fb.add_import(ImportSpec::wildcard("std::collections"));
-    fb.add_code(CodeBlock::<RustLang>::of("// code", ()).unwrap());
-    let output = fb.build().unwrap().render(80).unwrap();
+    let output = FileSpec::builder_with("main.rs", RustLang::new())
+        .add_import(ImportSpec::wildcard("std::collections"))
+        .add_code(CodeBlock::of("// code", ()).unwrap())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap();
 
     assert!(output.contains("use std::collections::*;"));
 }
@@ -147,35 +179,44 @@ fn test_rust_wildcard_import() {
 
 #[test]
 fn test_go_side_effect_import() {
-    let mut fb = FileSpec::builder_with("main.go", GoLang::new());
-    fb.header(CodeBlock::<GoLang>::of("package main", ()).unwrap());
-    fb.add_import(ImportSpec::side_effect("database/sql"));
-    fb.add_code(CodeBlock::<GoLang>::of("// init", ()).unwrap());
-    let output = fb.build().unwrap().render(80).unwrap();
+    let output = FileSpec::builder_with("main.go", GoLang::new())
+        .header(CodeBlock::of("package main", ()).unwrap())
+        .add_import(ImportSpec::side_effect("database/sql"))
+        .add_code(CodeBlock::of("// init", ()).unwrap())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap();
 
     assert!(output.contains("import _ \"database/sql\""));
 }
 
 #[test]
 fn test_go_wildcard_import() {
-    let mut fb = FileSpec::builder_with("main.go", GoLang::new());
-    fb.header(CodeBlock::<GoLang>::of("package main", ()).unwrap());
-    fb.add_import(ImportSpec::wildcard("math"));
-    fb.add_code(CodeBlock::<GoLang>::of("// use math", ()).unwrap());
-    let output = fb.build().unwrap().render(80).unwrap();
+    let output = FileSpec::builder_with("main.go", GoLang::new())
+        .header(CodeBlock::of("package main", ()).unwrap())
+        .add_import(ImportSpec::wildcard("math"))
+        .add_code(CodeBlock::of("// use math", ()).unwrap())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap();
 
     assert!(output.contains("import . \"math\""));
 }
 
 #[test]
 fn test_go_mixed_side_effect_and_named() {
-    let fmt = TypeName::<GoLang>::importable("fmt", "Println");
+    let fmt = TypeName::importable("fmt", "Println");
 
-    let mut fb = FileSpec::builder_with("main.go", GoLang::new());
-    fb.header(CodeBlock::<GoLang>::of("package main", ()).unwrap());
-    fb.add_import(ImportSpec::side_effect("github.com/lib/pq"));
-    fb.add_code(CodeBlock::<GoLang>::of("%T(\"hello\")", (fmt,)).unwrap());
-    let output = fb.build().unwrap().render(80).unwrap();
+    let output = FileSpec::builder_with("main.go", GoLang::new())
+        .header(CodeBlock::of("package main", ()).unwrap())
+        .add_import(ImportSpec::side_effect("github.com/lib/pq"))
+        .add_code(CodeBlock::of("%T(\"hello\")", (fmt,)).unwrap())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap();
 
     assert!(output.contains("import ("));
     assert!(output.contains("\"fmt\""));
@@ -186,20 +227,26 @@ fn test_go_mixed_side_effect_and_named() {
 
 #[test]
 fn test_python_side_effect_import() {
-    let mut fb = FileSpec::builder_with("app.py", Python::new());
-    fb.add_import(ImportSpec::side_effect("logging"));
-    fb.add_code(CodeBlock::<Python>::of("# code", ()).unwrap());
-    let output = fb.build().unwrap().render(80).unwrap();
+    let output = FileSpec::builder_with("app.py", Python::new())
+        .add_import(ImportSpec::side_effect("logging"))
+        .add_code(CodeBlock::of("# code", ()).unwrap())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap();
 
     assert!(output.contains("import logging"));
 }
 
 #[test]
 fn test_python_wildcard_import() {
-    let mut fb = FileSpec::builder_with("app.py", Python::new());
-    fb.add_import(ImportSpec::wildcard("os.path"));
-    fb.add_code(CodeBlock::<Python>::of("# code", ()).unwrap());
-    let output = fb.build().unwrap().render(80).unwrap();
+    let output = FileSpec::builder_with("app.py", Python::new())
+        .add_import(ImportSpec::wildcard("os.path"))
+        .add_code(CodeBlock::of("# code", ()).unwrap())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap();
 
     assert!(output.contains("from os.path import *"));
 }
@@ -208,20 +255,26 @@ fn test_python_wildcard_import() {
 
 #[test]
 fn test_java_wildcard_import() {
-    let mut fb = FileSpec::builder_with("App.java", JavaLang::new());
-    fb.add_import(ImportSpec::wildcard("java.util"));
-    fb.add_code(CodeBlock::<JavaLang>::of("// code", ()).unwrap());
-    let output = fb.build().unwrap().render(80).unwrap();
+    let output = FileSpec::builder_with("App.java", JavaLang::new())
+        .add_import(ImportSpec::wildcard("java.util"))
+        .add_code(CodeBlock::of("// code", ()).unwrap())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap();
 
     assert!(output.contains("import java.util.*;"));
 }
 
 #[test]
 fn test_java_forced_named_import() {
-    let mut fb = FileSpec::builder_with("App.java", JavaLang::new());
-    fb.add_import(ImportSpec::named("java.util", "List"));
-    fb.add_code(CodeBlock::<JavaLang>::of("// code", ()).unwrap());
-    let output = fb.build().unwrap().render(80).unwrap();
+    let output = FileSpec::builder_with("App.java", JavaLang::new())
+        .add_import(ImportSpec::named("java.util", "List"))
+        .add_code(CodeBlock::of("// code", ()).unwrap())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap();
 
     assert!(output.contains("import java.util.List;"));
 }
@@ -230,10 +283,13 @@ fn test_java_forced_named_import() {
 
 #[test]
 fn test_kotlin_wildcard_import() {
-    let mut fb = FileSpec::builder_with("App.kt", Kotlin::new());
-    fb.add_import(ImportSpec::wildcard("kotlin.collections"));
-    fb.add_code(CodeBlock::<Kotlin>::of("// code", ()).unwrap());
-    let output = fb.build().unwrap().render(80).unwrap();
+    let output = FileSpec::builder_with("App.kt", Kotlin::new())
+        .add_import(ImportSpec::wildcard("kotlin.collections"))
+        .add_code(CodeBlock::of("// code", ()).unwrap())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap();
 
     assert!(output.contains("import kotlin.collections.*"));
 }
@@ -242,10 +298,13 @@ fn test_kotlin_wildcard_import() {
 
 #[test]
 fn test_swift_forced_module_import() {
-    let mut fb = FileSpec::builder_with("App.swift", Swift::new());
-    fb.add_import(ImportSpec::side_effect("UIKit"));
-    fb.add_code(CodeBlock::<Swift>::of("// code", ()).unwrap());
-    let output = fb.build().unwrap().render(80).unwrap();
+    let output = FileSpec::builder_with("App.swift", Swift::new())
+        .add_import(ImportSpec::side_effect("UIKit"))
+        .add_code(CodeBlock::of("// code", ()).unwrap())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap();
 
     assert!(output.contains("import UIKit"));
 }
@@ -254,10 +313,13 @@ fn test_swift_forced_module_import() {
 
 #[test]
 fn test_dart_side_effect_import() {
-    let mut fb = FileSpec::builder_with("app.dart", DartLang::new());
-    fb.add_import(ImportSpec::side_effect("package:flutter/material.dart"));
-    fb.add_code(CodeBlock::<DartLang>::of("// code", ()).unwrap());
-    let output = fb.build().unwrap().render(80).unwrap();
+    let output = FileSpec::builder_with("app.dart", DartLang::new())
+        .add_import(ImportSpec::side_effect("package:flutter/material.dart"))
+        .add_code(CodeBlock::of("// code", ()).unwrap())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap();
 
     assert!(output.contains("import 'package:flutter/material.dart';"));
 }
@@ -266,12 +328,11 @@ fn test_dart_side_effect_import() {
 
 #[test]
 fn test_no_duplicate_when_explicit_matches_auto() {
-    let user = TypeName::<TypeScript>::importable("./models", "User");
+    let user = TypeName::importable("./models", "User");
 
-    let mut fb = FileSpec::<TypeScript>::builder("app.ts");
-    // Explicit import of the same thing that %T will auto-collect.
-    fb.add_import(ImportSpec::named("./models", "User"));
-    fb.add_code(CodeBlock::<TypeScript>::of("const u: %T = get()", (user,)).unwrap());
+    let fb = FileSpec::builder("app.ts")
+        .add_import(ImportSpec::named("./models", "User"))
+        .add_code(CodeBlock::of("const u: %T = get()", (user,)).unwrap());
     let output = fb.build().unwrap().render(80).unwrap();
 
     // Should appear only once.

--- a/tests/java/builder_control_flow.rs
+++ b/tests/java/builder_control_flow.rs
@@ -6,7 +6,7 @@ use super::golden;
 
 #[test]
 fn test_control_flow() {
-    let mut b = CodeBlock::<JavaLang>::builder();
+    let mut b = CodeBlock::builder();
     b.begin_control_flow("if (x > 0)", ());
     b.add_statement("return 1", ());
     b.next_control_flow("else if (x < 0)", ());
@@ -16,9 +16,10 @@ fn test_control_flow() {
     b.end_control_flow();
     let block = b.build().unwrap();
 
-    let mut fb = FileSpec::builder_with("Flow.java", JavaLang::new());
-    fb.add_code(block);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("Flow.java", JavaLang::new())
+        .add_code(block)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("java/control_flow.java", &output);

--- a/tests/java/builder_edge_cases.rs
+++ b/tests/java/builder_edge_cases.rs
@@ -12,34 +12,39 @@ use super::golden;
 
 #[test]
 fn test_static_final_field() {
-    let mut tb = TypeSpec::<JavaLang>::builder("Constants", TypeKind::Class);
-    tb.visibility(Visibility::Public);
-
-    let mut max_field = FieldSpec::builder("MAX_SIZE", TypeName::primitive("int"));
-    max_field.visibility(Visibility::Public);
-    max_field.is_static();
-    max_field.is_readonly();
-    max_field.initializer(CodeBlock::<JavaLang>::of("100", ()).unwrap());
-    tb.add_field(max_field.build().unwrap());
-
-    let mut name_field = FieldSpec::builder("APP_NAME", TypeName::primitive("String"));
-    name_field.visibility(Visibility::Public);
-    name_field.is_static();
-    name_field.is_readonly();
-    name_field.initializer(
-        CodeBlock::<JavaLang>::of(
-            "%S",
-            (sigil_stitch::code_block::StringLitArg("MyApp".to_string()),),
+    let ts = TypeSpec::builder("Constants", TypeKind::Class)
+        .visibility(Visibility::Public)
+        .add_field(
+            FieldSpec::builder("MAX_SIZE", TypeName::primitive("int"))
+                .visibility(Visibility::Public)
+                .is_static()
+                .is_readonly()
+                .initializer(CodeBlock::of("100", ()).unwrap())
+                .build()
+                .unwrap(),
         )
-        .unwrap(),
-    );
-    tb.add_field(name_field.build().unwrap());
+        .add_field(
+            FieldSpec::builder("APP_NAME", TypeName::primitive("String"))
+                .visibility(Visibility::Public)
+                .is_static()
+                .is_readonly()
+                .initializer(
+                    CodeBlock::of(
+                        "%S",
+                        (sigil_stitch::code_block::StringLitArg("MyApp".to_string()),),
+                    )
+                    .unwrap(),
+                )
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
 
-    let ts = tb.build().unwrap();
-
-    let mut fb = FileSpec::builder_with("Constants.java", JavaLang::new());
-    fb.add_type(ts);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("Constants.java", JavaLang::new())
+        .add_type(ts)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("java/static_final_field.java", &output);
@@ -47,23 +52,26 @@ fn test_static_final_field() {
 
 #[test]
 fn test_annotated_method() {
-    let mut tb = TypeSpec::<JavaLang>::builder("Dog", TypeKind::Class);
-    tb.visibility(Visibility::Public);
-    tb.extends(TypeName::primitive("Animal"));
+    let body = CodeBlock::of("return \"Woof!\";", ()).unwrap();
+    let ts = TypeSpec::builder("Dog", TypeKind::Class)
+        .visibility(Visibility::Public)
+        .extends(TypeName::primitive("Animal"))
+        .add_method(
+            FunSpec::builder("speak")
+                .visibility(Visibility::Public)
+                .returns(TypeName::primitive("String"))
+                .annotation(CodeBlock::of("@Override", ()).unwrap())
+                .body(body)
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
 
-    let body = CodeBlock::<JavaLang>::of("return \"Woof!\";", ()).unwrap();
-    let mut speak = FunSpec::<JavaLang>::builder("speak");
-    speak.visibility(Visibility::Public);
-    speak.returns(TypeName::primitive("String"));
-    speak.annotation(CodeBlock::<JavaLang>::of("@Override", ()).unwrap());
-    speak.body(body);
-    tb.add_method(speak.build().unwrap());
-
-    let ts = tb.build().unwrap();
-
-    let mut fb = FileSpec::builder_with("Dog.java", JavaLang::new());
-    fb.add_type(ts);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("Dog.java", JavaLang::new())
+        .add_type(ts)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("java/annotated_method.java", &output);
@@ -71,75 +79,85 @@ fn test_annotated_method() {
 
 #[test]
 fn test_full_module() {
-    let list = TypeName::<JavaLang>::importable("java.util", "List");
-    let array_list = TypeName::<JavaLang>::importable("java.util", "ArrayList");
-    let nullable = TypeName::<JavaLang>::importable("javax.annotation", "Nullable");
+    let list = TypeName::importable("java.util", "List");
+    let array_list = TypeName::importable("java.util", "ArrayList");
+    let nullable = TypeName::importable("javax.annotation", "Nullable");
 
     // Interface.
-    let mut iface = TypeSpec::<JavaLang>::builder("UserRepository", TypeKind::Interface);
-    iface.visibility(Visibility::Public);
-
-    let mut find = FunSpec::<JavaLang>::builder("findById");
-    find.returns(TypeName::primitive("User"));
-    find.add_param(ParameterSpec::new("id", TypeName::primitive("String")).unwrap());
-    find.annotation(CodeBlock::<JavaLang>::of("@%T", (nullable.clone(),)).unwrap());
-    iface.add_method(find.build().unwrap());
-
-    let mut find_all = FunSpec::<JavaLang>::builder("findAll");
-    find_all.returns(TypeName::primitive("List<User>"));
-    iface.add_method(find_all.build().unwrap());
-
-    let iface_spec = iface.build().unwrap();
+    let iface_spec = TypeSpec::builder("UserRepository", TypeKind::Interface)
+        .visibility(Visibility::Public)
+        .add_method(
+            FunSpec::builder("findById")
+                .returns(TypeName::primitive("User"))
+                .add_param(ParameterSpec::new("id", TypeName::primitive("String")).unwrap())
+                .annotation(CodeBlock::of("@%T", (nullable.clone(),)).unwrap())
+                .build()
+                .unwrap(),
+        )
+        .add_method(
+            FunSpec::builder("findAll")
+                .returns(TypeName::primitive("List<User>"))
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
 
     // Implementation class.
-    let mut cls = TypeSpec::<JavaLang>::builder("InMemoryUserRepository", TypeKind::Class);
-    cls.visibility(Visibility::Public);
-    cls.implements(TypeName::primitive("UserRepository"));
-    cls.doc("In-memory implementation of UserRepository.");
-
-    let mut users_field = FieldSpec::builder("users", TypeName::primitive("List<User>"));
-    users_field.visibility(Visibility::Private);
-    users_field.is_readonly();
-    cls.add_field(users_field.build().unwrap());
-
-    // Constructor — use imports.
-    let ctor_body = CodeBlock::<JavaLang>::of("this.users = new %T<>();", (array_list,)).unwrap();
-    let mut ctor = FunSpec::<JavaLang>::builder("InMemoryUserRepository");
-    ctor.visibility(Visibility::Public);
-    ctor.body(ctor_body);
-    cls.add_method(ctor.build().unwrap());
-
-    // findById with @Nullable.
-    let find_body = CodeBlock::<JavaLang>::of(
+    let ctor_body = CodeBlock::of("this.users = new %T<>();", (array_list,)).unwrap();
+    let find_body = CodeBlock::of(
         "return this.users.stream()\n    .filter(u -> u.getId().equals(id))\n    .findFirst()\n    .orElse(null);",
         (),
     )
     .unwrap();
-    let mut find_impl = FunSpec::<JavaLang>::builder("findById");
-    find_impl.visibility(Visibility::Public);
-    find_impl.returns(TypeName::primitive("User"));
-    find_impl.add_param(ParameterSpec::new("id", TypeName::primitive("String")).unwrap());
-    find_impl.annotation(CodeBlock::<JavaLang>::of("@Override", ()).unwrap());
-    find_impl.annotation(CodeBlock::<JavaLang>::of("@%T", (nullable,)).unwrap());
-    find_impl.body(find_body);
-    cls.add_method(find_impl.build().unwrap());
+    let find_all_body = CodeBlock::of("return new %T<>(this.users);", (list.clone(),)).unwrap();
 
-    // findAll — trigger List import.
-    let find_all_body =
-        CodeBlock::<JavaLang>::of("return new %T<>(this.users);", (list.clone(),)).unwrap();
-    let mut find_all_impl = FunSpec::<JavaLang>::builder("findAll");
-    find_all_impl.visibility(Visibility::Public);
-    find_all_impl.returns(TypeName::primitive("List<User>"));
-    find_all_impl.annotation(CodeBlock::<JavaLang>::of("@Override", ()).unwrap());
-    find_all_impl.body(find_all_body);
-    cls.add_method(find_all_impl.build().unwrap());
+    let cls_spec = TypeSpec::builder("InMemoryUserRepository", TypeKind::Class)
+        .visibility(Visibility::Public)
+        .implements(TypeName::primitive("UserRepository"))
+        .doc("In-memory implementation of UserRepository.")
+        .add_field(
+            FieldSpec::builder("users", TypeName::primitive("List<User>"))
+                .visibility(Visibility::Private)
+                .is_readonly()
+                .build()
+                .unwrap(),
+        )
+        .add_method(
+            FunSpec::builder("InMemoryUserRepository")
+                .visibility(Visibility::Public)
+                .body(ctor_body)
+                .build()
+                .unwrap(),
+        )
+        .add_method(
+            FunSpec::builder("findById")
+                .visibility(Visibility::Public)
+                .returns(TypeName::primitive("User"))
+                .add_param(ParameterSpec::new("id", TypeName::primitive("String")).unwrap())
+                .annotation(CodeBlock::of("@Override", ()).unwrap())
+                .annotation(CodeBlock::of("@%T", (nullable,)).unwrap())
+                .body(find_body)
+                .build()
+                .unwrap(),
+        )
+        .add_method(
+            FunSpec::builder("findAll")
+                .visibility(Visibility::Public)
+                .returns(TypeName::primitive("List<User>"))
+                .annotation(CodeBlock::of("@Override", ()).unwrap())
+                .body(find_all_body)
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
 
-    let cls_spec = cls.build().unwrap();
-
-    let mut fb = FileSpec::builder_with("UserRepo.java", JavaLang::new());
-    fb.add_type(iface_spec);
-    fb.add_type(cls_spec);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("UserRepo.java", JavaLang::new())
+        .add_type(iface_spec)
+        .add_type(cls_spec)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("java/full_module.java", &output);

--- a/tests/java/builder_functions.rs
+++ b/tests/java/builder_functions.rs
@@ -10,18 +10,20 @@ use super::golden;
 
 #[test]
 fn test_function_with_doc() {
-    let body = CodeBlock::<JavaLang>::of("return \"Hello, \" + name;", ()).unwrap();
-    let mut fb = FunSpec::<JavaLang>::builder("greet");
-    fb.visibility(Visibility::Public);
-    fb.doc("Greet the user by name.");
-    fb.add_param(ParameterSpec::new("name", TypeName::primitive("String")).unwrap());
-    fb.returns(TypeName::primitive("String"));
-    fb.body(body);
-    let fun = fb.build().unwrap();
+    let body = CodeBlock::of("return \"Hello, \" + name;", ()).unwrap();
+    let fun = FunSpec::builder("greet")
+        .visibility(Visibility::Public)
+        .doc("Greet the user by name.")
+        .add_param(ParameterSpec::new("name", TypeName::primitive("String")).unwrap())
+        .returns(TypeName::primitive("String"))
+        .body(body)
+        .build()
+        .unwrap();
 
-    let mut file_b = FileSpec::builder_with("Greet.java", JavaLang::new());
-    file_b.add_function(fun);
-    let file = file_b.build().unwrap();
+    let file = FileSpec::builder_with("Greet.java", JavaLang::new())
+        .add_function(fun)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("java/function_with_doc.java", &output);

--- a/tests/java/builder_imports.rs
+++ b/tests/java/builder_imports.rs
@@ -7,16 +7,17 @@ use super::golden;
 
 #[test]
 fn test_function_with_imports() {
-    let list = TypeName::<JavaLang>::importable("java.util", "List");
-    let user = TypeName::<JavaLang>::importable("com.example.model", "User");
+    let list = TypeName::importable("java.util", "List");
+    let user = TypeName::importable("com.example.model", "User");
 
-    let mut b = CodeBlock::<JavaLang>::builder();
+    let mut b = CodeBlock::builder();
     b.add_statement("%T<%T> users = getAll()", (list, user));
     let block = b.build().unwrap();
 
-    let mut fb = FileSpec::builder_with("App.java", JavaLang::new());
-    fb.add_code(block);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("App.java", JavaLang::new())
+        .add_code(block)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("java/function_with_imports.java", &output);
@@ -24,20 +25,21 @@ fn test_function_with_imports() {
 
 #[test]
 fn test_import_grouping() {
-    let list = TypeName::<JavaLang>::importable("java.util", "List");
-    let file_type = TypeName::<JavaLang>::importable("java.io", "File");
-    let entity = TypeName::<JavaLang>::importable("javax.persistence", "Entity");
-    let user = TypeName::<JavaLang>::importable("com.example.model", "User");
-    let helper = TypeName::<JavaLang>::importable("com.example.util", "Helper");
+    let list = TypeName::importable("java.util", "List");
+    let file_type = TypeName::importable("java.io", "File");
+    let entity = TypeName::importable("javax.persistence", "Entity");
+    let user = TypeName::importable("com.example.model", "User");
+    let helper = TypeName::importable("com.example.util", "Helper");
 
-    let mut b = CodeBlock::<JavaLang>::builder();
+    let mut b = CodeBlock::builder();
     b.add("// %T %T %T %T %T", (list, file_type, entity, user, helper));
     b.add_line();
     let block = b.build().unwrap();
 
-    let mut fb = FileSpec::builder_with("Imports.java", JavaLang::new());
-    fb.add_code(block);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("Imports.java", JavaLang::new())
+        .add_code(block)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("java/import_grouping.java", &output);

--- a/tests/java/builder_types.rs
+++ b/tests/java/builder_types.rs
@@ -13,44 +13,55 @@ use super::golden;
 
 #[test]
 fn test_class_with_methods() {
-    let mut tb = TypeSpec::<JavaLang>::builder("UserService", TypeKind::Class);
-    tb.visibility(Visibility::Public);
-    tb.doc("Service for managing users.");
-
-    // Private fields.
-    let mut repo_field = FieldSpec::builder("repo", TypeName::primitive("UserRepository"));
-    repo_field.visibility(Visibility::Private);
-    tb.add_field(repo_field.build().unwrap());
-
-    let mut logger_field = FieldSpec::builder("logger", TypeName::primitive("Logger"));
-    logger_field.visibility(Visibility::Private);
-    logger_field.is_readonly();
-    tb.add_field(logger_field.build().unwrap());
-
     // Constructor.
-    let ctor_body =
-        CodeBlock::<JavaLang>::of("this.repo = repo;\nthis.logger = logger;", ()).unwrap();
-    let mut ctor = FunSpec::<JavaLang>::builder("UserService");
-    ctor.visibility(Visibility::Public);
-    ctor.add_param(ParameterSpec::new("repo", TypeName::primitive("UserRepository")).unwrap());
-    ctor.add_param(ParameterSpec::new("logger", TypeName::primitive("Logger")).unwrap());
-    ctor.body(ctor_body);
-    tb.add_method(ctor.build().unwrap());
+    let ctor_body = CodeBlock::of("this.repo = repo;\nthis.logger = logger;", ()).unwrap();
 
     // Public method.
-    let find_body = CodeBlock::<JavaLang>::of("return this.repo.findById(id);", ()).unwrap();
-    let mut find = FunSpec::<JavaLang>::builder("findUser");
-    find.visibility(Visibility::Public);
-    find.returns(TypeName::primitive("User"));
-    find.add_param(ParameterSpec::new("id", TypeName::primitive("String")).unwrap());
-    find.body(find_body);
-    tb.add_method(find.build().unwrap());
+    let find_body = CodeBlock::of("return this.repo.findById(id);", ()).unwrap();
 
-    let ts = tb.build().unwrap();
+    let ts = TypeSpec::builder("UserService", TypeKind::Class)
+        .visibility(Visibility::Public)
+        .doc("Service for managing users.")
+        .add_field(
+            FieldSpec::builder("repo", TypeName::primitive("UserRepository"))
+                .visibility(Visibility::Private)
+                .build()
+                .unwrap(),
+        )
+        .add_field(
+            FieldSpec::builder("logger", TypeName::primitive("Logger"))
+                .visibility(Visibility::Private)
+                .is_readonly()
+                .build()
+                .unwrap(),
+        )
+        .add_method(
+            FunSpec::builder("UserService")
+                .visibility(Visibility::Public)
+                .add_param(
+                    ParameterSpec::new("repo", TypeName::primitive("UserRepository")).unwrap(),
+                )
+                .add_param(ParameterSpec::new("logger", TypeName::primitive("Logger")).unwrap())
+                .body(ctor_body)
+                .build()
+                .unwrap(),
+        )
+        .add_method(
+            FunSpec::builder("findUser")
+                .visibility(Visibility::Public)
+                .returns(TypeName::primitive("User"))
+                .add_param(ParameterSpec::new("id", TypeName::primitive("String")).unwrap())
+                .body(find_body)
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
 
-    let mut fb = FileSpec::builder_with("UserService.java", JavaLang::new());
-    fb.add_type(ts);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("UserService.java", JavaLang::new())
+        .add_type(ts)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("java/class_with_methods.java", &output);
@@ -58,34 +69,40 @@ fn test_class_with_methods() {
 
 #[test]
 fn test_interface() {
-    let tp = TypeParamSpec::<JavaLang>::new("T");
+    let tp = TypeParamSpec::new("T");
 
-    let mut tb = TypeSpec::<JavaLang>::builder("Repository", TypeKind::Interface);
-    tb.visibility(Visibility::Public);
-    tb.add_type_param(tp);
-    tb.doc("Generic data repository.");
+    let ts = TypeSpec::builder("Repository", TypeKind::Interface)
+        .visibility(Visibility::Public)
+        .add_type_param(tp)
+        .doc("Generic data repository.")
+        .add_method(
+            FunSpec::builder("findById")
+                .returns(TypeName::primitive("T"))
+                .add_param(ParameterSpec::new("id", TypeName::primitive("String")).unwrap())
+                .build()
+                .unwrap(),
+        )
+        .add_method(
+            FunSpec::builder("save")
+                .returns(TypeName::primitive("void"))
+                .add_param(ParameterSpec::new("entity", TypeName::primitive("T")).unwrap())
+                .build()
+                .unwrap(),
+        )
+        .add_method(
+            FunSpec::builder("delete")
+                .returns(TypeName::primitive("void"))
+                .add_param(ParameterSpec::new("id", TypeName::primitive("String")).unwrap())
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
 
-    // Abstract methods (no body).
-    let mut find = FunSpec::<JavaLang>::builder("findById");
-    find.returns(TypeName::primitive("T"));
-    find.add_param(ParameterSpec::new("id", TypeName::primitive("String")).unwrap());
-    tb.add_method(find.build().unwrap());
-
-    let mut save = FunSpec::<JavaLang>::builder("save");
-    save.returns(TypeName::primitive("void"));
-    save.add_param(ParameterSpec::new("entity", TypeName::primitive("T")).unwrap());
-    tb.add_method(save.build().unwrap());
-
-    let mut delete = FunSpec::<JavaLang>::builder("delete");
-    delete.returns(TypeName::primitive("void"));
-    delete.add_param(ParameterSpec::new("id", TypeName::primitive("String")).unwrap());
-    tb.add_method(delete.build().unwrap());
-
-    let ts = tb.build().unwrap();
-
-    let mut fb = FileSpec::builder_with("Repository.java", JavaLang::new());
-    fb.add_type(ts);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("Repository.java", JavaLang::new())
+        .add_type(ts)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("java/interface.java", &output);
@@ -93,34 +110,36 @@ fn test_interface() {
 
 #[test]
 fn test_abstract_class() {
-    let mut tb = TypeSpec::<JavaLang>::builder("Shape", TypeKind::Class);
-    tb.visibility(Visibility::Public);
-    tb.doc("Abstract shape.");
-
     // Concrete method.
-    let desc_body =
-        CodeBlock::<JavaLang>::of("return this.getClass().getSimpleName();", ()).unwrap();
-    let mut desc = FunSpec::<JavaLang>::builder("describe");
-    desc.visibility(Visibility::Public);
-    desc.returns(TypeName::primitive("String"));
-    desc.body(desc_body);
-    tb.add_method(desc.build().unwrap());
+    let desc_body = CodeBlock::of("return this.getClass().getSimpleName();", ()).unwrap();
 
-    // Abstract method.
-    let mut area = FunSpec::<JavaLang>::builder("area");
-    area.visibility(Visibility::Public);
-    area.is_abstract();
-    area.returns(TypeName::primitive("double"));
-    tb.add_method(area.build().unwrap());
+    let ts = TypeSpec::builder("Shape", TypeKind::Class)
+        .visibility(Visibility::Public)
+        .doc("Abstract shape.")
+        .add_method(
+            FunSpec::builder("describe")
+                .visibility(Visibility::Public)
+                .returns(TypeName::primitive("String"))
+                .body(desc_body)
+                .build()
+                .unwrap(),
+        )
+        .add_method(
+            FunSpec::builder("area")
+                .visibility(Visibility::Public)
+                .is_abstract()
+                .returns(TypeName::primitive("double"))
+                .build()
+                .unwrap(),
+        )
+        .is_abstract()
+        .build()
+        .unwrap();
 
-    // Mark class abstract via annotation-like prefix.
-    tb.is_abstract();
-
-    let ts = tb.build().unwrap();
-
-    let mut fb = FileSpec::builder_with("Shape.java", JavaLang::new());
-    fb.add_type(ts);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("Shape.java", JavaLang::new())
+        .add_type(ts)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("java/abstract_class.java", &output);
@@ -128,28 +147,31 @@ fn test_abstract_class() {
 
 #[test]
 fn test_class_extends_implements() {
-    let base = TypeName::<JavaLang>::importable("com.example.base", "BaseService");
-    let auth = TypeName::<JavaLang>::importable("com.example.auth", "Authenticatable");
-    let serial = TypeName::<JavaLang>::importable("com.example.serial", "Serializable");
+    let base = TypeName::importable("com.example.base", "BaseService");
+    let auth = TypeName::importable("com.example.auth", "Authenticatable");
+    let serial = TypeName::importable("com.example.serial", "Serializable");
 
-    let mut tb = TypeSpec::<JavaLang>::builder("AdminService", TypeKind::Class);
-    tb.visibility(Visibility::Public);
-    tb.extends(base);
-    tb.implements(auth);
-    tb.implements(serial);
+    let body = CodeBlock::of("return true;", ()).unwrap();
+    let ts = TypeSpec::builder("AdminService", TypeKind::Class)
+        .visibility(Visibility::Public)
+        .extends(base)
+        .implements(auth)
+        .implements(serial)
+        .add_method(
+            FunSpec::builder("isAdmin")
+                .visibility(Visibility::Public)
+                .returns(TypeName::primitive("boolean"))
+                .body(body)
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
 
-    let body = CodeBlock::<JavaLang>::of("return true;", ()).unwrap();
-    let mut is_admin = FunSpec::<JavaLang>::builder("isAdmin");
-    is_admin.visibility(Visibility::Public);
-    is_admin.returns(TypeName::primitive("boolean"));
-    is_admin.body(body);
-    tb.add_method(is_admin.build().unwrap());
-
-    let ts = tb.build().unwrap();
-
-    let mut fb = FileSpec::builder_with("AdminService.java", JavaLang::new());
-    fb.add_type(ts);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("AdminService.java", JavaLang::new())
+        .add_type(ts)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("java/class_extends_implements.java", &output);
@@ -157,19 +179,19 @@ fn test_class_extends_implements() {
 
 #[test]
 fn test_enum() {
-    let mut tb = TypeSpec::<JavaLang>::builder("Color", TypeKind::Enum);
-    tb.visibility(Visibility::Public);
-    tb.doc("Supported colors.");
+    let ts = TypeSpec::builder("Color", TypeKind::Enum)
+        .visibility(Visibility::Public)
+        .doc("Supported colors.")
+        .add_variant(EnumVariantSpec::new("RED").unwrap())
+        .add_variant(EnumVariantSpec::new("GREEN").unwrap())
+        .add_variant(EnumVariantSpec::new("BLUE").unwrap())
+        .build()
+        .unwrap();
 
-    tb.add_variant(EnumVariantSpec::new("RED").unwrap());
-    tb.add_variant(EnumVariantSpec::new("GREEN").unwrap());
-    tb.add_variant(EnumVariantSpec::new("BLUE").unwrap());
-
-    let ts = tb.build().unwrap();
-
-    let mut fb = FileSpec::builder_with("Color.java", JavaLang::new());
-    fb.add_type(ts);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("Color.java", JavaLang::new())
+        .add_type(ts)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("java/enum.java", &output);
@@ -177,32 +199,37 @@ fn test_enum() {
 
 #[test]
 fn test_generic_class() {
-    let tp = TypeParamSpec::<JavaLang>::new("T")
+    let tp = TypeParamSpec::new("T")
         .with_bound(TypeName::primitive("Comparable"))
         .with_bound(TypeName::primitive("Serializable"));
 
-    let mut tb = TypeSpec::<JavaLang>::builder("SortedContainer", TypeKind::Class);
-    tb.visibility(Visibility::Public);
-    tb.add_type_param(tp);
-    tb.doc("A sorted container with bounded type parameter.");
+    let add_body = CodeBlock::of("this.items.add(item);", ()).unwrap();
+    let ts = TypeSpec::builder("SortedContainer", TypeKind::Class)
+        .visibility(Visibility::Public)
+        .add_type_param(tp)
+        .doc("A sorted container with bounded type parameter.")
+        .add_field(
+            FieldSpec::builder("items", TypeName::primitive("List<T>"))
+                .visibility(Visibility::Private)
+                .build()
+                .unwrap(),
+        )
+        .add_method(
+            FunSpec::builder("add")
+                .visibility(Visibility::Public)
+                .returns(TypeName::primitive("void"))
+                .add_param(ParameterSpec::new("item", TypeName::primitive("T")).unwrap())
+                .body(add_body)
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
 
-    let mut items_field = FieldSpec::builder("items", TypeName::primitive("List<T>"));
-    items_field.visibility(Visibility::Private);
-    tb.add_field(items_field.build().unwrap());
-
-    let add_body = CodeBlock::<JavaLang>::of("this.items.add(item);", ()).unwrap();
-    let mut add = FunSpec::<JavaLang>::builder("add");
-    add.visibility(Visibility::Public);
-    add.returns(TypeName::primitive("void"));
-    add.add_param(ParameterSpec::new("item", TypeName::primitive("T")).unwrap());
-    add.body(add_body);
-    tb.add_method(add.build().unwrap());
-
-    let ts = tb.build().unwrap();
-
-    let mut fb = FileSpec::builder_with("SortedContainer.java", JavaLang::new());
-    fb.add_type(ts);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("SortedContainer.java", JavaLang::new())
+        .add_type(ts)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("java/generic_class.java", &output);

--- a/tests/java/quote_basic.rs
+++ b/tests/java/quote_basic.rs
@@ -5,10 +5,13 @@ use sigil_stitch::spec::file_spec::FileSpec;
 
 use super::golden;
 
-fn render(block: &CodeBlock<JavaLang>) -> String {
-    let mut fb = FileSpec::builder_with("Test.java", JavaLang::new());
-    fb.add_code(block.clone());
-    fb.build().unwrap().render(80).unwrap()
+fn render(block: &CodeBlock) -> String {
+    FileSpec::builder_with("Test.java", JavaLang::new())
+        .add_code(block.clone())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap()
 }
 
 #[test]

--- a/tests/java/quote_control_flow.rs
+++ b/tests/java/quote_control_flow.rs
@@ -5,10 +5,13 @@ use sigil_stitch::spec::file_spec::FileSpec;
 
 use super::golden;
 
-fn render(block: &CodeBlock<JavaLang>) -> String {
-    let mut fb = FileSpec::builder_with("Test.java", JavaLang::new());
-    fb.add_code(block.clone());
-    fb.build().unwrap().render(80).unwrap()
+fn render(block: &CodeBlock) -> String {
+    FileSpec::builder_with("Test.java", JavaLang::new())
+        .add_code(block.clone())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap()
 }
 
 #[test]

--- a/tests/java/quote_imports.rs
+++ b/tests/java/quote_imports.rs
@@ -6,16 +6,19 @@ use sigil_stitch::type_name::TypeName;
 
 use super::golden;
 
-fn render(block: &CodeBlock<JavaLang>) -> String {
-    let mut fb = FileSpec::builder_with("Test.java", JavaLang::new());
-    fb.add_code(block.clone());
-    fb.build().unwrap().render(80).unwrap()
+fn render(block: &CodeBlock) -> String {
+    FileSpec::builder_with("Test.java", JavaLang::new())
+        .add_code(block.clone())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap()
 }
 
 #[test]
 fn test_imports() {
-    let list_type = TypeName::<JavaLang>::importable("java.util", "List");
-    let map_type = TypeName::<JavaLang>::importable("java.util", "Map");
+    let list_type = TypeName::importable("java.util", "List");
+    let map_type = TypeName::importable("java.util", "Map");
     let block = sigil_quote!(JavaLang {
         $T(list_type) items = new ArrayList<>();
         $T(map_type) lookup = new HashMap<>();

--- a/tests/javascript/builder_control_flow.rs
+++ b/tests/javascript/builder_control_flow.rs
@@ -6,7 +6,7 @@ use super::golden;
 
 #[test]
 fn test_control_flow() {
-    let mut b = CodeBlock::<JavaScript>::builder();
+    let mut b = CodeBlock::builder();
     b.begin_control_flow("if (x > 0)", ());
     b.add_statement("return 1", ());
     b.next_control_flow("else if (x < 0)", ());
@@ -16,9 +16,10 @@ fn test_control_flow() {
     b.end_control_flow();
     let block = b.build().unwrap();
 
-    let mut fb = FileSpec::builder_with("flow.js", JavaScript::new());
-    fb.add_code(block);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("flow.js", JavaScript::new())
+        .add_code(block)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("javascript/control_flow.js", &output);

--- a/tests/javascript/builder_edge_cases.rs
+++ b/tests/javascript/builder_edge_cases.rs
@@ -11,12 +11,12 @@ use sigil_stitch::type_name::TypeName;
 use super::golden;
 
 /// Shorthand for a JS parameter (no type annotation).
-fn param(name: &str) -> ParameterSpec<JavaScript> {
+fn param(name: &str) -> ParameterSpec {
     ParameterSpec::new(name, TypeName::primitive("")).unwrap()
 }
 
 /// Shorthand for a JS field (no type annotation).
-fn field(name: &str) -> FieldSpec<JavaScript> {
+fn field(name: &str) -> FieldSpec {
     FieldSpec::builder(name, TypeName::primitive(""))
         .build()
         .unwrap()
@@ -24,51 +24,56 @@ fn field(name: &str) -> FieldSpec<JavaScript> {
 
 #[test]
 fn test_full_module() {
-    let event_emitter = TypeName::<JavaScript>::importable("events", "EventEmitter");
-    let uuid = TypeName::<JavaScript>::importable("uuid", "v4");
+    let event_emitter = TypeName::importable("events", "EventEmitter");
+    let uuid = TypeName::importable("uuid", "v4");
 
     // EventBus class extending EventEmitter.
-    let mut tb = TypeSpec::<JavaScript>::builder("EventBus", TypeKind::Class);
-    tb.visibility(Visibility::Public);
-    tb.extends(TypeName::primitive("EventEmitter"));
-    tb.doc("Application event bus.");
-
-    tb.add_field(field("#handlers"));
-
-    let ctor_body =
-        CodeBlock::<JavaScript>::of("super();\nthis.#handlers = new Map();", ()).unwrap();
-    let mut ctor = FunSpec::<JavaScript>::builder("constructor");
-    ctor.body(ctor_body);
-    tb.add_method(ctor.build().unwrap());
-
-    let pub_body = CodeBlock::<JavaScript>::of(
+    let ctor_body = CodeBlock::of("super();\nthis.#handlers = new Map();", ()).unwrap();
+    let pub_body = CodeBlock::of(
         "const id = %T();\nthis.emit(event, data);\nreturn id;",
         (uuid,),
     )
     .unwrap();
-    let mut publish = FunSpec::<JavaScript>::builder("publish");
-    publish.add_param(param("event"));
-    publish.add_param(param("data"));
-    publish.body(pub_body);
-    tb.add_method(publish.build().unwrap());
 
-    let ts = tb.build().unwrap();
+    let ts = TypeSpec::builder("EventBus", TypeKind::Class)
+        .visibility(Visibility::Public)
+        .extends(TypeName::primitive("EventEmitter"))
+        .doc("Application event bus.")
+        .add_field(field("#handlers"))
+        .add_method(
+            FunSpec::builder("constructor")
+                .body(ctor_body)
+                .build()
+                .unwrap(),
+        )
+        .add_method(
+            FunSpec::builder("publish")
+                .add_param(param("event"))
+                .add_param(param("data"))
+                .body(pub_body)
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
 
     // Trigger EventEmitter import.
-    let import_trigger = CodeBlock::<JavaScript>::of("// extends %T", (event_emitter,)).unwrap();
+    let import_trigger = CodeBlock::of("// extends %T", (event_emitter,)).unwrap();
 
     // Standalone exported function.
-    let create_body = CodeBlock::<JavaScript>::of("return new EventBus();", ()).unwrap();
-    let mut create_fn = FunSpec::<JavaScript>::builder("createEventBus");
-    create_fn.visibility(Visibility::Public);
-    create_fn.body(create_body);
-    let create = create_fn.build().unwrap();
+    let create_body = CodeBlock::of("return new EventBus();", ()).unwrap();
+    let create = FunSpec::builder("createEventBus")
+        .visibility(Visibility::Public)
+        .body(create_body)
+        .build()
+        .unwrap();
 
-    let mut fb = FileSpec::builder_with("event-bus.js", JavaScript::new());
-    fb.add_code(import_trigger);
-    fb.add_type(ts);
-    fb.add_function(create);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("event-bus.js", JavaScript::new())
+        .add_code(import_trigger)
+        .add_type(ts)
+        .add_function(create)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("javascript/full_module.js", &output);

--- a/tests/javascript/builder_functions.rs
+++ b/tests/javascript/builder_functions.rs
@@ -9,26 +9,28 @@ use sigil_stitch::type_name::TypeName;
 use super::golden;
 
 /// Shorthand for a JS parameter (no type annotation).
-fn param(name: &str) -> ParameterSpec<JavaScript> {
+fn param(name: &str) -> ParameterSpec {
     ParameterSpec::new(name, TypeName::primitive("")).unwrap()
 }
 
 #[test]
 fn test_export_function() {
-    let body = CodeBlock::<JavaScript>::of(
+    let body = CodeBlock::of(
         "console.log(%S + name);",
         (StringLitArg("Hello, ".to_string()),),
     )
     .unwrap();
-    let mut fb = FunSpec::<JavaScript>::builder("greet");
-    fb.visibility(Visibility::Public);
-    fb.add_param(param("name"));
-    fb.body(body);
-    let fun = fb.build().unwrap();
+    let fun = FunSpec::builder("greet")
+        .visibility(Visibility::Public)
+        .add_param(param("name"))
+        .body(body)
+        .build()
+        .unwrap();
 
-    let mut file_b = FileSpec::builder_with("greet.js", JavaScript::new());
-    file_b.add_function(fun);
-    let file = file_b.build().unwrap();
+    let file = FileSpec::builder_with("greet.js", JavaScript::new())
+        .add_function(fun)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("javascript/export_function.js", &output);
@@ -36,23 +38,25 @@ fn test_export_function() {
 
 #[test]
 fn test_async_function() {
-    let fetch_type = TypeName::<JavaScript>::importable("node-fetch", "fetch");
+    let fetch_type = TypeName::importable("node-fetch", "fetch");
 
-    let body = CodeBlock::<JavaScript>::of(
+    let body = CodeBlock::of(
         "const response = await %T(url);\nreturn response.json();",
         (fetch_type,),
     )
     .unwrap();
-    let mut fb = FunSpec::<JavaScript>::builder("fetchData");
-    fb.visibility(Visibility::Public);
-    fb.is_async();
-    fb.add_param(param("url"));
-    fb.body(body);
-    let fun = fb.build().unwrap();
+    let fun = FunSpec::builder("fetchData")
+        .visibility(Visibility::Public)
+        .is_async()
+        .add_param(param("url"))
+        .body(body)
+        .build()
+        .unwrap();
 
-    let mut file_b = FileSpec::builder_with("api.js", JavaScript::new());
-    file_b.add_function(fun);
-    let file = file_b.build().unwrap();
+    let file = FileSpec::builder_with("api.js", JavaScript::new())
+        .add_function(fun)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("javascript/async_function.js", &output);
@@ -60,17 +64,19 @@ fn test_async_function() {
 
 #[test]
 fn test_function_with_doc() {
-    let body = CodeBlock::<JavaScript>::of("console.log('Hello, ' + name);", ()).unwrap();
-    let mut fb = FunSpec::<JavaScript>::builder("greet");
-    fb.visibility(Visibility::Public);
-    fb.doc("Greet the user by name.");
-    fb.add_param(param("name"));
-    fb.body(body);
-    let fun = fb.build().unwrap();
+    let body = CodeBlock::of("console.log('Hello, ' + name);", ()).unwrap();
+    let fun = FunSpec::builder("greet")
+        .visibility(Visibility::Public)
+        .doc("Greet the user by name.")
+        .add_param(param("name"))
+        .body(body)
+        .build()
+        .unwrap();
 
-    let mut file_b = FileSpec::builder_with("greet_doc.js", JavaScript::new());
-    file_b.add_function(fun);
-    let file = file_b.build().unwrap();
+    let file = FileSpec::builder_with("greet_doc.js", JavaScript::new())
+        .add_function(fun)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("javascript/function_with_doc.js", &output);

--- a/tests/javascript/builder_imports.rs
+++ b/tests/javascript/builder_imports.rs
@@ -7,10 +7,10 @@ use super::golden;
 
 #[test]
 fn test_function_with_imports() {
-    let format_date = TypeName::<JavaScript>::importable("./utils", "formatDate");
-    let logger = TypeName::<JavaScript>::importable("./logger", "Logger");
+    let format_date = TypeName::importable("./utils", "formatDate");
+    let logger = TypeName::importable("./logger", "Logger");
 
-    let mut b = CodeBlock::<JavaScript>::builder();
+    let mut b = CodeBlock::builder();
     b.add("function greet(name) {", ());
     b.add_line();
     b.add("%>", ());
@@ -26,9 +26,10 @@ fn test_function_with_imports() {
     b.add_line();
     let block = b.build().unwrap();
 
-    let mut fb = FileSpec::builder_with("greet.js", JavaScript::new());
-    fb.add_code(block);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("greet.js", JavaScript::new())
+        .add_code(block)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("javascript/function_with_imports.js", &output);
@@ -37,19 +38,20 @@ fn test_function_with_imports() {
 #[test]
 fn test_no_import_type() {
     // Even when is_type_only is true, JS should NOT emit `import type`.
-    let user = TypeName::<JavaScript>::importable_type("./models", "User");
-    let create = TypeName::<JavaScript>::importable("./models", "createUser");
+    let user = TypeName::importable_type("./models", "User");
+    let create = TypeName::importable("./models", "createUser");
 
-    let mut b = CodeBlock::<JavaScript>::builder();
+    let mut b = CodeBlock::builder();
     b.add("const u = new %T();", (user,));
     b.add_line();
     b.add("%T();", (create,));
     b.add_line();
     let block = b.build().unwrap();
 
-    let mut fb = FileSpec::builder_with("test.js", JavaScript::new());
-    fb.add_code(block);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("test.js", JavaScript::new())
+        .add_code(block)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("javascript/no_import_type.js", &output);

--- a/tests/javascript/builder_types.rs
+++ b/tests/javascript/builder_types.rs
@@ -12,12 +12,12 @@ use sigil_stitch::type_name::TypeName;
 use super::golden;
 
 /// Shorthand for a JS parameter (no type annotation).
-fn param(name: &str) -> ParameterSpec<JavaScript> {
+fn param(name: &str) -> ParameterSpec {
     ParameterSpec::new(name, TypeName::primitive("")).unwrap()
 }
 
 /// Shorthand for a JS field (no type annotation).
-fn field(name: &str) -> FieldSpec<JavaScript> {
+fn field(name: &str) -> FieldSpec {
     FieldSpec::builder(name, TypeName::primitive(""))
         .build()
         .unwrap()
@@ -25,35 +25,37 @@ fn field(name: &str) -> FieldSpec<JavaScript> {
 
 #[test]
 fn test_class_with_methods() {
-    let mut tb = TypeSpec::<JavaScript>::builder("Counter", TypeKind::Class);
-    tb.visibility(Visibility::Public);
-    tb.doc("A simple counter.");
-
-    tb.add_field(field("count"));
-
     // Constructor.
-    let ctor_body = CodeBlock::<JavaScript>::of("this.count = 0;", ()).unwrap();
-    let mut ctor = FunSpec::<JavaScript>::builder("constructor");
-    ctor.body(ctor_body);
-    tb.add_method(ctor.build().unwrap());
-
+    let ctor_body = CodeBlock::of("this.count = 0;", ()).unwrap();
     // increment method.
-    let inc_body = CodeBlock::<JavaScript>::of("this.count++;", ()).unwrap();
-    let mut inc = FunSpec::<JavaScript>::builder("increment");
-    inc.body(inc_body);
-    tb.add_method(inc.build().unwrap());
-
+    let inc_body = CodeBlock::of("this.count++;", ()).unwrap();
     // getCount method.
-    let get_body = CodeBlock::<JavaScript>::of("return this.count;", ()).unwrap();
-    let mut get = FunSpec::<JavaScript>::builder("getCount");
-    get.body(get_body);
-    tb.add_method(get.build().unwrap());
+    let get_body = CodeBlock::of("return this.count;", ()).unwrap();
 
-    let ts = tb.build().unwrap();
+    let ts = TypeSpec::builder("Counter", TypeKind::Class)
+        .visibility(Visibility::Public)
+        .doc("A simple counter.")
+        .add_field(field("count"))
+        .add_method(
+            FunSpec::builder("constructor")
+                .body(ctor_body)
+                .build()
+                .unwrap(),
+        )
+        .add_method(
+            FunSpec::builder("increment")
+                .body(inc_body)
+                .build()
+                .unwrap(),
+        )
+        .add_method(FunSpec::builder("getCount").body(get_body).build().unwrap())
+        .build()
+        .unwrap();
 
-    let mut fb = FileSpec::builder_with("counter.js", JavaScript::new());
-    fb.add_type(ts);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("counter.js", JavaScript::new())
+        .add_type(ts)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("javascript/class_with_methods.js", &output);
@@ -61,25 +63,27 @@ fn test_class_with_methods() {
 
 #[test]
 fn test_class_with_constructor() {
-    let mut tb = TypeSpec::<JavaScript>::builder("User", TypeKind::Class);
-    tb.visibility(Visibility::Public);
+    let ctor_body = CodeBlock::of("this.name = name;\nthis.email = email;", ()).unwrap();
 
-    tb.add_field(field("name"));
-    tb.add_field(field("email"));
+    let ts = TypeSpec::builder("User", TypeKind::Class)
+        .visibility(Visibility::Public)
+        .add_field(field("name"))
+        .add_field(field("email"))
+        .add_method(
+            FunSpec::builder("constructor")
+                .add_param(param("name"))
+                .add_param(param("email"))
+                .body(ctor_body)
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
 
-    let ctor_body =
-        CodeBlock::<JavaScript>::of("this.name = name;\nthis.email = email;", ()).unwrap();
-    let mut ctor = FunSpec::<JavaScript>::builder("constructor");
-    ctor.add_param(param("name"));
-    ctor.add_param(param("email"));
-    ctor.body(ctor_body);
-    tb.add_method(ctor.build().unwrap());
-
-    let ts = tb.build().unwrap();
-
-    let mut fb = FileSpec::builder_with("user.js", JavaScript::new());
-    fb.add_type(ts);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("user.js", JavaScript::new())
+        .add_type(ts)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("javascript/class_with_constructor.js", &output);
@@ -87,33 +91,34 @@ fn test_class_with_constructor() {
 
 #[test]
 fn test_class_extends() {
-    let animal_import = TypeName::<JavaScript>::importable("./animal", "Animal");
+    let animal_import = TypeName::importable("./animal", "Animal");
 
-    let mut tb = TypeSpec::<JavaScript>::builder("Dog", TypeKind::Class);
-    tb.visibility(Visibility::Public);
-    tb.extends(TypeName::primitive("Animal"));
+    let ctor_body = CodeBlock::of("super(name);\nthis.breed = breed;", ()).unwrap();
+    let speak_body = CodeBlock::of("return 'Woof!';", ()).unwrap();
 
-    let ctor_body = CodeBlock::<JavaScript>::of("super(name);\nthis.breed = breed;", ()).unwrap();
-    let mut ctor = FunSpec::<JavaScript>::builder("constructor");
-    ctor.add_param(param("name"));
-    ctor.add_param(param("breed"));
-    ctor.body(ctor_body);
-    tb.add_method(ctor.build().unwrap());
-
-    let speak_body = CodeBlock::<JavaScript>::of("return 'Woof!';", ()).unwrap();
-    let mut speak = FunSpec::<JavaScript>::builder("speak");
-    speak.body(speak_body);
-    tb.add_method(speak.build().unwrap());
-
-    let ts = tb.build().unwrap();
+    let ts = TypeSpec::builder("Dog", TypeKind::Class)
+        .visibility(Visibility::Public)
+        .extends(TypeName::primitive("Animal"))
+        .add_method(
+            FunSpec::builder("constructor")
+                .add_param(param("name"))
+                .add_param(param("breed"))
+                .body(ctor_body)
+                .build()
+                .unwrap(),
+        )
+        .add_method(FunSpec::builder("speak").body(speak_body).build().unwrap())
+        .build()
+        .unwrap();
 
     // Trigger import via code block.
-    let import_trigger = CodeBlock::<JavaScript>::of("// Uses %T", (animal_import,)).unwrap();
+    let import_trigger = CodeBlock::of("// Uses %T", (animal_import,)).unwrap();
 
-    let mut fb = FileSpec::builder_with("dog.js", JavaScript::new());
-    fb.add_code(import_trigger);
-    fb.add_type(ts);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("dog.js", JavaScript::new())
+        .add_code(import_trigger)
+        .add_type(ts)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("javascript/class_extends.js", &output);
@@ -121,22 +126,25 @@ fn test_class_extends() {
 
 #[test]
 fn test_static_method() {
-    let mut tb = TypeSpec::<JavaScript>::builder("MathUtils", TypeKind::Class);
-    tb.visibility(Visibility::Public);
+    let body = CodeBlock::of("return a + b;", ()).unwrap();
+    let ts = TypeSpec::builder("MathUtils", TypeKind::Class)
+        .visibility(Visibility::Public)
+        .add_method(
+            FunSpec::builder("add")
+                .is_static()
+                .add_param(param("a"))
+                .add_param(param("b"))
+                .body(body)
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
 
-    let body = CodeBlock::<JavaScript>::of("return a + b;", ()).unwrap();
-    let mut add = FunSpec::<JavaScript>::builder("add");
-    add.is_static();
-    add.add_param(param("a"));
-    add.add_param(param("b"));
-    add.body(body);
-    tb.add_method(add.build().unwrap());
-
-    let ts = tb.build().unwrap();
-
-    let mut fb = FileSpec::builder_with("math.js", JavaScript::new());
-    fb.add_type(ts);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("math.js", JavaScript::new())
+        .add_type(ts)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("javascript/static_method.js", &output);
@@ -144,28 +152,32 @@ fn test_static_method() {
 
 #[test]
 fn test_private_field() {
-    let mut tb = TypeSpec::<JavaScript>::builder("BankAccount", TypeKind::Class);
-    tb.visibility(Visibility::Public);
+    let ctor_body = CodeBlock::of("this.#balance = initialBalance;", ()).unwrap();
+    let get_body = CodeBlock::of("return this.#balance;", ()).unwrap();
 
-    // ES2022 private fields use # prefix.
-    tb.add_field(field("#balance"));
+    let ts = TypeSpec::builder("BankAccount", TypeKind::Class)
+        .visibility(Visibility::Public)
+        .add_field(field("#balance"))
+        .add_method(
+            FunSpec::builder("constructor")
+                .add_param(param("initialBalance"))
+                .body(ctor_body)
+                .build()
+                .unwrap(),
+        )
+        .add_method(
+            FunSpec::builder("getBalance")
+                .body(get_body)
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
 
-    let ctor_body = CodeBlock::<JavaScript>::of("this.#balance = initialBalance;", ()).unwrap();
-    let mut ctor = FunSpec::<JavaScript>::builder("constructor");
-    ctor.add_param(param("initialBalance"));
-    ctor.body(ctor_body);
-    tb.add_method(ctor.build().unwrap());
-
-    let get_body = CodeBlock::<JavaScript>::of("return this.#balance;", ()).unwrap();
-    let mut get = FunSpec::<JavaScript>::builder("getBalance");
-    get.body(get_body);
-    tb.add_method(get.build().unwrap());
-
-    let ts = tb.build().unwrap();
-
-    let mut fb = FileSpec::builder_with("account.js", JavaScript::new());
-    fb.add_type(ts);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("account.js", JavaScript::new())
+        .add_type(ts)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("javascript/private_field.js", &output);
@@ -175,29 +187,40 @@ fn test_private_field() {
 fn test_enum() {
     // JavaScript has no native enums. TypeKind::Enum maps to `class`,
     // producing a class with constant-like variant members.
-    let mut tb = TypeSpec::<JavaScript>::builder("Direction", TypeKind::Enum);
-    tb.visibility(Visibility::Public);
-    tb.doc("Cardinal directions.");
-
-    let mut v_up = EnumVariantSpec::<JavaScript>::builder("Up");
-    v_up.value(CodeBlock::<JavaScript>::of("'UP'", ()).unwrap());
-    tb.add_variant(v_up.build().unwrap());
-
-    let mut v_down = EnumVariantSpec::<JavaScript>::builder("Down");
-    v_down.value(CodeBlock::<JavaScript>::of("'DOWN'", ()).unwrap());
-    tb.add_variant(v_down.build().unwrap());
-
-    let mut v_left = EnumVariantSpec::<JavaScript>::builder("Left");
-    v_left.value(CodeBlock::<JavaScript>::of("'LEFT'", ()).unwrap());
-    tb.add_variant(v_left.build().unwrap());
-
-    let mut v_right = EnumVariantSpec::<JavaScript>::builder("Right");
-    v_right.value(CodeBlock::<JavaScript>::of("'RIGHT'", ()).unwrap());
-    tb.add_variant(v_right.build().unwrap());
-
-    let mut fb = FileSpec::builder_with("direction.js", JavaScript::new());
-    fb.add_type(tb.build().unwrap());
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("direction.js", JavaScript::new())
+        .add_type(
+            TypeSpec::builder("Direction", TypeKind::Enum)
+                .visibility(Visibility::Public)
+                .doc("Cardinal directions.")
+                .add_variant(
+                    EnumVariantSpec::builder("Up")
+                        .value(CodeBlock::of("'UP'", ()).unwrap())
+                        .build()
+                        .unwrap(),
+                )
+                .add_variant(
+                    EnumVariantSpec::builder("Down")
+                        .value(CodeBlock::of("'DOWN'", ()).unwrap())
+                        .build()
+                        .unwrap(),
+                )
+                .add_variant(
+                    EnumVariantSpec::builder("Left")
+                        .value(CodeBlock::of("'LEFT'", ()).unwrap())
+                        .build()
+                        .unwrap(),
+                )
+                .add_variant(
+                    EnumVariantSpec::builder("Right")
+                        .value(CodeBlock::of("'RIGHT'", ()).unwrap())
+                        .build()
+                        .unwrap(),
+                )
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("javascript/enum.js", &output);

--- a/tests/javascript/quote_basic.rs
+++ b/tests/javascript/quote_basic.rs
@@ -5,10 +5,13 @@ use sigil_stitch::spec::file_spec::FileSpec;
 
 use super::golden;
 
-fn render(block: &CodeBlock<JavaScript>) -> String {
-    let mut fb = FileSpec::builder_with("test.js", JavaScript::new());
-    fb.add_code(block.clone());
-    fb.build().unwrap().render(80).unwrap()
+fn render(block: &CodeBlock) -> String {
+    FileSpec::builder_with("test.js", JavaScript::new())
+        .add_code(block.clone())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap()
 }
 
 #[test]

--- a/tests/javascript/quote_control_flow.rs
+++ b/tests/javascript/quote_control_flow.rs
@@ -5,10 +5,13 @@ use sigil_stitch::spec::file_spec::FileSpec;
 
 use super::golden;
 
-fn render(block: &CodeBlock<JavaScript>) -> String {
-    let mut fb = FileSpec::builder_with("test.js", JavaScript::new());
-    fb.add_code(block.clone());
-    fb.build().unwrap().render(80).unwrap()
+fn render(block: &CodeBlock) -> String {
+    FileSpec::builder_with("test.js", JavaScript::new())
+        .add_code(block.clone())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap()
 }
 
 #[test]

--- a/tests/javascript/quote_imports.rs
+++ b/tests/javascript/quote_imports.rs
@@ -6,16 +6,19 @@ use sigil_stitch::type_name::TypeName;
 
 use super::golden;
 
-fn render(block: &CodeBlock<JavaScript>) -> String {
-    let mut fb = FileSpec::builder_with("test.js", JavaScript::new());
-    fb.add_code(block.clone());
-    fb.build().unwrap().render(80).unwrap()
+fn render(block: &CodeBlock) -> String {
+    FileSpec::builder_with("test.js", JavaScript::new())
+        .add_code(block.clone())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap()
 }
 
 #[test]
 fn test_imports() {
-    let fs_type = TypeName::<JavaScript>::importable("fs", "readFileSync");
-    let path_type = TypeName::<JavaScript>::importable("path", "join");
+    let fs_type = TypeName::importable("fs", "readFileSync");
+    let path_type = TypeName::importable("path", "join");
     let block = sigil_quote!(JavaScript {
         const data = $T(fs_type)($S("input.txt"));
         const full = $T(path_type)($S("dir"), $S("file"));

--- a/tests/kotlin/builder_control_flow.rs
+++ b/tests/kotlin/builder_control_flow.rs
@@ -6,7 +6,7 @@ use super::golden;
 
 #[test]
 fn test_control_flow() {
-    let mut b = CodeBlock::<Kotlin>::builder();
+    let mut b = CodeBlock::builder();
     b.begin_control_flow("if (x > 0)", ());
     b.add_statement("return 1", ());
     b.next_control_flow("else if (x < 0)", ());
@@ -16,9 +16,10 @@ fn test_control_flow() {
     b.end_control_flow();
     let block = b.build().unwrap();
 
-    let mut fb = FileSpec::builder_with("Flow.kt", Kotlin::new());
-    fb.add_code(block);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("Flow.kt", Kotlin::new())
+        .add_code(block)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("kotlin/control_flow.kt", &output);

--- a/tests/kotlin/builder_edge_cases.rs
+++ b/tests/kotlin/builder_edge_cases.rs
@@ -12,7 +12,7 @@ use super::golden;
 
 #[test]
 fn test_full_module() {
-    let user = TypeName::<Kotlin>::primitive("User");
+    let user = TypeName::primitive("User");
     let list = TypeName::generic(
         TypeName::importable("kotlin.collections", "List"),
         vec![user.clone()],
@@ -27,53 +27,66 @@ fn test_full_module() {
     );
 
     // Interface.
-    let mut iface = TypeSpec::<Kotlin>::builder("UserRepository", TypeKind::Interface);
-
-    let mut find = FunSpec::<Kotlin>::builder("findById");
-    find.returns(TypeName::primitive("User?"));
-    find.add_param(ParameterSpec::new("id", TypeName::primitive("String")).unwrap());
-    iface.add_method(find.build().unwrap());
-
-    let mut find_all = FunSpec::<Kotlin>::builder("findAll");
-    find_all.returns(list.clone());
-    iface.add_method(find_all.build().unwrap());
-
-    let iface_spec = iface.build().unwrap();
+    let iface_spec = TypeSpec::builder("UserRepository", TypeKind::Interface)
+        .add_method(
+            FunSpec::builder("findById")
+                .returns(TypeName::primitive("User?"))
+                .add_param(ParameterSpec::new("id", TypeName::primitive("String")).unwrap())
+                .build()
+                .unwrap(),
+        )
+        .add_method(
+            FunSpec::builder("findAll")
+                .returns(list.clone())
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
 
     // Implementation class.
-    let mut cls = TypeSpec::<Kotlin>::builder("InMemoryUserRepository", TypeKind::Class);
-    cls.extends(TypeName::primitive("UserRepository"));
-    cls.doc("In-memory implementation of UserRepository.");
+    let cls = TypeSpec::builder("InMemoryUserRepository", TypeKind::Class);
+    let cls = cls.extends(TypeName::primitive("UserRepository"));
+    let cls = cls.doc("In-memory implementation of UserRepository.");
 
-    let mut users_field = FieldSpec::builder("users", mutable_list);
-    users_field.visibility(Visibility::Private);
-    users_field.is_readonly();
-    cls.add_field(users_field.build().unwrap());
+    let cls = cls.add_field(
+        FieldSpec::builder("users", mutable_list)
+            .visibility(Visibility::Private)
+            .is_readonly()
+            .build()
+            .unwrap(),
+    );
 
     // findById override.
-    let find_body =
-        CodeBlock::<Kotlin>::of("return users.firstOrNull { it.id == id }", ()).unwrap();
-    let mut find_impl = FunSpec::<Kotlin>::builder("findById");
-    find_impl.returns(TypeName::primitive("User?"));
-    find_impl.add_param(ParameterSpec::new("id", TypeName::primitive("String")).unwrap());
-    find_impl.is_override();
-    find_impl.body(find_body);
-    cls.add_method(find_impl.build().unwrap());
+    let find_body = CodeBlock::of("return users.firstOrNull { it.id == id }", ()).unwrap();
+    let cls = cls.add_method(
+        FunSpec::builder("findById")
+            .returns(TypeName::primitive("User?"))
+            .add_param(ParameterSpec::new("id", TypeName::primitive("String")).unwrap())
+            .is_override()
+            .body(find_body)
+            .build()
+            .unwrap(),
+    );
 
     // findAll override.
-    let find_all_body = CodeBlock::<Kotlin>::of("return %T(users)", (array_list,)).unwrap();
-    let mut find_all_impl = FunSpec::<Kotlin>::builder("findAll");
-    find_all_impl.returns(list);
-    find_all_impl.is_override();
-    find_all_impl.body(find_all_body);
-    cls.add_method(find_all_impl.build().unwrap());
+    let find_all_body = CodeBlock::of("return %T(users)", (array_list,)).unwrap();
+    let cls = cls.add_method(
+        FunSpec::builder("findAll")
+            .returns(list)
+            .is_override()
+            .body(find_all_body)
+            .build()
+            .unwrap(),
+    );
 
     let cls_spec = cls.build().unwrap();
 
-    let mut fb = FileSpec::builder_with("UserRepo.kt", Kotlin::new());
-    fb.add_type(iface_spec);
-    fb.add_type(cls_spec);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("UserRepo.kt", Kotlin::new())
+        .add_type(iface_spec)
+        .add_type(cls_spec)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("kotlin/full_module.kt", &output);
@@ -81,7 +94,7 @@ fn test_full_module() {
 
 #[test]
 fn test_string_dollar_escape() {
-    let body = CodeBlock::<Kotlin>::of(
+    let body = CodeBlock::of(
         "val greeting = %S\nval template = %S\nprintln(greeting)",
         (
             StringLitArg("Hello ${name}!".into()),
@@ -89,14 +102,16 @@ fn test_string_dollar_escape() {
         ),
     )
     .unwrap();
-    let mut fb = FunSpec::<Kotlin>::builder("greet");
-    fb.add_param(ParameterSpec::new("name", TypeName::primitive("String")).unwrap());
-    fb.body(body);
-    let fun = fb.build().unwrap();
+    let fun = FunSpec::builder("greet")
+        .add_param(ParameterSpec::new("name", TypeName::primitive("String")).unwrap())
+        .body(body)
+        .build()
+        .unwrap();
 
-    let mut file_b = FileSpec::builder_with("greet.kt", Kotlin::new());
-    file_b.add_function(fun);
-    let file = file_b.build().unwrap();
+    let file = FileSpec::builder_with("greet.kt", Kotlin::new())
+        .add_function(fun)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("kotlin/string_dollar_escape.kt", &output);

--- a/tests/kotlin/builder_functions.rs
+++ b/tests/kotlin/builder_functions.rs
@@ -10,19 +10,21 @@ use super::golden;
 
 #[test]
 fn test_suspend_function() {
-    let user = TypeName::<Kotlin>::importable("com.example.model", "User");
+    let user = TypeName::importable("com.example.model", "User");
 
-    let body = CodeBlock::<Kotlin>::of("return api.fetchUser(id)", ()).unwrap();
-    let mut fb_fun = FunSpec::<Kotlin>::builder("fetchUser");
-    fb_fun.is_async();
-    fb_fun.returns(user);
-    fb_fun.add_param(ParameterSpec::new("id", TypeName::primitive("String")).unwrap());
-    fb_fun.body(body);
-    let fun = fb_fun.build().unwrap();
+    let body = CodeBlock::of("return api.fetchUser(id)", ()).unwrap();
+    let fun = FunSpec::builder("fetchUser")
+        .is_async()
+        .returns(user)
+        .add_param(ParameterSpec::new("id", TypeName::primitive("String")).unwrap())
+        .body(body)
+        .build()
+        .unwrap();
 
-    let mut fb = FileSpec::builder_with("Api.kt", Kotlin::new());
-    fb.add_function(fun);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("Api.kt", Kotlin::new())
+        .add_function(fun)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("kotlin/suspend_function.kt", &output);
@@ -30,18 +32,20 @@ fn test_suspend_function() {
 
 #[test]
 fn test_function_with_doc() {
-    let body = CodeBlock::<Kotlin>::of("return \"Hello, $name!\"", ()).unwrap();
-    let mut fb = FunSpec::<Kotlin>::builder("greet");
-    fb.visibility(Visibility::Public);
-    fb.doc("Greet the user by name.");
-    fb.add_param(ParameterSpec::new("name", TypeName::primitive("String")).unwrap());
-    fb.returns(TypeName::primitive("String"));
-    fb.body(body);
-    let fun = fb.build().unwrap();
+    let body = CodeBlock::of("return \"Hello, $name!\"", ()).unwrap();
+    let fun = FunSpec::builder("greet")
+        .visibility(Visibility::Public)
+        .doc("Greet the user by name.")
+        .add_param(ParameterSpec::new("name", TypeName::primitive("String")).unwrap())
+        .returns(TypeName::primitive("String"))
+        .body(body)
+        .build()
+        .unwrap();
 
-    let mut file_b = FileSpec::<Kotlin>::builder("greet.kt");
-    file_b.add_function(fun);
-    let file = file_b.build().unwrap();
+    let file = FileSpec::builder("greet.kt")
+        .add_function(fun)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("kotlin/function_with_doc.kt", &output);

--- a/tests/kotlin/builder_imports.rs
+++ b/tests/kotlin/builder_imports.rs
@@ -7,16 +7,17 @@ use super::golden;
 
 #[test]
 fn test_function_with_imports() {
-    let list = TypeName::<Kotlin>::importable("kotlin.collections", "List");
-    let user = TypeName::<Kotlin>::importable("com.example.model", "User");
+    let list = TypeName::importable("kotlin.collections", "List");
+    let user = TypeName::importable("com.example.model", "User");
 
-    let mut b = CodeBlock::<Kotlin>::builder();
+    let mut b = CodeBlock::builder();
     b.add_statement("val users: %T<%T> = getAll()", (list, user));
     let block = b.build().unwrap();
 
-    let mut fb = FileSpec::builder_with("App.kt", Kotlin::new());
-    fb.add_code(block);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("App.kt", Kotlin::new())
+        .add_code(block)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("kotlin/function_with_imports.kt", &output);
@@ -24,14 +25,14 @@ fn test_function_with_imports() {
 
 #[test]
 fn test_import_grouping() {
-    let list = TypeName::<Kotlin>::importable("kotlin.collections", "List");
-    let scope = TypeName::<Kotlin>::importable("kotlinx.coroutines", "CoroutineScope");
-    let uuid = TypeName::<Kotlin>::importable("java.util", "UUID");
-    let inject = TypeName::<Kotlin>::importable("javax.inject", "Inject");
-    let user = TypeName::<Kotlin>::importable("com.example.model", "User");
-    let helper = TypeName::<Kotlin>::importable("io.ktor.server", "Application");
+    let list = TypeName::importable("kotlin.collections", "List");
+    let scope = TypeName::importable("kotlinx.coroutines", "CoroutineScope");
+    let uuid = TypeName::importable("java.util", "UUID");
+    let inject = TypeName::importable("javax.inject", "Inject");
+    let user = TypeName::importable("com.example.model", "User");
+    let helper = TypeName::importable("io.ktor.server", "Application");
 
-    let mut b = CodeBlock::<Kotlin>::builder();
+    let mut b = CodeBlock::builder();
     b.add(
         "// %T %T %T %T %T %T",
         (list, scope, uuid, inject, user, helper),
@@ -39,9 +40,10 @@ fn test_import_grouping() {
     b.add_line();
     let block = b.build().unwrap();
 
-    let mut fb = FileSpec::builder_with("Imports.kt", Kotlin::new());
-    fb.add_code(block);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("Imports.kt", Kotlin::new())
+        .add_code(block)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("kotlin/import_grouping.kt", &output);

--- a/tests/kotlin/builder_types.rs
+++ b/tests/kotlin/builder_types.rs
@@ -13,33 +13,39 @@ use super::golden;
 
 #[test]
 fn test_class_with_properties() {
-    let mut tb = TypeSpec::<Kotlin>::builder("UserService", TypeKind::Class);
-    tb.visibility(Visibility::Public);
-    tb.doc("Service for managing users.");
+    let find_body = CodeBlock::of("return repo.findById(id)", ()).unwrap();
 
-    // Properties.
-    let mut repo_field = FieldSpec::builder("repo", TypeName::primitive("UserRepository"));
-    repo_field.visibility(Visibility::Private);
-    tb.add_field(repo_field.build().unwrap());
+    let ts = TypeSpec::builder("UserService", TypeKind::Class)
+        .visibility(Visibility::Public)
+        .doc("Service for managing users.")
+        .add_field(
+            FieldSpec::builder("repo", TypeName::primitive("UserRepository"))
+                .visibility(Visibility::Private)
+                .build()
+                .unwrap(),
+        )
+        .add_field(
+            FieldSpec::builder("logger", TypeName::primitive("Logger"))
+                .visibility(Visibility::Private)
+                .is_readonly()
+                .build()
+                .unwrap(),
+        )
+        .add_method(
+            FunSpec::builder("findUser")
+                .returns(TypeName::primitive("User"))
+                .add_param(ParameterSpec::new("id", TypeName::primitive("String")).unwrap())
+                .body(find_body)
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
 
-    let mut logger_field = FieldSpec::builder("logger", TypeName::primitive("Logger"));
-    logger_field.visibility(Visibility::Private);
-    logger_field.is_readonly();
-    tb.add_field(logger_field.build().unwrap());
-
-    // Method.
-    let find_body = CodeBlock::<Kotlin>::of("return repo.findById(id)", ()).unwrap();
-    let mut find = FunSpec::<Kotlin>::builder("findUser");
-    find.returns(TypeName::primitive("User"));
-    find.add_param(ParameterSpec::new("id", TypeName::primitive("String")).unwrap());
-    find.body(find_body);
-    tb.add_method(find.build().unwrap());
-
-    let ts = tb.build().unwrap();
-
-    let mut fb = FileSpec::builder_with("UserService.kt", Kotlin::new());
-    fb.add_type(ts);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("UserService.kt", Kotlin::new())
+        .add_type(ts)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("kotlin/class_with_properties.kt", &output);
@@ -47,25 +53,25 @@ fn test_class_with_properties() {
 
 #[test]
 fn test_data_class() {
-    let mut tb = TypeSpec::<Kotlin>::builder("User", TypeKind::Struct);
-    tb.visibility(Visibility::Public);
-    tb.doc("A user data class.");
+    let ts = TypeSpec::builder("User", TypeKind::Struct)
+        .visibility(Visibility::Public)
+        .doc("A user data class.")
+        .add_primary_constructor_param(
+            ParameterSpec::new("name", TypeName::primitive("String")).unwrap(),
+        )
+        .add_primary_constructor_param(
+            ParameterSpec::new("age", TypeName::primitive("Int")).unwrap(),
+        )
+        .add_primary_constructor_param(
+            ParameterSpec::new("email", TypeName::primitive("String")).unwrap(),
+        )
+        .build()
+        .unwrap();
 
-    tb.add_primary_constructor_param(
-        ParameterSpec::new("name", TypeName::primitive("String")).unwrap(),
-    );
-    tb.add_primary_constructor_param(
-        ParameterSpec::new("age", TypeName::primitive("Int")).unwrap(),
-    );
-    tb.add_primary_constructor_param(
-        ParameterSpec::new("email", TypeName::primitive("String")).unwrap(),
-    );
-
-    let ts = tb.build().unwrap();
-
-    let mut fb = FileSpec::builder_with("User.kt", Kotlin::new());
-    fb.add_type(ts);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("User.kt", Kotlin::new())
+        .add_type(ts)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("kotlin/data_class.kt", &output);
@@ -73,31 +79,37 @@ fn test_data_class() {
 
 #[test]
 fn test_interface() {
-    let tp = TypeParamSpec::<Kotlin>::new("T");
+    let tp = TypeParamSpec::new("T");
 
-    let mut tb = TypeSpec::<Kotlin>::builder("Repository", TypeKind::Interface);
-    tb.add_type_param(tp);
-    tb.doc("Generic data repository.");
+    let ts = TypeSpec::builder("Repository", TypeKind::Interface)
+        .add_type_param(tp)
+        .doc("Generic data repository.")
+        .add_method(
+            FunSpec::builder("findById")
+                .returns(TypeName::primitive("T?"))
+                .add_param(ParameterSpec::new("id", TypeName::primitive("String")).unwrap())
+                .build()
+                .unwrap(),
+        )
+        .add_method(
+            FunSpec::builder("save")
+                .add_param(ParameterSpec::new("entity", TypeName::primitive("T")).unwrap())
+                .build()
+                .unwrap(),
+        )
+        .add_method(
+            FunSpec::builder("delete")
+                .add_param(ParameterSpec::new("id", TypeName::primitive("String")).unwrap())
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
 
-    // Abstract methods (no body).
-    let mut find = FunSpec::<Kotlin>::builder("findById");
-    find.returns(TypeName::primitive("T?"));
-    find.add_param(ParameterSpec::new("id", TypeName::primitive("String")).unwrap());
-    tb.add_method(find.build().unwrap());
-
-    let mut save = FunSpec::<Kotlin>::builder("save");
-    save.add_param(ParameterSpec::new("entity", TypeName::primitive("T")).unwrap());
-    tb.add_method(save.build().unwrap());
-
-    let mut delete = FunSpec::<Kotlin>::builder("delete");
-    delete.add_param(ParameterSpec::new("id", TypeName::primitive("String")).unwrap());
-    tb.add_method(delete.build().unwrap());
-
-    let ts = tb.build().unwrap();
-
-    let mut fb = FileSpec::builder_with("Repository.kt", Kotlin::new());
-    fb.add_type(ts);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("Repository.kt", Kotlin::new())
+        .add_type(ts)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("kotlin/interface.kt", &output);
@@ -105,29 +117,32 @@ fn test_interface() {
 
 #[test]
 fn test_abstract_class() {
-    let mut tb = TypeSpec::<Kotlin>::builder("Shape", TypeKind::Class);
-    tb.doc("Abstract shape.");
-    tb.is_abstract();
+    let desc_body = CodeBlock::of("return this::class.simpleName ?: \"Shape\"", ()).unwrap();
 
-    // Concrete method.
-    let desc_body =
-        CodeBlock::<Kotlin>::of("return this::class.simpleName ?: \"Shape\"", ()).unwrap();
-    let mut desc = FunSpec::<Kotlin>::builder("describe");
-    desc.returns(TypeName::primitive("String"));
-    desc.body(desc_body);
-    tb.add_method(desc.build().unwrap());
+    let ts = TypeSpec::builder("Shape", TypeKind::Class)
+        .doc("Abstract shape.")
+        .is_abstract()
+        .add_method(
+            FunSpec::builder("describe")
+                .returns(TypeName::primitive("String"))
+                .body(desc_body)
+                .build()
+                .unwrap(),
+        )
+        .add_method(
+            FunSpec::builder("area")
+                .is_abstract()
+                .returns(TypeName::primitive("Double"))
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
 
-    // Abstract method.
-    let mut area = FunSpec::<Kotlin>::builder("area");
-    area.is_abstract();
-    area.returns(TypeName::primitive("Double"));
-    tb.add_method(area.build().unwrap());
-
-    let ts = tb.build().unwrap();
-
-    let mut fb = FileSpec::builder_with("Shape.kt", Kotlin::new());
-    fb.add_type(ts);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("Shape.kt", Kotlin::new())
+        .add_type(ts)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("kotlin/abstract_class.kt", &output);
@@ -135,28 +150,30 @@ fn test_abstract_class() {
 
 #[test]
 fn test_class_extends_implements() {
-    let base = TypeName::<Kotlin>::importable("com.example.base", "BaseService");
-    let auth = TypeName::<Kotlin>::importable("com.example.auth", "Authenticatable");
-    let serial = TypeName::<Kotlin>::importable("com.example.serial", "Serializable");
+    let base = TypeName::importable("com.example.base", "BaseService");
+    let auth = TypeName::importable("com.example.auth", "Authenticatable");
+    let serial = TypeName::importable("com.example.serial", "Serializable");
 
+    let body = CodeBlock::of("return true", ()).unwrap();
     // Kotlin uses `:` for both extends and implements.
-    // Put everything in super_types.
-    let mut tb = TypeSpec::<Kotlin>::builder("AdminService", TypeKind::Class);
-    tb.extends(base);
-    tb.extends(auth);
-    tb.extends(serial);
+    let ts = TypeSpec::builder("AdminService", TypeKind::Class)
+        .extends(base)
+        .extends(auth)
+        .extends(serial)
+        .add_method(
+            FunSpec::builder("isAdmin")
+                .returns(TypeName::primitive("Boolean"))
+                .body(body)
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
 
-    let body = CodeBlock::<Kotlin>::of("return true", ()).unwrap();
-    let mut is_admin = FunSpec::<Kotlin>::builder("isAdmin");
-    is_admin.returns(TypeName::primitive("Boolean"));
-    is_admin.body(body);
-    tb.add_method(is_admin.build().unwrap());
-
-    let ts = tb.build().unwrap();
-
-    let mut fb = FileSpec::builder_with("AdminService.kt", Kotlin::new());
-    fb.add_type(ts);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("AdminService.kt", Kotlin::new())
+        .add_type(ts)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("kotlin/class_extends_implements.kt", &output);
@@ -164,18 +181,18 @@ fn test_class_extends_implements() {
 
 #[test]
 fn test_enum_class() {
-    let mut tb = TypeSpec::<Kotlin>::builder("Color", TypeKind::Enum);
-    tb.doc("Supported colors.");
+    let ts = TypeSpec::builder("Color", TypeKind::Enum)
+        .doc("Supported colors.")
+        .add_variant(EnumVariantSpec::new("RED").unwrap())
+        .add_variant(EnumVariantSpec::new("GREEN").unwrap())
+        .add_variant(EnumVariantSpec::new("BLUE").unwrap())
+        .build()
+        .unwrap();
 
-    tb.add_variant(EnumVariantSpec::new("RED").unwrap());
-    tb.add_variant(EnumVariantSpec::new("GREEN").unwrap());
-    tb.add_variant(EnumVariantSpec::new("BLUE").unwrap());
-
-    let ts = tb.build().unwrap();
-
-    let mut fb = FileSpec::builder_with("Color.kt", Kotlin::new());
-    fb.add_type(ts);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("Color.kt", Kotlin::new())
+        .add_type(ts)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("kotlin/enum_class.kt", &output);
@@ -183,25 +200,29 @@ fn test_enum_class() {
 
 #[test]
 fn test_override_method() {
-    let mut tb = TypeSpec::<Kotlin>::builder("Dog", TypeKind::Class);
-    tb.extends(TypeName::primitive("Animal"));
-
-    let body = CodeBlock::<Kotlin>::of(
+    let body = CodeBlock::of(
         "return %S",
         (sigil_stitch::code_block::StringLitArg("Woof!".to_string()),),
     )
     .unwrap();
-    let mut speak = FunSpec::<Kotlin>::builder("speak");
-    speak.returns(TypeName::primitive("String"));
-    speak.is_override();
-    speak.body(body);
-    tb.add_method(speak.build().unwrap());
 
-    let ts = tb.build().unwrap();
+    let ts = TypeSpec::builder("Dog", TypeKind::Class)
+        .extends(TypeName::primitive("Animal"))
+        .add_method(
+            FunSpec::builder("speak")
+                .returns(TypeName::primitive("String"))
+                .is_override()
+                .body(body)
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
 
-    let mut fb = FileSpec::builder_with("Dog.kt", Kotlin::new());
-    fb.add_type(ts);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("Dog.kt", Kotlin::new())
+        .add_type(ts)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("kotlin/override_method.kt", &output);

--- a/tests/kotlin/quote_basic.rs
+++ b/tests/kotlin/quote_basic.rs
@@ -1,14 +1,16 @@
 use sigil_stitch::code_block::CodeBlock;
-use sigil_stitch::lang::kotlin::Kotlin;
 use sigil_stitch::prelude::*;
 use sigil_stitch::spec::file_spec::FileSpec;
 
 use super::golden;
 
-fn render(block: &CodeBlock<Kotlin>) -> String {
-    let mut fb = FileSpec::<Kotlin>::builder("test.kt");
-    fb.add_code(block.clone());
-    fb.build().unwrap().render(80).unwrap()
+fn render(block: &CodeBlock) -> String {
+    FileSpec::builder("test.kt")
+        .add_code(block.clone())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap()
 }
 
 #[test]

--- a/tests/kotlin/quote_control_flow.rs
+++ b/tests/kotlin/quote_control_flow.rs
@@ -1,14 +1,16 @@
 use sigil_stitch::code_block::CodeBlock;
-use sigil_stitch::lang::kotlin::Kotlin;
 use sigil_stitch::prelude::*;
 use sigil_stitch::spec::file_spec::FileSpec;
 
 use super::golden;
 
-fn render(block: &CodeBlock<Kotlin>) -> String {
-    let mut fb = FileSpec::<Kotlin>::builder("test.kt");
-    fb.add_code(block.clone());
-    fb.build().unwrap().render(80).unwrap()
+fn render(block: &CodeBlock) -> String {
+    FileSpec::builder("test.kt")
+        .add_code(block.clone())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap()
 }
 
 #[test]

--- a/tests/kotlin/quote_imports.rs
+++ b/tests/kotlin/quote_imports.rs
@@ -1,20 +1,22 @@
 use sigil_stitch::code_block::CodeBlock;
-use sigil_stitch::lang::kotlin::Kotlin;
 use sigil_stitch::prelude::*;
 use sigil_stitch::spec::file_spec::FileSpec;
 use sigil_stitch::type_name::TypeName;
 
 use super::golden;
 
-fn render(block: &CodeBlock<Kotlin>) -> String {
-    let mut fb = FileSpec::<Kotlin>::builder("test.kt");
-    fb.add_code(block.clone());
-    fb.build().unwrap().render(80).unwrap()
+fn render(block: &CodeBlock) -> String {
+    FileSpec::builder("test.kt")
+        .add_code(block.clone())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap()
 }
 
 #[test]
 fn test_imports() {
-    let list_of = TypeName::<Kotlin>::importable("kotlin.collections", "listOf");
+    let list_of = TypeName::importable("kotlin.collections", "listOf");
     let block = sigil_quote!(Kotlin {
         val items = $T(list_of)(1, 2, 3);
     })

--- a/tests/macro_tests.rs
+++ b/tests/macro_tests.rs
@@ -2,12 +2,8 @@
 
 use sigil_stitch::code_block::{CodeBlock, NameArg, StringLitArg};
 use sigil_stitch::import_collector;
-use sigil_stitch::lang::go_lang::GoLang;
 use sigil_stitch::lang::haskell::Haskell;
 use sigil_stitch::lang::ocaml::OCaml;
-use sigil_stitch::lang::python::Python;
-use sigil_stitch::lang::rust_lang::RustLang;
-use sigil_stitch::lang::typescript::TypeScript;
 use sigil_stitch::prelude::*;
 use sigil_stitch::spec::file_spec::FileSpec;
 use sigil_stitch::type_name::TypeName;
@@ -54,7 +50,7 @@ fn test_empty_body() {
 
 #[test]
 fn test_type_interpolation_import_tracking() {
-    let user_type = TypeName::<TypeScript>::importable_type("./models", "User");
+    let user_type = TypeName::importable_type("./models", "User");
     let block = sigil_quote!(TypeScript {
         const user: $T(user_type) = getUser();
     })
@@ -67,7 +63,7 @@ fn test_type_interpolation_import_tracking() {
 
 #[test]
 fn test_type_interpolation_renders() {
-    let user_type = TypeName::<TypeScript>::importable_type("./models", "User");
+    let user_type = TypeName::importable_type("./models", "User");
     let block = sigil_quote!(TypeScript {
         const user: $T(user_type) = getUser();
     })
@@ -120,7 +116,7 @@ fn test_literal_interpolation() {
 
 #[test]
 fn test_code_block_interpolation() {
-    let inner = CodeBlock::<TypeScript>::of("doSomething()", ()).unwrap();
+    let inner = CodeBlock::of("doSomething()", ()).unwrap();
     let block = sigil_quote!(TypeScript {
         $C(inner);
     })
@@ -132,8 +128,8 @@ fn test_code_block_interpolation() {
 
 #[test]
 fn test_multiple_interpolations_in_one_statement() {
-    let t1 = TypeName::<TypeScript>::primitive("string");
-    let t2 = TypeName::<TypeScript>::primitive("number");
+    let t1 = TypeName::primitive("string");
+    let t2 = TypeName::primitive("number");
     let block = sigil_quote!(TypeScript {
         const x: $T(t1) = $L("getVal") as $T(t2);
     })
@@ -147,7 +143,7 @@ fn test_multiple_interpolations_in_one_statement() {
 
 #[test]
 fn test_mixed_arg_types_in_one_statement() {
-    let ty = TypeName::<TypeScript>::primitive("User");
+    let ty = TypeName::primitive("User");
     let block = sigil_quote!(TypeScript {
         const $N("x"): $T(ty) = $S("hello") + $L("42");
     })
@@ -286,7 +282,7 @@ fn test_interpolation_in_condition() {
 
 #[test]
 fn test_control_flow_with_type_and_string_interpolation() {
-    let error_type = TypeName::<TypeScript>::importable("./errors", "NotFoundError");
+    let error_type = TypeName::importable("./errors", "NotFoundError");
     let block = sigil_quote!(TypeScript {
         if(!user) {
             throw new $T(error_type)($S("not found"));
@@ -620,7 +616,7 @@ fn test_dollar_escape_with_interpolation() {
 
 #[test]
 fn test_wrap_point_in_params() {
-    let config_type = TypeName::<TypeScript>::primitive("Config");
+    let config_type = TypeName::primitive("Config");
     let block = sigil_quote!(TypeScript {
         export async function createUser($W name: string,$W age: number,$W config: $T(config_type) $W): Promise<void> {
             return undefined;
@@ -641,9 +637,10 @@ fn test_wrap_point_narrow_width() {
     .unwrap();
 
     // Render at narrow width to force line breaks.
-    let mut fb = FileSpec::<TypeScript>::builder("test.ts");
-    fb.add_code(block);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder("test.ts")
+        .add_code(block)
+        .build()
+        .unwrap();
     let output = file.render(20).unwrap();
     // With narrow width, %W should break lines.
     assert!(output.contains("doSomething"), "got: {output}");
@@ -667,7 +664,7 @@ fn test_rust_language() {
 #[test]
 fn test_python_control_flow() {
     // Python uses `:` instead of `{` for blocks, rendered by CodeLang.
-    let mut b = CodeBlock::<Python>::builder();
+    let mut b = CodeBlock::builder();
     b.begin_control_flow("if x > 0", ());
     b.add_statement("return True", ());
     b.end_control_flow();
@@ -709,9 +706,9 @@ fn test_go_language() {
 
 #[test]
 fn test_equiv_simple_statement() {
-    let user_type = TypeName::<TypeScript>::importable_type("./models", "User");
+    let user_type = TypeName::importable_type("./models", "User");
 
-    let mut b = CodeBlock::<TypeScript>::builder();
+    let mut b = CodeBlock::builder();
     b.add_statement("const user: %T = getUser()", (user_type.clone(),));
     b.add_statement("return user", ());
     let manual = b.build().unwrap();
@@ -731,7 +728,7 @@ fn test_equiv_simple_statement() {
 
 #[test]
 fn test_equiv_control_flow() {
-    let mut b = CodeBlock::<TypeScript>::builder();
+    let mut b = CodeBlock::builder();
     b.begin_control_flow("if(x > 0)", ());
     b.add_statement("return true", ());
     b.next_control_flow("else", ());
@@ -758,7 +755,7 @@ fn test_equiv_control_flow() {
 
 #[test]
 fn test_equiv_comment() {
-    let mut b = CodeBlock::<TypeScript>::builder();
+    let mut b = CodeBlock::builder();
     b.add_comment("hello");
     b.add_statement("const x = 1", ());
     let manual = b.build().unwrap();
@@ -779,7 +776,7 @@ fn test_equiv_comment() {
 
 #[test]
 fn test_equiv_blank_line() {
-    let mut b = CodeBlock::<TypeScript>::builder();
+    let mut b = CodeBlock::builder();
     b.add_statement("const a = 1", ());
     b.add_line();
     b.add_statement("const b = 2", ());
@@ -802,7 +799,7 @@ fn test_equiv_blank_line() {
 
 #[test]
 fn test_equiv_name_arg() {
-    let mut b = CodeBlock::<TypeScript>::builder();
+    let mut b = CodeBlock::builder();
     b.add_statement("const %N = 1", (NameArg("x".to_string()),));
     let manual = b.build().unwrap();
 
@@ -821,7 +818,7 @@ fn test_equiv_name_arg() {
 
 #[test]
 fn test_equiv_string_lit_arg() {
-    let mut b = CodeBlock::<TypeScript>::builder();
+    let mut b = CodeBlock::builder();
     b.add_statement("console.log(%S)", (StringLitArg("hi".to_string()),));
     let manual = b.build().unwrap();
 
@@ -840,9 +837,9 @@ fn test_equiv_string_lit_arg() {
 
 #[test]
 fn test_equiv_nested_code_block() {
-    let inner = CodeBlock::<TypeScript>::of("doWork()", ()).unwrap();
+    let inner = CodeBlock::of("doWork()", ()).unwrap();
 
-    let mut b = CodeBlock::<TypeScript>::builder();
+    let mut b = CodeBlock::builder();
     b.add_statement("%L", (inner.clone(),));
     let manual = b.build().unwrap();
 
@@ -892,7 +889,7 @@ fn test_zero_args_statement() {
 
 #[test]
 fn test_single_arg_statement() {
-    let ty = TypeName::<TypeScript>::primitive("number");
+    let ty = TypeName::primitive("number");
     let block = sigil_quote!(TypeScript {
         const x: $T(ty) = 1;
     })
@@ -904,9 +901,9 @@ fn test_single_arg_statement() {
 
 #[test]
 fn test_many_args_statement() {
-    let t1 = TypeName::<TypeScript>::primitive("string");
-    let t2 = TypeName::<TypeScript>::primitive("number");
-    let t3 = TypeName::<TypeScript>::primitive("boolean");
+    let t1 = TypeName::primitive("string");
+    let t2 = TypeName::primitive("number");
+    let t3 = TypeName::primitive("boolean");
     let block = sigil_quote!(TypeScript {
         function f(a: $T(t1), b: $T(t2), c: $T(t3)): void {};
     })
@@ -924,7 +921,7 @@ fn test_many_args_statement() {
 
 #[test]
 fn test_class_like_structure() {
-    let user_type = TypeName::<TypeScript>::importable_type("./models", "User");
+    let user_type = TypeName::importable_type("./models", "User");
     let block = sigil_quote!(TypeScript {
         export class UserService {
             getUser(id: $T(user_type)): void {
@@ -1024,9 +1021,9 @@ fn test_control_flow_then_statement() {
 
 #[test]
 fn test_many_types_with_imports() {
-    let t1 = TypeName::<TypeScript>::importable_type("./a", "TypeA");
-    let t2 = TypeName::<TypeScript>::importable_type("./b", "TypeB");
-    let t3 = TypeName::<TypeScript>::importable_type("./c", "TypeC");
+    let t1 = TypeName::importable_type("./a", "TypeA");
+    let t2 = TypeName::importable_type("./b", "TypeB");
+    let t3 = TypeName::importable_type("./c", "TypeC");
 
     let block = sigil_quote!(TypeScript {
         const a: $T(t1) = getA();
@@ -1048,7 +1045,7 @@ fn test_many_types_with_imports() {
 fn test_complex_expression_interpolation() {
     // Expression in $T() can be a method call.
     let block = sigil_quote!(TypeScript {
-        const x: $T(TypeName::<TypeScript>::primitive("string")) = $S("hello");
+        const x: $T(TypeName::primitive("string")) = $S("hello");
     })
     .unwrap();
 
@@ -1061,45 +1058,51 @@ fn test_complex_expression_interpolation() {
 // Helpers
 // ════════════════════════════════════════════════════════
 
-fn render_ts(block: &CodeBlock<TypeScript>) -> String {
-    let mut fb = FileSpec::<TypeScript>::builder("test.ts");
-    fb.add_code(block.clone());
-    let file = fb.build().unwrap();
+fn render_ts(block: &CodeBlock) -> String {
+    let file = FileSpec::builder("test.ts")
+        .add_code(block.clone())
+        .build()
+        .unwrap();
     file.render(80).unwrap()
 }
 
-fn render_rs(block: &CodeBlock<RustLang>) -> String {
-    let mut fb = FileSpec::<RustLang>::builder("test.rs");
-    fb.add_code(block.clone());
-    let file = fb.build().unwrap();
+fn render_rs(block: &CodeBlock) -> String {
+    let file = FileSpec::builder("test.rs")
+        .add_code(block.clone())
+        .build()
+        .unwrap();
     file.render(80).unwrap()
 }
 
-fn render_py(block: &CodeBlock<Python>) -> String {
-    let mut fb = FileSpec::<Python>::builder("test.py");
-    fb.add_code(block.clone());
-    let file = fb.build().unwrap();
+fn render_py(block: &CodeBlock) -> String {
+    let file = FileSpec::builder("test.py")
+        .add_code(block.clone())
+        .build()
+        .unwrap();
     file.render(80).unwrap()
 }
 
-fn render_go(block: &CodeBlock<GoLang>) -> String {
-    let mut fb = FileSpec::<GoLang>::builder("test.go");
-    fb.add_code(block.clone());
-    let file = fb.build().unwrap();
+fn render_go(block: &CodeBlock) -> String {
+    let file = FileSpec::builder("test.go")
+        .add_code(block.clone())
+        .build()
+        .unwrap();
     file.render(80).unwrap()
 }
 
-fn render_hs(block: &CodeBlock<Haskell>) -> String {
-    let mut fb = FileSpec::builder_with("test.hs", Haskell::new());
-    fb.add_code(block.clone());
-    let file = fb.build().unwrap();
+fn render_hs(block: &CodeBlock) -> String {
+    let file = FileSpec::builder_with("test.hs", Haskell::new())
+        .add_code(block.clone())
+        .build()
+        .unwrap();
     file.render(80).unwrap()
 }
 
-fn render_ml(block: &CodeBlock<OCaml>) -> String {
-    let mut fb = FileSpec::builder_with("test.ml", OCaml::new());
-    fb.add_code(block.clone());
-    let file = fb.build().unwrap();
+fn render_ml(block: &CodeBlock) -> String {
+    let file = FileSpec::builder_with("test.ml", OCaml::new())
+        .add_code(block.clone())
+        .build()
+        .unwrap();
     file.render(80).unwrap()
 }
 
@@ -1273,8 +1276,8 @@ fn test_ocaml_let_binding() {
 
 #[test]
 fn test_nested_code_block_import_propagation() {
-    let user_type = TypeName::<TypeScript>::importable_type("./models", "User");
-    let inner = CodeBlock::<TypeScript>::of("getUser(): %T", (user_type,)).unwrap();
+    let user_type = TypeName::importable_type("./models", "User");
+    let inner = CodeBlock::of("getUser(): %T", (user_type,)).unwrap();
 
     let block = sigil_quote!(TypeScript {
         $C(inner);

--- a/tests/ocaml/builder_control_flow.rs
+++ b/tests/ocaml/builder_control_flow.rs
@@ -6,15 +6,16 @@ use super::golden;
 
 #[test]
 fn test_let_binding() {
-    let mut b = CodeBlock::<OCaml>::builder();
+    let mut b = CodeBlock::builder();
     b.begin_control_flow("let add x y", ());
     b.add_statement("x + y", ());
     b.end_control_flow();
     let block = b.build().unwrap();
 
-    let mut fb = FileSpec::builder_with("add.ml", OCaml::new());
-    fb.add_code(block);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("add.ml", OCaml::new())
+        .add_code(block)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("ocaml/let_binding.ml", &output);
@@ -22,7 +23,7 @@ fn test_let_binding() {
 
 #[test]
 fn test_pattern_match() {
-    let mut b = CodeBlock::<OCaml>::builder();
+    let mut b = CodeBlock::builder();
     b.begin_control_flow("let describe color", ());
     b.begin_control_flow_with_open("match color with", (), "");
     b.add("| Red -> \"red\"", ());
@@ -35,9 +36,10 @@ fn test_pattern_match() {
     b.end_control_flow();
     let block = b.build().unwrap();
 
-    let mut fb = FileSpec::builder_with("match.ml", OCaml::new());
-    fb.add_code(block);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("match.ml", OCaml::new())
+        .add_code(block)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("ocaml/pattern_match.ml", &output);

--- a/tests/ocaml/builder_edge_cases.rs
+++ b/tests/ocaml/builder_edge_cases.rs
@@ -7,13 +7,14 @@ use super::golden;
 
 #[test]
 fn test_comment_closes() {
-    let mut b = CodeBlock::<OCaml>::builder();
+    let mut b = CodeBlock::builder();
     b.add_comment("this is a comment");
     let block = b.build().unwrap();
 
-    let mut fb = FileSpec::builder_with("comment.ml", OCaml::new());
-    fb.add_code(block);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("comment.ml", OCaml::new())
+        .add_code(block)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("ocaml/comment.ml", &output);

--- a/tests/ocaml/builder_functions.rs
+++ b/tests/ocaml/builder_functions.rs
@@ -9,17 +9,19 @@ use super::golden;
 
 #[test]
 fn test_function_with_params() {
-    let body = CodeBlock::<OCaml>::of("List.map f xs", ()).unwrap();
-    let mut fb_fun = FunSpec::<OCaml>::builder("transform");
-    fb_fun.returns(TypeName::primitive("'b list"));
-    fb_fun.add_param(ParameterSpec::new("f", TypeName::primitive("'a -> 'b")).unwrap());
-    fb_fun.add_param(ParameterSpec::new("xs", TypeName::primitive("'a list")).unwrap());
-    fb_fun.body(body);
-    let fun = fb_fun.build().unwrap();
+    let body = CodeBlock::of("List.map f xs", ()).unwrap();
+    let fun = FunSpec::builder("transform")
+        .returns(TypeName::primitive("'b list"))
+        .add_param(ParameterSpec::new("f", TypeName::primitive("'a -> 'b")).unwrap())
+        .add_param(ParameterSpec::new("xs", TypeName::primitive("'a list")).unwrap())
+        .body(body)
+        .build()
+        .unwrap();
 
-    let mut fb = FileSpec::builder_with("transform.ml", OCaml::new());
-    fb.add_function(fun);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("transform.ml", OCaml::new())
+        .add_function(fun)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("ocaml/function_with_params.ml", &output);
@@ -27,18 +29,20 @@ fn test_function_with_params() {
 
 #[test]
 fn test_function_with_doc() {
-    let body = CodeBlock::<OCaml>::of("List.map f xs", ()).unwrap();
-    let mut fb_fun = FunSpec::<OCaml>::builder("transform");
-    fb_fun.doc("Transform a list using a mapping function.");
-    fb_fun.returns(TypeName::primitive("'b list"));
-    fb_fun.add_param(ParameterSpec::new("f", TypeName::primitive("'a -> 'b")).unwrap());
-    fb_fun.add_param(ParameterSpec::new("xs", TypeName::primitive("'a list")).unwrap());
-    fb_fun.body(body);
-    let fun = fb_fun.build().unwrap();
+    let body = CodeBlock::of("List.map f xs", ()).unwrap();
+    let fun = FunSpec::builder("transform")
+        .doc("Transform a list using a mapping function.")
+        .returns(TypeName::primitive("'b list"))
+        .add_param(ParameterSpec::new("f", TypeName::primitive("'a -> 'b")).unwrap())
+        .add_param(ParameterSpec::new("xs", TypeName::primitive("'a list")).unwrap())
+        .body(body)
+        .build()
+        .unwrap();
 
-    let mut fb = FileSpec::builder_with("transform.ml", OCaml::new());
-    fb.add_function(fun);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("transform.ml", OCaml::new())
+        .add_function(fun)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("ocaml/function_with_doc.ml", &output);

--- a/tests/ocaml/builder_imports.rs
+++ b/tests/ocaml/builder_imports.rs
@@ -7,15 +7,16 @@ use super::golden;
 
 #[test]
 fn test_function_with_imports() {
-    let list_mod = TypeName::<OCaml>::importable("List", "t");
+    let list_mod = TypeName::importable("List", "t");
 
-    let mut b = CodeBlock::<OCaml>::builder();
+    let mut b = CodeBlock::builder();
     b.add_statement("let result = %T.map f xs", (list_mod,));
     let block = b.build().unwrap();
 
-    let mut fb = FileSpec::builder_with("app.ml", OCaml::new());
-    fb.add_code(block);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("app.ml", OCaml::new())
+        .add_code(block)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("ocaml/function_with_imports.ml", &output);

--- a/tests/ocaml/builder_types.rs
+++ b/tests/ocaml/builder_types.rs
@@ -11,30 +11,30 @@ use super::golden;
 
 #[test]
 fn test_record_type() {
-    let mut tb = TypeSpec::<OCaml>::builder("person", TypeKind::Struct);
-    tb.doc("A person record.");
+    let ts = TypeSpec::builder("person", TypeKind::Struct)
+        .doc("A person record.")
+        .add_field(
+            FieldSpec::builder("name", TypeName::primitive("string"))
+                .build()
+                .unwrap(),
+        )
+        .add_field(
+            FieldSpec::builder("age", TypeName::primitive("int"))
+                .build()
+                .unwrap(),
+        )
+        .add_field(
+            FieldSpec::builder("email", TypeName::primitive("string"))
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
 
-    tb.add_field(
-        FieldSpec::builder("name", TypeName::primitive("string"))
-            .build()
-            .unwrap(),
-    );
-    tb.add_field(
-        FieldSpec::builder("age", TypeName::primitive("int"))
-            .build()
-            .unwrap(),
-    );
-    tb.add_field(
-        FieldSpec::builder("email", TypeName::primitive("string"))
-            .build()
-            .unwrap(),
-    );
-
-    let ts = tb.build().unwrap();
-
-    let mut fb = FileSpec::builder_with("person.ml", OCaml::new());
-    fb.add_type(ts);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("person.ml", OCaml::new())
+        .add_type(ts)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("ocaml/record_type.ml", &output);
@@ -42,14 +42,15 @@ fn test_record_type() {
 
 #[test]
 fn test_type_alias() {
-    let mut tb = TypeSpec::<OCaml>::builder("string_list", TypeKind::TypeAlias);
-    tb.extends(TypeName::primitive("string list"));
+    let ts = TypeSpec::builder("string_list", TypeKind::TypeAlias)
+        .extends(TypeName::primitive("string list"))
+        .build()
+        .unwrap();
 
-    let ts = tb.build().unwrap();
-
-    let mut fb = FileSpec::builder_with("aliases.ml", OCaml::new());
-    fb.add_type(ts);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("aliases.ml", OCaml::new())
+        .add_type(ts)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("ocaml/type_alias.ml", &output);
@@ -59,12 +60,12 @@ fn test_type_alias() {
 fn test_module_type() {
     let ml = OCaml::new();
 
-    let mut outer = CodeBlock::<OCaml>::builder();
+    let mut outer = CodeBlock::builder();
     let doc = ml.render_doc_comment(&["Comparable interface."]);
     outer.add("%L", doc);
     outer.add_line();
 
-    let mut inner = CodeBlock::<OCaml>::builder();
+    let mut inner = CodeBlock::builder();
     inner.add_statement("val compare : t -> t -> int", ());
     let body = inner.build().unwrap();
 
@@ -72,9 +73,10 @@ fn test_module_type() {
     outer.add_code(module);
     let block = outer.build().unwrap();
 
-    let mut fb = FileSpec::builder_with("comparable.ml", OCaml::new());
-    fb.add_code(block);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("comparable.ml", OCaml::new())
+        .add_code(block)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("ocaml/module_type.ml", &output);
@@ -82,16 +84,17 @@ fn test_module_type() {
 
 #[test]
 fn test_module_block() {
-    let mut inner = CodeBlock::<OCaml>::builder();
+    let mut inner = CodeBlock::builder();
     inner.add_statement("let greeting = \"hello\"", ());
     inner.add_statement("let farewell = \"goodbye\"", ());
     let body = inner.build().unwrap();
 
     let module = OCaml::module_block("MyModule", body).unwrap();
 
-    let mut fb = FileSpec::builder_with("mymodule.ml", OCaml::new());
-    fb.add_code(module);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("mymodule.ml", OCaml::new())
+        .add_code(module)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("ocaml/module_block.ml", &output);
@@ -99,16 +102,17 @@ fn test_module_block() {
 
 #[test]
 fn test_module_sig_block() {
-    let mut inner = CodeBlock::<OCaml>::builder();
+    let mut inner = CodeBlock::builder();
     inner.add_statement("val greeting : string", ());
     inner.add_statement("val farewell : string", ());
     let body = inner.build().unwrap();
 
     let module = OCaml::module_sig_block("MY_SIG", body).unwrap();
 
-    let mut fb = FileSpec::builder_with("my_sig.ml", OCaml::new());
-    fb.add_code(module);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("my_sig.ml", OCaml::new())
+        .add_code(module)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("ocaml/module_sig.ml", &output);

--- a/tests/ocaml/quote_basic.rs
+++ b/tests/ocaml/quote_basic.rs
@@ -5,10 +5,13 @@ use sigil_stitch::spec::file_spec::FileSpec;
 
 use super::golden;
 
-fn render(block: &CodeBlock<OCaml>) -> String {
-    let mut fb = FileSpec::builder_with("test.ml", OCaml::new());
-    fb.add_code(block.clone());
-    fb.build().unwrap().render(80).unwrap()
+fn render(block: &CodeBlock) -> String {
+    FileSpec::builder_with("test.ml", OCaml::new())
+        .add_code(block.clone())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap()
 }
 
 #[test]

--- a/tests/ocaml/quote_control_flow.rs
+++ b/tests/ocaml/quote_control_flow.rs
@@ -5,10 +5,13 @@ use sigil_stitch::spec::file_spec::FileSpec;
 
 use super::golden;
 
-fn render(block: &CodeBlock<OCaml>) -> String {
-    let mut fb = FileSpec::builder_with("test.ml", OCaml::new());
-    fb.add_code(block.clone());
-    fb.build().unwrap().render(80).unwrap()
+fn render(block: &CodeBlock) -> String {
+    FileSpec::builder_with("test.ml", OCaml::new())
+        .add_code(block.clone())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap()
 }
 
 #[test]

--- a/tests/ocaml/quote_edge_cases.rs
+++ b/tests/ocaml/quote_edge_cases.rs
@@ -5,10 +5,13 @@ use sigil_stitch::spec::file_spec::FileSpec;
 
 use super::golden;
 
-fn render(block: &CodeBlock<OCaml>) -> String {
-    let mut fb = FileSpec::builder_with("test.ml", OCaml::new());
-    fb.add_code(block.clone());
-    fb.build().unwrap().render(80).unwrap()
+fn render(block: &CodeBlock) -> String {
+    FileSpec::builder_with("test.ml", OCaml::new())
+        .add_code(block.clone())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap()
 }
 
 #[test]

--- a/tests/project_spec_tests.rs
+++ b/tests/project_spec_tests.rs
@@ -1,6 +1,4 @@
 use sigil_stitch::code_block::CodeBlock;
-use sigil_stitch::lang::rust_lang::RustLang;
-use sigil_stitch::lang::typescript::TypeScript;
 use sigil_stitch::spec::file_spec::FileSpec;
 use sigil_stitch::spec::fun_spec::FunSpec;
 use sigil_stitch::spec::modifiers::Visibility;
@@ -11,7 +9,7 @@ use sigil_stitch::type_name::TypeName;
 
 #[test]
 fn test_empty_project_renders_empty_vec() {
-    let project = ProjectSpec::<TypeScript>::builder().build();
+    let project = ProjectSpec::builder().build();
     let rendered = project.render(80).unwrap();
     assert!(rendered.is_empty());
 }
@@ -20,11 +18,14 @@ fn test_empty_project_renders_empty_vec() {
 
 #[test]
 fn test_single_file_project() {
-    let mut fb = FileSpec::<TypeScript>::builder("index.ts");
-    fb.add_code(CodeBlock::of("console.log('hello')", ()).unwrap());
-    let mut pb = ProjectSpec::builder();
-    pb.add_file(fb.build().unwrap());
-    let project = pb.build();
+    let project = ProjectSpec::builder()
+        .add_file(
+            FileSpec::builder("index.ts")
+                .add_code(CodeBlock::of("console.log('hello')", ()).unwrap())
+                .build()
+                .unwrap(),
+        )
+        .build();
 
     let rendered = project.render(80).unwrap();
     assert_eq!(rendered.len(), 1);
@@ -37,20 +38,19 @@ fn test_single_file_project() {
 #[test]
 fn test_multi_file_project_with_imports() {
     // File 1: models.ts
-    let mut f1 = FileSpec::<TypeScript>::builder("models.ts");
-    f1.add_code(CodeBlock::of("export interface User { name: string }", ()).unwrap());
+    let f1 = FileSpec::builder("models.ts")
+        .add_code(CodeBlock::of("export interface User { name: string }", ()).unwrap());
 
     // File 2: service.ts — imports User from models
-    let user_type = TypeName::<TypeScript>::importable_type("./models", "User");
-    let mut f2 = FileSpec::<TypeScript>::builder("service.ts");
-    let mut cb = CodeBlock::<TypeScript>::builder();
+    let user_type = TypeName::importable_type("./models", "User");
+    let mut cb = CodeBlock::builder();
     cb.add_statement("const u: %T = getUser()", (user_type,));
-    f2.add_code(cb.build().unwrap());
+    let f2 = FileSpec::builder("service.ts").add_code(cb.build().unwrap());
 
-    let mut pb = ProjectSpec::builder();
-    pb.add_file(f1.build().unwrap());
-    pb.add_file(f2.build().unwrap());
-    let project = pb.build();
+    let project = ProjectSpec::builder()
+        .add_file(f1.build().unwrap())
+        .add_file(f2.build().unwrap())
+        .build();
 
     let rendered = project.render(80).unwrap();
     assert_eq!(rendered.len(), 2);
@@ -68,11 +68,14 @@ fn test_multi_file_project_with_imports() {
 
 #[test]
 fn test_file_ordering_preserved() {
-    let mut pb = ProjectSpec::<TypeScript>::builder();
+    let mut pb = ProjectSpec::builder();
     for name in ["c.ts", "a.ts", "b.ts"] {
-        let mut fb = FileSpec::builder(name);
-        fb.add_code(CodeBlock::of("// placeholder", ()).unwrap());
-        pb.add_file(fb.build().unwrap());
+        pb = pb.add_file(
+            FileSpec::builder(name)
+                .add_code(CodeBlock::of("// placeholder", ()).unwrap())
+                .build()
+                .unwrap(),
+        );
     }
     let rendered = pb.build().render(80).unwrap();
     let paths: Vec<&str> = rendered.iter().map(|r| r.path.as_str()).collect();
@@ -88,11 +91,15 @@ fn test_render_error_includes_filename() {
     // arity mismatches at build time. This test verifies the error
     // formatting indirectly: a project with a valid file renders fine,
     // confirming the error path is the only code branch producing errors.
-    let mut fb = FileSpec::<TypeScript>::builder("app.ts");
-    fb.add_code(CodeBlock::of("const x = 1", ()).unwrap());
-    let mut pb = ProjectSpec::builder();
-    pb.add_file(fb.build().unwrap());
-    let result = pb.build().render(80);
+    let result = ProjectSpec::builder()
+        .add_file(
+            FileSpec::builder("app.ts")
+                .add_code(CodeBlock::of("const x = 1", ()).unwrap())
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .render(80);
     assert!(result.is_ok());
 }
 
@@ -104,12 +111,16 @@ fn test_write_to_creates_files() {
     // Clean up from any previous run.
     let _ = std::fs::remove_dir_all(&dir);
 
-    let mut pb = ProjectSpec::<TypeScript>::builder();
-    let mut fb = FileSpec::builder("hello.ts");
-    fb.add_code(CodeBlock::of("export const x = 1", ()).unwrap());
-    pb.add_file(fb.build().unwrap());
-
-    let written = pb.build().write_to(&dir, 80).unwrap();
+    let written = ProjectSpec::builder()
+        .add_file(
+            FileSpec::builder("hello.ts")
+                .add_code(CodeBlock::of("export const x = 1", ()).unwrap())
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .write_to(&dir, 80)
+        .unwrap();
     assert_eq!(written.len(), 1);
     assert_eq!(written[0], dir.join("hello.ts"));
     let content = std::fs::read_to_string(&written[0]).unwrap();
@@ -126,12 +137,16 @@ fn test_write_to_creates_nested_dirs() {
     let dir = std::env::temp_dir().join("sigil_stitch_test_nested");
     let _ = std::fs::remove_dir_all(&dir);
 
-    let mut pb = ProjectSpec::<TypeScript>::builder();
-    let mut fb = FileSpec::builder("src/models/user.ts");
-    fb.add_code(CodeBlock::of("export class User {}", ()).unwrap());
-    pb.add_file(fb.build().unwrap());
-
-    let written = pb.build().write_to(&dir, 80).unwrap();
+    let written = ProjectSpec::builder()
+        .add_file(
+            FileSpec::builder("src/models/user.ts")
+                .add_code(CodeBlock::of("export class User {}", ()).unwrap())
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .write_to(&dir, 80)
+        .unwrap();
     assert_eq!(written.len(), 1);
     assert_eq!(written[0], dir.join("src/models/user.ts"));
     assert!(written[0].exists());
@@ -143,16 +158,23 @@ fn test_write_to_creates_nested_dirs() {
 
 #[test]
 fn test_rust_project() {
-    let mut fb = FileSpec::<RustLang>::builder("lib.rs");
-    let mut fun = FunSpec::<RustLang>::builder("greet");
-    fun.visibility(Visibility::Public);
-    fun.returns(TypeName::primitive("String"));
-    fun.body(CodeBlock::of("String::from(\"hello\")", ()).unwrap());
-    fb.add_function(fun.build().unwrap());
-
-    let mut pb = ProjectSpec::builder();
-    pb.add_file(fb.build().unwrap());
-    let rendered = pb.build().render(80).unwrap();
+    let rendered = ProjectSpec::builder()
+        .add_file(
+            FileSpec::builder("lib.rs")
+                .add_function(
+                    FunSpec::builder("greet")
+                        .visibility(Visibility::Public)
+                        .returns(TypeName::primitive("String"))
+                        .body(CodeBlock::of("String::from(\"hello\")", ()).unwrap())
+                        .build()
+                        .unwrap(),
+                )
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .render(80)
+        .unwrap();
 
     assert_eq!(rendered.len(), 1);
     assert_eq!(rendered[0].path, "lib.rs");
@@ -161,19 +183,20 @@ fn test_rust_project() {
 
 #[test]
 fn test_multi_file_rust_project() {
-    let mut f1 = FileSpec::<RustLang>::builder("types.rs");
-    f1.add_code(CodeBlock::of("pub struct Config {}", ()).unwrap());
+    let f1 =
+        FileSpec::builder("types.rs").add_code(CodeBlock::of("pub struct Config {}", ()).unwrap());
 
-    let config_type = TypeName::<RustLang>::importable("crate::types", "Config");
-    let mut f2 = FileSpec::<RustLang>::builder("main.rs");
-    let mut cb = CodeBlock::<RustLang>::builder();
+    let config_type = TypeName::importable("crate::types", "Config");
+    let mut cb = CodeBlock::builder();
     cb.add_statement("let _cfg: %T = Config::default()", (config_type,));
-    f2.add_code(cb.build().unwrap());
+    let f2 = FileSpec::builder("main.rs").add_code(cb.build().unwrap());
 
-    let mut pb = ProjectSpec::builder();
-    pb.add_file(f1.build().unwrap());
-    pb.add_file(f2.build().unwrap());
-    let rendered = pb.build().render(80).unwrap();
+    let rendered = ProjectSpec::builder()
+        .add_file(f1.build().unwrap())
+        .add_file(f2.build().unwrap())
+        .build()
+        .render(80)
+        .unwrap();
 
     assert_eq!(rendered.len(), 2);
     assert_eq!(rendered[0].path, "types.rs");

--- a/tests/property_spec_tests.rs
+++ b/tests/property_spec_tests.rs
@@ -10,9 +10,9 @@ use sigil_stitch::type_name::TypeName;
 
 // ── Helpers ──────────────────────────────────────────────
 
-fn render_property<L: sigil_stitch::lang::CodeLang>(
-    spec: &PropertySpec<L>,
-    lang: &L,
+fn render_property(
+    spec: &PropertySpec,
+    lang: &dyn sigil_stitch::lang::CodeLang,
     ctx: DeclarationContext,
 ) -> String {
     let blocks = spec.emit(lang, ctx).unwrap();
@@ -28,7 +28,7 @@ fn render_property<L: sigil_stitch::lang::CodeLang>(
     output
 }
 
-fn render_type<L: sigil_stitch::lang::CodeLang>(spec: &TypeSpec<L>, lang: &L) -> String {
+fn render_type(spec: &TypeSpec, lang: &dyn sigil_stitch::lang::CodeLang) -> String {
     let blocks = spec.emit(lang).unwrap();
     let imports = sigil_stitch::import::ImportGroup::new();
     let mut output = String::new();
@@ -47,9 +47,14 @@ fn render_type<L: sigil_stitch::lang::CodeLang>(spec: &TypeSpec<L>, lang: &L) ->
 #[test]
 fn test_ts_getter_only() {
     let ts = TypeScript::new();
-    let mut pb = PropertySpec::<TypeScript>::builder("count", TypeName::primitive("number"));
-    pb.getter(CodeBlock::of("return this._count", ()).unwrap());
-    let output = render_property(&pb.build().unwrap(), &ts, DeclarationContext::Member);
+    let output = render_property(
+        &PropertySpec::builder("count", TypeName::primitive("number"))
+            .getter(CodeBlock::of("return this._count", ()).unwrap())
+            .build()
+            .unwrap(),
+        &ts,
+        DeclarationContext::Member,
+    );
     assert!(output.contains("get count(): number {"));
     assert!(output.contains("return this._count"));
 }
@@ -57,10 +62,15 @@ fn test_ts_getter_only() {
 #[test]
 fn test_ts_getter_setter() {
     let ts = TypeScript::new();
-    let mut pb = PropertySpec::<TypeScript>::builder("name", TypeName::primitive("string"));
-    pb.getter(CodeBlock::of("return this._name", ()).unwrap());
-    pb.setter("value", CodeBlock::of("this._name = value", ()).unwrap());
-    let output = render_property(&pb.build().unwrap(), &ts, DeclarationContext::Member);
+    let output = render_property(
+        &PropertySpec::builder("name", TypeName::primitive("string"))
+            .getter(CodeBlock::of("return this._name", ()).unwrap())
+            .setter("value", CodeBlock::of("this._name = value", ()).unwrap())
+            .build()
+            .unwrap(),
+        &ts,
+        DeclarationContext::Member,
+    );
     assert!(output.contains("get name(): string {"));
     assert!(output.contains("return this._name"));
     assert!(output.contains("set name(value: string) {"));
@@ -70,25 +80,35 @@ fn test_ts_getter_setter() {
 #[test]
 fn test_ts_property_with_visibility() {
     let ts = TypeScript::new();
-    let mut pb = PropertySpec::<TypeScript>::builder("age", TypeName::primitive("number"));
-    pb.visibility(Visibility::Private);
-    pb.getter(CodeBlock::of("return this._age", ()).unwrap());
-    let output = render_property(&pb.build().unwrap(), &ts, DeclarationContext::Member);
+    let output = render_property(
+        &PropertySpec::builder("age", TypeName::primitive("number"))
+            .visibility(Visibility::Private)
+            .getter(CodeBlock::of("return this._age", ()).unwrap())
+            .build()
+            .unwrap(),
+        &ts,
+        DeclarationContext::Member,
+    );
     assert!(output.contains("private get age(): number {"));
 }
 
 #[test]
 fn test_ts_property_in_class() {
     let ts = TypeScript::new();
-    let mut tb = TypeSpec::<TypeScript>::builder("User", TypeKind::Class);
-    tb.visibility(Visibility::Public);
-
-    let mut pb = PropertySpec::builder("name", TypeName::primitive("string"));
-    pb.getter(CodeBlock::of("return this._name", ()).unwrap());
-    pb.setter("value", CodeBlock::of("this._name = value", ()).unwrap());
-    tb.add_property(pb.build().unwrap());
-
-    let output = render_type(&tb.build().unwrap(), &ts);
+    let output = render_type(
+        &TypeSpec::builder("User", TypeKind::Class)
+            .visibility(Visibility::Public)
+            .add_property(
+                PropertySpec::builder("name", TypeName::primitive("string"))
+                    .getter(CodeBlock::of("return this._name", ()).unwrap())
+                    .setter("value", CodeBlock::of("this._name = value", ()).unwrap())
+                    .build()
+                    .unwrap(),
+            )
+            .build()
+            .unwrap(),
+        &ts,
+    );
     assert!(output.contains("export class User {"));
     assert!(output.contains("get name(): string {"));
     assert!(output.contains("set name(value: string) {"));
@@ -99,10 +119,15 @@ fn test_ts_property_in_class() {
 #[test]
 fn test_js_getter_setter() {
     let js = JavaScript::new();
-    let mut pb = PropertySpec::<JavaScript>::builder("name", TypeName::primitive(""));
-    pb.getter(CodeBlock::of("return this._name", ()).unwrap());
-    pb.setter("value", CodeBlock::of("this._name = value", ()).unwrap());
-    let output = render_property(&pb.build().unwrap(), &js, DeclarationContext::Member);
+    let output = render_property(
+        &PropertySpec::builder("name", TypeName::primitive(""))
+            .getter(CodeBlock::of("return this._name", ()).unwrap())
+            .setter("value", CodeBlock::of("this._name = value", ()).unwrap())
+            .build()
+            .unwrap(),
+        &js,
+        DeclarationContext::Member,
+    );
     assert!(output.contains("get name() {"));
     assert!(output.contains("set name(value) {"));
     // No type annotation.
@@ -114,9 +139,14 @@ fn test_js_getter_setter() {
 #[test]
 fn test_swift_getter_only() {
     let swift = Swift::new();
-    let mut pb = PropertySpec::<Swift>::builder("count", TypeName::primitive("Int"));
-    pb.getter(CodeBlock::of("return _count", ()).unwrap());
-    let output = render_property(&pb.build().unwrap(), &swift, DeclarationContext::Member);
+    let output = render_property(
+        &PropertySpec::builder("count", TypeName::primitive("Int"))
+            .getter(CodeBlock::of("return _count", ()).unwrap())
+            .build()
+            .unwrap(),
+        &swift,
+        DeclarationContext::Member,
+    );
     // Getter-only → readonly → "let" keyword.
     assert!(output.contains("let count: Int {"));
     assert!(output.contains("get {"));
@@ -126,10 +156,15 @@ fn test_swift_getter_only() {
 #[test]
 fn test_swift_getter_setter() {
     let swift = Swift::new();
-    let mut pb = PropertySpec::<Swift>::builder("name", TypeName::primitive("String"));
-    pb.getter(CodeBlock::of("return _name", ()).unwrap());
-    pb.setter("newValue", CodeBlock::of("_name = newValue", ()).unwrap());
-    let output = render_property(&pb.build().unwrap(), &swift, DeclarationContext::Member);
+    let output = render_property(
+        &PropertySpec::builder("name", TypeName::primitive("String"))
+            .getter(CodeBlock::of("return _name", ()).unwrap())
+            .setter("newValue", CodeBlock::of("_name = newValue", ()).unwrap())
+            .build()
+            .unwrap(),
+        &swift,
+        DeclarationContext::Member,
+    );
     // Getter+setter → mutable → "var" keyword.
     assert!(output.contains("var name: String {"));
     assert!(output.contains("get {"));
@@ -141,22 +176,34 @@ fn test_swift_getter_setter() {
 #[test]
 fn test_swift_property_with_visibility() {
     let swift = Swift::new();
-    let mut pb = PropertySpec::<Swift>::builder("count", TypeName::primitive("Int"));
-    pb.visibility(Visibility::Public);
-    pb.getter(CodeBlock::of("return _count", ()).unwrap());
-    let output = render_property(&pb.build().unwrap(), &swift, DeclarationContext::Member);
+    let output = render_property(
+        &PropertySpec::builder("count", TypeName::primitive("Int"))
+            .visibility(Visibility::Public)
+            .getter(CodeBlock::of("return _count", ()).unwrap())
+            .build()
+            .unwrap(),
+        &swift,
+        DeclarationContext::Member,
+    );
     assert!(output.contains("public let count: Int {"));
 }
 
 #[test]
 fn test_swift_property_in_class() {
     let swift = Swift::new();
-    let mut tb = TypeSpec::<Swift>::builder("Counter", TypeKind::Class);
-    let mut pb = PropertySpec::builder("count", TypeName::primitive("Int"));
-    pb.getter(CodeBlock::of("return _count", ()).unwrap());
-    pb.setter("newValue", CodeBlock::of("_count = newValue", ()).unwrap());
-    tb.add_property(pb.build().unwrap());
-    let output = render_type(&tb.build().unwrap(), &swift);
+    let output = render_type(
+        &TypeSpec::builder("Counter", TypeKind::Class)
+            .add_property(
+                PropertySpec::builder("count", TypeName::primitive("Int"))
+                    .getter(CodeBlock::of("return _count", ()).unwrap())
+                    .setter("newValue", CodeBlock::of("_count = newValue", ()).unwrap())
+                    .build()
+                    .unwrap(),
+            )
+            .build()
+            .unwrap(),
+        &swift,
+    );
     assert!(output.contains("class Counter {"));
     assert!(output.contains("var count: Int {"));
     assert!(output.contains("get {"));
@@ -168,9 +215,14 @@ fn test_swift_property_in_class() {
 #[test]
 fn test_kotlin_getter_only() {
     let kt = Kotlin::new();
-    let mut pb = PropertySpec::<Kotlin>::builder("count", TypeName::primitive("Int"));
-    pb.getter(CodeBlock::of("return _count", ()).unwrap());
-    let output = render_property(&pb.build().unwrap(), &kt, DeclarationContext::Member);
+    let output = render_property(
+        &PropertySpec::builder("count", TypeName::primitive("Int"))
+            .getter(CodeBlock::of("return _count", ()).unwrap())
+            .build()
+            .unwrap(),
+        &kt,
+        DeclarationContext::Member,
+    );
     // Getter-only → readonly → "val" keyword.
     assert!(output.contains("val count: Int {"));
     assert!(output.contains("get() {"));
@@ -180,10 +232,15 @@ fn test_kotlin_getter_only() {
 #[test]
 fn test_kotlin_getter_setter() {
     let kt = Kotlin::new();
-    let mut pb = PropertySpec::<Kotlin>::builder("name", TypeName::primitive("String"));
-    pb.getter(CodeBlock::of("return field", ()).unwrap());
-    pb.setter("value", CodeBlock::of("field = value", ()).unwrap());
-    let output = render_property(&pb.build().unwrap(), &kt, DeclarationContext::Member);
+    let output = render_property(
+        &PropertySpec::builder("name", TypeName::primitive("String"))
+            .getter(CodeBlock::of("return field", ()).unwrap())
+            .setter("value", CodeBlock::of("field = value", ()).unwrap())
+            .build()
+            .unwrap(),
+        &kt,
+        DeclarationContext::Member,
+    );
     // Getter+setter → mutable → "var" keyword.
     assert!(output.contains("var name: String {"));
     assert!(output.contains("get() {"));
@@ -193,11 +250,18 @@ fn test_kotlin_getter_setter() {
 #[test]
 fn test_kotlin_property_in_class() {
     let kt = Kotlin::new();
-    let mut tb = TypeSpec::<Kotlin>::builder("Person", TypeKind::Class);
-    let mut pb = PropertySpec::builder("name", TypeName::primitive("String"));
-    pb.getter(CodeBlock::of("return field", ()).unwrap());
-    tb.add_property(pb.build().unwrap());
-    let output = render_type(&tb.build().unwrap(), &kt);
+    let output = render_type(
+        &TypeSpec::builder("Person", TypeKind::Class)
+            .add_property(
+                PropertySpec::builder("name", TypeName::primitive("String"))
+                    .getter(CodeBlock::of("return field", ()).unwrap())
+                    .build()
+                    .unwrap(),
+            )
+            .build()
+            .unwrap(),
+        &kt,
+    );
     assert!(output.contains("class Person {"));
     assert!(output.contains("val name: String {"));
     assert!(output.contains("get() {"));
@@ -208,10 +272,15 @@ fn test_kotlin_property_in_class() {
 #[test]
 fn test_property_with_doc() {
     let ts = TypeScript::new();
-    let mut pb = PropertySpec::<TypeScript>::builder("count", TypeName::primitive("number"));
-    pb.doc("The current count.");
-    pb.getter(CodeBlock::of("return this._count", ()).unwrap());
-    let output = render_property(&pb.build().unwrap(), &ts, DeclarationContext::Member);
+    let output = render_property(
+        &PropertySpec::builder("count", TypeName::primitive("number"))
+            .doc("The current count.")
+            .getter(CodeBlock::of("return this._count", ()).unwrap())
+            .build()
+            .unwrap(),
+        &ts,
+        DeclarationContext::Member,
+    );
     assert!(output.contains("* The current count."));
     assert!(output.contains("get count(): number {"));
 }
@@ -221,9 +290,14 @@ fn test_property_with_doc() {
 #[test]
 fn test_ts_static_property() {
     let ts = TypeScript::new();
-    let mut pb = PropertySpec::<TypeScript>::builder("instance", TypeName::primitive("App"));
-    pb.is_static();
-    pb.getter(CodeBlock::of("return App._instance", ()).unwrap());
-    let output = render_property(&pb.build().unwrap(), &ts, DeclarationContext::Member);
+    let output = render_property(
+        &PropertySpec::builder("instance", TypeName::primitive("App"))
+            .is_static()
+            .getter(CodeBlock::of("return App._instance", ()).unwrap())
+            .build()
+            .unwrap(),
+        &ts,
+        DeclarationContext::Member,
+    );
     assert!(output.contains("static get instance(): App {"));
 }

--- a/tests/python/builder_control_flow.rs
+++ b/tests/python/builder_control_flow.rs
@@ -6,7 +6,7 @@ use super::golden;
 
 #[test]
 fn test_control_flow() {
-    let mut b = CodeBlock::<Python>::builder();
+    let mut b = CodeBlock::builder();
     b.add("def classify(x: int) -> str:", ());
     b.add_line();
     b.add("%>", ());
@@ -20,9 +20,10 @@ fn test_control_flow() {
     b.add("%<", ());
     let block = b.build().unwrap();
 
-    let mut fb = FileSpec::builder_with("classify.py", Python::new());
-    fb.add_code(block);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("classify.py", Python::new())
+        .add_code(block)
+        .build()
+        .unwrap();
 
     let output = file.render(80).unwrap();
     golden::assert_golden("python/control_flow.py", &output);
@@ -30,7 +31,7 @@ fn test_control_flow() {
 
 #[test]
 fn test_class_basic() {
-    let mut b = CodeBlock::<Python>::builder();
+    let mut b = CodeBlock::builder();
     b.add("class Config:", ());
     b.add_line();
     b.add("%>", ());
@@ -40,9 +41,10 @@ fn test_class_basic() {
     b.add("%<", ());
     let block = b.build().unwrap();
 
-    let mut fb = FileSpec::builder_with("config.py", Python::new());
-    fb.add_code(block);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("config.py", Python::new())
+        .add_code(block)
+        .build()
+        .unwrap();
 
     let output = file.render(80).unwrap();
     golden::assert_golden("python/class_basic.py", &output);

--- a/tests/python/builder_edge_cases.rs
+++ b/tests/python/builder_edge_cases.rs
@@ -11,29 +11,32 @@ use super::golden;
 
 #[test]
 fn test_abstract_method() {
-    let abc = TypeName::<Python>::importable("abc", "ABC");
-    let abstractmethod = TypeName::<Python>::importable("abc", "abstractmethod");
+    let abc = TypeName::importable("abc", "ABC");
+    let abstractmethod = TypeName::importable("abc", "abstractmethod");
 
-    let mut tb = TypeSpec::<Python>::builder("BaseController", TypeKind::Class);
-    tb.extends(abc);
-
-    let mut handle = FunSpec::<Python>::builder("handle_request");
-    handle.annotation(CodeBlock::<Python>::of("@%T", (abstractmethod,)).unwrap());
-    handle.add_param(ParameterSpec::new("self", TypeName::primitive("")).unwrap());
-    handle.add_param(ParameterSpec::new("req", TypeName::primitive("Request")).unwrap());
-    handle.returns(TypeName::primitive("Response"));
+    let handle = FunSpec::builder("handle_request")
+        .annotation(CodeBlock::of("@%T", (abstractmethod,)).unwrap())
+        .add_param(ParameterSpec::new("self", TypeName::primitive("")).unwrap())
+        .add_param(ParameterSpec::new("req", TypeName::primitive("Request")).unwrap())
+        .returns(TypeName::primitive("Response"));
     // No body — should emit `...`
-    tb.add_method(handle.build().unwrap());
 
-    let mut log_fn = FunSpec::<Python>::builder("log");
-    log_fn.add_param(ParameterSpec::new("self", TypeName::primitive("")).unwrap());
-    log_fn.returns(TypeName::primitive("None"));
-    log_fn.body(CodeBlock::<Python>::of("print('handled')", ()).unwrap());
-    tb.add_method(log_fn.build().unwrap());
+    let tb = TypeSpec::builder("BaseController", TypeKind::Class)
+        .extends(abc)
+        .add_method(handle.build().unwrap())
+        .add_method(
+            FunSpec::builder("log")
+                .add_param(ParameterSpec::new("self", TypeName::primitive("")).unwrap())
+                .returns(TypeName::primitive("None"))
+                .body(CodeBlock::of("print('handled')", ()).unwrap())
+                .build()
+                .unwrap(),
+        );
 
-    let mut fb = FileSpec::builder_with("controller.py", Python::new());
-    fb.add_type(tb.build().unwrap());
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("controller.py", Python::new())
+        .add_type(tb.build().unwrap())
+        .build()
+        .unwrap();
 
     let output = file.render(80).unwrap();
     golden::assert_golden("python/abstract_class.py", &output);
@@ -41,14 +44,17 @@ fn test_abstract_method() {
 
 #[test]
 fn test_decorated_function() {
-    let mut fb = FunSpec::<Python>::builder("my_view");
-    fb.annotation(CodeBlock::<Python>::of("@app.route('/hello')", ()).unwrap());
-    fb.returns(TypeName::primitive("str"));
-    fb.body(CodeBlock::<Python>::of("return 'Hello, World!'", ()).unwrap());
-
-    let mut file_b = FileSpec::builder_with("views.py", Python::new());
-    file_b.add_function(fb.build().unwrap());
-    let file = file_b.build().unwrap();
+    let file = FileSpec::builder_with("views.py", Python::new())
+        .add_function(
+            FunSpec::builder("my_view")
+                .annotation(CodeBlock::of("@app.route('/hello')", ()).unwrap())
+                .returns(TypeName::primitive("str"))
+                .body(CodeBlock::of("return 'Hello, World!'", ()).unwrap())
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
 
     let output = file.render(80).unwrap();
     golden::assert_golden("python/decorated_function.py", &output);

--- a/tests/python/builder_functions.rs
+++ b/tests/python/builder_functions.rs
@@ -9,17 +9,20 @@ use super::golden;
 
 #[test]
 fn test_top_level_function() {
-    let json_dumps = TypeName::<Python>::importable("json", "dumps");
+    let json_dumps = TypeName::importable("json", "dumps");
 
-    let mut fb = FunSpec::<Python>::builder("serialize");
-    fb.doc("Serialize an object to JSON.");
-    fb.add_param(ParameterSpec::new("value", TypeName::primitive("object")).unwrap());
-    fb.returns(TypeName::primitive("str"));
-    fb.body(CodeBlock::<Python>::of("return %T(value)", (json_dumps,)).unwrap());
-
-    let mut file_b = FileSpec::builder_with("utils.py", Python::new());
-    file_b.add_function(fb.build().unwrap());
-    let file = file_b.build().unwrap();
+    let file = FileSpec::builder_with("utils.py", Python::new())
+        .add_function(
+            FunSpec::builder("serialize")
+                .doc("Serialize an object to JSON.")
+                .add_param(ParameterSpec::new("value", TypeName::primitive("object")).unwrap())
+                .returns(TypeName::primitive("str"))
+                .body(CodeBlock::of("return %T(value)", (json_dumps,)).unwrap())
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
 
     let output = file.render(80).unwrap();
     golden::assert_golden("python/top_level_function.py", &output);
@@ -27,17 +30,19 @@ fn test_top_level_function() {
 
 #[test]
 fn test_function_with_doc() {
-    let body = CodeBlock::<Python>::of("return f\"Hello, {name}!\"", ()).unwrap();
-    let mut fb = FunSpec::<Python>::builder("greet");
-    fb.doc("Greet the user by name.");
-    fb.add_param(ParameterSpec::new("name", TypeName::primitive("str")).unwrap());
-    fb.returns(TypeName::primitive("str"));
-    fb.body(body);
-    let fun = fb.build().unwrap();
+    let body = CodeBlock::of("return f\"Hello, {name}!\"", ()).unwrap();
+    let fun = FunSpec::builder("greet")
+        .doc("Greet the user by name.")
+        .add_param(ParameterSpec::new("name", TypeName::primitive("str")).unwrap())
+        .returns(TypeName::primitive("str"))
+        .body(body)
+        .build()
+        .unwrap();
 
-    let mut file_b = FileSpec::<Python>::builder("greet.py");
-    file_b.add_function(fun);
-    let file = file_b.build().unwrap();
+    let file = FileSpec::builder("greet.py")
+        .add_function(fun)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("python/function_with_doc.py", &output);

--- a/tests/python/builder_imports.rs
+++ b/tests/python/builder_imports.rs
@@ -7,10 +7,10 @@ use super::golden;
 
 #[test]
 fn test_function_with_imports() {
-    let json_dumps = TypeName::<Python>::importable("json", "dumps");
-    let http_server = TypeName::<Python>::importable("http.server", "HTTPServer");
+    let json_dumps = TypeName::importable("json", "dumps");
+    let http_server = TypeName::importable("http.server", "HTTPServer");
 
-    let mut b = CodeBlock::<Python>::builder();
+    let mut b = CodeBlock::builder();
     b.add("def start_server():", ());
     b.add_line();
     b.add("%>", ());
@@ -19,9 +19,10 @@ fn test_function_with_imports() {
     b.add("%<", ());
     let block = b.build().unwrap();
 
-    let mut fb = FileSpec::builder_with("server.py", Python::new());
-    fb.add_code(block);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("server.py", Python::new())
+        .add_code(block)
+        .build()
+        .unwrap();
 
     let output = file.render(80).unwrap();
     golden::assert_golden("python/function_with_imports.py", &output);
@@ -29,21 +30,22 @@ fn test_function_with_imports() {
 
 #[test]
 fn test_import_grouping() {
-    let json_dumps = TypeName::<Python>::importable("json", "dumps");
-    let json_loads = TypeName::<Python>::importable("json", "loads");
-    let flask = TypeName::<Python>::importable("flask", "Flask");
-    let os_path = TypeName::<Python>::importable("os.path", "join");
+    let json_dumps = TypeName::importable("json", "dumps");
+    let json_loads = TypeName::importable("json", "loads");
+    let flask = TypeName::importable("flask", "Flask");
+    let os_path = TypeName::importable("os.path", "join");
 
-    let mut b = CodeBlock::<Python>::builder();
+    let mut b = CodeBlock::builder();
     b.add_statement("_ = %T()", (json_dumps,));
     b.add_statement("_ = %T()", (json_loads,));
     b.add_statement("_ = %T()", (flask,));
     b.add_statement("_ = %T()", (os_path,));
     let block = b.build().unwrap();
 
-    let mut fb = FileSpec::builder_with("app.py", Python::new());
-    fb.add_code(block);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("app.py", Python::new())
+        .add_code(block)
+        .build()
+        .unwrap();
 
     let output = file.render(80).unwrap();
     golden::assert_golden("python/import_grouping.py", &output);

--- a/tests/python/builder_types.rs
+++ b/tests/python/builder_types.rs
@@ -13,28 +13,32 @@ use super::golden;
 
 #[test]
 fn test_dataclass() {
-    let mut tb = TypeSpec::<Python>::builder("Config", TypeKind::Class);
-    tb.doc("Application configuration.");
-    tb.annotation(CodeBlock::<Python>::of("@dataclass", ()).unwrap());
-
-    tb.add_field(
-        FieldSpec::builder("name", TypeName::primitive("str"))
-            .build()
-            .unwrap(),
-    );
-    tb.add_field(
-        FieldSpec::builder("port", TypeName::primitive("int"))
-            .build()
-            .unwrap(),
-    );
-
-    let mut f3 = FieldSpec::builder("debug", TypeName::primitive("bool"));
-    f3.initializer(CodeBlock::<Python>::of("False", ()).unwrap());
-    tb.add_field(f3.build().unwrap());
-
-    let mut fb = FileSpec::builder_with("config.py", Python::new());
-    fb.add_type(tb.build().unwrap());
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("config.py", Python::new())
+        .add_type(
+            TypeSpec::builder("Config", TypeKind::Class)
+                .doc("Application configuration.")
+                .annotation(CodeBlock::of("@dataclass", ()).unwrap())
+                .add_field(
+                    FieldSpec::builder("name", TypeName::primitive("str"))
+                        .build()
+                        .unwrap(),
+                )
+                .add_field(
+                    FieldSpec::builder("port", TypeName::primitive("int"))
+                        .build()
+                        .unwrap(),
+                )
+                .add_field(
+                    FieldSpec::builder("debug", TypeName::primitive("bool"))
+                        .initializer(CodeBlock::of("False", ()).unwrap())
+                        .build()
+                        .unwrap(),
+                )
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
 
     let output = file.render(80).unwrap();
     golden::assert_golden("python/dataclass.py", &output);
@@ -42,32 +46,40 @@ fn test_dataclass() {
 
 #[test]
 fn test_class_with_methods() {
-    let mut tb = TypeSpec::<Python>::builder("UserService", TypeKind::Class);
-    tb.doc("Service for managing users.");
-
-    tb.add_field(
-        FieldSpec::builder("_repo", TypeName::primitive("UserRepository"))
-            .build()
-            .unwrap(),
-    );
-
-    let mut get_user = FunSpec::<Python>::builder("get_user");
-    get_user.add_param(ParameterSpec::new("self", TypeName::primitive("")).unwrap());
-    get_user.add_param(ParameterSpec::new("user_id", TypeName::primitive("str")).unwrap());
-    get_user.returns(TypeName::primitive("User"));
-    get_user.body(CodeBlock::<Python>::of("return self._repo.find(user_id)", ()).unwrap());
-    tb.add_method(get_user.build().unwrap());
-
-    let mut save_user = FunSpec::<Python>::builder("save_user");
-    save_user.add_param(ParameterSpec::new("self", TypeName::primitive("")).unwrap());
-    save_user.add_param(ParameterSpec::new("user", TypeName::primitive("User")).unwrap());
-    save_user.returns(TypeName::primitive("None"));
-    save_user.body(CodeBlock::<Python>::of("self._repo.save(user)", ()).unwrap());
-    tb.add_method(save_user.build().unwrap());
-
-    let mut fb = FileSpec::builder_with("service.py", Python::new());
-    fb.add_type(tb.build().unwrap());
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("service.py", Python::new())
+        .add_type(
+            TypeSpec::builder("UserService", TypeKind::Class)
+                .doc("Service for managing users.")
+                .add_field(
+                    FieldSpec::builder("_repo", TypeName::primitive("UserRepository"))
+                        .build()
+                        .unwrap(),
+                )
+                .add_method(
+                    FunSpec::builder("get_user")
+                        .add_param(ParameterSpec::new("self", TypeName::primitive("")).unwrap())
+                        .add_param(
+                            ParameterSpec::new("user_id", TypeName::primitive("str")).unwrap(),
+                        )
+                        .returns(TypeName::primitive("User"))
+                        .body(CodeBlock::of("return self._repo.find(user_id)", ()).unwrap())
+                        .build()
+                        .unwrap(),
+                )
+                .add_method(
+                    FunSpec::builder("save_user")
+                        .add_param(ParameterSpec::new("self", TypeName::primitive("")).unwrap())
+                        .add_param(ParameterSpec::new("user", TypeName::primitive("User")).unwrap())
+                        .returns(TypeName::primitive("None"))
+                        .body(CodeBlock::of("self._repo.save(user)", ()).unwrap())
+                        .build()
+                        .unwrap(),
+                )
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
 
     let output = file.render(80).unwrap();
     golden::assert_golden("python/class_with_methods.py", &output);
@@ -75,22 +87,27 @@ fn test_class_with_methods() {
 
 #[test]
 fn test_class_with_bases() {
-    let base = TypeName::<Python>::primitive("BaseService");
-    let auth = TypeName::<Python>::primitive("Authenticatable");
+    let base = TypeName::primitive("BaseService");
+    let auth = TypeName::primitive("Authenticatable");
 
-    let mut tb = TypeSpec::<Python>::builder("AdminService", TypeKind::Class);
-    tb.extends(base);
-    tb.implements(auth);
-
-    let mut method = FunSpec::<Python>::builder("is_admin");
-    method.add_param(ParameterSpec::new("self", TypeName::primitive("")).unwrap());
-    method.returns(TypeName::primitive("bool"));
-    method.body(CodeBlock::<Python>::of("return True", ()).unwrap());
-    tb.add_method(method.build().unwrap());
-
-    let mut fb = FileSpec::builder_with("admin.py", Python::new());
-    fb.add_type(tb.build().unwrap());
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("admin.py", Python::new())
+        .add_type(
+            TypeSpec::builder("AdminService", TypeKind::Class)
+                .extends(base)
+                .implements(auth)
+                .add_method(
+                    FunSpec::builder("is_admin")
+                        .add_param(ParameterSpec::new("self", TypeName::primitive("")).unwrap())
+                        .returns(TypeName::primitive("bool"))
+                        .body(CodeBlock::of("return True", ()).unwrap())
+                        .build()
+                        .unwrap(),
+                )
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
 
     let output = file.render(80).unwrap();
     golden::assert_golden("python/class_with_bases.py", &output);
@@ -98,27 +115,36 @@ fn test_class_with_bases() {
 
 #[test]
 fn test_protocol() {
-    let protocol = TypeName::<Python>::importable("typing", "Protocol");
+    let protocol = TypeName::importable("typing", "Protocol");
 
-    let mut tb = TypeSpec::<Python>::builder("Repository", TypeKind::Interface);
-    tb.doc("Repository defines data access methods.");
-    tb.extends(protocol);
-
-    let mut find = FunSpec::<Python>::builder("find_by_id");
-    find.add_param(ParameterSpec::new("self", TypeName::primitive("")).unwrap());
-    find.add_param(ParameterSpec::new("id", TypeName::primitive("str")).unwrap());
-    find.returns(TypeName::primitive("Entity"));
-    tb.add_method(find.build().unwrap());
-
-    let mut save = FunSpec::<Python>::builder("save");
-    save.add_param(ParameterSpec::new("self", TypeName::primitive("")).unwrap());
-    save.add_param(ParameterSpec::new("entity", TypeName::primitive("Entity")).unwrap());
-    save.returns(TypeName::primitive("None"));
-    tb.add_method(save.build().unwrap());
-
-    let mut fb = FileSpec::builder_with("repo.py", Python::new());
-    fb.add_type(tb.build().unwrap());
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("repo.py", Python::new())
+        .add_type(
+            TypeSpec::builder("Repository", TypeKind::Interface)
+                .doc("Repository defines data access methods.")
+                .extends(protocol)
+                .add_method(
+                    FunSpec::builder("find_by_id")
+                        .add_param(ParameterSpec::new("self", TypeName::primitive("")).unwrap())
+                        .add_param(ParameterSpec::new("id", TypeName::primitive("str")).unwrap())
+                        .returns(TypeName::primitive("Entity"))
+                        .build()
+                        .unwrap(),
+                )
+                .add_method(
+                    FunSpec::builder("save")
+                        .add_param(ParameterSpec::new("self", TypeName::primitive("")).unwrap())
+                        .add_param(
+                            ParameterSpec::new("entity", TypeName::primitive("Entity")).unwrap(),
+                        )
+                        .returns(TypeName::primitive("None"))
+                        .build()
+                        .unwrap(),
+                )
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
 
     let output = file.render(80).unwrap();
     golden::assert_golden("python/protocol.py", &output);
@@ -126,31 +152,39 @@ fn test_protocol() {
 
 #[test]
 fn test_enum() {
-    let enum_base = TypeName::<Python>::importable("enum", "Enum");
+    let enum_base = TypeName::importable("enum", "Enum");
 
-    let mut tb = TypeSpec::<Python>::builder("Direction", TypeKind::Enum);
-    tb.extends(enum_base);
+    let tb = TypeSpec::builder("Direction", TypeKind::Enum)
+        .extends(enum_base)
+        .add_variant(
+            EnumVariantSpec::builder("UP")
+                .value(CodeBlock::of("'UP'", ()).unwrap())
+                .build()
+                .unwrap(),
+        )
+        .add_variant(
+            EnumVariantSpec::builder("DOWN")
+                .value(CodeBlock::of("'DOWN'", ()).unwrap())
+                .build()
+                .unwrap(),
+        )
+        .add_variant(
+            EnumVariantSpec::builder("LEFT")
+                .value(CodeBlock::of("'LEFT'", ()).unwrap())
+                .build()
+                .unwrap(),
+        )
+        .add_variant(
+            EnumVariantSpec::builder("RIGHT")
+                .value(CodeBlock::of("'RIGHT'", ()).unwrap())
+                .build()
+                .unwrap(),
+        );
 
-    // Enum members as variants with values.
-    let mut v_up = EnumVariantSpec::<Python>::builder("UP");
-    v_up.value(CodeBlock::<Python>::of("'UP'", ()).unwrap());
-    tb.add_variant(v_up.build().unwrap());
-
-    let mut v_down = EnumVariantSpec::<Python>::builder("DOWN");
-    v_down.value(CodeBlock::<Python>::of("'DOWN'", ()).unwrap());
-    tb.add_variant(v_down.build().unwrap());
-
-    let mut v_left = EnumVariantSpec::<Python>::builder("LEFT");
-    v_left.value(CodeBlock::<Python>::of("'LEFT'", ()).unwrap());
-    tb.add_variant(v_left.build().unwrap());
-
-    let mut v_right = EnumVariantSpec::<Python>::builder("RIGHT");
-    v_right.value(CodeBlock::<Python>::of("'RIGHT'", ()).unwrap());
-    tb.add_variant(v_right.build().unwrap());
-
-    let mut fb = FileSpec::builder_with("direction.py", Python::new());
-    fb.add_type(tb.build().unwrap());
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("direction.py", Python::new())
+        .add_type(tb.build().unwrap())
+        .build()
+        .unwrap();
 
     let output = file.render(80).unwrap();
     golden::assert_golden("python/enum.py", &output);

--- a/tests/python/quote_basic.rs
+++ b/tests/python/quote_basic.rs
@@ -1,14 +1,16 @@
 use sigil_stitch::code_block::CodeBlock;
-use sigil_stitch::lang::python::Python;
 use sigil_stitch::prelude::*;
 use sigil_stitch::spec::file_spec::FileSpec;
 
 use super::golden;
 
-fn render(block: &CodeBlock<Python>) -> String {
-    let mut fb = FileSpec::<Python>::builder("test.py");
-    fb.add_code(block.clone());
-    fb.build().unwrap().render(80).unwrap()
+fn render(block: &CodeBlock) -> String {
+    FileSpec::builder("test.py")
+        .add_code(block.clone())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap()
 }
 
 #[test]

--- a/tests/python/quote_control_flow.rs
+++ b/tests/python/quote_control_flow.rs
@@ -1,14 +1,16 @@
 use sigil_stitch::code_block::CodeBlock;
-use sigil_stitch::lang::python::Python;
 use sigil_stitch::prelude::*;
 use sigil_stitch::spec::file_spec::FileSpec;
 
 use super::golden;
 
-fn render(block: &CodeBlock<Python>) -> String {
-    let mut fb = FileSpec::<Python>::builder("test.py");
-    fb.add_code(block.clone());
-    fb.build().unwrap().render(80).unwrap()
+fn render(block: &CodeBlock) -> String {
+    FileSpec::builder("test.py")
+        .add_code(block.clone())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap()
 }
 
 #[test]

--- a/tests/rust/builder_control_flow.rs
+++ b/tests/rust/builder_control_flow.rs
@@ -6,7 +6,7 @@ use super::golden;
 
 #[test]
 fn test_control_flow() {
-    let mut b = CodeBlock::<RustLang>::builder();
+    let mut b = CodeBlock::builder();
     b.add("pub fn classify(x: i32) -> &'static str {", ());
     b.add_line();
     b.add("%>", ());
@@ -25,9 +25,10 @@ fn test_control_flow() {
     b.add_line();
     let block = b.build().unwrap();
 
-    let mut fb = FileSpec::builder_with("classify.rs", RustLang::new());
-    fb.add_code(block);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("classify.rs", RustLang::new())
+        .add_code(block)
+        .build()
+        .unwrap();
 
     let output = file.render(80).unwrap();
     golden::assert_golden("rust/control_flow.rs", &output);

--- a/tests/rust/builder_edge_cases.rs
+++ b/tests/rust/builder_edge_cases.rs
@@ -10,48 +10,55 @@ use sigil_stitch::type_name::TypeName;
 
 #[test]
 fn test_optional_field() {
-    let mut tb = TypeSpec::<RustLang>::builder("Config", TypeKind::Struct);
-    tb.visibility(Visibility::Public);
-
-    tb.add_field(
-        FieldSpec::builder("name", TypeName::<RustLang>::primitive("String"))
-            .build()
-            .unwrap(),
-    );
-
-    let mut opt = FieldSpec::builder("description", TypeName::<RustLang>::primitive("String"));
-    opt.is_optional();
-    tb.add_field(opt.build().unwrap());
-
-    let mut file = FileSpec::builder_with("config.rs", RustLang::new());
-    file.add_type(tb.build().unwrap());
-    let output = file.build().unwrap().render(80).unwrap();
+    let output = FileSpec::builder_with("config.rs", RustLang::new())
+        .add_type(
+            TypeSpec::builder("Config", TypeKind::Struct)
+                .visibility(Visibility::Public)
+                .add_field(
+                    FieldSpec::builder("name", TypeName::primitive("String"))
+                        .build()
+                        .unwrap(),
+                )
+                .add_field(
+                    FieldSpec::builder("description", TypeName::primitive("String"))
+                        .is_optional()
+                        .build()
+                        .unwrap(),
+                )
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap();
 
     golden::assert_golden("rust/optional_field.rs", &output);
 }
 
 #[test]
 fn test_derive_annotation() {
-    let mut tb = TypeSpec::<RustLang>::builder("Point", TypeKind::Struct);
-    tb.visibility(Visibility::Public);
+    let derive = CodeBlock::of("#[derive(Debug, Clone, PartialEq)]", ()).unwrap();
+    let tb = TypeSpec::builder("Point", TypeKind::Struct)
+        .visibility(Visibility::Public)
+        .annotation(derive)
+        .add_field(
+            FieldSpec::builder("x", TypeName::primitive("f64"))
+                .build()
+                .unwrap(),
+        )
+        .add_field(
+            FieldSpec::builder("y", TypeName::primitive("f64"))
+                .build()
+                .unwrap(),
+        );
 
-    let derive = CodeBlock::<RustLang>::of("#[derive(Debug, Clone, PartialEq)]", ()).unwrap();
-    tb.annotation(derive);
-
-    tb.add_field(
-        FieldSpec::builder("x", TypeName::<RustLang>::primitive("f64"))
-            .build()
-            .unwrap(),
-    );
-    tb.add_field(
-        FieldSpec::builder("y", TypeName::<RustLang>::primitive("f64"))
-            .build()
-            .unwrap(),
-    );
-
-    let mut file = FileSpec::builder_with("point.rs", RustLang::new());
-    file.add_type(tb.build().unwrap());
-    let output = file.build().unwrap().render(80).unwrap();
+    let output = FileSpec::builder_with("point.rs", RustLang::new())
+        .add_type(tb.build().unwrap())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap();
 
     golden::assert_golden("rust/derive_annotation.rs", &output);
 }

--- a/tests/rust/builder_functions.rs
+++ b/tests/rust/builder_functions.rs
@@ -10,36 +10,41 @@ use super::golden;
 
 #[test]
 fn test_top_level_function() {
-    let tp =
-        TypeParamSpec::<RustLang>::new("T").with_bound(TypeName::primitive("std::fmt::Display"));
+    let tp = TypeParamSpec::new("T").with_bound(TypeName::primitive("std::fmt::Display"));
 
-    let mut fb = FunSpec::<RustLang>::builder("print_value");
-    fb.visibility(Visibility::Public);
-    fb.add_type_param(tp);
-    fb.add_param(ParameterSpec::new("value", TypeName::primitive("&T")).unwrap());
-    let body = CodeBlock::<RustLang>::of("println!(\"{}\", value)", ()).unwrap();
-    fb.body(body);
+    let body = CodeBlock::of("println!(\"{}\", value)", ()).unwrap();
+    let fb = FunSpec::builder("print_value")
+        .visibility(Visibility::Public)
+        .add_type_param(tp)
+        .add_param(ParameterSpec::new("value", TypeName::primitive("&T")).unwrap())
+        .body(body);
 
-    let mut file = FileSpec::builder_with("utils.rs", RustLang::new());
-    file.add_function(fb.build().unwrap());
-    let output = file.build().unwrap().render(80).unwrap();
+    let output = FileSpec::builder_with("utils.rs", RustLang::new())
+        .add_function(fb.build().unwrap())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap();
 
     golden::assert_golden("rust/top_level_function.rs", &output);
 }
 
 #[test]
 fn test_function_with_doc() {
-    let mut fb = FunSpec::<RustLang>::builder("greet");
-    fb.visibility(Visibility::Public);
-    fb.doc("Greet the user by name.");
-    fb.add_param(ParameterSpec::new("name", TypeName::primitive("&str")).unwrap());
-    fb.returns(TypeName::primitive("String"));
-    let body = CodeBlock::<RustLang>::of("format!(\"Hello, {}!\", name)", ()).unwrap();
-    fb.body(body);
+    let body = CodeBlock::of("format!(\"Hello, {}!\", name)", ()).unwrap();
+    let fb = FunSpec::builder("greet")
+        .visibility(Visibility::Public)
+        .doc("Greet the user by name.")
+        .add_param(ParameterSpec::new("name", TypeName::primitive("&str")).unwrap())
+        .returns(TypeName::primitive("String"))
+        .body(body);
 
-    let mut file = FileSpec::builder_with("greet.rs", RustLang::new());
-    file.add_function(fb.build().unwrap());
-    let output = file.build().unwrap().render(80).unwrap();
+    let output = FileSpec::builder_with("greet.rs", RustLang::new())
+        .add_function(fb.build().unwrap())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap();
 
     golden::assert_golden("rust/function_with_doc.rs", &output);
 }

--- a/tests/rust/builder_imports.rs
+++ b/tests/rust/builder_imports.rs
@@ -7,10 +7,10 @@ use super::golden;
 
 #[test]
 fn test_function_with_imports() {
-    let hashmap = TypeName::<RustLang>::importable("std::collections", "HashMap");
-    let serialize = TypeName::<RustLang>::importable("serde", "Serialize");
+    let hashmap = TypeName::importable("std::collections", "HashMap");
+    let serialize = TypeName::importable("serde", "Serialize");
 
-    let mut b = CodeBlock::<RustLang>::builder();
+    let mut b = CodeBlock::builder();
     b.add("pub fn create_map() -> %T<String, String> {", (hashmap,));
     b.add_line();
     b.add("%>", ());
@@ -22,7 +22,7 @@ fn test_function_with_imports() {
     b.add_line();
     let func_block = b.build().unwrap();
 
-    let mut b2 = CodeBlock::<RustLang>::builder();
+    let mut b2 = CodeBlock::builder();
     b2.add("#[derive(%T)]", (serialize,));
     b2.add_line();
     b2.add("pub struct Config {", ());
@@ -34,10 +34,11 @@ fn test_function_with_imports() {
     b2.add_line();
     let struct_block = b2.build().unwrap();
 
-    let mut fb = FileSpec::builder_with("lib.rs", RustLang::new());
-    fb.add_code(func_block);
-    fb.add_code(struct_block);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("lib.rs", RustLang::new())
+        .add_code(func_block)
+        .add_code(struct_block)
+        .build()
+        .unwrap();
 
     let output = file.render(80).unwrap();
     golden::assert_golden("rust/function_with_imports.rs", &output);
@@ -45,14 +46,14 @@ fn test_function_with_imports() {
 
 #[test]
 fn test_import_grouping() {
-    let hashmap = TypeName::<RustLang>::importable("std::collections", "HashMap");
-    let btreemap = TypeName::<RustLang>::importable("std::collections", "BTreeMap");
-    let arc = TypeName::<RustLang>::importable("std::sync", "Arc");
-    let serialize = TypeName::<RustLang>::importable("serde", "Serialize");
-    let deserialize = TypeName::<RustLang>::importable("serde", "Deserialize");
-    let user = TypeName::<RustLang>::importable("crate::models", "User");
+    let hashmap = TypeName::importable("std::collections", "HashMap");
+    let btreemap = TypeName::importable("std::collections", "BTreeMap");
+    let arc = TypeName::importable("std::sync", "Arc");
+    let serialize = TypeName::importable("serde", "Serialize");
+    let deserialize = TypeName::importable("serde", "Deserialize");
+    let user = TypeName::importable("crate::models", "User");
 
-    let mut b = CodeBlock::<RustLang>::builder();
+    let mut b = CodeBlock::builder();
     b.add_statement(
         "let _h: %T<String, String> = Default::default()",
         (hashmap,),
@@ -67,9 +68,10 @@ fn test_import_grouping() {
     b.add_statement("let _u: %T = todo!()", (user,));
     let block = b.build().unwrap();
 
-    let mut fb = FileSpec::builder_with("main.rs", RustLang::new());
-    fb.add_code(block);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("main.rs", RustLang::new())
+        .add_code(block)
+        .build()
+        .unwrap();
 
     let output = file.render(80).unwrap();
     golden::assert_golden("rust/import_grouping.rs", &output);
@@ -77,17 +79,18 @@ fn test_import_grouping() {
 
 #[test]
 fn test_import_conflict() {
-    let user1 = TypeName::<RustLang>::importable("models", "User");
-    let user2 = TypeName::<RustLang>::importable("other_models", "User");
+    let user1 = TypeName::importable("models", "User");
+    let user2 = TypeName::importable("other_models", "User");
 
-    let mut b = CodeBlock::<RustLang>::builder();
+    let mut b = CodeBlock::builder();
     b.add_statement("let u1: %T = todo!()", (user1,));
     b.add_statement("let u2: %T = todo!()", (user2,));
     let block = b.build().unwrap();
 
-    let mut fb = FileSpec::builder_with("conflict.rs", RustLang::new());
-    fb.add_code(block);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("conflict.rs", RustLang::new())
+        .add_code(block)
+        .build()
+        .unwrap();
 
     let output = file.render(80).unwrap();
     golden::assert_golden("rust/import_conflict.rs", &output);

--- a/tests/rust/builder_types.rs
+++ b/tests/rust/builder_types.rs
@@ -13,11 +13,7 @@ use super::golden;
 
 #[test]
 fn test_struct_with_impl() {
-    let mut tb = TypeSpec::<RustLang>::builder("Config", TypeKind::Struct);
-    tb.visibility(Visibility::Public);
-    tb.doc("Application configuration.");
-
-    let derive = CodeBlock::<RustLang>::of(
+    let derive = CodeBlock::of(
         "#[derive(%T, %T)]",
         (
             TypeName::importable("serde", "Serialize"),
@@ -25,172 +21,206 @@ fn test_struct_with_impl() {
         ),
     )
     .unwrap();
-    tb.annotation(derive);
 
-    let mut fb1 = FieldSpec::builder("name", TypeName::primitive("String"));
-    fb1.visibility(Visibility::Public);
-    tb.add_field(fb1.build().unwrap());
-
-    let mut fb2 = FieldSpec::builder(
-        "values",
-        TypeName::generic(
-            TypeName::importable("std::collections", "HashMap"),
-            vec![TypeName::primitive("String"), TypeName::primitive("i64")],
-        ),
-    );
-    fb2.visibility(Visibility::Public);
-    tb.add_field(fb2.build().unwrap());
-
-    let body = CodeBlock::<RustLang>::of(
+    let body = CodeBlock::of(
         "Self { name: name.to_string(), values: HashMap::new() }",
         (),
     )
     .unwrap();
-    let mut mfb = FunSpec::<RustLang>::builder("new");
-    mfb.visibility(Visibility::Public);
-    mfb.add_param(ParameterSpec::new("name", TypeName::primitive("&str")).unwrap());
-    mfb.returns(TypeName::primitive("Self"));
-    mfb.body(body);
-    tb.add_method(mfb.build().unwrap());
 
-    let mut file = FileSpec::builder_with("config.rs", RustLang::new());
-    file.add_type(tb.build().unwrap());
-    let output = file.build().unwrap().render(100).unwrap();
+    let tb = TypeSpec::builder("Config", TypeKind::Struct)
+        .visibility(Visibility::Public)
+        .doc("Application configuration.")
+        .annotation(derive)
+        .add_field(
+            FieldSpec::builder("name", TypeName::primitive("String"))
+                .visibility(Visibility::Public)
+                .build()
+                .unwrap(),
+        )
+        .add_field(
+            FieldSpec::builder(
+                "values",
+                TypeName::generic(
+                    TypeName::importable("std::collections", "HashMap"),
+                    vec![TypeName::primitive("String"), TypeName::primitive("i64")],
+                ),
+            )
+            .visibility(Visibility::Public)
+            .build()
+            .unwrap(),
+        )
+        .add_method(
+            FunSpec::builder("new")
+                .visibility(Visibility::Public)
+                .add_param(ParameterSpec::new("name", TypeName::primitive("&str")).unwrap())
+                .returns(TypeName::primitive("Self"))
+                .body(body)
+                .build()
+                .unwrap(),
+        );
+
+    let output = FileSpec::builder_with("config.rs", RustLang::new())
+        .add_type(tb.build().unwrap())
+        .build()
+        .unwrap()
+        .render(100)
+        .unwrap();
 
     golden::assert_golden("rust/struct_with_impl.rs", &output);
 }
 
 #[test]
 fn test_generic_struct() {
-    let tp = TypeParamSpec::<RustLang>::new("T")
+    let tp = TypeParamSpec::new("T")
         .with_bound(TypeName::primitive("Clone"))
         .with_bound(TypeName::primitive("Send"));
 
-    let mut tb = TypeSpec::<RustLang>::builder("Container", TypeKind::Struct);
-    tb.visibility(Visibility::Public);
-    tb.add_type_param(tp);
+    let body = CodeBlock::of("self.items.len()", ()).unwrap();
+    let tb = TypeSpec::builder("Container", TypeKind::Struct)
+        .visibility(Visibility::Public)
+        .add_type_param(tp)
+        .add_field(
+            FieldSpec::builder(
+                "items",
+                TypeName::generic(TypeName::primitive("Vec"), vec![TypeName::primitive("T")]),
+            )
+            .visibility(Visibility::Public)
+            .build()
+            .unwrap(),
+        )
+        .add_method(
+            FunSpec::builder("len")
+                .visibility(Visibility::Public)
+                .add_param(ParameterSpec::new("&self", TypeName::primitive("")).unwrap())
+                .returns(TypeName::primitive("usize"))
+                .body(body)
+                .build()
+                .unwrap(),
+        );
 
-    let mut fb = FieldSpec::builder(
-        "items",
-        TypeName::generic(TypeName::primitive("Vec"), vec![TypeName::primitive("T")]),
-    );
-    fb.visibility(Visibility::Public);
-    tb.add_field(fb.build().unwrap());
-
-    let body = CodeBlock::<RustLang>::of("self.items.len()", ()).unwrap();
-    let mut mfb = FunSpec::<RustLang>::builder("len");
-    mfb.visibility(Visibility::Public);
-    mfb.add_param(ParameterSpec::new("&self", TypeName::primitive("")).unwrap());
-    mfb.returns(TypeName::primitive("usize"));
-    mfb.body(body);
-    tb.add_method(mfb.build().unwrap());
-
-    let mut file = FileSpec::builder_with("container.rs", RustLang::new());
-    file.add_type(tb.build().unwrap());
-    let output = file.build().unwrap().render(80).unwrap();
+    let output = FileSpec::builder_with("container.rs", RustLang::new())
+        .add_type(tb.build().unwrap())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap();
 
     golden::assert_golden("rust/generic_struct.rs", &output);
 }
 
 #[test]
 fn test_enum() {
-    let mut tb = TypeSpec::<RustLang>::builder("Color", TypeKind::Enum);
-    tb.visibility(Visibility::Public);
+    let derive = CodeBlock::of("#[derive(Debug, Clone, Copy)]", ()).unwrap();
+    let tb = TypeSpec::builder("Color", TypeKind::Enum)
+        .visibility(Visibility::Public)
+        .annotation(derive)
+        .add_variant(EnumVariantSpec::new("Red").unwrap())
+        .add_variant(EnumVariantSpec::new("Green").unwrap())
+        .add_variant(EnumVariantSpec::new("Blue").unwrap());
 
-    let derive = CodeBlock::<RustLang>::of("#[derive(Debug, Clone, Copy)]", ()).unwrap();
-    tb.annotation(derive);
-
-    tb.add_variant(EnumVariantSpec::new("Red").unwrap());
-    tb.add_variant(EnumVariantSpec::new("Green").unwrap());
-    tb.add_variant(EnumVariantSpec::new("Blue").unwrap());
-
-    let mut file = FileSpec::builder_with("color.rs", RustLang::new());
-    file.add_type(tb.build().unwrap());
-    let output = file.build().unwrap().render(80).unwrap();
+    let output = FileSpec::builder_with("color.rs", RustLang::new())
+        .add_type(tb.build().unwrap())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap();
 
     golden::assert_golden("rust/enum.rs", &output);
 }
 
 #[test]
 fn test_enum_tuple_variants() {
-    let mut tb = TypeSpec::<RustLang>::builder("Expr", TypeKind::Enum);
-    tb.visibility(Visibility::Public);
+    let derive = CodeBlock::of("#[derive(Debug, Clone)]", ()).unwrap();
+    let tb = TypeSpec::builder("Expr", TypeKind::Enum)
+        .visibility(Visibility::Public)
+        .annotation(derive)
+        .add_variant(EnumVariantSpec::new("Unit").unwrap())
+        .add_variant(
+            EnumVariantSpec::builder("Literal")
+                .associated_type(TypeName::primitive("i64"))
+                .build()
+                .unwrap(),
+        )
+        .add_variant(
+            EnumVariantSpec::builder("Add")
+                .associated_type(TypeName::generic(
+                    TypeName::primitive("Box"),
+                    vec![TypeName::primitive("Expr")],
+                ))
+                .associated_type(TypeName::generic(
+                    TypeName::primitive("Box"),
+                    vec![TypeName::primitive("Expr")],
+                ))
+                .build()
+                .unwrap(),
+        );
 
-    let derive = CodeBlock::<RustLang>::of("#[derive(Debug, Clone)]", ()).unwrap();
-    tb.annotation(derive);
-
-    tb.add_variant(EnumVariantSpec::new("Unit").unwrap());
-
-    let mut v_lit = EnumVariantSpec::<RustLang>::builder("Literal");
-    v_lit.associated_type(TypeName::primitive("i64"));
-    tb.add_variant(v_lit.build().unwrap());
-
-    let mut v_add = EnumVariantSpec::<RustLang>::builder("Add");
-    v_add.associated_type(TypeName::generic(
-        TypeName::primitive("Box"),
-        vec![TypeName::primitive("Expr")],
-    ));
-    v_add.associated_type(TypeName::generic(
-        TypeName::primitive("Box"),
-        vec![TypeName::primitive("Expr")],
-    ));
-    tb.add_variant(v_add.build().unwrap());
-
-    let mut file = FileSpec::builder_with("expr.rs", RustLang::new());
-    file.add_type(tb.build().unwrap());
-    let output = file.build().unwrap().render(80).unwrap();
+    let output = FileSpec::builder_with("expr.rs", RustLang::new())
+        .add_type(tb.build().unwrap())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap();
 
     golden::assert_golden("rust/enum_tuple.rs", &output);
 }
 
 #[test]
 fn test_enum_struct_variants() {
-    let mut tb = TypeSpec::<RustLang>::builder("Message", TypeKind::Enum);
-    tb.visibility(Visibility::Public);
+    let derive = CodeBlock::of("#[derive(Debug)]", ()).unwrap();
+    let tb = TypeSpec::builder("Message", TypeKind::Enum)
+        .visibility(Visibility::Public)
+        .annotation(derive)
+        .add_variant(EnumVariantSpec::new("Quit").unwrap())
+        .add_variant(
+            EnumVariantSpec::builder("Move")
+                .add_field(
+                    FieldSpec::builder("x", TypeName::primitive("i32"))
+                        .build()
+                        .unwrap(),
+                )
+                .add_field(
+                    FieldSpec::builder("y", TypeName::primitive("i32"))
+                        .build()
+                        .unwrap(),
+                )
+                .build()
+                .unwrap(),
+        )
+        .add_variant(
+            EnumVariantSpec::builder("Write")
+                .associated_type(TypeName::primitive("String"))
+                .build()
+                .unwrap(),
+        )
+        .add_variant(
+            EnumVariantSpec::builder("ChangeColor")
+                .add_field(
+                    FieldSpec::builder("r", TypeName::primitive("u8"))
+                        .build()
+                        .unwrap(),
+                )
+                .add_field(
+                    FieldSpec::builder("g", TypeName::primitive("u8"))
+                        .build()
+                        .unwrap(),
+                )
+                .add_field(
+                    FieldSpec::builder("b", TypeName::primitive("u8"))
+                        .build()
+                        .unwrap(),
+                )
+                .build()
+                .unwrap(),
+        );
 
-    let derive = CodeBlock::<RustLang>::of("#[derive(Debug)]", ()).unwrap();
-    tb.annotation(derive);
-
-    tb.add_variant(EnumVariantSpec::new("Quit").unwrap());
-
-    let mut v_move = EnumVariantSpec::<RustLang>::builder("Move");
-    v_move.add_field(
-        FieldSpec::builder("x", TypeName::primitive("i32"))
-            .build()
-            .unwrap(),
-    );
-    v_move.add_field(
-        FieldSpec::builder("y", TypeName::primitive("i32"))
-            .build()
-            .unwrap(),
-    );
-    tb.add_variant(v_move.build().unwrap());
-
-    let mut v_write = EnumVariantSpec::<RustLang>::builder("Write");
-    v_write.associated_type(TypeName::primitive("String"));
-    tb.add_variant(v_write.build().unwrap());
-
-    let mut v_color = EnumVariantSpec::<RustLang>::builder("ChangeColor");
-    v_color.add_field(
-        FieldSpec::builder("r", TypeName::primitive("u8"))
-            .build()
-            .unwrap(),
-    );
-    v_color.add_field(
-        FieldSpec::builder("g", TypeName::primitive("u8"))
-            .build()
-            .unwrap(),
-    );
-    v_color.add_field(
-        FieldSpec::builder("b", TypeName::primitive("u8"))
-            .build()
-            .unwrap(),
-    );
-    tb.add_variant(v_color.build().unwrap());
-
-    let mut file = FileSpec::builder_with("message.rs", RustLang::new());
-    file.add_type(tb.build().unwrap());
-    let output = file.build().unwrap().render(80).unwrap();
+    let output = FileSpec::builder_with("message.rs", RustLang::new())
+        .add_type(tb.build().unwrap())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap();
 
     golden::assert_golden("rust/enum_struct.rs", &output);
 }

--- a/tests/rust/quote_basic.rs
+++ b/tests/rust/quote_basic.rs
@@ -5,10 +5,13 @@ use sigil_stitch::spec::file_spec::FileSpec;
 
 use super::golden;
 
-fn render(block: &CodeBlock<RustLang>) -> String {
-    let mut fb = FileSpec::builder_with("test.rs", RustLang::new());
-    fb.add_code(block.clone());
-    fb.build().unwrap().render(80).unwrap()
+fn render(block: &CodeBlock) -> String {
+    FileSpec::builder_with("test.rs", RustLang::new())
+        .add_code(block.clone())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap()
 }
 
 #[test]

--- a/tests/rust/quote_control_flow.rs
+++ b/tests/rust/quote_control_flow.rs
@@ -5,10 +5,13 @@ use sigil_stitch::spec::file_spec::FileSpec;
 
 use super::golden;
 
-fn render(block: &CodeBlock<RustLang>) -> String {
-    let mut fb = FileSpec::builder_with("test.rs", RustLang::new());
-    fb.add_code(block.clone());
-    fb.build().unwrap().render(80).unwrap()
+fn render(block: &CodeBlock) -> String {
+    FileSpec::builder_with("test.rs", RustLang::new())
+        .add_code(block.clone())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap()
 }
 
 #[test]

--- a/tests/rust/quote_edge_cases.rs
+++ b/tests/rust/quote_edge_cases.rs
@@ -5,10 +5,13 @@ use sigil_stitch::spec::file_spec::FileSpec;
 
 use super::golden;
 
-fn render(block: &CodeBlock<RustLang>) -> String {
-    let mut fb = FileSpec::builder_with("test.rs", RustLang::new());
-    fb.add_code(block.clone());
-    fb.build().unwrap().render(80).unwrap()
+fn render(block: &CodeBlock) -> String {
+    FileSpec::builder_with("test.rs", RustLang::new())
+        .add_code(block.clone())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap()
 }
 
 #[test]

--- a/tests/rust/quote_imports.rs
+++ b/tests/rust/quote_imports.rs
@@ -6,16 +6,19 @@ use sigil_stitch::type_name::TypeName;
 
 use super::golden;
 
-fn render(block: &CodeBlock<RustLang>) -> String {
-    let mut fb = FileSpec::builder_with("test.rs", RustLang::new());
-    fb.add_code(block.clone());
-    fb.build().unwrap().render(80).unwrap()
+fn render(block: &CodeBlock) -> String {
+    FileSpec::builder_with("test.rs", RustLang::new())
+        .add_code(block.clone())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap()
 }
 
 #[test]
 fn test_imports() {
-    let hashmap = TypeName::<RustLang>::importable("std::collections", "HashMap");
-    let vec_deque = TypeName::<RustLang>::importable("std::collections", "VecDeque");
+    let hashmap = TypeName::importable("std::collections", "HashMap");
+    let vec_deque = TypeName::importable("std::collections", "VecDeque");
     let block = sigil_quote!(RustLang {
         let map: $T(hashmap.clone()) = $T(hashmap)::new();
         let deque: $T(vec_deque.clone()) = $T(vec_deque)::new();

--- a/tests/scala/builder_control_flow.rs
+++ b/tests/scala/builder_control_flow.rs
@@ -6,7 +6,7 @@ use super::golden;
 
 #[test]
 fn test_control_flow() {
-    let mut b = CodeBlock::<Scala>::builder();
+    let mut b = CodeBlock::builder();
     b.begin_control_flow("if (x > 0)", ());
     b.add_statement("return 1", ());
     b.next_control_flow("else if (x < 0)", ());
@@ -16,9 +16,10 @@ fn test_control_flow() {
     b.end_control_flow();
     let block = b.build().unwrap();
 
-    let mut fb = FileSpec::builder_with("Flow.scala", Scala::new());
-    fb.add_code(block);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("Flow.scala", Scala::new())
+        .add_code(block)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("scala/control_flow.scala", &output);

--- a/tests/scala/builder_edge_cases.rs
+++ b/tests/scala/builder_edge_cases.rs
@@ -9,7 +9,7 @@ use super::golden;
 
 #[test]
 fn test_string_dollar_escape() {
-    let body = CodeBlock::<Scala>::of(
+    let body = CodeBlock::of(
         "val greeting = %S\nval template = %S\nprintln(greeting)",
         (
             StringLitArg("Hello ${name}!".into()),
@@ -17,14 +17,16 @@ fn test_string_dollar_escape() {
         ),
     )
     .unwrap();
-    let mut fb = FunSpec::<Scala>::builder("greet");
-    fb.add_param(ParameterSpec::new("name", TypeName::primitive("String")).unwrap());
-    fb.body(body);
-    let fun = fb.build().unwrap();
+    let fun = FunSpec::builder("greet")
+        .add_param(ParameterSpec::new("name", TypeName::primitive("String")).unwrap())
+        .body(body)
+        .build()
+        .unwrap();
 
-    let mut file_b = FileSpec::builder_with("greet.scala", Scala::new());
-    file_b.add_function(fun);
-    let file = file_b.build().unwrap();
+    let file = FileSpec::builder_with("greet.scala", Scala::new())
+        .add_function(fun)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("scala/string_dollar_escape.scala", &output);

--- a/tests/scala/builder_functions.rs
+++ b/tests/scala/builder_functions.rs
@@ -10,18 +10,20 @@ use super::golden;
 
 #[test]
 fn test_function_with_return() {
-    let user = TypeName::<Scala>::importable("com.example.model", "User");
+    let user = TypeName::importable("com.example.model", "User");
 
-    let body = CodeBlock::<Scala>::of("api.fetchUser(id)", ()).unwrap();
-    let mut fb_fun = FunSpec::<Scala>::builder("fetchUser");
-    fb_fun.returns(user);
-    fb_fun.add_param(ParameterSpec::new("id", TypeName::primitive("String")).unwrap());
-    fb_fun.body(body);
-    let fun = fb_fun.build().unwrap();
+    let body = CodeBlock::of("api.fetchUser(id)", ()).unwrap();
+    let fun = FunSpec::builder("fetchUser")
+        .returns(user)
+        .add_param(ParameterSpec::new("id", TypeName::primitive("String")).unwrap())
+        .body(body)
+        .build()
+        .unwrap();
 
-    let mut fb = FileSpec::builder_with("Api.scala", Scala::new());
-    fb.add_function(fun);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("Api.scala", Scala::new())
+        .add_function(fun)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("scala/function_with_return.scala", &output);
@@ -29,18 +31,20 @@ fn test_function_with_return() {
 
 #[test]
 fn test_function_with_doc() {
-    let body = CodeBlock::<Scala>::of("s\"Hello, $name!\"", ()).unwrap();
-    let mut fb = FunSpec::<Scala>::builder("greet");
-    fb.visibility(Visibility::Public);
-    fb.doc("Greet the user by name.");
-    fb.add_param(ParameterSpec::new("name", TypeName::primitive("String")).unwrap());
-    fb.returns(TypeName::primitive("String"));
-    fb.body(body);
-    let fun = fb.build().unwrap();
+    let body = CodeBlock::of("s\"Hello, $name!\"", ()).unwrap();
+    let fun = FunSpec::builder("greet")
+        .visibility(Visibility::Public)
+        .doc("Greet the user by name.")
+        .add_param(ParameterSpec::new("name", TypeName::primitive("String")).unwrap())
+        .returns(TypeName::primitive("String"))
+        .body(body)
+        .build()
+        .unwrap();
 
-    let mut file_b = FileSpec::<Scala>::builder("greet.scala");
-    file_b.add_function(fun);
-    let file = file_b.build().unwrap();
+    let file = FileSpec::builder("greet.scala")
+        .add_function(fun)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("scala/function_with_doc.scala", &output);

--- a/tests/scala/builder_imports.rs
+++ b/tests/scala/builder_imports.rs
@@ -7,16 +7,17 @@ use super::golden;
 
 #[test]
 fn test_function_with_imports() {
-    let list = TypeName::<Scala>::importable("scala.collection.immutable", "List");
-    let user = TypeName::<Scala>::importable("com.example.model", "User");
+    let list = TypeName::importable("scala.collection.immutable", "List");
+    let user = TypeName::importable("com.example.model", "User");
 
-    let mut b = CodeBlock::<Scala>::builder();
+    let mut b = CodeBlock::builder();
     b.add_statement("val users: %T[%T] = getAll()", (list, user));
     let block = b.build().unwrap();
 
-    let mut fb = FileSpec::builder_with("App.scala", Scala::new());
-    fb.add_code(block);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("App.scala", Scala::new())
+        .add_code(block)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("scala/function_with_imports.scala", &output);
@@ -24,20 +25,21 @@ fn test_function_with_imports() {
 
 #[test]
 fn test_import_grouping() {
-    let list = TypeName::<Scala>::importable("scala.collection.immutable", "List");
-    let uuid = TypeName::<Scala>::importable("java.util", "UUID");
-    let inject = TypeName::<Scala>::importable("javax.inject", "Inject");
-    let user = TypeName::<Scala>::importable("com.example.model", "User");
-    let spark = TypeName::<Scala>::importable("org.apache.spark", "SparkContext");
+    let list = TypeName::importable("scala.collection.immutable", "List");
+    let uuid = TypeName::importable("java.util", "UUID");
+    let inject = TypeName::importable("javax.inject", "Inject");
+    let user = TypeName::importable("com.example.model", "User");
+    let spark = TypeName::importable("org.apache.spark", "SparkContext");
 
-    let mut b = CodeBlock::<Scala>::builder();
+    let mut b = CodeBlock::builder();
     b.add("// %T %T %T %T %T", (list, uuid, inject, user, spark));
     b.add_line();
     let block = b.build().unwrap();
 
-    let mut fb = FileSpec::builder_with("Imports.scala", Scala::new());
-    fb.add_code(block);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("Imports.scala", Scala::new())
+        .add_code(block)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("scala/import_grouping.scala", &output);

--- a/tests/scala/builder_types.rs
+++ b/tests/scala/builder_types.rs
@@ -12,24 +12,24 @@ use super::golden;
 
 #[test]
 fn test_case_class() {
-    let mut tb = TypeSpec::<Scala>::builder("User", TypeKind::Struct);
-    tb.doc("A user case class.");
+    let ts = TypeSpec::builder("User", TypeKind::Struct)
+        .doc("A user case class.")
+        .add_primary_constructor_param(
+            ParameterSpec::new("name", TypeName::primitive("String")).unwrap(),
+        )
+        .add_primary_constructor_param(
+            ParameterSpec::new("age", TypeName::primitive("Int")).unwrap(),
+        )
+        .add_primary_constructor_param(
+            ParameterSpec::new("email", TypeName::primitive("String")).unwrap(),
+        )
+        .build()
+        .unwrap();
 
-    tb.add_primary_constructor_param(
-        ParameterSpec::new("name", TypeName::primitive("String")).unwrap(),
-    );
-    tb.add_primary_constructor_param(
-        ParameterSpec::new("age", TypeName::primitive("Int")).unwrap(),
-    );
-    tb.add_primary_constructor_param(
-        ParameterSpec::new("email", TypeName::primitive("String")).unwrap(),
-    );
-
-    let ts = tb.build().unwrap();
-
-    let mut fb = FileSpec::builder_with("User.scala", Scala::new());
-    fb.add_type(ts);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("User.scala", Scala::new())
+        .add_type(ts)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("scala/case_class.scala", &output);
@@ -37,26 +37,31 @@ fn test_case_class() {
 
 #[test]
 fn test_trait_with_type_param() {
-    let tp = TypeParamSpec::<Scala>::new("T");
+    let tp = TypeParamSpec::new("T");
 
-    let mut tb = TypeSpec::<Scala>::builder("Repository", TypeKind::Trait);
-    tb.add_type_param(tp);
-    tb.doc("Generic data repository.");
+    let ts = TypeSpec::builder("Repository", TypeKind::Trait)
+        .add_type_param(tp)
+        .doc("Generic data repository.")
+        .add_method(
+            FunSpec::builder("findById")
+                .returns(TypeName::primitive("Option[T]"))
+                .add_param(ParameterSpec::new("id", TypeName::primitive("String")).unwrap())
+                .build()
+                .unwrap(),
+        )
+        .add_method(
+            FunSpec::builder("save")
+                .add_param(ParameterSpec::new("entity", TypeName::primitive("T")).unwrap())
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
 
-    let mut find = FunSpec::<Scala>::builder("findById");
-    find.returns(TypeName::primitive("Option[T]"));
-    find.add_param(ParameterSpec::new("id", TypeName::primitive("String")).unwrap());
-    tb.add_method(find.build().unwrap());
-
-    let mut save = FunSpec::<Scala>::builder("save");
-    save.add_param(ParameterSpec::new("entity", TypeName::primitive("T")).unwrap());
-    tb.add_method(save.build().unwrap());
-
-    let ts = tb.build().unwrap();
-
-    let mut fb = FileSpec::builder_with("Repository.scala", Scala::new());
-    fb.add_type(ts);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("Repository.scala", Scala::new())
+        .add_type(ts)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("scala/trait_with_type_param.scala", &output);
@@ -64,24 +69,27 @@ fn test_trait_with_type_param() {
 
 #[test]
 fn test_class_extends() {
-    let base = TypeName::<Scala>::importable("com.example.base", "BaseService");
-    let serial = TypeName::<Scala>::importable("com.example.serial", "Serializable");
+    let base = TypeName::importable("com.example.base", "BaseService");
+    let serial = TypeName::importable("com.example.serial", "Serializable");
 
-    let mut tb = TypeSpec::<Scala>::builder("AdminService", TypeKind::Class);
-    tb.extends(base);
-    tb.extends(serial);
+    let body = CodeBlock::of("true", ()).unwrap();
+    let ts = TypeSpec::builder("AdminService", TypeKind::Class)
+        .extends(base)
+        .extends(serial)
+        .add_method(
+            FunSpec::builder("isAdmin")
+                .returns(TypeName::primitive("Boolean"))
+                .body(body)
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
 
-    let body = CodeBlock::<Scala>::of("true", ()).unwrap();
-    let mut is_admin = FunSpec::<Scala>::builder("isAdmin");
-    is_admin.returns(TypeName::primitive("Boolean"));
-    is_admin.body(body);
-    tb.add_method(is_admin.build().unwrap());
-
-    let ts = tb.build().unwrap();
-
-    let mut fb = FileSpec::builder_with("AdminService.scala", Scala::new());
-    fb.add_type(ts);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("AdminService.scala", Scala::new())
+        .add_type(ts)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("scala/class_extends.scala", &output);
@@ -89,16 +97,17 @@ fn test_class_extends() {
 
 #[test]
 fn test_class_extends_multiple() {
-    let mut tb = TypeSpec::<Scala>::builder("Worker", TypeKind::Class);
-    tb.extends(TypeName::primitive("Actor"));
-    tb.extends(TypeName::primitive("Logging"));
-    tb.extends(TypeName::primitive("Serializable"));
+    let ts = TypeSpec::builder("Worker", TypeKind::Class)
+        .extends(TypeName::primitive("Actor"))
+        .extends(TypeName::primitive("Logging"))
+        .extends(TypeName::primitive("Serializable"))
+        .build()
+        .unwrap();
 
-    let ts = tb.build().unwrap();
-
-    let mut fb = FileSpec::builder_with("Worker.scala", Scala::new());
-    fb.add_type(ts);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("Worker.scala", Scala::new())
+        .add_type(ts)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("scala/class_extends_multiple.scala", &output);
@@ -106,18 +115,18 @@ fn test_class_extends_multiple() {
 
 #[test]
 fn test_enum() {
-    let mut tb = TypeSpec::<Scala>::builder("Color", TypeKind::Enum);
-    tb.doc("Supported colors.");
+    let ts = TypeSpec::builder("Color", TypeKind::Enum)
+        .doc("Supported colors.")
+        .add_variant(EnumVariantSpec::new("Red").unwrap())
+        .add_variant(EnumVariantSpec::new("Green").unwrap())
+        .add_variant(EnumVariantSpec::new("Blue").unwrap())
+        .build()
+        .unwrap();
 
-    tb.add_variant(EnumVariantSpec::new("Red").unwrap());
-    tb.add_variant(EnumVariantSpec::new("Green").unwrap());
-    tb.add_variant(EnumVariantSpec::new("Blue").unwrap());
-
-    let ts = tb.build().unwrap();
-
-    let mut fb = FileSpec::builder_with("Color.scala", Scala::new());
-    fb.add_type(ts);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("Color.scala", Scala::new())
+        .add_type(ts)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("scala/enum.scala", &output);
@@ -125,22 +134,24 @@ fn test_enum() {
 
 #[test]
 fn test_hkt_type_param() {
-    let tp_f = TypeParamSpec::<Scala>::new("F").with_kind(TypeParamKind::Constructor1);
-    let tp_a = TypeParamSpec::<Scala>::new("A");
+    let tp_f = TypeParamSpec::new("F").with_kind(TypeParamKind::Constructor1);
+    let tp_a = TypeParamSpec::new("A");
 
-    let mut fb_fun = FunSpec::<Scala>::builder("traverse");
-    fb_fun.add_type_param(tp_f);
-    fb_fun.add_type_param(tp_a);
-    fb_fun.returns(TypeName::primitive("F[List[A]]"));
-    fb_fun.add_param(ParameterSpec::new("list", TypeName::primitive("List[A]")).unwrap());
-    fb_fun.add_param(ParameterSpec::new("f", TypeName::primitive("A => F[A]")).unwrap());
-    let body = CodeBlock::<Scala>::of("???", ()).unwrap();
-    fb_fun.body(body);
-    let fun = fb_fun.build().unwrap();
+    let body = CodeBlock::of("???", ()).unwrap();
+    let fun = FunSpec::builder("traverse")
+        .add_type_param(tp_f)
+        .add_type_param(tp_a)
+        .returns(TypeName::primitive("F[List[A]]"))
+        .add_param(ParameterSpec::new("list", TypeName::primitive("List[A]")).unwrap())
+        .add_param(ParameterSpec::new("f", TypeName::primitive("A => F[A]")).unwrap())
+        .body(body)
+        .build()
+        .unwrap();
 
-    let mut fb = FileSpec::builder_with("Traverse.scala", Scala::new());
-    fb.add_function(fun);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("Traverse.scala", Scala::new())
+        .add_function(fun)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("scala/hkt_type_param.scala", &output);
@@ -148,20 +159,22 @@ fn test_hkt_type_param() {
 
 #[test]
 fn test_bounded_type_param() {
-    let tp = TypeParamSpec::<Scala>::new("T").with_bound(TypeName::primitive("Comparable[T]"));
+    let tp = TypeParamSpec::new("T").with_bound(TypeName::primitive("Comparable[T]"));
 
-    let mut fb_fun = FunSpec::<Scala>::builder("max");
-    fb_fun.add_type_param(tp);
-    fb_fun.returns(TypeName::primitive("T"));
-    fb_fun.add_param(ParameterSpec::new("a", TypeName::primitive("T")).unwrap());
-    fb_fun.add_param(ParameterSpec::new("b", TypeName::primitive("T")).unwrap());
-    let body = CodeBlock::<Scala>::of("if (a.compareTo(b) >= 0) a else b", ()).unwrap();
-    fb_fun.body(body);
-    let fun = fb_fun.build().unwrap();
+    let body = CodeBlock::of("if (a.compareTo(b) >= 0) a else b", ()).unwrap();
+    let fun = FunSpec::builder("max")
+        .add_type_param(tp)
+        .returns(TypeName::primitive("T"))
+        .add_param(ParameterSpec::new("a", TypeName::primitive("T")).unwrap())
+        .add_param(ParameterSpec::new("b", TypeName::primitive("T")).unwrap())
+        .body(body)
+        .build()
+        .unwrap();
 
-    let mut fb = FileSpec::builder_with("Max.scala", Scala::new());
-    fb.add_function(fun);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("Max.scala", Scala::new())
+        .add_function(fun)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("scala/bounded_type_param.scala", &output);
@@ -169,26 +182,32 @@ fn test_bounded_type_param() {
 
 #[test]
 fn test_abstract_class() {
-    let mut tb = TypeSpec::<Scala>::builder("Shape", TypeKind::Class);
-    tb.doc("Abstract shape.");
-    tb.is_abstract();
+    let desc_body = CodeBlock::of("getClass.getSimpleName", ()).unwrap();
 
-    let desc_body = CodeBlock::<Scala>::of("getClass.getSimpleName", ()).unwrap();
-    let mut desc = FunSpec::<Scala>::builder("describe");
-    desc.returns(TypeName::primitive("String"));
-    desc.body(desc_body);
-    tb.add_method(desc.build().unwrap());
+    let ts = TypeSpec::builder("Shape", TypeKind::Class)
+        .doc("Abstract shape.")
+        .is_abstract()
+        .add_method(
+            FunSpec::builder("describe")
+                .returns(TypeName::primitive("String"))
+                .body(desc_body)
+                .build()
+                .unwrap(),
+        )
+        .add_method(
+            FunSpec::builder("area")
+                .is_abstract()
+                .returns(TypeName::primitive("Double"))
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
 
-    let mut area = FunSpec::<Scala>::builder("area");
-    area.is_abstract();
-    area.returns(TypeName::primitive("Double"));
-    tb.add_method(area.build().unwrap());
-
-    let ts = tb.build().unwrap();
-
-    let mut fb = FileSpec::builder_with("Shape.scala", Scala::new());
-    fb.add_type(ts);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("Shape.scala", Scala::new())
+        .add_type(ts)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("scala/abstract_class.scala", &output);
@@ -196,23 +215,23 @@ fn test_abstract_class() {
 
 #[test]
 fn test_context_bound() {
-    let body = CodeBlock::<Scala>::of("implicitly[Ordering[T]].compare(a, b)", ()).unwrap();
-    let mut fb_fun = FunSpec::<Scala>::builder("sortedPair");
-    fb_fun.add_type_param(
-        TypeParamSpec::new("T").with_context_bound(TypeName::primitive("Ordering")),
-    );
-    fb_fun.add_param(ParameterSpec::new("a", TypeName::primitive("T")).unwrap());
-    fb_fun.add_param(ParameterSpec::new("b", TypeName::primitive("T")).unwrap());
-    fb_fun.returns(TypeName::generic(
-        TypeName::primitive("Tuple2"),
-        vec![TypeName::primitive("T"), TypeName::primitive("T")],
-    ));
-    fb_fun.body(body);
-    let fun = fb_fun.build().unwrap();
+    let body = CodeBlock::of("implicitly[Ordering[T]].compare(a, b)", ()).unwrap();
+    let fun = FunSpec::builder("sortedPair")
+        .add_type_param(TypeParamSpec::new("T").with_context_bound(TypeName::primitive("Ordering")))
+        .add_param(ParameterSpec::new("a", TypeName::primitive("T")).unwrap())
+        .add_param(ParameterSpec::new("b", TypeName::primitive("T")).unwrap())
+        .returns(TypeName::generic(
+            TypeName::primitive("Tuple2"),
+            vec![TypeName::primitive("T"), TypeName::primitive("T")],
+        ))
+        .body(body)
+        .build()
+        .unwrap();
 
-    let mut fb = FileSpec::builder_with("sorted.scala", Scala::new());
-    fb.add_function(fun);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("sorted.scala", Scala::new())
+        .add_function(fun)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("scala/context_bound.scala", &output);
@@ -220,14 +239,15 @@ fn test_context_bound() {
 
 #[test]
 fn test_newtype() {
-    let mut tb = TypeSpec::<Scala>::builder("Meters", TypeKind::Newtype);
-    tb.extends(TypeName::primitive("Double"));
+    let ts = TypeSpec::builder("Meters", TypeKind::Newtype)
+        .extends(TypeName::primitive("Double"))
+        .build()
+        .unwrap();
 
-    let ts = tb.build().unwrap();
-
-    let mut fb = FileSpec::builder_with("meters.scala", Scala::new());
-    fb.add_type(ts);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("meters.scala", Scala::new())
+        .add_type(ts)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("scala/newtype.scala", &output);
@@ -235,22 +255,24 @@ fn test_newtype() {
 
 #[test]
 fn test_multiple_context_bounds() {
-    let body = CodeBlock::<Scala>::of("implicitly[Ordering[T]].compare(a, b)", ()).unwrap();
-    let mut fb_fun = FunSpec::<Scala>::builder("compare");
-    fb_fun.add_type_param(
-        TypeParamSpec::new("T")
-            .with_context_bound(TypeName::primitive("Ordering"))
-            .with_context_bound(TypeName::primitive("Numeric")),
-    );
-    fb_fun.add_param(ParameterSpec::new("a", TypeName::primitive("T")).unwrap());
-    fb_fun.add_param(ParameterSpec::new("b", TypeName::primitive("T")).unwrap());
-    fb_fun.returns(TypeName::primitive("Int"));
-    fb_fun.body(body);
-    let fun = fb_fun.build().unwrap();
+    let body = CodeBlock::of("implicitly[Ordering[T]].compare(a, b)", ()).unwrap();
+    let fun = FunSpec::builder("compare")
+        .add_type_param(
+            TypeParamSpec::new("T")
+                .with_context_bound(TypeName::primitive("Ordering"))
+                .with_context_bound(TypeName::primitive("Numeric")),
+        )
+        .add_param(ParameterSpec::new("a", TypeName::primitive("T")).unwrap())
+        .add_param(ParameterSpec::new("b", TypeName::primitive("T")).unwrap())
+        .returns(TypeName::primitive("Int"))
+        .body(body)
+        .build()
+        .unwrap();
 
-    let mut fb = FileSpec::builder_with("compare.scala", Scala::new());
-    fb.add_function(fun);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("compare.scala", Scala::new())
+        .add_function(fun)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("scala/multiple_context_bounds.scala", &output);

--- a/tests/scala/quote_basic.rs
+++ b/tests/scala/quote_basic.rs
@@ -1,14 +1,16 @@
 use sigil_stitch::code_block::CodeBlock;
-use sigil_stitch::lang::scala::Scala;
 use sigil_stitch::prelude::*;
 use sigil_stitch::spec::file_spec::FileSpec;
 
 use super::golden;
 
-fn render(block: &CodeBlock<Scala>) -> String {
-    let mut fb = FileSpec::<Scala>::builder("test.scala");
-    fb.add_code(block.clone());
-    fb.build().unwrap().render(80).unwrap()
+fn render(block: &CodeBlock) -> String {
+    FileSpec::builder("test.scala")
+        .add_code(block.clone())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap()
 }
 
 #[test]

--- a/tests/scala/quote_control_flow.rs
+++ b/tests/scala/quote_control_flow.rs
@@ -1,14 +1,16 @@
 use sigil_stitch::code_block::CodeBlock;
-use sigil_stitch::lang::scala::Scala;
 use sigil_stitch::prelude::*;
 use sigil_stitch::spec::file_spec::FileSpec;
 
 use super::golden;
 
-fn render(block: &CodeBlock<Scala>) -> String {
-    let mut fb = FileSpec::<Scala>::builder("test.scala");
-    fb.add_code(block.clone());
-    fb.build().unwrap().render(80).unwrap()
+fn render(block: &CodeBlock) -> String {
+    FileSpec::builder("test.scala")
+        .add_code(block.clone())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap()
 }
 
 #[test]

--- a/tests/scala/quote_imports.rs
+++ b/tests/scala/quote_imports.rs
@@ -1,20 +1,22 @@
 use sigil_stitch::code_block::CodeBlock;
-use sigil_stitch::lang::scala::Scala;
 use sigil_stitch::prelude::*;
 use sigil_stitch::spec::file_spec::FileSpec;
 use sigil_stitch::type_name::TypeName;
 
 use super::golden;
 
-fn render(block: &CodeBlock<Scala>) -> String {
-    let mut fb = FileSpec::<Scala>::builder("test.scala");
-    fb.add_code(block.clone());
-    fb.build().unwrap().render(80).unwrap()
+fn render(block: &CodeBlock) -> String {
+    FileSpec::builder("test.scala")
+        .add_code(block.clone())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap()
 }
 
 #[test]
 fn test_imports() {
-    let list_buffer = TypeName::<Scala>::importable("scala.collection.mutable", "ListBuffer");
+    let list_buffer = TypeName::importable("scala.collection.mutable", "ListBuffer");
     let block = sigil_quote!(Scala {
         val buf = new $T(list_buffer)();
     })

--- a/tests/swift/builder_control_flow.rs
+++ b/tests/swift/builder_control_flow.rs
@@ -6,7 +6,7 @@ use super::golden;
 
 #[test]
 fn test_control_flow() {
-    let mut b = CodeBlock::<Swift>::builder();
+    let mut b = CodeBlock::builder();
     b.begin_control_flow("if x > 0", ());
     b.add_statement("return 1", ());
     b.next_control_flow("else if x < 0", ());
@@ -16,9 +16,10 @@ fn test_control_flow() {
     b.end_control_flow();
     let block = b.build().unwrap();
 
-    let mut fb = FileSpec::builder_with("Flow.swift", Swift::new());
-    fb.add_code(block);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("Flow.swift", Swift::new())
+        .add_code(block)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("swift/control_flow.swift", &output);

--- a/tests/swift/builder_edge_cases.rs
+++ b/tests/swift/builder_edge_cases.rs
@@ -12,73 +12,87 @@ use super::golden;
 
 #[test]
 fn test_full_module() {
-    let url = TypeName::<Swift>::importable("Foundation", "URL");
-    let data = TypeName::<Swift>::importable("Foundation", "Data");
+    let url = TypeName::importable("Foundation", "URL");
+    let data = TypeName::importable("Foundation", "Data");
 
     // Protocol.
-    let mut proto = TypeSpec::<Swift>::builder("DataFetcher", TypeKind::Interface);
-
-    let mut fetch = FunSpec::<Swift>::builder("fetchData");
-    fetch.is_async();
-    fetch.returns(data.clone());
-    fetch.add_param(ParameterSpec::new("from", TypeName::primitive("URL")).unwrap());
-    proto.add_method(fetch.build().unwrap());
-
-    let proto_spec = proto.build().unwrap();
+    let proto_spec = TypeSpec::builder("DataFetcher", TypeKind::Interface)
+        .add_method(
+            FunSpec::builder("fetchData")
+                .is_async()
+                .returns(data.clone())
+                .add_param(ParameterSpec::new("from", TypeName::primitive("URL")).unwrap())
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
 
     // Struct.
-    let mut model = TypeSpec::<Swift>::builder("Response", TypeKind::Struct);
-    model.doc("API response model.");
-
-    let mut status_field = FieldSpec::builder("statusCode", TypeName::primitive("Int"));
-    status_field.is_readonly();
-    model.add_field(status_field.build().unwrap());
-
-    let mut body_field = FieldSpec::builder("body", TypeName::primitive("Data"));
-    body_field.is_readonly();
-    model.add_field(body_field.build().unwrap());
-
-    let model_spec = model.build().unwrap();
+    let model_spec = TypeSpec::builder("Response", TypeKind::Struct)
+        .doc("API response model.")
+        .add_field(
+            FieldSpec::builder("statusCode", TypeName::primitive("Int"))
+                .is_readonly()
+                .build()
+                .unwrap(),
+        )
+        .add_field(
+            FieldSpec::builder("body", TypeName::primitive("Data"))
+                .is_readonly()
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
 
     // Implementation class.
-    let mut cls = TypeSpec::<Swift>::builder("NetworkFetcher", TypeKind::Class);
-    cls.extends(TypeName::primitive("DataFetcher"));
-    cls.doc("Network-based data fetcher.");
+    let cls = TypeSpec::builder("NetworkFetcher", TypeKind::Class);
+    let cls = cls.extends(TypeName::primitive("DataFetcher"));
+    let cls = cls.doc("Network-based data fetcher.");
 
-    let mut session_field = FieldSpec::builder("session", TypeName::primitive("URLSession"));
-    session_field.visibility(Visibility::Private);
-    session_field.is_readonly();
-    cls.add_field(session_field.build().unwrap());
+    let cls = cls.add_field(
+        FieldSpec::builder("session", TypeName::primitive("URLSession"))
+            .visibility(Visibility::Private)
+            .is_readonly()
+            .build()
+            .unwrap(),
+    );
 
     // fetchData implementation.
-    let fetch_body = CodeBlock::<Swift>::of(
+    let fetch_body = CodeBlock::of(
         "let (data, _) = try await session.data(from: from)\nreturn data",
         (),
     )
     .unwrap();
-    let mut fetch_impl = FunSpec::<Swift>::builder("fetchData");
-    fetch_impl.is_async();
-    fetch_impl.returns(data);
-    fetch_impl.add_param(ParameterSpec::new("from", TypeName::primitive("URL")).unwrap());
-    fetch_impl.body(fetch_body);
-    cls.add_method(fetch_impl.build().unwrap());
+    let cls = cls.add_method(
+        FunSpec::builder("fetchData")
+            .is_async()
+            .returns(data)
+            .add_param(ParameterSpec::new("from", TypeName::primitive("URL")).unwrap())
+            .body(fetch_body)
+            .build()
+            .unwrap(),
+    );
 
     let cls_spec = cls.build().unwrap();
 
     // Standalone function using URL import.
-    let make_body = CodeBlock::<Swift>::of("return %T(string: urlString)!", (url,)).unwrap();
-    let mut make_fn = FunSpec::<Swift>::builder("makeURL");
-    make_fn.returns(TypeName::primitive("URL"));
-    make_fn.add_param(ParameterSpec::new("urlString", TypeName::primitive("String")).unwrap());
-    make_fn.body(make_body);
-    let make_url = make_fn.build().unwrap();
+    let make_body = CodeBlock::of("return %T(string: urlString)!", (url,)).unwrap();
+    let make_url = FunSpec::builder("makeURL")
+        .returns(TypeName::primitive("URL"))
+        .add_param(ParameterSpec::new("urlString", TypeName::primitive("String")).unwrap())
+        .body(make_body)
+        .build()
+        .unwrap();
 
-    let mut fb = FileSpec::builder_with("Network.swift", Swift::new());
-    fb.add_type(proto_spec);
-    fb.add_type(model_spec);
-    fb.add_type(cls_spec);
-    fb.add_function(make_url);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("Network.swift", Swift::new())
+        .add_type(proto_spec)
+        .add_type(model_spec)
+        .add_type(cls_spec)
+        .add_function(make_url)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("swift/full_module.swift", &output);
@@ -86,7 +100,7 @@ fn test_full_module() {
 
 #[test]
 fn test_string_interpolation_escape() {
-    let body = CodeBlock::<Swift>::of(
+    let body = CodeBlock::of(
         "let greeting = %S\nlet escaped = %S\nprint(greeting)",
         (
             StringLitArg("Hello \\(name)!".into()),
@@ -94,14 +108,16 @@ fn test_string_interpolation_escape() {
         ),
     )
     .unwrap();
-    let mut fb = FunSpec::<Swift>::builder("greet");
-    fb.add_param(ParameterSpec::new("name", TypeName::primitive("String")).unwrap());
-    fb.body(body);
-    let fun = fb.build().unwrap();
+    let fun = FunSpec::builder("greet")
+        .add_param(ParameterSpec::new("name", TypeName::primitive("String")).unwrap())
+        .body(body)
+        .build()
+        .unwrap();
 
-    let mut file_b = FileSpec::builder_with("greet.swift", Swift::new());
-    file_b.add_function(fun);
-    let file = file_b.build().unwrap();
+    let file = FileSpec::builder_with("greet.swift", Swift::new())
+        .add_function(fun)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("swift/string_interpolation_escape.swift", &output);

--- a/tests/swift/builder_functions.rs
+++ b/tests/swift/builder_functions.rs
@@ -11,19 +11,21 @@ use super::golden;
 
 #[test]
 fn test_async_function() {
-    let user = TypeName::<Swift>::importable("MyModule", "User");
+    let user = TypeName::importable("MyModule", "User");
 
-    let body = CodeBlock::<Swift>::of("return try await api.fetchUser(id: id)", ()).unwrap();
-    let mut fb_fun = FunSpec::<Swift>::builder("fetchUser");
-    fb_fun.is_async();
-    fb_fun.returns(user);
-    fb_fun.add_param(ParameterSpec::new("id", TypeName::primitive("String")).unwrap());
-    fb_fun.body(body);
-    let fun = fb_fun.build().unwrap();
+    let body = CodeBlock::of("return try await api.fetchUser(id: id)", ()).unwrap();
+    let fun = FunSpec::builder("fetchUser")
+        .is_async()
+        .returns(user)
+        .add_param(ParameterSpec::new("id", TypeName::primitive("String")).unwrap())
+        .body(body)
+        .build()
+        .unwrap();
 
-    let mut fb = FileSpec::builder_with("Api.swift", Swift::new());
-    fb.add_function(fun);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("Api.swift", Swift::new())
+        .add_function(fun)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("swift/async_function.swift", &output);
@@ -31,25 +33,29 @@ fn test_async_function() {
 
 #[test]
 fn test_override_method() {
-    let mut tb = TypeSpec::<Swift>::builder("Dog", TypeKind::Class);
-    tb.extends(TypeName::primitive("Animal"));
-
-    let body = CodeBlock::<Swift>::of(
+    let body = CodeBlock::of(
         "return %S",
         (sigil_stitch::code_block::StringLitArg("Woof!".to_string()),),
     )
     .unwrap();
-    let mut speak = FunSpec::<Swift>::builder("speak");
-    speak.returns(TypeName::primitive("String"));
-    speak.is_override();
-    speak.body(body);
-    tb.add_method(speak.build().unwrap());
 
-    let ts = tb.build().unwrap();
+    let ts = TypeSpec::builder("Dog", TypeKind::Class)
+        .extends(TypeName::primitive("Animal"))
+        .add_method(
+            FunSpec::builder("speak")
+                .returns(TypeName::primitive("String"))
+                .is_override()
+                .body(body)
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
 
-    let mut fb = FileSpec::builder_with("Dog.swift", Swift::new());
-    fb.add_type(ts);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("Dog.swift", Swift::new())
+        .add_type(ts)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("swift/override_method.swift", &output);
@@ -57,18 +63,20 @@ fn test_override_method() {
 
 #[test]
 fn test_function_with_doc() {
-    let body = CodeBlock::<Swift>::of("return \"Hello, \\(name)!\"", ()).unwrap();
-    let mut fb = FunSpec::<Swift>::builder("greet");
-    fb.visibility(Visibility::Public);
-    fb.doc("Greet the user by name.");
-    fb.add_param(ParameterSpec::new("name", TypeName::primitive("String")).unwrap());
-    fb.returns(TypeName::primitive("String"));
-    fb.body(body);
-    let fun = fb.build().unwrap();
+    let body = CodeBlock::of("return \"Hello, \\(name)!\"", ()).unwrap();
+    let fun = FunSpec::builder("greet")
+        .visibility(Visibility::Public)
+        .doc("Greet the user by name.")
+        .add_param(ParameterSpec::new("name", TypeName::primitive("String")).unwrap())
+        .returns(TypeName::primitive("String"))
+        .body(body)
+        .build()
+        .unwrap();
 
-    let mut file_b = FileSpec::<Swift>::builder("greet.swift");
-    file_b.add_function(fun);
-    let file = file_b.build().unwrap();
+    let file = FileSpec::builder("greet.swift")
+        .add_function(fun)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("swift/function_with_doc.swift", &output);

--- a/tests/swift/builder_imports.rs
+++ b/tests/swift/builder_imports.rs
@@ -7,17 +7,18 @@ use super::golden;
 
 #[test]
 fn test_function_with_imports() {
-    let url = TypeName::<Swift>::importable("Foundation", "URL");
-    let user = TypeName::<Swift>::importable("MyModule", "User");
+    let url = TypeName::importable("Foundation", "URL");
+    let user = TypeName::importable("MyModule", "User");
 
-    let mut b = CodeBlock::<Swift>::builder();
+    let mut b = CodeBlock::builder();
     b.add_statement("let endpoint: %T = getEndpoint()", (url,));
     b.add_statement("let user: %T = fetchUser(endpoint)", (user,));
     let block = b.build().unwrap();
 
-    let mut fb = FileSpec::builder_with("App.swift", Swift::new());
-    fb.add_code(block);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("App.swift", Swift::new())
+        .add_code(block)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("swift/function_with_imports.swift", &output);
@@ -25,14 +26,14 @@ fn test_function_with_imports() {
 
 #[test]
 fn test_import_grouping() {
-    let url = TypeName::<Swift>::importable("Foundation", "URL");
-    let view = TypeName::<Swift>::importable("SwiftUI", "View");
-    let vc = TypeName::<Swift>::importable("UIKit", "UIViewController");
-    let combine = TypeName::<Swift>::importable("Combine", "Publisher");
-    let alamofire = TypeName::<Swift>::importable("Alamofire", "Session");
-    let my_type = TypeName::<Swift>::importable("MyModule", "MyType");
+    let url = TypeName::importable("Foundation", "URL");
+    let view = TypeName::importable("SwiftUI", "View");
+    let vc = TypeName::importable("UIKit", "UIViewController");
+    let combine = TypeName::importable("Combine", "Publisher");
+    let alamofire = TypeName::importable("Alamofire", "Session");
+    let my_type = TypeName::importable("MyModule", "MyType");
 
-    let mut b = CodeBlock::<Swift>::builder();
+    let mut b = CodeBlock::builder();
     b.add(
         "// %T %T %T %T %T %T",
         (url, view, vc, combine, alamofire, my_type),
@@ -40,9 +41,10 @@ fn test_import_grouping() {
     b.add_line();
     let block = b.build().unwrap();
 
-    let mut fb = FileSpec::builder_with("Imports.swift", Swift::new());
-    fb.add_code(block);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("Imports.swift", Swift::new())
+        .add_code(block)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("swift/import_grouping.swift", &output);

--- a/tests/swift/builder_types.rs
+++ b/tests/swift/builder_types.rs
@@ -13,34 +13,40 @@ use super::golden;
 
 #[test]
 fn test_class_with_properties() {
-    let mut tb = TypeSpec::<Swift>::builder("UserService", TypeKind::Class);
-    tb.visibility(Visibility::Public);
-    tb.doc("Service for managing users.");
+    let find_body = CodeBlock::of("return repo.find(by: id)", ()).unwrap();
 
-    // Properties.
-    let mut repo_field = FieldSpec::builder("repo", TypeName::primitive("UserRepository"));
-    repo_field.visibility(Visibility::Private);
-    tb.add_field(repo_field.build().unwrap());
+    let ts = TypeSpec::builder("UserService", TypeKind::Class)
+        .visibility(Visibility::Public)
+        .doc("Service for managing users.")
+        .add_field(
+            FieldSpec::builder("repo", TypeName::primitive("UserRepository"))
+                .visibility(Visibility::Private)
+                .build()
+                .unwrap(),
+        )
+        .add_field(
+            FieldSpec::builder("logger", TypeName::primitive("Logger"))
+                .visibility(Visibility::Private)
+                .is_readonly()
+                .build()
+                .unwrap(),
+        )
+        .add_method(
+            FunSpec::builder("findUser")
+                .visibility(Visibility::Public)
+                .returns(TypeName::primitive("User?"))
+                .add_param(ParameterSpec::new("id", TypeName::primitive("String")).unwrap())
+                .body(find_body)
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
 
-    let mut logger_field = FieldSpec::builder("logger", TypeName::primitive("Logger"));
-    logger_field.visibility(Visibility::Private);
-    logger_field.is_readonly();
-    tb.add_field(logger_field.build().unwrap());
-
-    // Method.
-    let find_body = CodeBlock::<Swift>::of("return repo.find(by: id)", ()).unwrap();
-    let mut find = FunSpec::<Swift>::builder("findUser");
-    find.visibility(Visibility::Public);
-    find.returns(TypeName::primitive("User?"));
-    find.add_param(ParameterSpec::new("id", TypeName::primitive("String")).unwrap());
-    find.body(find_body);
-    tb.add_method(find.build().unwrap());
-
-    let ts = tb.build().unwrap();
-
-    let mut fb = FileSpec::builder_with("UserService.swift", Swift::new());
-    fb.add_type(ts);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("UserService.swift", Swift::new())
+        .add_type(ts)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("swift/class_with_properties.swift", &output);
@@ -48,29 +54,36 @@ fn test_class_with_properties() {
 
 #[test]
 fn test_struct() {
-    let mut tb = TypeSpec::<Swift>::builder("User", TypeKind::Struct);
-    tb.visibility(Visibility::Public);
-    tb.doc("A user value type.");
+    let ts = TypeSpec::builder("User", TypeKind::Struct)
+        .visibility(Visibility::Public)
+        .doc("A user value type.")
+        .add_field(
+            FieldSpec::builder("name", TypeName::primitive("String"))
+                .visibility(Visibility::Public)
+                .is_readonly()
+                .build()
+                .unwrap(),
+        )
+        .add_field(
+            FieldSpec::builder("age", TypeName::primitive("Int"))
+                .visibility(Visibility::Public)
+                .is_readonly()
+                .build()
+                .unwrap(),
+        )
+        .add_field(
+            FieldSpec::builder("email", TypeName::primitive("String?"))
+                .visibility(Visibility::Public)
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
 
-    let mut name_field = FieldSpec::builder("name", TypeName::primitive("String"));
-    name_field.visibility(Visibility::Public);
-    name_field.is_readonly();
-    tb.add_field(name_field.build().unwrap());
-
-    let mut age_field = FieldSpec::builder("age", TypeName::primitive("Int"));
-    age_field.visibility(Visibility::Public);
-    age_field.is_readonly();
-    tb.add_field(age_field.build().unwrap());
-
-    let mut email_field = FieldSpec::builder("email", TypeName::primitive("String?"));
-    email_field.visibility(Visibility::Public);
-    tb.add_field(email_field.build().unwrap());
-
-    let ts = tb.build().unwrap();
-
-    let mut fb = FileSpec::builder_with("User.swift", Swift::new());
-    fb.add_type(ts);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("User.swift", Swift::new())
+        .add_type(ts)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("swift/struct.swift", &output);
@@ -78,31 +91,37 @@ fn test_struct() {
 
 #[test]
 fn test_protocol() {
-    let tp = TypeParamSpec::<Swift>::new("T");
+    let tp = TypeParamSpec::new("T");
 
-    let mut tb = TypeSpec::<Swift>::builder("Repository", TypeKind::Interface);
-    tb.add_type_param(tp);
-    tb.doc("Generic data repository.");
+    let ts = TypeSpec::builder("Repository", TypeKind::Interface)
+        .add_type_param(tp)
+        .doc("Generic data repository.")
+        .add_method(
+            FunSpec::builder("findById")
+                .returns(TypeName::primitive("T?"))
+                .add_param(ParameterSpec::new("id", TypeName::primitive("String")).unwrap())
+                .build()
+                .unwrap(),
+        )
+        .add_method(
+            FunSpec::builder("save")
+                .add_param(ParameterSpec::new("entity", TypeName::primitive("T")).unwrap())
+                .build()
+                .unwrap(),
+        )
+        .add_method(
+            FunSpec::builder("delete")
+                .add_param(ParameterSpec::new("id", TypeName::primitive("String")).unwrap())
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
 
-    // Protocol method requirements (no body).
-    let mut find = FunSpec::<Swift>::builder("findById");
-    find.returns(TypeName::primitive("T?"));
-    find.add_param(ParameterSpec::new("id", TypeName::primitive("String")).unwrap());
-    tb.add_method(find.build().unwrap());
-
-    let mut save = FunSpec::<Swift>::builder("save");
-    save.add_param(ParameterSpec::new("entity", TypeName::primitive("T")).unwrap());
-    tb.add_method(save.build().unwrap());
-
-    let mut delete = FunSpec::<Swift>::builder("delete");
-    delete.add_param(ParameterSpec::new("id", TypeName::primitive("String")).unwrap());
-    tb.add_method(delete.build().unwrap());
-
-    let ts = tb.build().unwrap();
-
-    let mut fb = FileSpec::builder_with("Repository.swift", Swift::new());
-    fb.add_type(ts);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("Repository.swift", Swift::new())
+        .add_type(ts)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("swift/protocol.swift", &output);
@@ -110,29 +129,32 @@ fn test_protocol() {
 
 #[test]
 fn test_abstract_class() {
-    let mut tb = TypeSpec::<Swift>::builder("Shape", TypeKind::Class);
-    tb.doc("Abstract shape base class.");
+    let desc_body = CodeBlock::of("return String(describing: type(of: self))", ()).unwrap();
+    let area_body = CodeBlock::of("fatalError(\"Subclasses must override\")", ()).unwrap();
 
-    // Concrete method.
-    let desc_body =
-        CodeBlock::<Swift>::of("return String(describing: type(of: self))", ()).unwrap();
-    let mut desc = FunSpec::<Swift>::builder("describe");
-    desc.returns(TypeName::primitive("String"));
-    desc.body(desc_body);
-    tb.add_method(desc.build().unwrap());
+    let ts = TypeSpec::builder("Shape", TypeKind::Class)
+        .doc("Abstract shape base class.")
+        .add_method(
+            FunSpec::builder("describe")
+                .returns(TypeName::primitive("String"))
+                .body(desc_body)
+                .build()
+                .unwrap(),
+        )
+        .add_method(
+            FunSpec::builder("area")
+                .returns(TypeName::primitive("Double"))
+                .body(area_body)
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
 
-    // Abstract-like method (fatalError convention).
-    let area_body = CodeBlock::<Swift>::of("fatalError(\"Subclasses must override\")", ()).unwrap();
-    let mut area = FunSpec::<Swift>::builder("area");
-    area.returns(TypeName::primitive("Double"));
-    area.body(area_body);
-    tb.add_method(area.build().unwrap());
-
-    let ts = tb.build().unwrap();
-
-    let mut fb = FileSpec::builder_with("Shape.swift", Swift::new());
-    fb.add_type(ts);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("Shape.swift", Swift::new())
+        .add_type(ts)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("swift/abstract_class.swift", &output);
@@ -140,27 +162,30 @@ fn test_abstract_class() {
 
 #[test]
 fn test_class_extends_implements() {
-    let base = TypeName::<Swift>::importable("MyModule", "BaseService");
-    let codable = TypeName::<Swift>::importable("Foundation", "Codable");
-    let hashable = TypeName::<Swift>::primitive("Hashable");
+    let base = TypeName::importable("MyModule", "BaseService");
+    let codable = TypeName::importable("Foundation", "Codable");
+    let hashable = TypeName::primitive("Hashable");
 
+    let body = CodeBlock::of("return true", ()).unwrap();
     // Swift uses `:` for both superclass and protocol conformance.
-    let mut tb = TypeSpec::<Swift>::builder("AdminService", TypeKind::Class);
-    tb.extends(base);
-    tb.extends(codable);
-    tb.extends(hashable);
+    let ts = TypeSpec::builder("AdminService", TypeKind::Class)
+        .extends(base)
+        .extends(codable)
+        .extends(hashable)
+        .add_method(
+            FunSpec::builder("isAdmin")
+                .returns(TypeName::primitive("Bool"))
+                .body(body)
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
 
-    let body = CodeBlock::<Swift>::of("return true", ()).unwrap();
-    let mut is_admin = FunSpec::<Swift>::builder("isAdmin");
-    is_admin.returns(TypeName::primitive("Bool"));
-    is_admin.body(body);
-    tb.add_method(is_admin.build().unwrap());
-
-    let ts = tb.build().unwrap();
-
-    let mut fb = FileSpec::builder_with("AdminService.swift", Swift::new());
-    fb.add_type(ts);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("AdminService.swift", Swift::new())
+        .add_type(ts)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("swift/class_extends_implements.swift", &output);
@@ -168,19 +193,19 @@ fn test_class_extends_implements() {
 
 #[test]
 fn test_enum() {
-    let mut tb = TypeSpec::<Swift>::builder("Color", TypeKind::Enum);
-    tb.visibility(Visibility::Public);
-    tb.doc("Supported colors.");
+    let ts = TypeSpec::builder("Color", TypeKind::Enum)
+        .visibility(Visibility::Public)
+        .doc("Supported colors.")
+        .add_variant(EnumVariantSpec::new("red").unwrap())
+        .add_variant(EnumVariantSpec::new("green").unwrap())
+        .add_variant(EnumVariantSpec::new("blue").unwrap())
+        .build()
+        .unwrap();
 
-    tb.add_variant(EnumVariantSpec::new("red").unwrap());
-    tb.add_variant(EnumVariantSpec::new("green").unwrap());
-    tb.add_variant(EnumVariantSpec::new("blue").unwrap());
-
-    let ts = tb.build().unwrap();
-
-    let mut fb = FileSpec::builder_with("Color.swift", Swift::new());
-    fb.add_type(ts);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("Color.swift", Swift::new())
+        .add_type(ts)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("swift/enum.swift", &output);
@@ -188,27 +213,30 @@ fn test_enum() {
 
 #[test]
 fn test_enum_associated_values() {
-    let mut tb = TypeSpec::<Swift>::builder("NetworkResult", TypeKind::Enum);
-    tb.visibility(Visibility::Public);
-    tb.doc("Result of a network request.");
+    let ts = TypeSpec::builder("NetworkResult", TypeKind::Enum)
+        .visibility(Visibility::Public)
+        .doc("Result of a network request.")
+        .add_variant(
+            EnumVariantSpec::builder("success")
+                .associated_type(TypeName::primitive("Data"))
+                .build()
+                .unwrap(),
+        )
+        .add_variant(
+            EnumVariantSpec::builder("failure")
+                .associated_type(TypeName::primitive("Error"))
+                .associated_type(TypeName::primitive("Int"))
+                .build()
+                .unwrap(),
+        )
+        .add_variant(EnumVariantSpec::new("loading").unwrap())
+        .build()
+        .unwrap();
 
-    // case success(Data)
-    let mut v_success = EnumVariantSpec::<Swift>::builder("success");
-    v_success.associated_type(TypeName::primitive("Data"));
-    tb.add_variant(v_success.build().unwrap());
-
-    // case failure(Error, Int) — multi-element associated value
-    let mut v_failure = EnumVariantSpec::<Swift>::builder("failure");
-    v_failure.associated_type(TypeName::primitive("Error"));
-    v_failure.associated_type(TypeName::primitive("Int"));
-    tb.add_variant(v_failure.build().unwrap());
-
-    // case loading — simple variant
-    tb.add_variant(EnumVariantSpec::new("loading").unwrap());
-
-    let mut fb = FileSpec::builder_with("NetworkResult.swift", Swift::new());
-    fb.add_type(tb.build().unwrap());
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder_with("NetworkResult.swift", Swift::new())
+        .add_type(ts)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("swift/enum_associated.swift", &output);

--- a/tests/swift/quote_basic.rs
+++ b/tests/swift/quote_basic.rs
@@ -1,14 +1,16 @@
 use sigil_stitch::code_block::CodeBlock;
-use sigil_stitch::lang::swift::Swift;
 use sigil_stitch::prelude::*;
 use sigil_stitch::spec::file_spec::FileSpec;
 
 use super::golden;
 
-fn render(block: &CodeBlock<Swift>) -> String {
-    let mut fb = FileSpec::<Swift>::builder("test.swift");
-    fb.add_code(block.clone());
-    fb.build().unwrap().render(80).unwrap()
+fn render(block: &CodeBlock) -> String {
+    FileSpec::builder("test.swift")
+        .add_code(block.clone())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap()
 }
 
 #[test]

--- a/tests/swift/quote_control_flow.rs
+++ b/tests/swift/quote_control_flow.rs
@@ -1,14 +1,16 @@
 use sigil_stitch::code_block::CodeBlock;
-use sigil_stitch::lang::swift::Swift;
 use sigil_stitch::prelude::*;
 use sigil_stitch::spec::file_spec::FileSpec;
 
 use super::golden;
 
-fn render(block: &CodeBlock<Swift>) -> String {
-    let mut fb = FileSpec::<Swift>::builder("test.swift");
-    fb.add_code(block.clone());
-    fb.build().unwrap().render(80).unwrap()
+fn render(block: &CodeBlock) -> String {
+    FileSpec::builder("test.swift")
+        .add_code(block.clone())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap()
 }
 
 #[test]

--- a/tests/swift/quote_imports.rs
+++ b/tests/swift/quote_imports.rs
@@ -1,21 +1,23 @@
 use sigil_stitch::code_block::CodeBlock;
-use sigil_stitch::lang::swift::Swift;
 use sigil_stitch::prelude::*;
 use sigil_stitch::spec::file_spec::FileSpec;
 use sigil_stitch::type_name::TypeName;
 
 use super::golden;
 
-fn render(block: &CodeBlock<Swift>) -> String {
-    let mut fb = FileSpec::<Swift>::builder("test.swift");
-    fb.add_code(block.clone());
-    fb.build().unwrap().render(80).unwrap()
+fn render(block: &CodeBlock) -> String {
+    FileSpec::builder("test.swift")
+        .add_code(block.clone())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap()
 }
 
 #[test]
 fn test_imports() {
-    let foundation = TypeName::<Swift>::importable("Foundation", "URL");
-    let uikit = TypeName::<Swift>::importable("UIKit", "UIView");
+    let foundation = TypeName::importable("Foundation", "URL");
+    let uikit = TypeName::importable("UIKit", "UIView");
     let block = sigil_quote!(Swift {
         let url: $T(foundation.clone()) = $T(foundation)(string: $S("https://example.com"));
         let view: $T(uikit.clone()) = $T(uikit)();

--- a/tests/template_tests.rs
+++ b/tests/template_tests.rs
@@ -1,7 +1,5 @@
 use sigil_stitch::code_block::{CodeBlock, NameArg};
 use sigil_stitch::code_template::CodeTemplate;
-use sigil_stitch::lang::rust_lang::RustLang;
-use sigil_stitch::lang::typescript::TypeScript;
 use sigil_stitch::spec::file_spec::FileSpec;
 use sigil_stitch::type_name::TypeName;
 
@@ -10,19 +8,22 @@ use sigil_stitch::type_name::TypeName;
 #[test]
 fn test_template_full_render_ts() {
     let tmpl = CodeTemplate::new("const #{var:N}: #{type:T} = #{init:L}").unwrap();
-    let user_type = TypeName::<TypeScript>::importable_type("./models", "User");
+    let user_type = TypeName::importable_type("./models", "User");
 
     let block = tmpl
-        .apply::<TypeScript>()
+        .apply()
         .set("var", NameArg("currentUser".into()))
         .set("type", user_type)
         .set("init", "getUser()")
         .build()
         .unwrap();
 
-    let mut fb = FileSpec::<TypeScript>::builder("app.ts");
-    fb.add_code(block);
-    let output = fb.build().unwrap().render(80).unwrap();
+    let output = FileSpec::builder("app.ts")
+        .add_code(block)
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap();
 
     assert!(output.contains("import type { User } from './models'"));
     assert!(output.contains("const currentUser: User = getUser()"));
@@ -31,27 +32,30 @@ fn test_template_full_render_ts() {
 #[test]
 fn test_template_reuse_with_dedup() {
     let tmpl = CodeTemplate::new("const #{var:N}: #{type:T} = new #{type:T}()").unwrap();
-    let user = TypeName::<TypeScript>::importable_type("./models", "User");
-    let config = TypeName::<TypeScript>::importable("./config", "Config");
+    let user = TypeName::importable_type("./models", "User");
+    let config = TypeName::importable("./config", "Config");
 
     let block1 = tmpl
-        .apply::<TypeScript>()
+        .apply()
         .set("var", NameArg("user".into()))
         .set("type", user)
         .build()
         .unwrap();
 
     let block2 = tmpl
-        .apply::<TypeScript>()
+        .apply()
         .set("var", NameArg("config".into()))
         .set("type", config)
         .build()
         .unwrap();
 
-    let mut fb = FileSpec::<TypeScript>::builder("service.ts");
-    fb.add_code(block1);
-    fb.add_code(block2);
-    let output = fb.build().unwrap().render(80).unwrap();
+    let output = FileSpec::builder("service.ts")
+        .add_code(block1)
+        .add_code(block2)
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap();
 
     assert!(output.contains("import type { User } from './models'"));
     assert!(output.contains("import { Config } from './config'"));
@@ -65,22 +69,21 @@ fn test_template_composition_via_literal() {
     let inner_tmpl = CodeTemplate::new("return #{val:L}").unwrap();
     let outer_tmpl = CodeTemplate::new("function #{name:N}() { #{body:L} }").unwrap();
 
-    let inner = inner_tmpl
-        .apply::<TypeScript>()
-        .set("val", "42")
-        .build()
-        .unwrap();
+    let inner = inner_tmpl.apply().set("val", "42").build().unwrap();
 
     let outer = outer_tmpl
-        .apply::<TypeScript>()
+        .apply()
         .set("name", NameArg("getAnswer".into()))
         .set("body", inner)
         .build()
         .unwrap();
 
-    let mut fb = FileSpec::<TypeScript>::builder("answer.ts");
-    fb.add_code(outer);
-    let output = fb.build().unwrap().render(80).unwrap();
+    let output = FileSpec::builder("answer.ts")
+        .add_code(outer)
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap();
 
     assert!(output.contains("function getAnswer()"));
     assert!(output.contains("return 42"));
@@ -90,11 +93,14 @@ fn test_template_composition_via_literal() {
 
 #[test]
 fn test_raw_with_imports_triggers_import() {
-    let user_type = TypeName::<TypeScript>::importable_type("./models", "User");
+    let user_type = TypeName::importable_type("./models", "User");
 
-    let mut fb = FileSpec::<TypeScript>::builder("handler.ts");
-    fb.add_raw_with_imports("const u: User = fetchUser();\n", vec![user_type]);
-    let output = fb.build().unwrap().render(80).unwrap();
+    let output = FileSpec::builder("handler.ts")
+        .add_raw_with_imports("const u: User = fetchUser();\n", vec![user_type])
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap();
 
     // Import should be generated.
     assert!(output.contains("import type { User } from './models'"));
@@ -104,11 +110,14 @@ fn test_raw_with_imports_triggers_import() {
 
 #[test]
 fn test_raw_with_imports_no_substitution() {
-    let ty = TypeName::<TypeScript>::importable("./lib", "Helper");
+    let ty = TypeName::importable("./lib", "Helper");
 
-    let mut fb = FileSpec::<TypeScript>::builder("test.ts");
-    fb.add_raw_with_imports("// Helper is used here\n", vec![ty]);
-    let output = fb.build().unwrap().render(80).unwrap();
+    let output = FileSpec::builder("test.ts")
+        .add_raw_with_imports("// Helper is used here\n", vec![ty])
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap();
 
     // Raw content unchanged.
     assert!(output.contains("// Helper is used here"));
@@ -118,18 +127,18 @@ fn test_raw_with_imports_no_substitution() {
 
 #[test]
 fn test_raw_with_imports_mixed_with_code() {
-    let user_type = TypeName::<TypeScript>::importable_type("./models", "User");
-    let same_user = TypeName::<TypeScript>::importable_type("./models", "User");
+    let user_type = TypeName::importable_type("./models", "User");
+    let same_user = TypeName::importable_type("./models", "User");
 
-    let mut fb = FileSpec::<TypeScript>::builder("mixed.ts");
+    let fb = FileSpec::builder("mixed.ts");
 
     // Raw content referencing User.
-    fb.add_raw_with_imports("// User type is used below\n", vec![user_type]);
-
     // CodeBlock also referencing User.
-    let mut cb = CodeBlock::<TypeScript>::builder();
+    let mut cb = CodeBlock::builder();
     cb.add_statement("const u: %T = getUser()", (same_user,));
-    fb.add_code(cb.build().unwrap());
+    let fb = fb
+        .add_raw_with_imports("// User type is used below\n", vec![user_type])
+        .add_code(cb.build().unwrap());
 
     let output = fb.build().unwrap().render(80).unwrap();
 
@@ -143,19 +152,22 @@ fn test_raw_with_imports_mixed_with_code() {
 #[test]
 fn test_template_rust_render() {
     let tmpl = CodeTemplate::new("let #{var:N}: #{type:T} = #{init:L}").unwrap();
-    let config_type = TypeName::<RustLang>::importable("crate::config", "Config");
+    let config_type = TypeName::importable("crate::config", "Config");
 
     let block = tmpl
-        .apply::<RustLang>()
+        .apply()
         .set("var", NameArg("cfg".into()))
         .set("type", config_type)
         .set("init", "Config::default()")
         .build()
         .unwrap();
 
-    let mut fb = FileSpec::<RustLang>::builder("main.rs");
-    fb.add_code(block);
-    let output = fb.build().unwrap().render(80).unwrap();
+    let output = FileSpec::builder("main.rs")
+        .add_code(block)
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap();
 
     assert!(output.contains("use crate::config::Config;"));
     assert!(output.contains("let cfg: Config = Config::default()"));

--- a/tests/typescript/builder_control_flow.rs
+++ b/tests/typescript/builder_control_flow.rs
@@ -1,5 +1,4 @@
 use sigil_stitch::code_block::CodeBlock;
-use sigil_stitch::lang::typescript::TypeScript;
 use sigil_stitch::spec::file_spec::FileSpec;
 use sigil_stitch::type_name::TypeName;
 
@@ -7,9 +6,9 @@ use super::golden;
 
 #[test]
 fn test_control_flow() {
-    let error_type = TypeName::<TypeScript>::importable_type("./errors", "NotFoundError");
+    let error_type = TypeName::importable_type("./errors", "NotFoundError");
 
-    let mut b = CodeBlock::<TypeScript>::builder();
+    let mut b = CodeBlock::builder();
     b.add("export function validate(input: string): boolean {", ());
     b.add_line();
     b.add("%>", ());
@@ -25,9 +24,10 @@ fn test_control_flow() {
     b.add_line();
     let block = b.build().unwrap();
 
-    let mut fb = FileSpec::<TypeScript>::builder("validate.ts");
-    fb.add_code(block);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder("validate.ts")
+        .add_code(block)
+        .build()
+        .unwrap();
 
     let output = file.render(80).unwrap();
     golden::assert_golden("typescript/control_flow.ts", &output);

--- a/tests/typescript/builder_edge_cases.rs
+++ b/tests/typescript/builder_edge_cases.rs
@@ -1,6 +1,5 @@
 use sigil_stitch::code_block::{CodeBlock, NameArg, StringLitArg};
 use sigil_stitch::import::validate_module_path;
-use sigil_stitch::lang::typescript::TypeScript;
 use sigil_stitch::spec::field_spec::FieldSpec;
 use sigil_stitch::spec::file_spec::FileSpec;
 use sigil_stitch::spec::modifiers::{TypeKind, Visibility};
@@ -11,12 +10,11 @@ use super::golden;
 
 #[test]
 fn test_long_params() {
-    let config_type = TypeName::<TypeScript>::importable_type("./config", "Configuration");
-    let request_type = TypeName::<TypeScript>::importable_type("./http", "RequestInit");
-    let override_type =
-        TypeName::<TypeScript>::importable_type("./runtime", "InitOverrideFunction");
+    let config_type = TypeName::importable_type("./config", "Configuration");
+    let request_type = TypeName::importable_type("./http", "RequestInit");
+    let override_type = TypeName::importable_type("./runtime", "InitOverrideFunction");
 
-    let mut b = CodeBlock::<TypeScript>::builder();
+    let mut b = CodeBlock::builder();
     b.add("export async function createUser(%Wname: string,%Wage: number,%Wconfig: %T,%Wrequest: %T,%Woverride: %T%W): Promise<void> {", (config_type, request_type, override_type));
     b.add_line();
     b.add("%>", ());
@@ -26,9 +24,7 @@ fn test_long_params() {
     b.add_line();
     let block = b.build().unwrap();
 
-    let mut fb = FileSpec::<TypeScript>::builder("api.ts");
-    fb.add_code(block);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder("api.ts").add_code(block).build().unwrap();
 
     let output = file.render(80).unwrap();
     golden::assert_golden("typescript/long_params.ts", &output);
@@ -36,14 +32,14 @@ fn test_long_params() {
 
 #[test]
 fn test_nested_codeblock() {
-    let user_type = TypeName::<TypeScript>::importable_type("./models", "User");
+    let user_type = TypeName::importable_type("./models", "User");
 
-    let mut inner_b = CodeBlock::<TypeScript>::builder();
+    let mut inner_b = CodeBlock::builder();
     inner_b.add_statement("const user = new %T()", (user_type,));
     inner_b.add_statement("return user", ());
     let inner = inner_b.build().unwrap();
 
-    let mut b = CodeBlock::<TypeScript>::builder();
+    let mut b = CodeBlock::builder();
     b.add("export function getUser(): User {", ());
     b.add_line();
     b.add("%>", ());
@@ -53,9 +49,10 @@ fn test_nested_codeblock() {
     b.add_line();
     let block = b.build().unwrap();
 
-    let mut fb = FileSpec::<TypeScript>::builder("getUser.ts");
-    fb.add_code(block);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder("getUser.ts")
+        .add_code(block)
+        .build()
+        .unwrap();
 
     let output = file.render(80).unwrap();
     golden::assert_golden("typescript/nested_codeblock.ts", &output);
@@ -63,16 +60,17 @@ fn test_nested_codeblock() {
 
 #[test]
 fn test_empty_file() {
-    let file = FileSpec::<TypeScript>::builder("empty.ts").build().unwrap();
+    let file = FileSpec::builder("empty.ts").build().unwrap();
     let output = file.render(80).unwrap();
     golden::assert_golden("typescript/empty.ts", &output);
 }
 
 #[test]
 fn test_raw_content() {
-    let mut fb = FileSpec::<TypeScript>::builder("version.ts");
-    fb.add_raw("// Auto-generated, do not edit.\n\nexport const VERSION = '1.0.0';\n");
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder("version.ts")
+        .add_raw("// Auto-generated, do not edit.\n\nexport const VERSION = '1.0.0';\n")
+        .build()
+        .unwrap();
 
     let output = file.render(80).unwrap();
     golden::assert_golden("typescript/raw_content.ts", &output);
@@ -80,14 +78,15 @@ fn test_raw_content() {
 
 #[test]
 fn test_string_and_name() {
-    let mut b = CodeBlock::<TypeScript>::builder();
+    let mut b = CodeBlock::builder();
     b.add_statement("const url = %S", (StringLitArg("/api/users".to_string()),));
     b.add_statement("this.%N(url)", (NameArg("fetchData".to_string()),));
     let block = b.build().unwrap();
 
-    let mut fb = FileSpec::<TypeScript>::builder("fetch.ts");
-    fb.add_code(block);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder("fetch.ts")
+        .add_code(block)
+        .build()
+        .unwrap();
 
     let output = file.render(80).unwrap();
     golden::assert_golden("typescript/string_and_name.ts", &output);
@@ -114,13 +113,13 @@ fn test_column_width_120() {
     golden::assert_golden("typescript/width_120.ts", &output);
 }
 
-fn build_width_test_file() -> FileSpec<TypeScript> {
-    let config = TypeName::<TypeScript>::importable_type("./config", "Configuration");
-    let request = TypeName::<TypeScript>::importable_type("./http", "RequestInit");
-    let response = TypeName::<TypeScript>::importable_type("./http", "ResponseBody");
-    let logger = TypeName::<TypeScript>::importable_type("./logging", "Logger");
+fn build_width_test_file() -> FileSpec {
+    let config = TypeName::importable_type("./config", "Configuration");
+    let request = TypeName::importable_type("./http", "RequestInit");
+    let response = TypeName::importable_type("./http", "ResponseBody");
+    let logger = TypeName::importable_type("./logging", "Logger");
 
-    let mut b = CodeBlock::<TypeScript>::builder();
+    let mut b = CodeBlock::builder();
     b.add(
         "export async function handleRequest(%Wconfig: %T,%Wrequest: %T,%Wlogger: %T%W): Promise<%T> {",
         (config, request, logger, response),
@@ -133,18 +132,19 @@ fn build_width_test_file() -> FileSpec<TypeScript> {
     b.add_line();
     let block = b.build().unwrap();
 
-    let mut fb = FileSpec::<TypeScript>::builder("handler.ts");
-    fb.add_code(block);
-    fb.build().unwrap()
+    FileSpec::builder("handler.ts")
+        .add_code(block)
+        .build()
+        .unwrap()
 }
 
 #[test]
 fn test_divergence_regression() {
-    let config1 = TypeName::<TypeScript>::importable_type("./app", "Config");
-    let config2 = TypeName::<TypeScript>::importable_type("./server", "Config");
-    let config3 = TypeName::<TypeScript>::importable_type("./database", "Config");
+    let config1 = TypeName::importable_type("./app", "Config");
+    let config2 = TypeName::importable_type("./server", "Config");
+    let config3 = TypeName::importable_type("./database", "Config");
 
-    let mut b = CodeBlock::<TypeScript>::builder();
+    let mut b = CodeBlock::builder();
     b.add(
         "export function mergeConfigs(%Wapp: %T,%Wserver: %T,%Wdb: %T%W): %T {",
         (config1.clone(), config2.clone(), config3.clone(), config1),
@@ -158,9 +158,10 @@ fn test_divergence_regression() {
     b.add_line();
     let block = b.build().unwrap();
 
-    let mut fb = FileSpec::<TypeScript>::builder("merge.ts");
-    fb.add_code(block);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder("merge.ts")
+        .add_code(block)
+        .build()
+        .unwrap();
 
     let output = file.render(60).unwrap();
     golden::assert_golden("typescript/divergence_regression.ts", &output);
@@ -168,20 +169,21 @@ fn test_divergence_regression() {
 
 #[test]
 fn test_multiline_type_semicolons() {
-    let user = TypeName::<TypeScript>::importable_type("./models", "UserAccount");
-    let admin = TypeName::<TypeScript>::importable_type("./models", "AdminAccount");
-    let service = TypeName::<TypeScript>::importable_type("./models", "ServiceAccount");
-    let guest = TypeName::<TypeScript>::importable_type("./models", "GuestAccount");
+    let user = TypeName::importable_type("./models", "UserAccount");
+    let admin = TypeName::importable_type("./models", "AdminAccount");
+    let service = TypeName::importable_type("./models", "ServiceAccount");
+    let guest = TypeName::importable_type("./models", "GuestAccount");
 
-    let union = TypeName::<TypeScript>::union(vec![user, admin, service, guest]);
+    let union = TypeName::union(vec![user, admin, service, guest]);
 
-    let mut b = CodeBlock::<TypeScript>::builder();
+    let mut b = CodeBlock::builder();
     b.add_statement("type Account = %T", (union,));
     let block = b.build().unwrap();
 
-    let mut fb = FileSpec::<TypeScript>::builder("account.ts");
-    fb.add_code(block);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder("account.ts")
+        .add_code(block)
+        .build()
+        .unwrap();
 
     let output = file.render(40).unwrap();
     golden::assert_golden("typescript/multiline_type_semicolons.ts", &output);
@@ -190,22 +192,23 @@ fn test_multiline_type_semicolons() {
 #[test]
 fn test_deep_nesting() {
     let mut current = {
-        let mut b = CodeBlock::<TypeScript>::builder();
+        let mut b = CodeBlock::builder();
         b.add_statement("console.log('leaf')", ());
         b.build().unwrap()
     };
 
     for i in (0..12).rev() {
-        let mut b = CodeBlock::<TypeScript>::builder();
+        let mut b = CodeBlock::builder();
         b.add(&format!("// level {i}"), ());
         b.add_line();
         b.add_code(current);
         current = b.build().unwrap();
     }
 
-    let mut fb = FileSpec::<TypeScript>::builder("deep.ts");
-    fb.add_code(current);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder("deep.ts")
+        .add_code(current)
+        .build()
+        .unwrap();
 
     let output = file.render(80).unwrap();
     golden::assert_golden("typescript/deep_nesting.ts", &output);
@@ -234,22 +237,28 @@ fn test_module_path_validation() {
 
 #[test]
 fn test_optional_field() {
-    let mut tb = TypeSpec::<TypeScript>::builder("Config", TypeKind::Interface);
-    tb.visibility(Visibility::Public);
-
-    tb.add_field(
-        FieldSpec::builder("name", TypeName::<TypeScript>::primitive("string"))
-            .build()
-            .unwrap(),
-    );
-
-    let mut opt = FieldSpec::builder("description", TypeName::<TypeScript>::primitive("string"));
-    opt.is_optional();
-    tb.add_field(opt.build().unwrap());
-
-    let mut file = FileSpec::<TypeScript>::builder("Config.ts");
-    file.add_type(tb.build().unwrap());
-    let output = file.build().unwrap().render(80).unwrap();
+    let output = FileSpec::builder("Config.ts")
+        .add_type(
+            TypeSpec::builder("Config", TypeKind::Interface)
+                .visibility(Visibility::Public)
+                .add_field(
+                    FieldSpec::builder("name", TypeName::primitive("string"))
+                        .build()
+                        .unwrap(),
+                )
+                .add_field(
+                    FieldSpec::builder("description", TypeName::primitive("string"))
+                        .is_optional()
+                        .build()
+                        .unwrap(),
+                )
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap();
 
     golden::assert_golden("typescript/optional_field.ts", &output);
 }

--- a/tests/typescript/builder_functions.rs
+++ b/tests/typescript/builder_functions.rs
@@ -1,5 +1,4 @@
 use sigil_stitch::code_block::CodeBlock;
-use sigil_stitch::lang::typescript::TypeScript;
 use sigil_stitch::spec::file_spec::FileSpec;
 use sigil_stitch::spec::fun_spec::{FunSpec, TypeParamSpec};
 use sigil_stitch::spec::modifiers::Visibility;
@@ -10,36 +9,42 @@ use super::golden;
 
 #[test]
 fn test_top_level_function() {
-    let tp = TypeParamSpec::<TypeScript>::new("T").with_bound(TypeName::primitive("Serializable"));
+    let tp = TypeParamSpec::new("T").with_bound(TypeName::primitive("Serializable"));
 
-    let mut fb = FunSpec::<TypeScript>::builder("serialize");
-    fb.visibility(Visibility::Public);
-    fb.add_type_param(tp);
-    fb.add_param(ParameterSpec::new("value", TypeName::primitive("T")).unwrap());
-    fb.returns(TypeName::primitive("string"));
-    let body = CodeBlock::<TypeScript>::of("return JSON.stringify(value)", ()).unwrap();
-    fb.body(body);
+    let body = CodeBlock::of("return JSON.stringify(value)", ()).unwrap();
+    let fb = FunSpec::builder("serialize")
+        .visibility(Visibility::Public)
+        .add_type_param(tp)
+        .add_param(ParameterSpec::new("value", TypeName::primitive("T")).unwrap())
+        .returns(TypeName::primitive("string"))
+        .body(body);
 
-    let mut file = FileSpec::<TypeScript>::builder("serialize.ts");
-    file.add_function(fb.build().unwrap());
-    let output = file.build().unwrap().render(80).unwrap();
+    let output = FileSpec::builder("serialize.ts")
+        .add_function(fb.build().unwrap())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap();
 
     golden::assert_golden("typescript/top_level_function.ts", &output);
 }
 
 #[test]
 fn test_function_with_doc() {
-    let mut fb = FunSpec::<TypeScript>::builder("greet");
-    fb.visibility(Visibility::Public);
-    fb.doc("Greet the user by name.");
-    fb.add_param(ParameterSpec::new("name", TypeName::primitive("string")).unwrap());
-    fb.returns(TypeName::primitive("string"));
-    let body = CodeBlock::<TypeScript>::of("return `Hello, ${name}!`", ()).unwrap();
-    fb.body(body);
+    let body = CodeBlock::of("return `Hello, ${name}!`", ()).unwrap();
+    let fb = FunSpec::builder("greet")
+        .visibility(Visibility::Public)
+        .doc("Greet the user by name.")
+        .add_param(ParameterSpec::new("name", TypeName::primitive("string")).unwrap())
+        .returns(TypeName::primitive("string"))
+        .body(body);
 
-    let mut file = FileSpec::<TypeScript>::builder("greet.ts");
-    file.add_function(fb.build().unwrap());
-    let output = file.build().unwrap().render(80).unwrap();
+    let output = FileSpec::builder("greet.ts")
+        .add_function(fb.build().unwrap())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap();
 
     golden::assert_golden("typescript/function_with_doc.ts", &output);
 }

--- a/tests/typescript/builder_imports.rs
+++ b/tests/typescript/builder_imports.rs
@@ -1,5 +1,4 @@
 use sigil_stitch::code_block::CodeBlock;
-use sigil_stitch::lang::typescript::TypeScript;
 use sigil_stitch::spec::file_spec::FileSpec;
 use sigil_stitch::type_name::TypeName;
 
@@ -7,9 +6,9 @@ use super::golden;
 
 #[test]
 fn test_hello_world() {
-    let user_type = TypeName::<TypeScript>::importable_type("./models", "User");
+    let user_type = TypeName::importable_type("./models", "User");
 
-    let mut b = CodeBlock::<TypeScript>::builder();
+    let mut b = CodeBlock::builder();
     b.add("export class UserService {", ());
     b.add_line();
     b.add("%>", ());
@@ -19,9 +18,10 @@ fn test_hello_world() {
     b.add_line();
     let block = b.build().unwrap();
 
-    let mut fb = FileSpec::<TypeScript>::builder("UserService.ts");
-    fb.add_code(block);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder("UserService.ts")
+        .add_code(block)
+        .build()
+        .unwrap();
 
     let output = file.render(80).unwrap();
     golden::assert_golden("typescript/hello_world.ts", &output);
@@ -29,17 +29,18 @@ fn test_hello_world() {
 
 #[test]
 fn test_conflicting_imports() {
-    let user1 = TypeName::<TypeScript>::importable_type("./models", "User");
-    let user2 = TypeName::<TypeScript>::importable_type("./other", "User");
+    let user1 = TypeName::importable_type("./models", "User");
+    let user2 = TypeName::importable_type("./other", "User");
 
-    let mut b = CodeBlock::<TypeScript>::builder();
+    let mut b = CodeBlock::builder();
     b.add_statement("const u1: %T = getUser1()", (user1,));
     b.add_statement("const u2: %T = getUser2()", (user2,));
     let block = b.build().unwrap();
 
-    let mut fb = FileSpec::<TypeScript>::builder("users.ts");
-    fb.add_code(block);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder("users.ts")
+        .add_code(block)
+        .build()
+        .unwrap();
 
     let output = file.render(80).unwrap();
     golden::assert_golden("typescript/conflicting_imports.ts", &output);
@@ -47,19 +48,20 @@ fn test_conflicting_imports() {
 
 #[test]
 fn test_same_module_multiple_types() {
-    let user = TypeName::<TypeScript>::importable_type("./models", "User");
-    let tag = TypeName::<TypeScript>::importable_type("./models", "Tag");
-    let category = TypeName::<TypeScript>::importable_type("./models", "Category");
+    let user = TypeName::importable_type("./models", "User");
+    let tag = TypeName::importable_type("./models", "Tag");
+    let category = TypeName::importable_type("./models", "Category");
 
-    let mut b = CodeBlock::<TypeScript>::builder();
+    let mut b = CodeBlock::builder();
     b.add_statement("const u: %T = null", (user,));
     b.add_statement("const t: %T = null", (tag,));
     b.add_statement("const c: %T = null", (category,));
     let block = b.build().unwrap();
 
-    let mut fb = FileSpec::<TypeScript>::builder("types.ts");
-    fb.add_code(block);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder("types.ts")
+        .add_code(block)
+        .build()
+        .unwrap();
 
     let output = file.render(80).unwrap();
     golden::assert_golden("typescript/same_module_types.ts", &output);
@@ -67,15 +69,16 @@ fn test_same_module_multiple_types() {
 
 #[test]
 fn test_single_type_reference() {
-    let user = TypeName::<TypeScript>::importable_type("./models", "User");
+    let user = TypeName::importable_type("./models", "User");
 
-    let mut b = CodeBlock::<TypeScript>::builder();
+    let mut b = CodeBlock::builder();
     b.add_statement("type Alias = %T", (user,));
     let block = b.build().unwrap();
 
-    let mut fb = FileSpec::<TypeScript>::builder("alias.ts");
-    fb.add_code(block);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder("alias.ts")
+        .add_code(block)
+        .build()
+        .unwrap();
 
     let output = file.render(80).unwrap();
     golden::assert_golden("typescript/single_type_ref.ts", &output);

--- a/tests/typescript/builder_types.rs
+++ b/tests/typescript/builder_types.rs
@@ -1,5 +1,4 @@
 use sigil_stitch::code_block::CodeBlock;
-use sigil_stitch::lang::typescript::TypeScript;
 use sigil_stitch::spec::enum_variant_spec::EnumVariantSpec;
 use sigil_stitch::spec::field_spec::FieldSpec;
 use sigil_stitch::spec::file_spec::FileSpec;
@@ -13,161 +12,208 @@ use super::golden;
 
 #[test]
 fn test_class_with_fields_and_methods() {
-    let mut tb = TypeSpec::<TypeScript>::builder("UserService", TypeKind::Class);
-    tb.visibility(Visibility::Public);
-    tb.doc("Service for managing users.");
+    let body = CodeBlock::of("return this.userRepo.findById(id)", ()).unwrap();
+    let tb = TypeSpec::builder("UserService", TypeKind::Class)
+        .visibility(Visibility::Public)
+        .doc("Service for managing users.")
+        .add_field(
+            FieldSpec::builder("userRepo", TypeName::primitive("UserRepository"))
+                .visibility(Visibility::Private)
+                .build()
+                .unwrap(),
+        )
+        .add_field(
+            FieldSpec::builder("logger", TypeName::primitive("Logger"))
+                .visibility(Visibility::Private)
+                .is_readonly()
+                .build()
+                .unwrap(),
+        )
+        .add_method(
+            FunSpec::builder("getUser")
+                .is_async()
+                .add_param(ParameterSpec::new("id", TypeName::primitive("string")).unwrap())
+                .returns(TypeName::generic(
+                    TypeName::primitive("Promise"),
+                    vec![TypeName::importable_type("./models", "User")],
+                ))
+                .body(body)
+                .build()
+                .unwrap(),
+        );
 
-    let mut field_b = FieldSpec::builder("userRepo", TypeName::primitive("UserRepository"));
-    field_b.visibility(Visibility::Private);
-    tb.add_field(field_b.build().unwrap());
-
-    let mut field_b2 = FieldSpec::builder("logger", TypeName::primitive("Logger"));
-    field_b2.visibility(Visibility::Private);
-    field_b2.is_readonly();
-    tb.add_field(field_b2.build().unwrap());
-
-    let body = CodeBlock::<TypeScript>::of("return this.userRepo.findById(id)", ()).unwrap();
-    let mut fb = FunSpec::builder("getUser");
-    fb.is_async();
-    fb.add_param(ParameterSpec::new("id", TypeName::primitive("string")).unwrap());
-    fb.returns(TypeName::generic(
-        TypeName::primitive("Promise"),
-        vec![TypeName::importable_type("./models", "User")],
-    ));
-    fb.body(body);
-    tb.add_method(fb.build().unwrap());
-
-    let mut file = FileSpec::<TypeScript>::builder("UserService.ts");
-    file.add_type(tb.build().unwrap());
-    let output = file.build().unwrap().render(80).unwrap();
+    let output = FileSpec::builder("UserService.ts")
+        .add_type(tb.build().unwrap())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap();
 
     golden::assert_golden("typescript/class_with_methods.ts", &output);
 }
 
 #[test]
 fn test_interface_generic() {
-    let mut tb = TypeSpec::<TypeScript>::builder("Repository", TypeKind::Interface);
-    tb.visibility(Visibility::Public);
+    let tp = TypeParamSpec::new("T");
+    let tb = TypeSpec::builder("Repository", TypeKind::Interface)
+        .visibility(Visibility::Public)
+        .add_type_param(tp)
+        .add_method(
+            FunSpec::builder("findById")
+                .add_param(ParameterSpec::new("id", TypeName::primitive("string")).unwrap())
+                .returns(TypeName::generic(
+                    TypeName::primitive("Promise"),
+                    vec![TypeName::primitive("T")],
+                ))
+                .build()
+                .unwrap(),
+        )
+        .add_method(
+            FunSpec::builder("save")
+                .add_param(ParameterSpec::new("entity", TypeName::primitive("T")).unwrap())
+                .returns(TypeName::generic(
+                    TypeName::primitive("Promise"),
+                    vec![TypeName::primitive("void")],
+                ))
+                .build()
+                .unwrap(),
+        );
 
-    let tp = TypeParamSpec::<TypeScript>::new("T");
-    tb.add_type_param(tp);
-
-    let mut fb = FunSpec::builder("findById");
-    fb.add_param(ParameterSpec::new("id", TypeName::primitive("string")).unwrap());
-    fb.returns(TypeName::generic(
-        TypeName::primitive("Promise"),
-        vec![TypeName::primitive("T")],
-    ));
-    tb.add_method(fb.build().unwrap());
-
-    let mut fb2 = FunSpec::builder("save");
-    fb2.add_param(ParameterSpec::new("entity", TypeName::primitive("T")).unwrap());
-    fb2.returns(TypeName::generic(
-        TypeName::primitive("Promise"),
-        vec![TypeName::primitive("void")],
-    ));
-    tb.add_method(fb2.build().unwrap());
-
-    let mut file = FileSpec::<TypeScript>::builder("Repository.ts");
-    file.add_type(tb.build().unwrap());
-    let output = file.build().unwrap().render(80).unwrap();
+    let output = FileSpec::builder("Repository.ts")
+        .add_type(tb.build().unwrap())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap();
 
     golden::assert_golden("typescript/interface_generic.ts", &output);
 }
 
 #[test]
 fn test_abstract_class() {
-    let mut tb = TypeSpec::<TypeScript>::builder("BaseController", TypeKind::Class);
-    tb.visibility(Visibility::Public);
-    tb.is_abstract();
+    let body = CodeBlock::of("console.log('handled')", ()).unwrap();
+    let tb = TypeSpec::builder("BaseController", TypeKind::Class)
+        .visibility(Visibility::Public)
+        .is_abstract()
+        .add_method(
+            FunSpec::builder("handleRequest")
+                .is_abstract()
+                .add_param(ParameterSpec::new("req", TypeName::primitive("Request")).unwrap())
+                .returns(TypeName::primitive("Response"))
+                .build()
+                .unwrap(),
+        )
+        .add_method(
+            FunSpec::builder("log")
+                .visibility(Visibility::Protected)
+                .body(body)
+                .build()
+                .unwrap(),
+        );
 
-    let mut fb = FunSpec::builder("handleRequest");
-    fb.is_abstract();
-    fb.add_param(ParameterSpec::new("req", TypeName::primitive("Request")).unwrap());
-    fb.returns(TypeName::primitive("Response"));
-    tb.add_method(fb.build().unwrap());
-
-    let body = CodeBlock::<TypeScript>::of("console.log('handled')", ()).unwrap();
-    let mut fb2 = FunSpec::builder("log");
-    fb2.visibility(Visibility::Protected);
-    fb2.body(body);
-    tb.add_method(fb2.build().unwrap());
-
-    let mut file = FileSpec::<TypeScript>::builder("BaseController.ts");
-    file.add_type(tb.build().unwrap());
-    let output = file.build().unwrap().render(80).unwrap();
+    let output = FileSpec::builder("BaseController.ts")
+        .add_type(tb.build().unwrap())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap();
 
     golden::assert_golden("typescript/abstract_class.ts", &output);
 }
 
 #[test]
 fn test_class_extends_implements() {
-    let mut tb = TypeSpec::<TypeScript>::builder("AdminService", TypeKind::Class);
-    tb.visibility(Visibility::Public);
-    tb.extends(TypeName::importable("./base", "BaseService"));
-    tb.implements(TypeName::importable("./auth", "Authenticatable"));
-    tb.implements(TypeName::importable_type("./serial", "Serializable"));
+    let body = CodeBlock::of("return true", ()).unwrap();
+    let tb = TypeSpec::builder("AdminService", TypeKind::Class)
+        .visibility(Visibility::Public)
+        .extends(TypeName::importable("./base", "BaseService"))
+        .implements(TypeName::importable("./auth", "Authenticatable"))
+        .implements(TypeName::importable_type("./serial", "Serializable"))
+        .add_method(
+            FunSpec::builder("isAdmin")
+                .returns(TypeName::primitive("boolean"))
+                .body(body)
+                .build()
+                .unwrap(),
+        );
 
-    let body = CodeBlock::<TypeScript>::of("return true", ()).unwrap();
-    let mut fb = FunSpec::builder("isAdmin");
-    fb.returns(TypeName::primitive("boolean"));
-    fb.body(body);
-    tb.add_method(fb.build().unwrap());
-
-    let mut file = FileSpec::<TypeScript>::builder("AdminService.ts");
-    file.add_type(tb.build().unwrap());
-    let output = file.build().unwrap().render(80).unwrap();
+    let output = FileSpec::builder("AdminService.ts")
+        .add_type(tb.build().unwrap())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap();
 
     golden::assert_golden("typescript/class_extends_implements.ts", &output);
 }
 
 #[test]
 fn test_enum() {
-    let mut tb = TypeSpec::<TypeScript>::builder("Direction", TypeKind::Enum);
-    tb.visibility(Visibility::Public);
-
-    let mut v_up = EnumVariantSpec::<TypeScript>::builder("Up");
-    v_up.value(CodeBlock::<TypeScript>::of("'UP'", ()).unwrap());
-    tb.add_variant(v_up.build().unwrap());
-
-    let mut v_down = EnumVariantSpec::<TypeScript>::builder("Down");
-    v_down.value(CodeBlock::<TypeScript>::of("'DOWN'", ()).unwrap());
-    tb.add_variant(v_down.build().unwrap());
-
-    let mut v_left = EnumVariantSpec::<TypeScript>::builder("Left");
-    v_left.value(CodeBlock::<TypeScript>::of("'LEFT'", ()).unwrap());
-    tb.add_variant(v_left.build().unwrap());
-
-    let mut v_right = EnumVariantSpec::<TypeScript>::builder("Right");
-    v_right.value(CodeBlock::<TypeScript>::of("'RIGHT'", ()).unwrap());
-    tb.add_variant(v_right.build().unwrap());
-
-    let mut file = FileSpec::<TypeScript>::builder("Direction.ts");
-    file.add_type(tb.build().unwrap());
-    let output = file.build().unwrap().render(80).unwrap();
+    let output = FileSpec::builder("Direction.ts")
+        .add_type(
+            TypeSpec::builder("Direction", TypeKind::Enum)
+                .visibility(Visibility::Public)
+                .add_variant(
+                    EnumVariantSpec::builder("Up")
+                        .value(CodeBlock::of("'UP'", ()).unwrap())
+                        .build()
+                        .unwrap(),
+                )
+                .add_variant(
+                    EnumVariantSpec::builder("Down")
+                        .value(CodeBlock::of("'DOWN'", ()).unwrap())
+                        .build()
+                        .unwrap(),
+                )
+                .add_variant(
+                    EnumVariantSpec::builder("Left")
+                        .value(CodeBlock::of("'LEFT'", ()).unwrap())
+                        .build()
+                        .unwrap(),
+                )
+                .add_variant(
+                    EnumVariantSpec::builder("Right")
+                        .value(CodeBlock::of("'RIGHT'", ()).unwrap())
+                        .build()
+                        .unwrap(),
+                )
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap();
 
     golden::assert_golden("typescript/enum.ts", &output);
 }
 
 #[test]
 fn test_readonly_array_field() {
-    let mut tb = TypeSpec::<TypeScript>::builder("Pet", TypeKind::Interface);
-    tb.visibility(Visibility::Public);
+    let tb = TypeSpec::builder("Pet", TypeKind::Interface)
+        .visibility(Visibility::Public)
+        .add_field(
+            FieldSpec::builder("name", TypeName::primitive("string"))
+                .is_readonly()
+                .build()
+                .unwrap(),
+        )
+        .add_field(
+            FieldSpec::builder(
+                "tags",
+                TypeName::readonly_array(TypeName::primitive("string")),
+            )
+            .is_readonly()
+            .build()
+            .unwrap(),
+        );
 
-    let mut name = FieldSpec::builder("name", TypeName::<TypeScript>::primitive("string"));
-    name.is_readonly();
-    tb.add_field(name.build().unwrap());
-
-    let mut tags = FieldSpec::builder(
-        "tags",
-        TypeName::<TypeScript>::readonly_array(TypeName::primitive("string")),
-    );
-    tags.is_readonly();
-    tb.add_field(tags.build().unwrap());
-
-    let mut file = FileSpec::<TypeScript>::builder("Pet.ts");
-    file.add_type(tb.build().unwrap());
-    let output = file.build().unwrap().render(80).unwrap();
+    let output = FileSpec::builder("Pet.ts")
+        .add_type(tb.build().unwrap())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap();
 
     assert!(
         output.contains("readonly tags: readonly string[];"),

--- a/tests/typescript/quote_basic.rs
+++ b/tests/typescript/quote_basic.rs
@@ -1,14 +1,16 @@
 use sigil_stitch::code_block::CodeBlock;
-use sigil_stitch::lang::typescript::TypeScript;
 use sigil_stitch::prelude::*;
 use sigil_stitch::spec::file_spec::FileSpec;
 
 use super::golden;
 
-fn render(block: &CodeBlock<TypeScript>) -> String {
-    let mut fb = FileSpec::<TypeScript>::builder("test.ts");
-    fb.add_code(block.clone());
-    fb.build().unwrap().render(80).unwrap()
+fn render(block: &CodeBlock) -> String {
+    FileSpec::builder("test.ts")
+        .add_code(block.clone())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap()
 }
 
 #[test]

--- a/tests/typescript/quote_control_flow.rs
+++ b/tests/typescript/quote_control_flow.rs
@@ -1,20 +1,22 @@
 use sigil_stitch::code_block::CodeBlock;
-use sigil_stitch::lang::typescript::TypeScript;
 use sigil_stitch::prelude::*;
 use sigil_stitch::spec::file_spec::FileSpec;
 use sigil_stitch::type_name::TypeName;
 
 use super::golden;
 
-fn render(block: &CodeBlock<TypeScript>) -> String {
-    let mut fb = FileSpec::<TypeScript>::builder("test.ts");
-    fb.add_code(block.clone());
-    fb.build().unwrap().render(80).unwrap()
+fn render(block: &CodeBlock) -> String {
+    FileSpec::builder("test.ts")
+        .add_code(block.clone())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap()
 }
 
 #[test]
 fn test_control_flow() {
-    let error_type = TypeName::<TypeScript>::importable_type("./errors", "NotFoundError");
+    let error_type = TypeName::importable_type("./errors", "NotFoundError");
     let block = sigil_quote!(TypeScript {
         if(!user) {
             throw new $T(error_type)($S("not found"));

--- a/tests/typescript/quote_edge_cases.rs
+++ b/tests/typescript/quote_edge_cases.rs
@@ -1,14 +1,16 @@
 use sigil_stitch::code_block::CodeBlock;
-use sigil_stitch::lang::typescript::TypeScript;
 use sigil_stitch::prelude::*;
 use sigil_stitch::spec::file_spec::FileSpec;
 
 use super::golden;
 
-fn render(block: &CodeBlock<TypeScript>) -> String {
-    let mut fb = FileSpec::<TypeScript>::builder("test.ts");
-    fb.add_code(block.clone());
-    fb.build().unwrap().render(80).unwrap()
+fn render(block: &CodeBlock) -> String {
+    FileSpec::builder("test.ts")
+        .add_code(block.clone())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap()
 }
 
 #[test]

--- a/tests/typescript/quote_imports.rs
+++ b/tests/typescript/quote_imports.rs
@@ -1,22 +1,24 @@
 use sigil_stitch::code_block::CodeBlock;
-use sigil_stitch::lang::typescript::TypeScript;
 use sigil_stitch::prelude::*;
 use sigil_stitch::spec::file_spec::FileSpec;
 use sigil_stitch::type_name::TypeName;
 
 use super::golden;
 
-fn render(block: &CodeBlock<TypeScript>) -> String {
-    let mut fb = FileSpec::<TypeScript>::builder("test.ts");
-    fb.add_code(block.clone());
-    fb.build().unwrap().render(80).unwrap()
+fn render(block: &CodeBlock) -> String {
+    FileSpec::builder("test.ts")
+        .add_code(block.clone())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap()
 }
 
 #[test]
 fn test_imports() {
-    let user_type = TypeName::<TypeScript>::importable_type("./models", "User");
-    let repo_type = TypeName::<TypeScript>::importable_type("./repos", "UserRepository");
-    let logger_type = TypeName::<TypeScript>::importable_type("./logging", "Logger");
+    let user_type = TypeName::importable_type("./models", "User");
+    let repo_type = TypeName::importable_type("./repos", "UserRepository");
+    let logger_type = TypeName::importable_type("./logging", "Logger");
     let block = sigil_quote!(TypeScript {
         const repo: $T(repo_type) = getRepo();
         const logger: $T(logger_type) = getLogger();

--- a/tests/zsh/builder_control_flow.rs
+++ b/tests/zsh/builder_control_flow.rs
@@ -1,12 +1,11 @@
 use sigil_stitch::code_block::CodeBlock;
-use sigil_stitch::lang::zsh::Zsh;
 use sigil_stitch::spec::file_spec::FileSpec;
 
 use super::golden;
 
 #[test]
 fn test_if_then_fi() {
-    let mut b = CodeBlock::<Zsh>::builder();
+    let mut b = CodeBlock::builder();
     b.add("if [[ -f \"$1\" ]]; then\n", ());
     b.add("%>", ());
     b.add_statement("echo \"file exists\"", ());
@@ -18,9 +17,10 @@ fn test_if_then_fi() {
     b.add("fi\n", ());
     let block = b.build().unwrap();
 
-    let mut fb = FileSpec::<Zsh>::builder("check.zsh");
-    fb.add_code(block);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder("check.zsh")
+        .add_code(block)
+        .build()
+        .unwrap();
 
     let output = file.render(80).unwrap();
     golden::assert_golden("zsh/if_then_fi.zsh", &output);

--- a/tests/zsh/builder_edge_cases.rs
+++ b/tests/zsh/builder_edge_cases.rs
@@ -1,19 +1,19 @@
 use sigil_stitch::code_block::{CodeBlock, StringLitArg};
-use sigil_stitch::lang::zsh::Zsh;
 use sigil_stitch::spec::file_spec::FileSpec;
 
 use super::golden;
 
 #[test]
 fn test_variable_assignment() {
-    let mut b = CodeBlock::<Zsh>::builder();
+    let mut b = CodeBlock::builder();
     b.add("NAME=%S\n", (StringLitArg("world".into()),));
     b.add("COUNT=42\n", ());
     let block = b.build().unwrap();
 
-    let mut fb = FileSpec::<Zsh>::builder("vars.zsh");
-    fb.add_code(block);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder("vars.zsh")
+        .add_code(block)
+        .build()
+        .unwrap();
 
     let output = file.render(80).unwrap();
     golden::assert_golden("zsh/variable_assignment.zsh", &output);
@@ -21,14 +21,15 @@ fn test_variable_assignment() {
 
 #[test]
 fn test_percent_escaping() {
-    let mut b = CodeBlock::<Zsh>::builder();
+    let mut b = CodeBlock::builder();
     b.add("MSG=%S\n", (StringLitArg("100% done".into()),));
     b.add("PROMPT=%S\n", (StringLitArg("%F{red}error%f".into()),));
     let block = b.build().unwrap();
 
-    let mut fb = FileSpec::<Zsh>::builder("prompt.zsh");
-    fb.add_code(block);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder("prompt.zsh")
+        .add_code(block)
+        .build()
+        .unwrap();
 
     let output = file.render(80).unwrap();
     golden::assert_golden("zsh/percent_escaping.zsh", &output);

--- a/tests/zsh/builder_functions.rs
+++ b/tests/zsh/builder_functions.rs
@@ -1,5 +1,4 @@
 use sigil_stitch::code_block::CodeBlock;
-use sigil_stitch::lang::zsh::Zsh;
 use sigil_stitch::spec::file_spec::FileSpec;
 use sigil_stitch::spec::fun_spec::FunSpec;
 use sigil_stitch::type_name::TypeName;
@@ -8,18 +7,17 @@ use super::golden;
 
 #[test]
 fn test_function_spec() {
-    let mut body_b = CodeBlock::<Zsh>::builder();
+    let mut body_b = CodeBlock::builder();
     body_b.add("local name=$1\n", ());
     body_b.add_statement("echo \"Hello, $name\"", ());
     let body = body_b.build().unwrap();
 
-    let mut fb = FunSpec::<Zsh>::builder("greet");
-    fb.body(body);
-    let fun = fb.build().unwrap();
+    let fun = FunSpec::builder("greet").body(body).build().unwrap();
 
-    let mut file_b = FileSpec::<Zsh>::builder("funcs.zsh");
-    file_b.add_function(fun);
-    let file = file_b.build().unwrap();
+    let file = FileSpec::builder("funcs.zsh")
+        .add_function(fun)
+        .build()
+        .unwrap();
 
     let output = file.render(80).unwrap();
     golden::assert_golden("zsh/function_spec.zsh", &output);
@@ -27,14 +25,14 @@ fn test_function_spec() {
 
 #[test]
 fn test_complete_script() {
-    let utils_fn = TypeName::<Zsh>::importable("./lib/utils.zsh", "log_info");
+    let utils_fn = TypeName::importable("./lib/utils.zsh", "log_info");
 
-    let mut header_b = CodeBlock::<Zsh>::builder();
+    let mut header_b = CodeBlock::builder();
     header_b.add("#!/usr/bin/env zsh\n", ());
     header_b.add("setopt ERR_EXIT PIPE_FAIL", ());
     let header = header_b.build().unwrap();
 
-    let mut fun_body = CodeBlock::<Zsh>::builder();
+    let mut fun_body = CodeBlock::builder();
     fun_body.add("local target=$1\n", ());
     fun_body.add("if [[ -z \"$target\" ]]; then\n", ());
     fun_body.add("%>", ());
@@ -45,19 +43,18 @@ fn test_complete_script() {
     fun_body.add_statement("%T \"deploying to $target\"", (utils_fn,));
     let fun_body = fun_body.build().unwrap();
 
-    let mut fun = FunSpec::<Zsh>::builder("deploy");
-    fun.body(fun_body);
-    let fun = fun.build().unwrap();
+    let fun = FunSpec::builder("deploy").body(fun_body).build().unwrap();
 
-    let mut main = CodeBlock::<Zsh>::builder();
+    let mut main = CodeBlock::builder();
     main.add_statement("deploy \"$@\"", ());
     let main = main.build().unwrap();
 
-    let mut fb = FileSpec::<Zsh>::builder("deploy.zsh");
-    fb.header(header);
-    fb.add_function(fun);
-    fb.add_code(main);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder("deploy.zsh")
+        .header(header)
+        .add_function(fun)
+        .add_code(main)
+        .build()
+        .unwrap();
 
     let output = file.render(80).unwrap();
     golden::assert_golden("zsh/complete_script.zsh", &output);
@@ -65,15 +62,17 @@ fn test_complete_script() {
 
 #[test]
 fn test_function_with_doc() {
-    let body = CodeBlock::<Zsh>::of("echo \"Hello, $1!\"", ()).unwrap();
-    let mut fb = FunSpec::<Zsh>::builder("greet");
-    fb.doc("Greet the user by name.");
-    fb.body(body);
-    let fun = fb.build().unwrap();
+    let body = CodeBlock::of("echo \"Hello, $1!\"", ()).unwrap();
+    let fun = FunSpec::builder("greet")
+        .doc("Greet the user by name.")
+        .body(body)
+        .build()
+        .unwrap();
 
-    let mut file_b = FileSpec::<Zsh>::builder("greet.zsh");
-    file_b.add_function(fun);
-    let file = file_b.build().unwrap();
+    let file = FileSpec::builder("greet.zsh")
+        .add_function(fun)
+        .build()
+        .unwrap();
     let output = file.render(80).unwrap();
 
     golden::assert_golden("zsh/function_with_doc.zsh", &output);

--- a/tests/zsh/builder_imports.rs
+++ b/tests/zsh/builder_imports.rs
@@ -1,5 +1,4 @@
 use sigil_stitch::code_block::CodeBlock;
-use sigil_stitch::lang::zsh::Zsh;
 use sigil_stitch::spec::file_spec::FileSpec;
 use sigil_stitch::type_name::TypeName;
 
@@ -7,17 +6,18 @@ use super::golden;
 
 #[test]
 fn test_source_imports() {
-    let utils_fn = TypeName::<Zsh>::importable("./lib/utils.zsh", "log_info");
-    let config_fn = TypeName::<Zsh>::importable("./lib/config.zsh", "load_config");
+    let utils_fn = TypeName::importable("./lib/utils.zsh", "log_info");
+    let config_fn = TypeName::importable("./lib/config.zsh", "load_config");
 
-    let mut b = CodeBlock::<Zsh>::builder();
+    let mut b = CodeBlock::builder();
     b.add_statement("%T", (config_fn,));
     b.add_statement("%T \"starting up\"", (utils_fn,));
     let block = b.build().unwrap();
 
-    let mut fb = FileSpec::<Zsh>::builder("main.zsh");
-    fb.add_code(block);
-    let file = fb.build().unwrap();
+    let file = FileSpec::builder("main.zsh")
+        .add_code(block)
+        .build()
+        .unwrap();
 
     let output = file.render(80).unwrap();
     golden::assert_golden("zsh/source_imports.zsh", &output);

--- a/tests/zsh/quote_basic.rs
+++ b/tests/zsh/quote_basic.rs
@@ -1,14 +1,16 @@
 use sigil_stitch::code_block::CodeBlock;
-use sigil_stitch::lang::zsh::Zsh;
 use sigil_stitch::prelude::*;
 use sigil_stitch::spec::file_spec::FileSpec;
 
 use super::golden;
 
-fn render(block: &CodeBlock<Zsh>) -> String {
-    let mut fb = FileSpec::<Zsh>::builder("test.zsh");
-    fb.add_code(block.clone());
-    fb.build().unwrap().render(80).unwrap()
+fn render(block: &CodeBlock) -> String {
+    FileSpec::builder("test.zsh")
+        .add_code(block.clone())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap()
 }
 
 #[test]

--- a/tests/zsh/quote_control_flow.rs
+++ b/tests/zsh/quote_control_flow.rs
@@ -1,14 +1,16 @@
 use sigil_stitch::code_block::CodeBlock;
-use sigil_stitch::lang::zsh::Zsh;
 use sigil_stitch::prelude::*;
 use sigil_stitch::spec::file_spec::FileSpec;
 
 use super::golden;
 
-fn render(block: &CodeBlock<Zsh>) -> String {
-    let mut fb = FileSpec::<Zsh>::builder("test.zsh");
-    fb.add_code(block.clone());
-    fb.build().unwrap().render(80).unwrap()
+fn render(block: &CodeBlock) -> String {
+    FileSpec::builder("test.zsh")
+        .add_code(block.clone())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap()
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- **Erase language generic**: Replace `<L: CodeLang>` type parameter on all public types (`CodeBlock`, `FileSpec`, `TypeSpec`, `FunSpec`, etc.) with `&dyn CodeLang` trait objects. Eliminates monomorphization overhead and simplifies the public API.
- **Split CodeLang into config structs**: Factor the 33-method `CodeLang` trait into 6 config struct accessors (`type_presentation()`, `generic_syntax()`, `block_syntax()`, `function_syntax()`, `type_decl_syntax()`, `enum_and_annotation()`) so language implementations are declarative data rather than method overrides.
- **CodeNode tree IR**: Replace `CodeBlock`'s internal `(Vec<FormatPart>, Vec<Arg>)` parallel-vector encoding with a self-contained `Vec<CodeNode>` tree. Eliminates the `__COMMENT__` string-prefix hack, unifies the two duplicate render paths (`render_direct` + `build_doc_from_parts`) into a single `CodeNode`-based dispatch, and makes `FormatPart` crate-internal.
- **Doc comment cleanup**: Fix 7 stale doc references to removed methods and generics.

All 1009 tests pass. Golden files byte-identical (output-preserving refactor).

## Test plan
- [x] `cargo fmt --all` clean
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo test --workspace` — all 1009 tests pass
- [x] Golden files unchanged (`git diff -- tests/golden/` empty)
- [x] All 11 examples compile (`cargo build --examples`)