### PR TITLE
chore: release 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,75 @@
 # Changelog
 
+## 0.3.0
+
+### Breaking
+
+- **Erased `<L: CodeLang>` generic from all public types.** `CodeBlock`,
+  `TypeName`, all spec types, and `FileSpec` are no longer parameterized by
+  language. The language enters at render time via `&dyn CodeLang`.
+- **Spec builders use owning-chain `(mut self) -> Self` pattern.** `TypeSpec`,
+  `FunSpec`, `FieldSpec`, `FileSpec`, and all other spec builders now consume
+  `self` and return `Self`. Chain calls fluently instead of using `&mut self`.
+  `CodeBlockBuilder` is unchanged (still `&mut self`).
+- **`CodeBlock` internals replaced with `Vec<CodeNode>` tree IR.** The parallel
+  vectors (`formats`, `args`, etc.) are replaced by a single `Vec<CodeNode>`
+  containing typed nodes. External API is unchanged but internal
+  representations differ.
+- **`CodeLang` trait reorganized into 6 config struct accessors.** The many
+  individual trait methods are now grouped into `block_syntax()`,
+  `function_syntax()`, `type_decl_syntax()`, `generic_syntax()`,
+  `enum_and_annotation()`, and `type_presentation()`. Each returns a config
+  struct with `..Default::default()` support.
+
+### Added
+
+- Data-driven `TypePresentation` layer: languages declare syntactic patterns
+  (GenericWrap, Prefix, Postfix, Surround, Delimited, Infix) instead of
+  building `BoxDoc` directly. A single rendering engine handles all patterns.
+- `FunctionPresentation` struct for declarative function type rendering across
+  all languages.
+- `TypeName::Tuple` variant with cross-language rendering.
+- `TypeName::Reference` variant with mutable/immutable distinction.
+- `TypePresentation::Surround` for C++ `const T&` and similar patterns.
+- `TypeKind::TypeAlias` and `TypeKind::Newtype` with cross-language emission.
+- `GenericApplicationStyle` enum: `AngleBracket`, `SquareBracket`,
+  `PostfixJuxtaposition` (OCaml), `PrefixJuxtaposition` (Haskell).
+- `AssociatedTypeStyle` for TypeScript `Foo["bar"]`, Rust `Foo::Bar`, etc.
+- `ImplTrait` and `DynTrait` TypeName variants.
+- `Wildcard` TypeName variant with language-specific rendering.
+- Where-clause support for `FunSpec` and `TypeSpec`.
+- `TypeParamKind` for higher-kinded type parameters and lifetime parameters.
+- Scala language support (`sigil_stitch::lang::scala::Scala`).
+- Haskell language support (`sigil_stitch::lang::haskell::Haskell`), including
+  split signature style, `deriving` via `.implements()`, and Haddock comments.
+- OCaml language support (`sigil_stitch::lang::ocaml::OCaml`), including
+  postfix generics, `module_block`/`module_sig_block` helpers, and OCamldoc.
+- `sigil_quote!` improvements: `$open("text")` for custom block openers,
+  `$>`/`$<` for explicit indent/dedent control.
+- Per-language `sigil_quote!` golden tests for all 16 languages.
+
+### Fixed
+
+- String escaping for Swift (backslash and interpolation escaping) and Scala
+  (triple-quote and interpolation escaping).
+- Wildcard rendering across all languages.
+- Where-clause indentation alignment.
+- Doc-comment emission unified across all spec emitters.
+- Format parser byte indexing replaced with `char_indices` for correct
+  handling of multi-byte characters.
+- Multi-line literal re-indentation in `CodeRenderer`.
+- Golden file quality improvements for Go, Kotlin, JavaScript, C++, and Bash.
+
+### Documentation
+
+- Complete documentation rewrite for the 0.3.0 API across 13 mdbook chapters.
+- Per-language cookbook pages expanded to 12 languages (TypeScript, Rust, Go,
+  Python, Java, Kotlin, Swift, C++, C, Scala, Haskell, OCaml) with 4–5
+  recipes each.
+- New chapters: Type Presentation, Code Templates.
+- Architecture chapter rewritten to cover CodeNode IR, config structs, and
+  the three-pillar refactoring.
+
 ## 0.2.2
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,7 +100,7 @@ dependencies = [
 
 [[package]]
 name = "sigil-stitch"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "pretty",
  "serde",
@@ -111,7 +111,7 @@ dependencies = [
 
 [[package]]
 name = "sigil-stitch-macros"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["macros"]
 resolver = "3"
 
 [workspace.package]
-version = "0.2.2"
+version = "0.3.0"
 edition = "2024"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"
@@ -35,7 +35,7 @@ exclude = [
 [dependencies]
 pretty = "0.12"
 snafu = "0.9"
-sigil-stitch-macros = { path = "macros", version = "0.2.2" }
+sigil-stitch-macros = { path = "macros", version = "0.3.0" }
 serde = { version = "1", features = ["derive"] }
 
 [dev-dependencies]

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -21,6 +21,9 @@
   - [Swift](cookbook_swift.md)
   - [C++](cookbook_cpp.md)
   - [C](cookbook_c.md)
+  - [Scala](cookbook_scala.md)
+  - [Haskell](cookbook_haskell.md)
+  - [OCaml](cookbook_ocaml.md)
 
 ---
 

--- a/docs/src/adding_a_language.md
+++ b/docs/src/adding_a_language.md
@@ -327,6 +327,9 @@ Study these existing implementations for patterns similar to your target:
 | C | `src/lang/c_lang.rs` | Type-before-name, `#include`, `__attribute__`, struct close semicolon |
 | C++ | `src/lang/cpp_lang.rs` | `virtual` instead of `abstract`, `#include` + `using`, `[[attributes]]` |
 | Bash | `src/lang/bash.rs` | Keyword-based block closers (`fi`/`done`/`esac`), `source` imports, shell escaping |
+| Scala | `src/lang/scala.rs` | `case class`, `trait`, `[T]` generics, `<:` bounds, `= {`/`}` blocks |
+| Haskell | `src/lang/haskell.rs` | Split signature style, `where`/indentation blocks, postfix generics, `deriving` |
+| OCaml | `src/lang/ocaml.rs` | Postfix generics, `let` keyword, `= `/indentation blocks, `open Module` imports, `module_block` helper |
 
 ## Type Presentation
 

--- a/docs/src/cookbook_c.md
+++ b/docs/src/cookbook_c.md
@@ -16,3 +16,95 @@ let type_spec = TypeSpec::builder("Meters", TypeKind::TypeAlias)
 ```c
 typedef double Meters;
 ```
+
+## Struct with fields
+
+```rust,ignore
+use sigil_stitch::prelude::*;
+
+let type_spec = TypeSpec::builder("Config", TypeKind::Struct)
+    .doc("Application configuration.")
+    .add_field(
+        FieldSpec::builder("timeout", TypeName::primitive("int"))
+            .build()
+            .unwrap(),
+    )
+    .add_field(
+        FieldSpec::builder("name", TypeName::primitive("char*"))
+            .build()
+            .unwrap(),
+    )
+    .add_field(
+        FieldSpec::builder("verbose", TypeName::primitive("int"))
+            .build()
+            .unwrap(),
+    )
+    .build()
+    .unwrap();
+
+let file = FileSpec::builder("config.h")
+    .header(CodeBlock::of("#pragma once", ()).unwrap())
+    .add_type(type_spec)
+    .build()
+    .unwrap();
+let output = file.render(80).unwrap();
+```
+
+```c
+#pragma once
+
+/* Application configuration. */
+struct Config {
+    int timeout;
+    char* name;
+    int verbose;
+};
+```
+
+## Function declaration
+
+```rust,ignore
+use sigil_stitch::prelude::*;
+
+let fun = FunSpec::builder("process")
+    .add_param(ParameterSpec::new("data", TypeName::primitive("const char*")).unwrap())
+    .add_param(ParameterSpec::new("len", TypeName::primitive("size_t")).unwrap())
+    .returns(TypeName::primitive("int"))
+    .build()
+    .unwrap();
+
+let file = FileSpec::builder("api.h")
+    .add_function(fun)
+    .build()
+    .unwrap();
+let output = file.render(80).unwrap();
+```
+
+```c
+int process(const char* data, size_t len);
+```
+
+## Enum
+
+```rust,ignore
+use sigil_stitch::prelude::*;
+
+let type_spec = TypeSpec::builder("Direction", TypeKind::Enum)
+    .doc("Cardinal directions.")
+    .add_variant(EnumVariantSpec::new("UP").unwrap())
+    .add_variant(EnumVariantSpec::new("DOWN").unwrap())
+    .add_variant(EnumVariantSpec::new("LEFT").unwrap())
+    .add_variant(EnumVariantSpec::new("RIGHT").unwrap())
+    .build()
+    .unwrap();
+```
+
+```c
+/* Cardinal directions. */
+enum Direction {
+    UP,
+    DOWN,
+    LEFT,
+    RIGHT
+};
+```

--- a/docs/src/cookbook_cpp.md
+++ b/docs/src/cookbook_cpp.md
@@ -62,3 +62,122 @@ let type_spec = TypeSpec::builder("StringVec", TypeKind::TypeAlias)
 ```cpp
 using StringVec = std::vector<std::string>;
 ```
+
+## Enum class
+
+```rust,ignore
+use sigil_stitch::prelude::*;
+
+let type_spec = TypeSpec::builder("Color", TypeKind::Enum)
+    .doc("Available colors.")
+    .add_variant(EnumVariantSpec::new("Red").unwrap())
+    .add_variant(EnumVariantSpec::new("Green").unwrap())
+    .add_variant(EnumVariantSpec::new("Blue").unwrap())
+    .build()
+    .unwrap();
+```
+
+```cpp
+/// Available colors.
+enum class Color {
+    Red,
+    Green,
+    Blue
+};
+```
+
+## Virtual method
+
+C++ abstract classes with pure virtual methods require the `extra_member` escape hatch. Use `FunSpec::emit()` to render each method signature as a `CodeBlock`, then attach it to the type via `extra_member`.
+
+```rust,ignore
+use sigil_stitch::prelude::*;
+use sigil_stitch::lang::cpp_lang::CppLang;
+
+fn emit_fun(fun: &FunSpec) -> CodeBlock {
+    let lang = CppLang::new();
+    fun.emit(&lang, DeclarationContext::Member).unwrap()
+}
+
+let mut pub_section = CodeBlock::builder();
+pub_section.add("%<", ());
+pub_section.add("public:", ());
+pub_section.add_line();
+pub_section.add("%>", ());
+
+pub_section.add_code(emit_fun(
+    &FunSpec::builder("area")
+        .is_abstract()
+        .returns(TypeName::primitive("double"))
+        .suffix("const")
+        .suffix("= 0")
+        .build()
+        .unwrap(),
+));
+
+pub_section.add_line();
+pub_section.add_code(emit_fun(
+    &FunSpec::builder("~Shape")
+        .is_abstract()
+        .suffix("= default")
+        .build()
+        .unwrap(),
+));
+
+let type_spec = TypeSpec::builder("Shape", TypeKind::Class)
+    .doc("Abstract shape base class.")
+    .extra_member(pub_section.build().unwrap())
+    .build()
+    .unwrap();
+```
+
+```cpp
+/// Abstract shape base class.
+class Shape {
+public:
+    virtual double area() const = 0;
+
+    virtual ~Shape() = default;
+};
+```
+
+## Namespace wrapping
+
+Use `FileSpec::add_raw` to wrap generated code in a namespace block.
+
+```rust,ignore
+use sigil_stitch::prelude::*;
+
+let mut b = CodeBlock::builder();
+b.add("int square(int x) {", ());
+b.add_line();
+b.add("%>", ());
+b.add("return x * x;", ());
+b.add_line();
+b.add("%<", ());
+b.add("}", ());
+b.add_line();
+let block = b.build().unwrap();
+
+let file = FileSpec::builder("math.hpp")
+    .header(CodeBlock::of("#pragma once", ()).unwrap())
+    .add_raw("namespace math {\n")
+    .add_code(block)
+    .add_raw("\n} // namespace math\n")
+    .build()
+    .unwrap();
+let output = file.render(80).unwrap();
+```
+
+```cpp
+#pragma once
+
+namespace math {
+
+int square(int x) {
+    return x * x;
+}
+
+
+} // namespace math
+```

--- a/docs/src/cookbook_go.md
+++ b/docs/src/cookbook_go.md
@@ -52,3 +52,88 @@ let type_spec = TypeSpec::builder("Meters", TypeKind::Newtype)
 ```go
 type Meters float64
 ```
+
+## Interface
+
+```rust,ignore
+use sigil_stitch::prelude::*;
+
+let type_spec = TypeSpec::builder("Repository", TypeKind::Interface)
+    .doc("Repository defines data access methods.")
+    .add_method(
+        FunSpec::builder("FindByID")
+            .add_param(ParameterSpec::new("id", TypeName::primitive("string")).unwrap())
+            .returns(TypeName::raw("(Entity, error)"))
+            .build()
+            .unwrap(),
+    )
+    .add_method(
+        FunSpec::builder("Save")
+            .add_param(ParameterSpec::new("entity", TypeName::primitive("Entity")).unwrap())
+            .returns(TypeName::primitive("error"))
+            .build()
+            .unwrap(),
+    )
+    .build()
+    .unwrap();
+
+let file = FileSpec::builder("repo.go")
+    .header(CodeBlock::of("package repo", ()).unwrap())
+    .add_type(type_spec)
+    .build()
+    .unwrap();
+let output = file.render(80).unwrap();
+```
+
+```go
+package repo
+
+// Repository defines data access methods.
+type Repository interface {
+	FindByID(id string) (Entity, error)
+
+	Save(entity Entity) error
+}
+```
+
+## Generic function
+
+```rust,ignore
+use sigil_stitch::prelude::*;
+
+let tp = TypeParamSpec::new("T").with_bound(TypeName::primitive("comparable"));
+
+let mut body_b = CodeBlock::builder();
+body_b.begin_control_flow("if a > b", ());
+body_b.add_statement("return a", ());
+body_b.end_control_flow();
+body_b.add_statement("return b", ());
+let body = body_b.build().unwrap();
+
+let fun = FunSpec::builder("Max")
+    .add_type_param(tp)
+    .add_param(ParameterSpec::new("a", TypeName::primitive("T")).unwrap())
+    .add_param(ParameterSpec::new("b", TypeName::primitive("T")).unwrap())
+    .returns(TypeName::primitive("T"))
+    .body(body)
+    .build()
+    .unwrap();
+
+let file = FileSpec::builder("max.go")
+    .header(CodeBlock::of("package main", ()).unwrap())
+    .add_function(fun)
+    .build()
+    .unwrap();
+let output = file.render(80).unwrap();
+```
+
+```go
+package main
+
+func Max[T comparable](a T, b T) T {
+	if a > b {
+		return a
+	}
+	return b
+}
+```

--- a/docs/src/cookbook_haskell.md
+++ b/docs/src/cookbook_haskell.md
@@ -1,0 +1,106 @@
+# Haskell Cookbook
+
+Practical, copy-paste-ready recipes for Haskell code generation. For the full API of each spec type, see [Building Functions & Fields](functions_and_fields.md), [Building Types & Enums](types_and_enums.md), and [Files & Projects](files_and_projects.md).
+
+## Data record with deriving
+
+```rust,ignore
+use sigil_stitch::prelude::*;
+
+let type_spec = TypeSpec::builder("Person", TypeKind::Struct)
+    .add_field(
+        FieldSpec::builder("personName", TypeName::primitive("String")).build().unwrap(),
+    )
+    .add_field(
+        FieldSpec::builder("personAge", TypeName::primitive("Int")).build().unwrap(),
+    )
+    .implements(TypeName::primitive("Show"))
+    .implements(TypeName::primitive("Eq"))
+    .build()
+    .unwrap();
+```
+
+```haskell
+data Person =
+  Person {
+    personName :: String,
+    personAge :: Int,
+  }
+  deriving (Show, Eq)
+```
+
+## Type class
+
+```rust,ignore
+use sigil_stitch::prelude::*;
+
+let type_spec = TypeSpec::builder("Printable", TypeKind::Trait)
+    .doc("Things that can be printed.")
+    .add_method(
+        FunSpec::builder("prettyPrint")
+            .add_param(ParameterSpec::new("a", TypeName::primitive("a")).unwrap())
+            .returns(TypeName::primitive("String"))
+            .build()
+            .unwrap(),
+    )
+    .build()
+    .unwrap();
+```
+
+```haskell
+-- | Things that can be printed.
+class Printable where
+  prettyPrint :: a -> String
+```
+
+## Function with split signature
+
+```rust,ignore
+use sigil_stitch::prelude::*;
+
+let body = CodeBlock::of("x + y", ()).unwrap();
+
+let fun = FunSpec::builder("add")
+    .add_param(ParameterSpec::new("x", TypeName::primitive("Int")).unwrap())
+    .add_param(ParameterSpec::new("y", TypeName::primitive("Int")).unwrap())
+    .returns(TypeName::primitive("Int"))
+    .body(body)
+    .build()
+    .unwrap();
+```
+
+```haskell
+add :: Int -> Int -> Int
+add x y =
+  x + y
+```
+
+## Newtype
+
+```rust,ignore
+use sigil_stitch::prelude::*;
+
+let type_spec = TypeSpec::builder("Meters", TypeKind::Newtype)
+    .extends(TypeName::primitive("Int"))
+    .build()
+    .unwrap();
+```
+
+```haskell
+newtype Meters = Meters Int
+```
+
+## Type alias
+
+```rust,ignore
+use sigil_stitch::prelude::*;
+
+let type_spec = TypeSpec::builder("Name", TypeKind::TypeAlias)
+    .extends(TypeName::primitive("String"))
+    .build()
+    .unwrap();
+```
+
+```haskell
+type Name = String
+```

--- a/docs/src/cookbook_java.md
+++ b/docs/src/cookbook_java.md
@@ -44,3 +44,120 @@ public class UserService {
     }
 }
 ```
+
+## Interface
+
+```rust,ignore
+use sigil_stitch::prelude::*;
+
+let type_spec = TypeSpec::builder("Repository", TypeKind::Interface)
+    .visibility(Visibility::Public)
+    .add_type_param(TypeParamSpec::new("T"))
+    .doc("Generic data repository.")
+    .add_method(
+        FunSpec::builder("findById")
+            .returns(TypeName::primitive("T"))
+            .add_param(ParameterSpec::new("id", TypeName::primitive("String")).unwrap())
+            .build()
+            .unwrap(),
+    )
+    .add_method(
+        FunSpec::builder("save")
+            .returns(TypeName::primitive("void"))
+            .add_param(ParameterSpec::new("entity", TypeName::primitive("T")).unwrap())
+            .build()
+            .unwrap(),
+    )
+    .add_method(
+        FunSpec::builder("delete")
+            .returns(TypeName::primitive("void"))
+            .add_param(ParameterSpec::new("id", TypeName::primitive("String")).unwrap())
+            .build()
+            .unwrap(),
+    )
+    .build()
+    .unwrap();
+```
+
+```java
+/**
+ * Generic data repository.
+ */
+public interface Repository<T> {
+    T findById(String id);
+
+    void save(T entity);
+
+    void delete(String id);
+}
+```
+
+## Enum
+
+```rust,ignore
+use sigil_stitch::prelude::*;
+
+let type_spec = TypeSpec::builder("Color", TypeKind::Enum)
+    .visibility(Visibility::Public)
+    .doc("Supported colors.")
+    .add_variant(EnumVariantSpec::new("RED").unwrap())
+    .add_variant(EnumVariantSpec::new("GREEN").unwrap())
+    .add_variant(EnumVariantSpec::new("BLUE").unwrap())
+    .build()
+    .unwrap();
+```
+
+```java
+/**
+ * Supported colors.
+ */
+public enum Color {
+    RED,
+    GREEN,
+    BLUE
+}
+```
+
+## Abstract class
+
+```rust,ignore
+use sigil_stitch::prelude::*;
+
+let desc_body = CodeBlock::of("return this.getClass().getSimpleName();", ()).unwrap();
+
+let type_spec = TypeSpec::builder("Shape", TypeKind::Class)
+    .visibility(Visibility::Public)
+    .doc("Abstract shape.")
+    .add_method(
+        FunSpec::builder("describe")
+            .visibility(Visibility::Public)
+            .returns(TypeName::primitive("String"))
+            .body(desc_body)
+            .build()
+            .unwrap(),
+    )
+    .add_method(
+        FunSpec::builder("area")
+            .visibility(Visibility::Public)
+            .is_abstract()
+            .returns(TypeName::primitive("double"))
+            .build()
+            .unwrap(),
+    )
+    .is_abstract()
+    .build()
+    .unwrap();
+```
+
+```java
+/**
+ * Abstract shape.
+ */
+public abstract class Shape {
+    public String describe() {
+        return this.getClass().getSimpleName();
+    }
+
+    public abstract double area();
+}
+```

--- a/docs/src/cookbook_kotlin.md
+++ b/docs/src/cookbook_kotlin.md
@@ -22,3 +22,104 @@ data class User(
     val email: String,
 )
 ```
+
+## Enum
+
+```rust,ignore
+use sigil_stitch::prelude::*;
+
+let type_spec = TypeSpec::builder("Color", TypeKind::Enum)
+    .doc("Supported colors.")
+    .add_variant(EnumVariantSpec::new("RED").unwrap())
+    .add_variant(EnumVariantSpec::new("GREEN").unwrap())
+    .add_variant(EnumVariantSpec::new("BLUE").unwrap())
+    .build()
+    .unwrap();
+```
+
+```kotlin
+/**
+ * Supported colors.
+ */
+internal enum class Color {
+    RED,
+    GREEN,
+    BLUE
+}
+```
+
+## Interface
+
+```rust,ignore
+use sigil_stitch::prelude::*;
+
+let type_spec = TypeSpec::builder("Repository", TypeKind::Interface)
+    .add_type_param(TypeParamSpec::new("T"))
+    .doc("Generic data repository.")
+    .add_method(
+        FunSpec::builder("findById")
+            .returns(TypeName::primitive("T?"))
+            .add_param(ParameterSpec::new("id", TypeName::primitive("String")).unwrap())
+            .build()
+            .unwrap(),
+    )
+    .add_method(
+        FunSpec::builder("save")
+            .add_param(ParameterSpec::new("entity", TypeName::primitive("T")).unwrap())
+            .build()
+            .unwrap(),
+    )
+    .add_method(
+        FunSpec::builder("delete")
+            .add_param(ParameterSpec::new("id", TypeName::primitive("String")).unwrap())
+            .build()
+            .unwrap(),
+    )
+    .build()
+    .unwrap();
+```
+
+```kotlin
+/**
+ * Generic data repository.
+ */
+internal interface Repository<T> {
+    internal fun findById(id: String): T?
+
+    internal fun save(entity: T)
+
+    internal fun delete(id: String)
+}
+```
+
+## Suspend function
+
+```rust,ignore
+use sigil_stitch::prelude::*;
+
+let user = TypeName::importable("com.example.model", "User");
+
+let body = CodeBlock::of("return api.fetchUser(id)", ()).unwrap();
+
+let fun = FunSpec::builder("fetchUser")
+    .is_async()
+    .returns(user)
+    .add_param(ParameterSpec::new("id", TypeName::primitive("String")).unwrap())
+    .body(body)
+    .build()
+    .unwrap();
+
+let file = FileSpec::builder("Api.kt")
+    .add_function(fun)
+    .build()
+    .unwrap();
+let output = file.render(80).unwrap();
+```
+
+```kotlin
+import com.example.model.User
+
+internal suspend fun fetchUser(id: String): User {
+    return api.fetchUser(id)
+}
+```

--- a/docs/src/cookbook_ocaml.md
+++ b/docs/src/cookbook_ocaml.md
@@ -1,0 +1,121 @@
+# OCaml Cookbook
+
+Practical, copy-paste-ready recipes for OCaml code generation. For the full API of each spec type, see [Building Functions & Fields](functions_and_fields.md), [Building Types & Enums](types_and_enums.md), and [Files & Projects](files_and_projects.md).
+
+## Record type
+
+```rust,ignore
+use sigil_stitch::prelude::*;
+
+let type_spec = TypeSpec::builder("person", TypeKind::Struct)
+    .doc("A person record.")
+    .add_field(
+        FieldSpec::builder("name", TypeName::primitive("string")).build().unwrap(),
+    )
+    .add_field(
+        FieldSpec::builder("age", TypeName::primitive("int")).build().unwrap(),
+    )
+    .add_field(
+        FieldSpec::builder("email", TypeName::primitive("string")).build().unwrap(),
+    )
+    .build()
+    .unwrap();
+```
+
+```ocaml
+(** A person record. *)
+type person =
+  {
+    name : string;
+    age : int;
+    email : string;
+  }
+```
+
+## Function with curried params
+
+```rust,ignore
+use sigil_stitch::prelude::*;
+
+let body = CodeBlock::of("List.map f xs", ()).unwrap();
+
+let fun = FunSpec::builder("transform")
+    .add_param(ParameterSpec::new("f", TypeName::primitive("'a -> 'b")).unwrap())
+    .add_param(ParameterSpec::new("xs", TypeName::primitive("'a list")).unwrap())
+    .returns(TypeName::primitive("'b list"))
+    .body(body)
+    .build()
+    .unwrap();
+```
+
+```ocaml
+let transform (f : 'a -> 'b) (xs : 'a list) : 'b list =
+  List.map f xs
+```
+
+## Module block
+
+OCaml modules are structurally different from types -- they can contain multiple types and values. Use the `OCaml::module_block` helper to build a `module Name = struct ... end` block as a raw `CodeBlock`.
+
+```rust,ignore
+use sigil_stitch::code_block::CodeBlock;
+use sigil_stitch::lang::ocaml::OCaml;
+
+let mut inner = CodeBlock::builder();
+inner.add_statement("let greeting = \"hello\"", ());
+inner.add_statement("let farewell = \"goodbye\"", ());
+let body = inner.build().unwrap();
+
+let module = OCaml::module_block("MyModule", body).unwrap();
+```
+
+```ocaml
+module MyModule = struct
+  let greeting = "hello"
+  let farewell = "goodbye"
+end
+```
+
+## Type alias
+
+```rust,ignore
+use sigil_stitch::prelude::*;
+
+let type_spec = TypeSpec::builder("string_list", TypeKind::TypeAlias)
+    .extends(TypeName::primitive("string list"))
+    .build()
+    .unwrap();
+```
+
+```ocaml
+type string_list = string list
+```
+
+## Pattern match
+
+Pattern matching is built using `CodeBlock` control-flow methods. Use `begin_control_flow` for the outer binding, then `begin_control_flow_with_open` to open the `match` expression with no trailing brace.
+
+```rust,ignore
+use sigil_stitch::code_block::CodeBlock;
+
+let mut b = CodeBlock::builder();
+b.begin_control_flow("let describe color", ());
+b.begin_control_flow_with_open("match color with", (), "");
+b.add("| Red -> \"red\"", ());
+b.add_line();
+b.add("| Green -> \"green\"", ());
+b.add_line();
+b.add("| Blue -> \"blue\"", ());
+b.add_line();
+b.end_control_flow();
+b.end_control_flow();
+let block = b.build().unwrap();
+```
+
+```ocaml
+let describe color =
+  match color with
+    | Red -> "red"
+    | Green -> "green"
+    | Blue -> "blue"
+```

--- a/docs/src/cookbook_python.md
+++ b/docs/src/cookbook_python.md
@@ -42,3 +42,119 @@ let type_spec = TypeSpec::builder("UserId", TypeKind::TypeAlias)
 ```python
 type UserId = str
 ```
+
+## Class with bases
+
+```rust,ignore
+use sigil_stitch::prelude::*;
+
+let type_spec = TypeSpec::builder("AdminService", TypeKind::Class)
+    .extends(TypeName::primitive("BaseService"))
+    .implements(TypeName::primitive("Authenticatable"))
+    .add_method(
+        FunSpec::builder("is_admin")
+            .add_param(ParameterSpec::new("self", TypeName::primitive("")).unwrap())
+            .returns(TypeName::primitive("bool"))
+            .body(CodeBlock::of("return True", ()).unwrap())
+            .build()
+            .unwrap(),
+    )
+    .build()
+    .unwrap();
+```
+
+```python
+class AdminService(BaseService, Authenticatable):
+    def is_admin(self) -> bool:
+        return True
+```
+
+## Dataclass
+
+```rust,ignore
+use sigil_stitch::prelude::*;
+
+let type_spec = TypeSpec::builder("Config", TypeKind::Class)
+    .doc("Application configuration.")
+    .annotation(CodeBlock::of("@dataclass", ()).unwrap())
+    .add_field(
+        FieldSpec::builder("name", TypeName::primitive("str"))
+            .build()
+            .unwrap(),
+    )
+    .add_field(
+        FieldSpec::builder("port", TypeName::primitive("int"))
+            .build()
+            .unwrap(),
+    )
+    .add_field(
+        FieldSpec::builder("debug", TypeName::primitive("bool"))
+            .initializer(CodeBlock::of("False", ()).unwrap())
+            .build()
+            .unwrap(),
+    )
+    .build()
+    .unwrap();
+```
+
+```python
+@dataclass
+class Config:
+    """Application configuration."""
+    name: str
+    port: int
+    debug: bool = False
+```
+
+## Enum
+
+```rust,ignore
+use sigil_stitch::prelude::*;
+
+let enum_base = TypeName::importable("enum", "Enum");
+
+let type_spec = TypeSpec::builder("Direction", TypeKind::Enum)
+    .extends(enum_base)
+    .add_variant(
+        EnumVariantSpec::builder("UP")
+            .value(CodeBlock::of("'UP'", ()).unwrap())
+            .build()
+            .unwrap(),
+    )
+    .add_variant(
+        EnumVariantSpec::builder("DOWN")
+            .value(CodeBlock::of("'DOWN'", ()).unwrap())
+            .build()
+            .unwrap(),
+    )
+    .add_variant(
+        EnumVariantSpec::builder("LEFT")
+            .value(CodeBlock::of("'LEFT'", ()).unwrap())
+            .build()
+            .unwrap(),
+    )
+    .add_variant(
+        EnumVariantSpec::builder("RIGHT")
+            .value(CodeBlock::of("'RIGHT'", ()).unwrap())
+            .build()
+            .unwrap(),
+    )
+    .build()
+    .unwrap();
+
+let file = FileSpec::builder("direction.py")
+    .add_type(type_spec)
+    .build()
+    .unwrap();
+let output = file.render(80).unwrap();
+```
+
+```python
+from enum import Enum
+
+class Direction(Enum):
+    UP = 'UP'
+    DOWN = 'DOWN'
+    LEFT = 'LEFT'
+    RIGHT = 'RIGHT'
+```

--- a/docs/src/cookbook_rust.md
+++ b/docs/src/cookbook_rust.md
@@ -104,3 +104,59 @@ let type_spec = TypeSpec::builder("Meters", TypeKind::Newtype)
 ```rust
 pub struct Meters(f64);
 ```
+
+## Trait
+
+```rust,ignore
+use sigil_stitch::prelude::*;
+
+let type_spec = TypeSpec::builder("Summary", TypeKind::Trait)
+    .visibility(Visibility::Public)
+    .add_method(
+        FunSpec::builder("summarize")
+            .add_param(ParameterSpec::new("&self", TypeName::primitive("")).unwrap())
+            .returns(TypeName::primitive("String"))
+            .build()
+            .unwrap(),
+    )
+    .add_method(
+        FunSpec::builder("preview")
+            .add_param(ParameterSpec::new("&self", TypeName::primitive("")).unwrap())
+            .returns(TypeName::primitive("String"))
+            .body(CodeBlock::of("self.summarize()[..50].to_string()", ()).unwrap())
+            .build()
+            .unwrap(),
+    )
+    .build()
+    .unwrap();
+```
+
+```rust
+pub trait Summary {
+    fn summarize(&self) -> String;
+
+    fn preview(&self) -> String {
+        self.summarize()[..50].to_string()
+    }
+}
+```
+
+## Type alias
+
+```rust,ignore
+use sigil_stitch::prelude::*;
+
+let type_spec = TypeSpec::builder("Result", TypeKind::TypeAlias)
+    .visibility(Visibility::Public)
+    .add_type_param(TypeParamSpec::new("T"))
+    .extends(TypeName::generic(
+        TypeName::primitive("std::result::Result"),
+        vec![TypeName::primitive("T"), TypeName::primitive("MyError")],
+    ))
+    .build()
+    .unwrap();
+```
+
+```rust
+pub type Result<T> = std::result::Result<T, MyError>;
+```

--- a/docs/src/cookbook_scala.md
+++ b/docs/src/cookbook_scala.md
@@ -1,0 +1,133 @@
+# Scala Cookbook
+
+Practical, copy-paste-ready recipes for Scala code generation. For the full API of each spec type, see [Building Functions & Fields](functions_and_fields.md), [Building Types & Enums](types_and_enums.md), and [Files & Projects](files_and_projects.md).
+
+## Case class
+
+```rust,ignore
+use sigil_stitch::prelude::*;
+
+let type_spec = TypeSpec::builder("User", TypeKind::Struct)
+    .doc("A user case class.")
+    .add_primary_constructor_param(
+        ParameterSpec::new("name", TypeName::primitive("String")).unwrap(),
+    )
+    .add_primary_constructor_param(
+        ParameterSpec::new("age", TypeName::primitive("Int")).unwrap(),
+    )
+    .add_primary_constructor_param(
+        ParameterSpec::new("email", TypeName::primitive("String")).unwrap(),
+    )
+    .build()
+    .unwrap();
+```
+
+```scala
+/**
+ * A user case class.
+ */
+case class User(name: String, age: Int, email: String) {
+}
+```
+
+## Trait with type parameter
+
+```rust,ignore
+use sigil_stitch::prelude::*;
+
+let type_spec = TypeSpec::builder("Repository", TypeKind::Trait)
+    .add_type_param(TypeParamSpec::new("T"))
+    .doc("Generic data repository.")
+    .add_method(
+        FunSpec::builder("findById")
+            .returns(TypeName::primitive("Option[T]"))
+            .add_param(ParameterSpec::new("id", TypeName::primitive("String")).unwrap())
+            .build()
+            .unwrap(),
+    )
+    .add_method(
+        FunSpec::builder("save")
+            .add_param(ParameterSpec::new("entity", TypeName::primitive("T")).unwrap())
+            .build()
+            .unwrap(),
+    )
+    .build()
+    .unwrap();
+```
+
+```scala
+/**
+ * Generic data repository.
+ */
+trait Repository[T] {
+  def findById(id: String): Option[T]
+
+  def save(entity: T)
+}
+```
+
+## Enum
+
+```rust,ignore
+use sigil_stitch::prelude::*;
+use sigil_stitch::spec::enum_variant_spec::EnumVariantSpec;
+
+let type_spec = TypeSpec::builder("Color", TypeKind::Enum)
+    .doc("Supported colors.")
+    .add_variant(EnumVariantSpec::new("Red").unwrap())
+    .add_variant(EnumVariantSpec::new("Green").unwrap())
+    .add_variant(EnumVariantSpec::new("Blue").unwrap())
+    .build()
+    .unwrap();
+```
+
+```scala
+/**
+ * Supported colors.
+ */
+enum Color {
+  Red,
+  Green,
+  Blue
+}
+```
+
+## Bounded type parameter
+
+```rust,ignore
+use sigil_stitch::prelude::*;
+
+let body = CodeBlock::of("if (a.compareTo(b) >= 0) a else b", ()).unwrap();
+
+let fun = FunSpec::builder("max")
+    .add_type_param(
+        TypeParamSpec::new("T").with_bound(TypeName::primitive("Comparable[T]")),
+    )
+    .returns(TypeName::primitive("T"))
+    .add_param(ParameterSpec::new("a", TypeName::primitive("T")).unwrap())
+    .add_param(ParameterSpec::new("b", TypeName::primitive("T")).unwrap())
+    .body(body)
+    .build()
+    .unwrap();
+```
+
+```scala
+def max[T <: Comparable[T]](a: T, b: T): T = {
+  if (a.compareTo(b) >= 0) a else b
+}
+```
+
+## Newtype
+
+```rust,ignore
+use sigil_stitch::prelude::*;
+
+let type_spec = TypeSpec::builder("Meters", TypeKind::Newtype)
+    .extends(TypeName::primitive("Double"))
+    .build()
+    .unwrap();
+```
+
+```scala
+class Meters(val value: Double)
+```

--- a/docs/src/cookbook_swift.md
+++ b/docs/src/cookbook_swift.md
@@ -21,3 +21,104 @@ struct Point: Codable {
     var y: Double
 }
 ```
+
+## Enum
+
+```rust,ignore
+use sigil_stitch::prelude::*;
+
+let type_spec = TypeSpec::builder("Color", TypeKind::Enum)
+    .visibility(Visibility::Public)
+    .doc("Supported colors.")
+    .add_variant(EnumVariantSpec::new("red").unwrap())
+    .add_variant(EnumVariantSpec::new("green").unwrap())
+    .add_variant(EnumVariantSpec::new("blue").unwrap())
+    .build()
+    .unwrap();
+```
+
+```swift
+/// Supported colors.
+public enum Color {
+    case red
+    case green
+    case blue
+}
+```
+
+## Enum with associated values
+
+```rust,ignore
+use sigil_stitch::prelude::*;
+
+let type_spec = TypeSpec::builder("NetworkResult", TypeKind::Enum)
+    .visibility(Visibility::Public)
+    .doc("Result of a network request.")
+    .add_variant(
+        EnumVariantSpec::builder("success")
+            .associated_type(TypeName::primitive("Data"))
+            .build()
+            .unwrap(),
+    )
+    .add_variant(
+        EnumVariantSpec::builder("failure")
+            .associated_type(TypeName::primitive("Error"))
+            .associated_type(TypeName::primitive("Int"))
+            .build()
+            .unwrap(),
+    )
+    .add_variant(EnumVariantSpec::new("loading").unwrap())
+    .build()
+    .unwrap();
+```
+
+```swift
+/// Result of a network request.
+public enum NetworkResult {
+    case success(Data)
+    case failure(Error, Int)
+    case loading
+}
+```
+
+## Protocol
+
+```rust,ignore
+use sigil_stitch::prelude::*;
+
+let type_spec = TypeSpec::builder("Repository", TypeKind::Interface)
+    .add_type_param(TypeParamSpec::new("T"))
+    .doc("Generic data repository.")
+    .add_method(
+        FunSpec::builder("findById")
+            .returns(TypeName::primitive("T?"))
+            .add_param(ParameterSpec::new("id", TypeName::primitive("String")).unwrap())
+            .build()
+            .unwrap(),
+    )
+    .add_method(
+        FunSpec::builder("save")
+            .add_param(ParameterSpec::new("entity", TypeName::primitive("T")).unwrap())
+            .build()
+            .unwrap(),
+    )
+    .add_method(
+        FunSpec::builder("delete")
+            .add_param(ParameterSpec::new("id", TypeName::primitive("String")).unwrap())
+            .build()
+            .unwrap(),
+    )
+    .build()
+    .unwrap();
+```
+
+```swift
+/// Generic data repository.
+protocol Repository<T> {
+    func findById(id: String) -> T?
+
+    func save(entity: T)
+
+    func delete(id: String)
+}
+```

--- a/docs/src/cookbook_typescript.md
+++ b/docs/src/cookbook_typescript.md
@@ -102,3 +102,86 @@ let type_spec = TypeSpec::builder("UserId", TypeKind::TypeAlias)
 ```typescript
 export type UserId = string;
 ```
+
+## Enum
+
+```rust,ignore
+use sigil_stitch::prelude::*;
+
+let type_spec = TypeSpec::builder("Direction", TypeKind::Enum)
+    .visibility(Visibility::Public)
+    .add_variant(
+        EnumVariantSpec::builder("Up")
+            .value(CodeBlock::of("'UP'", ()).unwrap())
+            .build()
+            .unwrap(),
+    )
+    .add_variant(
+        EnumVariantSpec::builder("Down")
+            .value(CodeBlock::of("'DOWN'", ()).unwrap())
+            .build()
+            .unwrap(),
+    )
+    .add_variant(
+        EnumVariantSpec::builder("Left")
+            .value(CodeBlock::of("'LEFT'", ()).unwrap())
+            .build()
+            .unwrap(),
+    )
+    .add_variant(
+        EnumVariantSpec::builder("Right")
+            .value(CodeBlock::of("'RIGHT'", ()).unwrap())
+            .build()
+            .unwrap(),
+    )
+    .build()
+    .unwrap();
+```
+
+```typescript
+export enum Direction {
+  Up = 'UP',
+  Down = 'DOWN',
+  Left = 'LEFT',
+  Right = 'RIGHT',
+}
+```
+
+## Abstract class
+
+```rust,ignore
+use sigil_stitch::prelude::*;
+
+let body = CodeBlock::of("console.log('handled')", ()).unwrap();
+
+let type_spec = TypeSpec::builder("BaseController", TypeKind::Class)
+    .visibility(Visibility::Public)
+    .is_abstract()
+    .add_method(
+        FunSpec::builder("handleRequest")
+            .is_abstract()
+            .add_param(ParameterSpec::new("req", TypeName::primitive("Request")).unwrap())
+            .returns(TypeName::primitive("Response"))
+            .build()
+            .unwrap(),
+    )
+    .add_method(
+        FunSpec::builder("log")
+            .visibility(Visibility::Protected)
+            .body(body)
+            .build()
+            .unwrap(),
+    )
+    .build()
+    .unwrap();
+```
+
+```typescript
+export abstract class BaseController {
+  abstract handleRequest(req: Request): Response;
+
+  protected log() {
+    console.log('handled')
+  }
+}
+```

--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -12,7 +12,7 @@ Or add it directly to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-sigil-stitch = "0.2"
+sigil-stitch = "0.3"
 ```
 
 sigil-stitch requires Rust edition 2024 and MSRV 1.88.0. Runtime dependencies (`pretty`, `serde` with `derive`, and `snafu`) are pulled in automatically. No feature flags are needed -- all spec types implement `serde::Serialize` and `serde::Deserialize` out of the box.

--- a/docs/src/language_cookbook.md
+++ b/docs/src/language_cookbook.md
@@ -4,15 +4,18 @@ This chapter collects practical, copy-paste-ready recipes for each supported lan
 
 ## Languages
 
-- [TypeScript](cookbook_typescript.md) -- class with imports, interface with generics, type alias
-- [Rust](cookbook_rust.md) -- struct with impl, enum with variants, newtype
-- [Go](cookbook_go.md) -- struct with tags, newtype
-- [Python](cookbook_python.md) -- function with type hints, type alias
-- [Java](cookbook_java.md) -- class with annotations
-- [Kotlin](cookbook_kotlin.md) -- data class
-- [Swift](cookbook_swift.md) -- struct with protocol conformance
-- [C++](cookbook_cpp.md) -- class with template, using alias
-- [C](cookbook_c.md) -- typedef
+- [TypeScript](cookbook_typescript.md) -- class with imports, interface with generics, type alias, enum, abstract class
+- [Rust](cookbook_rust.md) -- struct with impl, enum with variants, newtype, trait, type alias
+- [Go](cookbook_go.md) -- struct with tags, newtype, interface, generic function
+- [Python](cookbook_python.md) -- function with type hints, type alias, class with bases, dataclass, enum
+- [Java](cookbook_java.md) -- class with annotations, interface, enum, abstract class
+- [Kotlin](cookbook_kotlin.md) -- data class, enum, interface, suspend function
+- [Swift](cookbook_swift.md) -- struct with protocol conformance, enum, enum with associated values, protocol
+- [C++](cookbook_cpp.md) -- class with template, using alias, enum class, virtual method, namespace wrapping
+- [C](cookbook_c.md) -- typedef, struct with fields, function declaration, enum
+- [Scala](cookbook_scala.md) -- case class, trait with type parameter, enum, bounded type parameter, newtype
+- [Haskell](cookbook_haskell.md) -- data record with deriving, type class, function with split signature, newtype, type alias
+- [OCaml](cookbook_ocaml.md) -- record type, function with curried params, module block, type alias, pattern match
 
 ## Cross-language comparison
 
@@ -24,5 +27,8 @@ The same logical concept -- a simple data type with two fields -- rendered acros
 | Rust       | `pub struct Point { pub x: f64, pub y: f64, }` + separate `impl` block |
 | Go         | `type Point struct { X float64; Y float64 }` |
 | Python     | `class Point: x: float; y: float` |
+| Scala      | `case class Point(x: Double, y: Double)` |
+| Haskell    | `data Point = Point { pointX :: Double, pointY :: Double }` |
+| OCaml      | `type point = { x : float; y : float }` |
 
 The language's `CodeLang` trait controls every syntax detail: keywords, delimiters, field ordering, visibility rendering, and whether methods live inside the type body or in a separate `impl` block. You build the spec once and the language passed to `render()` does the rest.


### PR DESCRIPTION
## Summary

- Add Scala, Haskell, and OCaml cookbook pages (5 recipes each) and expand all 9 existing cookbooks with 2–3 additional recipes (39 new recipes total across 12 languages)
- Bump workspace version `0.2.2` → `0.3.0`, update install snippet and macros dependency
- Add full `## 0.3.0` changelog section covering breaking changes, new features, fixes, and documentation

## Test plan

- [x] `cargo test --workspace` — 485+ tests pass
- [x] `mdbook build docs` — clean build
- [x] `grep -r '0\.2' Cargo.toml docs/src/getting_started.md` — no stale version references
- [x] All 12 cookbook files use correct builder patterns (owning-chain for specs, `&mut self` for CodeBlockBuilder)