### PR TITLE
feat: add TypeName::qualified() for inline module-qualified type rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.3.1
+
+### Added
+
+- `TypeName::qualified()` constructor for inline module-qualified type rendering
+  (e.g., `serde_json::Value`, `super::Foo`) without generating import statements.
+- `.qualify()` modifier to convert an existing `TypeName::importable()` into
+  qualified inline rendering.
+- `CodeLang::module_separator()` trait method returning `Option<&str>`. Languages
+  with module-qualified paths (`::` for Rust/C++, `.` for Go/Python/Java/Kotlin/
+  Scala/Swift/Dart/Haskell/OCaml) return `Some(sep)`. Languages without inline
+  qualification (TypeScript, JavaScript, C, Bash, Zsh) return `None`, and
+  qualified types silently fall back to unqualified rendering.
+
 ## 0.3.0
 
 ### Breaking

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,7 +100,7 @@ dependencies = [
 
 [[package]]
 name = "sigil-stitch"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "pretty",
  "serde",
@@ -111,7 +111,7 @@ dependencies = [
 
 [[package]]
 name = "sigil-stitch-macros"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["macros"]
 resolver = "3"
 
 [workspace.package]
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"
@@ -35,7 +35,7 @@ exclude = [
 [dependencies]
 pretty = "0.12"
 snafu = "0.9"
-sigil-stitch-macros = { path = "macros", version = "0.3.0" }
+sigil-stitch-macros = { path = "macros", version = "0.3.1" }
 serde = { version = "1", features = ["derive"] }
 
 [dev-dependencies]

--- a/docs/src/adding_a_language.md
+++ b/docs/src/adding_a_language.md
@@ -140,6 +140,7 @@ These methods don't belong to a config struct but have sensible defaults you can
 
 - `escape_reserved()` -- how reserved words are escaped.
 - `qualify_import_name()` -- default passthrough. Go overrides to return `"http.Server"` (package-qualified names).
+- `module_separator()` -- returns `Option<&str>`. Default `None`. Override to `Some("::")` (Rust/C++) or `Some(".")` (Go/Python/Java/etc.) to enable `TypeName::qualified()` inline rendering.
 - `type_kind_suffix()` -- suffix after type close for specific type kinds.
 - `render_newtype_line()` -- default emits Rust tuple struct `struct Name(Inner);`. Go: `type Name Inner`, Kotlin: `value class Name(val value: Inner)`, Python: `Name = NewType("Name", Inner)`, C: `typedef Inner Name;`.
 - `fun_block_open()` -- custom block opener for functions.

--- a/docs/src/cookbook_rust.md
+++ b/docs/src/cookbook_rust.md
@@ -160,3 +160,31 @@ let type_spec = TypeSpec::builder("Result", TypeKind::TypeAlias)
 ```rust
 pub type Result<T> = std::result::Result<T, MyError>;
 ```
+
+## Qualified paths (no import)
+
+Use `TypeName::qualified()` to render types with their full module path inline without generating a `use` statement:
+
+```rust,ignore
+use sigil_stitch::prelude::*;
+
+let field = FieldSpec::builder("data", TypeName::qualified("serde_json", "Value"))
+    .visibility(Visibility::Public)
+    .build()
+    .unwrap();
+
+// In a generic:
+let map_type = TypeName::generic(
+    TypeName::qualified("std::collections", "HashMap"),
+    vec![
+        TypeName::primitive("String"),
+        TypeName::qualified("serde_json", "Value"),
+    ],
+);
+```
+
+```rust
+pub data: serde_json::Value
+
+std::collections::HashMap<String, serde_json::Value>
+```

--- a/docs/src/type_name.md
+++ b/docs/src/type_name.md
@@ -40,6 +40,43 @@ let n = TypeName::primitive("number");
 let t = TypeName::primitive("T");  // type parameter
 ```
 
+## Qualified types
+
+For types that should render with their full module path inline *without* generating an import statement:
+
+```rust,ignore
+// Rust: serde_json::Value  (no `use serde_json::Value;`)
+let val = TypeName::qualified("serde_json", "Value");
+
+// Rust: super::Foo
+let foo = TypeName::qualified("super", "Foo");
+
+// Java: java.util.HashMap
+let map = TypeName::qualified("java.util", "HashMap");
+```
+
+The separator between module and name comes from `CodeLang::module_separator()` — `"::"` for Rust/C++, `"."` for Go/Python/Java/Kotlin/Scala/Swift/Dart/Haskell/OCaml. Languages without module-qualified paths (TypeScript, JavaScript, C, Bash, Zsh) silently fall back to rendering just the name.
+
+Qualified types work anywhere a `TypeName` is accepted, including inside generics:
+
+```rust,ignore
+// Rust: std::collections::HashMap<String, serde_json::Value>
+let map = TypeName::generic(
+    TypeName::qualified("std::collections", "HashMap"),
+    vec![
+        TypeName::primitive("String"),
+        TypeName::qualified("serde_json", "Value"),
+    ],
+);
+```
+
+You can also convert an existing importable type to qualified rendering with `.qualify()`:
+
+```rust,ignore
+// Equivalent to TypeName::qualified("serde_json", "Value")
+let val = TypeName::importable("serde_json", "Value").qualify();
+```
+
 ## Collections
 
 ### Arrays

--- a/src/lang/bash.rs
+++ b/src/lang/bash.rs
@@ -423,4 +423,10 @@ mod tests {
         assert_eq!(bash.file_extension(), "sh");
         assert_eq!(bash.block_syntax().indent_unit, "  ");
     }
+
+    #[test]
+    fn test_module_separator() {
+        let bash = Bash::new();
+        assert_eq!(bash.module_separator(), None);
+    }
 }

--- a/src/lang/c_lang.rs
+++ b/src/lang/c_lang.rs
@@ -497,4 +497,10 @@ mod tests {
         assert_eq!(c.file_extension(), "h");
         assert_eq!(c.block_syntax().indent_unit, "\t");
     }
+
+    #[test]
+    fn test_module_separator() {
+        let c = CLang::new();
+        assert_eq!(c.module_separator(), None);
+    }
 }

--- a/src/lang/cpp_lang.rs
+++ b/src/lang/cpp_lang.rs
@@ -303,6 +303,10 @@ impl CodeLang for CppLang {
         }
     }
 
+    fn module_separator(&self) -> Option<&str> {
+        Some("::")
+    }
+
     fn block_syntax(&self) -> crate::lang::config::BlockSyntaxConfig<'_> {
         crate::lang::config::BlockSyntaxConfig {
             indent_unit: &self.indent,
@@ -559,5 +563,11 @@ mod tests {
         let cpp = CppLang::new().with_indent("  ").with_extension("cxx");
         assert_eq!(cpp.file_extension(), "cxx");
         assert_eq!(cpp.block_syntax().indent_unit, "  ");
+    }
+
+    #[test]
+    fn test_module_separator() {
+        let cpp = CppLang::new();
+        assert_eq!(cpp.module_separator(), Some("::"));
     }
 }

--- a/src/lang/dart.rs
+++ b/src/lang/dart.rs
@@ -255,6 +255,10 @@ impl CodeLang for DartLang {
         }
     }
 
+    fn module_separator(&self) -> Option<&str> {
+        Some(".")
+    }
+
     fn block_syntax(&self) -> crate::lang::config::BlockSyntaxConfig<'_> {
         crate::lang::config::BlockSyntaxConfig {
             indent_unit: &self.indent,
@@ -521,5 +525,11 @@ mod tests {
         let d = DartLang::new().with_indent("    ").with_extension("g.dart");
         assert_eq!(d.file_extension(), "g.dart");
         assert_eq!(d.block_syntax().indent_unit, "    ");
+    }
+
+    #[test]
+    fn test_module_separator() {
+        let d = DartLang::new();
+        assert_eq!(d.module_separator(), Some("."));
     }
 }

--- a/src/lang/go_lang.rs
+++ b/src/lang/go_lang.rs
@@ -263,6 +263,10 @@ impl CodeLang for GoLang {
         crate::lang::config::OptionalFieldStyle::TypePrefix("*")
     }
 
+    fn module_separator(&self) -> Option<&str> {
+        Some(".")
+    }
+
     // --- Config struct accessors ---
 
     fn type_presentation(&self) -> TypePresentationConfig<'_> {
@@ -508,5 +512,11 @@ mod tests {
         let go = GoLang::new().with_indent("    ").with_extension("go2");
         assert_eq!(go.file_extension(), "go2");
         assert_eq!(go.block_syntax().indent_unit, "    ");
+    }
+
+    #[test]
+    fn test_module_separator() {
+        let go = GoLang::new();
+        assert_eq!(go.module_separator(), Some("."));
     }
 }

--- a/src/lang/haskell.rs
+++ b/src/lang/haskell.rs
@@ -327,6 +327,10 @@ impl CodeLang for Haskell {
         }
     }
 
+    fn module_separator(&self) -> Option<&str> {
+        Some(".")
+    }
+
     fn block_syntax(&self) -> crate::lang::config::BlockSyntaxConfig<'_> {
         crate::lang::config::BlockSyntaxConfig {
             block_open: " =",
@@ -619,5 +623,11 @@ mod tests {
             hs.function_syntax().function_signature_style,
             crate::spec::fun_spec::FunctionSignatureStyle::Split
         );
+    }
+
+    #[test]
+    fn test_module_separator() {
+        let hs = Haskell::new();
+        assert_eq!(hs.module_separator(), Some("."));
     }
 }

--- a/src/lang/java_lang.rs
+++ b/src/lang/java_lang.rs
@@ -260,6 +260,10 @@ impl CodeLang for JavaLang {
         }
     }
 
+    fn module_separator(&self) -> Option<&str> {
+        Some(".")
+    }
+
     fn block_syntax(&self) -> crate::lang::config::BlockSyntaxConfig<'_> {
         crate::lang::config::BlockSyntaxConfig {
             indent_unit: &self.indent,
@@ -539,5 +543,11 @@ mod tests {
         let java = JavaLang::new().with_indent("\t").with_extension("jav");
         assert_eq!(java.file_extension(), "jav");
         assert_eq!(java.block_syntax().indent_unit, "\t");
+    }
+
+    #[test]
+    fn test_module_separator() {
+        let java = JavaLang::new();
+        assert_eq!(java.module_separator(), Some("."));
     }
 }

--- a/src/lang/javascript.rs
+++ b/src/lang/javascript.rs
@@ -553,4 +553,10 @@ mod tests {
         assert_eq!(js.type_keyword(TypeKind::Interface), "class");
         assert_eq!(js.type_keyword(TypeKind::Enum), "class");
     }
+
+    #[test]
+    fn test_module_separator() {
+        let js = JavaScript::new();
+        assert_eq!(js.module_separator(), None);
+    }
 }

--- a/src/lang/kotlin.rs
+++ b/src/lang/kotlin.rs
@@ -345,6 +345,10 @@ impl CodeLang for Kotlin {
         }
     }
 
+    fn module_separator(&self) -> Option<&str> {
+        Some(".")
+    }
+
     fn block_syntax(&self) -> crate::lang::config::BlockSyntaxConfig<'_> {
         crate::lang::config::BlockSyntaxConfig {
             indent_unit: &self.indent,
@@ -632,5 +636,11 @@ mod tests {
         let kt = Kotlin::new().with_indent("  ").with_extension("kts");
         assert_eq!(kt.file_extension(), "kts");
         assert_eq!(kt.block_syntax().indent_unit, "  ");
+    }
+
+    #[test]
+    fn test_module_separator() {
+        let kt = Kotlin::new();
+        assert_eq!(kt.module_separator(), Some("."));
     }
 }

--- a/src/lang/mod.rs
+++ b/src/lang/mod.rs
@@ -110,6 +110,18 @@ pub trait CodeLang: std::fmt::Debug + 'static {
         resolved_name.to_string()
     }
 
+    /// The separator between module path and type name for qualified inline
+    /// references (e.g., `"::"` for Rust/C++, `"."` for Go/Python/Java).
+    ///
+    /// Return `Some(sep)` if [`crate::type_name::TypeName::qualified()`] should render
+    /// `module{sep}name` inline. Return `None` if the language has no concept
+    /// of module-qualified inline type references (e.g., TypeScript, Bash),
+    /// in which case [`crate::type_name::TypeName::qualified()`] silently falls back to
+    /// unqualified rendering.
+    fn module_separator(&self) -> Option<&str> {
+        None
+    }
+
     /// Optional kind suffix after the type name (e.g., Go's `type Foo struct`).
     ///
     /// Default: empty (TS/Rust put the kind keyword before the name).

--- a/src/lang/ocaml.rs
+++ b/src/lang/ocaml.rs
@@ -243,6 +243,10 @@ impl CodeLang for OCaml {
         }
     }
 
+    fn module_separator(&self) -> Option<&str> {
+        Some(".")
+    }
+
     // --- Config struct accessors ---
 
     fn type_presentation(&self) -> TypePresentationConfig<'_> {
@@ -457,5 +461,11 @@ mod tests {
         let ml = OCaml::new().with_indent("\t").with_extension("mli");
         assert_eq!(ml.file_extension(), "mli");
         assert_eq!(ml.block_syntax().indent_unit, "\t");
+    }
+
+    #[test]
+    fn test_module_separator() {
+        let ml = OCaml::new();
+        assert_eq!(ml.module_separator(), Some("."));
     }
 }

--- a/src/lang/python.rs
+++ b/src/lang/python.rs
@@ -324,6 +324,10 @@ impl CodeLang for Python {
         crate::lang::config::OptionalFieldStyle::UnionWithNone(" | ")
     }
 
+    fn module_separator(&self) -> Option<&str> {
+        Some(".")
+    }
+
     // --- Config struct accessors ---
 
     fn type_presentation(&self) -> TypePresentationConfig<'_> {
@@ -586,5 +590,11 @@ mod tests {
         assert_eq!(py.file_extension(), "pyi");
         assert_eq!(py.block_syntax().indent_unit, "  ");
         assert_eq!(py.render_string_literal("hi"), "\"hi\"");
+    }
+
+    #[test]
+    fn test_module_separator() {
+        let py = Python::new();
+        assert_eq!(py.module_separator(), Some("."));
     }
 }

--- a/src/lang/rust_lang.rs
+++ b/src/lang/rust_lang.rs
@@ -230,6 +230,10 @@ impl CodeLang for RustLang {
         }
     }
 
+    fn module_separator(&self) -> Option<&str> {
+        Some("::")
+    }
+
     // --- Config struct accessors ---
 
     fn type_presentation(&self) -> TypePresentationConfig<'_> {
@@ -411,5 +415,11 @@ mod tests {
         let rs = RustLang::new().with_indent("\t").with_extension("rsi");
         assert_eq!(rs.file_extension(), "rsi");
         assert_eq!(rs.block_syntax().indent_unit, "\t");
+    }
+
+    #[test]
+    fn test_module_separator() {
+        let rs = RustLang::new();
+        assert_eq!(rs.module_separator(), Some("::"));
     }
 }

--- a/src/lang/scala.rs
+++ b/src/lang/scala.rs
@@ -296,6 +296,10 @@ impl CodeLang for Scala {
         }
     }
 
+    fn module_separator(&self) -> Option<&str> {
+        Some(".")
+    }
+
     fn block_syntax(&self) -> crate::lang::config::BlockSyntaxConfig<'_> {
         crate::lang::config::BlockSyntaxConfig {
             indent_unit: &self.indent,
@@ -609,5 +613,11 @@ mod tests {
             sc.render_newtype_line("", "Meters", "Double"),
             "class Meters(val value: Double)"
         );
+    }
+
+    #[test]
+    fn test_module_separator() {
+        let sc = Scala::new();
+        assert_eq!(sc.module_separator(), Some("."));
     }
 }

--- a/src/lang/swift.rs
+++ b/src/lang/swift.rs
@@ -322,6 +322,10 @@ impl CodeLang for Swift {
         }
     }
 
+    fn module_separator(&self) -> Option<&str> {
+        Some(".")
+    }
+
     fn block_syntax(&self) -> crate::lang::config::BlockSyntaxConfig<'_> {
         crate::lang::config::BlockSyntaxConfig {
             indent_unit: &self.indent,
@@ -575,5 +579,11 @@ mod tests {
             .with_extension("swiftinterface");
         assert_eq!(sw.file_extension(), "swiftinterface");
         assert_eq!(sw.block_syntax().indent_unit, "  ");
+    }
+
+    #[test]
+    fn test_module_separator() {
+        let sw = Swift::new();
+        assert_eq!(sw.module_separator(), Some("."));
     }
 }

--- a/src/lang/typescript.rs
+++ b/src/lang/typescript.rs
@@ -493,4 +493,10 @@ mod tests {
         assert!(doc.contains(" *\n"));
         assert!(doc.ends_with(" */"));
     }
+
+    #[test]
+    fn test_module_separator() {
+        let ts = TypeScript::new();
+        assert_eq!(ts.module_separator(), None);
+    }
 }

--- a/src/lang/zsh.rs
+++ b/src/lang/zsh.rs
@@ -318,4 +318,10 @@ mod tests {
         assert_eq!(zsh.file_extension(), "sh");
         assert_eq!(zsh.block_syntax().indent_unit, "\t");
     }
+
+    #[test]
+    fn test_module_separator() {
+        let zsh = Zsh::new();
+        assert_eq!(zsh.module_separator(), None);
+    }
 }

--- a/src/type_name.rs
+++ b/src/type_name.rs
@@ -190,6 +190,12 @@ pub enum TypeName {
         is_type_only: bool,
         /// Optional preferred alias for this import (e.g., `Foo as Bar`).
         alias: Option<String>,
+        /// When true, render as `module{sep}name` inline (e.g., `serde_json::Value`)
+        /// and skip import generation. The separator comes from
+        /// [`CodeLang::module_separator()`]. Falls back to unqualified rendering
+        /// if the language returns `None`.
+        #[serde(default)]
+        qualified: bool,
     },
     /// A primitive/built-in type (no import needed).
     Primitive(String),
@@ -381,6 +387,7 @@ impl TypeName {
             name: name.to_string(),
             is_type_only: false,
             alias: None,
+            qualified: false,
         }
     }
 
@@ -391,12 +398,36 @@ impl TypeName {
             name: name.to_string(),
             is_type_only: true,
             alias: None,
+            qualified: false,
         }
     }
 
     /// Create a primitive type name (no import).
     pub fn primitive(name: &str) -> Self {
         TypeName::Primitive(name.to_string())
+    }
+
+    /// Create a qualified type name that renders inline as `module{sep}name`.
+    ///
+    /// The separator comes from [`CodeLang::module_separator()`] — `"::"` for
+    /// Rust/C++, `"."` for Go/Python/Java/etc.  No import statement is generated.
+    ///
+    /// If the target language returns `None` from `module_separator()`, the
+    /// qualified flag is silently ignored and the type renders as just `name`.
+    ///
+    /// ```ignore
+    /// TypeName::qualified("serde_json", "Value")      // Rust: serde_json::Value
+    /// TypeName::qualified("super", "Foo")              // Rust: super::Foo
+    /// TypeName::qualified("java.util", "HashMap")      // Java: java.util.HashMap
+    /// ```
+    pub fn qualified(module: &str, name: &str) -> Self {
+        TypeName::Importable {
+            module: module.to_string(),
+            name: name.to_string(),
+            is_type_only: false,
+            alias: None,
+            qualified: true,
+        }
     }
 
     /// Returns true if this type name renders to an empty string.
@@ -419,6 +450,24 @@ impl TypeName {
         } = self
         {
             *a = Some(alias.to_string());
+        }
+        self
+    }
+
+    /// Mark this type for qualified inline rendering (`module{sep}name`).
+    ///
+    /// When qualified, no import statement is generated and the type renders
+    /// with its full module path. Only affects `Importable` variants; other
+    /// variants are returned unchanged.
+    ///
+    /// See [`TypeName::qualified()`] for details on separator and fallback behavior.
+    pub fn qualify(mut self) -> Self {
+        if let TypeName::Importable {
+            qualified: ref mut q,
+            ..
+        } = self
+        {
+            *q = true;
         }
         self
     }
@@ -609,10 +658,14 @@ impl TypeName {
     pub fn collect_imports(&self, out: &mut Vec<ImportRef>) {
         match self {
             TypeName::Importable {
+                qualified: true, ..
+            } => {}
+            TypeName::Importable {
                 module,
                 name,
                 is_type_only,
                 alias,
+                ..
             } => {
                 out.push(ImportRef {
                     module: module.clone(),
@@ -1073,6 +1126,19 @@ impl TypeName {
                     BoxDoc::text(tp.wildcard.lower_keyword.to_string()).append(lb_doc)
                 } else {
                     BoxDoc::text(tp.wildcard.unbounded.to_string())
+                }
+            }
+            TypeName::Importable {
+                module,
+                name,
+                qualified: true,
+                ..
+            } => {
+                if let Some(sep) = lang.module_separator() {
+                    BoxDoc::text(format!("{module}{sep}{name}"))
+                } else {
+                    let display = resolve(module, name);
+                    BoxDoc::text(display)
                 }
             }
             // Leaf variants delegate to to_doc (no recursion needed).
@@ -1938,5 +2004,80 @@ mod tests {
         let mut buf = Vec::new();
         doc.render(80, &mut buf).unwrap();
         assert_eq!(String::from_utf8(buf).unwrap(), "&String");
+    }
+
+    #[test]
+    fn test_qualified_renders_with_rust_separator() {
+        use crate::lang::rust_lang::RustLang;
+        let lang = RustLang::new();
+        let t = TypeName::qualified("serde_json", "Value");
+        let doc = t.to_doc_with_lang(&identity_resolve, &lang);
+        let mut buf = Vec::new();
+        doc.render(80, &mut buf).unwrap();
+        assert_eq!(String::from_utf8(buf).unwrap(), "serde_json::Value");
+    }
+
+    #[test]
+    fn test_qualified_renders_with_go_separator() {
+        use crate::lang::go_lang::GoLang;
+        let lang = GoLang::new();
+        let t = TypeName::qualified("net/http", "Server");
+        let doc = t.to_doc_with_lang(&identity_resolve, &lang);
+        let mut buf = Vec::new();
+        doc.render(80, &mut buf).unwrap();
+        assert_eq!(String::from_utf8(buf).unwrap(), "net/http.Server");
+    }
+
+    #[test]
+    fn test_qualified_skips_import_collection() {
+        let t = TypeName::qualified("serde_json", "Value");
+        let mut imports = Vec::new();
+        t.collect_imports(&mut imports);
+        assert!(imports.is_empty());
+    }
+
+    #[test]
+    fn test_qualify_modifier() {
+        let t = TypeName::importable("serde_json", "Value").qualify();
+        let mut imports = Vec::new();
+        t.collect_imports(&mut imports);
+        assert!(imports.is_empty());
+
+        use crate::lang::rust_lang::RustLang;
+        let lang = RustLang::new();
+        let doc = t.to_doc_with_lang(&identity_resolve, &lang);
+        let mut buf = Vec::new();
+        doc.render(80, &mut buf).unwrap();
+        assert_eq!(String::from_utf8(buf).unwrap(), "serde_json::Value");
+    }
+
+    #[test]
+    fn test_qualified_in_generic() {
+        use crate::lang::rust_lang::RustLang;
+        let lang = RustLang::new();
+        let t = TypeName::generic(
+            TypeName::qualified("std::collections", "HashMap"),
+            vec![
+                TypeName::primitive("String"),
+                TypeName::qualified("serde_json", "Value"),
+            ],
+        );
+        let doc = t.to_doc_with_lang(&identity_resolve, &lang);
+        let mut buf = Vec::new();
+        doc.render(80, &mut buf).unwrap();
+        assert_eq!(
+            String::from_utf8(buf).unwrap(),
+            "std::collections::HashMap<String, serde_json::Value>"
+        );
+    }
+
+    #[test]
+    fn test_qualified_fallback_unsupported_lang() {
+        let lang = TypeScript::new();
+        let t = TypeName::qualified("serde_json", "Value");
+        let doc = t.to_doc_with_lang(&identity_resolve, &lang);
+        let mut buf = Vec::new();
+        doc.render(80, &mut buf).unwrap();
+        assert_eq!(String::from_utf8(buf).unwrap(), "Value");
     }
 }


### PR DESCRIPTION
## Summary

- Add `TypeName::qualified("module", "Name")` constructor and `.qualify()` modifier for rendering types with their full module path inline (e.g., `serde_json::Value`, `super::Foo`) without generating import statements.
- Add `CodeLang::module_separator() -> Option<&str>` trait method. 11 languages return `Some` (`::` for Rust/C++, `.` for Go/Python/Java/Kotlin/Scala/Swift/Dart/Haskell/OCaml); 5 return `None` (TS, JS, C, Bash, Zsh) with silent fallback to unqualified rendering.
- Add `module_separator()` unit tests for all 16 languages.
- Document in `type_name.md`, `adding_a_language.md`, and `cookbook_rust.md`.
- Bump version to 0.3.1 with changelog.

## Test plan

- [x] 6 new unit tests in `type_name.rs`: Rust separator, Go separator, import suppression, `.qualify()` modifier, generic nesting, unsupported-lang fallback
- [x] 16 new `test_module_separator` tests across all language files
- [x] All 507 tests pass
- [x] `cargo clippy` clean
- [x] `cargo fmt` clean
- [x] `mdbook build` clean
- [x] Serde backwards compat via `#[serde(default)]` on new `qualified` field