### PR TITLE
fix: Java/Kotlin enum rendering — constructor-arg values, variant-first ordering, section terminator

### DIFF
--- a/src/lang/config.rs
+++ b/src/lang/config.rs
@@ -314,6 +314,16 @@ impl Default for TypeDeclSyntaxConfig<'_> {
     }
 }
 
+/// How an enum variant's value is formatted.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum VariantValueFormat {
+    /// `NAME = value` — TypeScript, Rust, C, Swift, etc.
+    #[default]
+    Assignment,
+    /// `NAME(value)` — Java, Kotlin constructor-arg style.
+    ConstructorArg,
+}
+
 /// Enum variant formatting, annotation syntax, and field mutability keywords.
 #[derive(Debug, Clone, Copy)]
 pub struct EnumAndAnnotationConfig<'a> {
@@ -325,6 +335,12 @@ pub struct EnumAndAnnotationConfig<'a> {
     pub variant_separator: &'a str,
     /// Whether the separator appears after the last variant too.
     pub variant_trailing_separator: bool,
+    /// How the variant value is rendered (assignment `= val` vs constructor `(val)`).
+    pub variant_value_format: VariantValueFormat,
+    /// Whether enum variants are emitted before fields (Java/Kotlin pattern).
+    pub variants_before_fields: bool,
+    /// Terminator emitted after the last variant when fields/methods follow (e.g. `";"`).
+    pub variant_section_terminator: &'a str,
     /// Prefix wrapping an annotation name (e.g. `"@"`, `"#["`).
     pub annotation_prefix: &'a str,
     /// Suffix closing an annotation (e.g. `""`, `"]"`).
@@ -342,6 +358,9 @@ impl Default for EnumAndAnnotationConfig<'_> {
             variant_prefix_first: None,
             variant_separator: ",",
             variant_trailing_separator: false,
+            variant_value_format: VariantValueFormat::Assignment,
+            variants_before_fields: false,
+            variant_section_terminator: "",
             annotation_prefix: "@",
             annotation_suffix: "",
             readonly_keyword: "const ",

--- a/src/lang/java_lang.rs
+++ b/src/lang/java_lang.rs
@@ -293,6 +293,9 @@ impl CodeLang for JavaLang {
     fn enum_and_annotation(&self) -> crate::lang::config::EnumAndAnnotationConfig<'_> {
         crate::lang::config::EnumAndAnnotationConfig {
             readonly_keyword: "final ",
+            variant_value_format: crate::lang::config::VariantValueFormat::ConstructorArg,
+            variants_before_fields: true,
+            variant_section_terminator: ";",
             ..Default::default()
         }
     }
@@ -549,5 +552,17 @@ mod tests {
     fn test_module_separator() {
         let java = JavaLang::new();
         assert_eq!(java.module_separator(), Some("."));
+    }
+
+    #[test]
+    fn test_enum_and_annotation_config() {
+        let java = JavaLang::new();
+        let ea = java.enum_and_annotation();
+        assert_eq!(
+            ea.variant_value_format,
+            crate::lang::config::VariantValueFormat::ConstructorArg
+        );
+        assert!(ea.variants_before_fields);
+        assert_eq!(ea.variant_section_terminator, ";");
     }
 }

--- a/src/lang/kotlin.rs
+++ b/src/lang/kotlin.rs
@@ -380,6 +380,9 @@ impl CodeLang for Kotlin {
         crate::lang::config::EnumAndAnnotationConfig {
             readonly_keyword: "val ",
             mutable_field_keyword: "var ",
+            variant_value_format: crate::lang::config::VariantValueFormat::ConstructorArg,
+            variants_before_fields: true,
+            variant_section_terminator: ";",
             ..Default::default()
         }
     }
@@ -619,6 +622,18 @@ mod tests {
         let kt = Kotlin::new();
         assert_eq!(kt.enum_and_annotation().readonly_keyword, "val ");
         assert_eq!(kt.enum_and_annotation().mutable_field_keyword, "var ");
+    }
+
+    #[test]
+    fn test_enum_config() {
+        let kt = Kotlin::new();
+        let ea = kt.enum_and_annotation();
+        assert_eq!(
+            ea.variant_value_format,
+            crate::lang::config::VariantValueFormat::ConstructorArg
+        );
+        assert!(ea.variants_before_fields);
+        assert_eq!(ea.variant_section_terminator, ";");
     }
 
     #[test]

--- a/src/spec/type_spec.rs
+++ b/src/spec/type_spec.rs
@@ -147,18 +147,35 @@ impl TypeSpec {
             cb.add("%L", doc_str);
             cb.add_line();
         }
-        for (i, field) in self.fields.iter().enumerate() {
-            if i > 0 {
-                // No extra blank line between fields.
+        let ea = lang.enum_and_annotation();
+        let has_trailing_members =
+            !self.fields.is_empty() || !self.properties.is_empty() || !self.methods.is_empty();
+
+        if ea.variants_before_fields {
+            // Variants first (Java/Kotlin pattern).
+            if !self.variants.is_empty() {
+                self.emit_variants(&mut cb, lang, has_trailing_members)?;
             }
-            cb.add_code(field.emit(lang, DeclarationContext::Member)?);
-        }
-        // Enum variants.
-        if !self.variants.is_empty() {
-            if !self.fields.is_empty() {
-                cb.add_line();
+            for (i, field) in self.fields.iter().enumerate() {
+                if i == 0 && !self.variants.is_empty() {
+                    cb.add_line();
+                }
+                cb.add_code(field.emit(lang, DeclarationContext::Member)?);
             }
-            self.emit_variants(&mut cb, lang)?;
+        } else {
+            // Fields first, then variants (default).
+            for (i, field) in self.fields.iter().enumerate() {
+                if i > 0 {
+                    // No extra blank line between fields.
+                }
+                cb.add_code(field.emit(lang, DeclarationContext::Member)?);
+            }
+            if !self.variants.is_empty() {
+                if !self.fields.is_empty() {
+                    cb.add_line();
+                }
+                self.emit_variants(&mut cb, lang, has_trailing_members)?;
+            }
         }
         let has_body_above = !self.fields.is_empty() || !self.variants.is_empty();
         // Properties (after fields, before methods).
@@ -245,7 +262,8 @@ impl TypeSpec {
             if !self.fields.is_empty() {
                 cb.add_line();
             }
-            self.emit_variants(&mut cb, lang)?;
+            let has_trailing = !self.extra_members.is_empty();
+            self.emit_variants(&mut cb, lang, has_trailing)?;
         }
         for extra in &self.extra_members {
             cb.add_code(extra.clone());
@@ -423,6 +441,7 @@ impl TypeSpec {
         &self,
         cb: &mut CodeBlockBuilder,
         lang: &dyn CodeLang,
+        has_trailing_members: bool,
     ) -> Result<(), crate::error::SigilStitchError> {
         let ea = lang.enum_and_annotation();
         let sep = ea.variant_separator;
@@ -490,7 +509,6 @@ impl TypeSpec {
             // Struct fields: Name { field: Type, ... }
             if !variant.fields.is_empty() {
                 let is_last = i == count - 1;
-                let needs_sep = !sep.is_empty() && (!is_last || trailing);
 
                 fmt.push_str(" {");
                 cb.add(&fmt, args);
@@ -526,7 +544,9 @@ impl TypeSpec {
                     cb.add_line();
                 }
                 cb.add("%<", ());
-                if needs_sep {
+                if is_last && has_trailing_members && !ea.variant_section_terminator.is_empty() {
+                    cb.add(&format!("}}{}", ea.variant_section_terminator), ());
+                } else if !sep.is_empty() && (!is_last || trailing) {
                     cb.add(&format!("}}{sep}"), ());
                 } else {
                     cb.add("}", ());
@@ -536,12 +556,21 @@ impl TypeSpec {
             }
 
             if let Some(val) = &variant.value {
-                fmt.push_str(" = %L");
+                match ea.variant_value_format {
+                    crate::lang::config::VariantValueFormat::Assignment => {
+                        fmt.push_str(" = %L");
+                    }
+                    crate::lang::config::VariantValueFormat::ConstructorArg => {
+                        fmt.push_str("(%L)");
+                    }
+                }
                 args.push(Arg::Code(val.clone()));
             }
 
             let is_last = i == count - 1;
-            if !sep.is_empty() && (!is_last || trailing) {
+            if is_last && has_trailing_members && !ea.variant_section_terminator.is_empty() {
+                fmt.push_str(ea.variant_section_terminator);
+            } else if !sep.is_empty() && (!is_last || trailing) {
                 fmt.push_str(sep);
             }
 

--- a/test-goldens/java/enum_with_values.java
+++ b/test-goldens/java/enum_with_values.java
@@ -1,0 +1,15 @@
+public enum PetStatus {
+    AVAILABLE("available"),
+    PENDING("pending"),
+    SOLD("sold");
+
+    private final String value;
+
+    PetStatus(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return this.value;
+    }
+}

--- a/test-goldens/kotlin/enum_with_values.kt
+++ b/test-goldens/kotlin/enum_with_values.kt
@@ -1,0 +1,10 @@
+internal enum class Status {
+    ACTIVE("active"),
+    INACTIVE("inactive");
+
+    internal val value: String
+
+    internal fun getValue(): String {
+        return value
+    }
+}

--- a/tests/java/builder_types.rs
+++ b/tests/java/builder_types.rs
@@ -198,6 +198,62 @@ fn test_enum() {
 }
 
 #[test]
+fn test_enum_with_values() {
+    let ts = TypeSpec::builder("PetStatus", TypeKind::Enum)
+        .visibility(Visibility::Public)
+        .add_variant(
+            EnumVariantSpec::builder("AVAILABLE")
+                .value(CodeBlock::of("\"available\"", ()).unwrap())
+                .build()
+                .unwrap(),
+        )
+        .add_variant(
+            EnumVariantSpec::builder("PENDING")
+                .value(CodeBlock::of("\"pending\"", ()).unwrap())
+                .build()
+                .unwrap(),
+        )
+        .add_variant(
+            EnumVariantSpec::builder("SOLD")
+                .value(CodeBlock::of("\"sold\"", ()).unwrap())
+                .build()
+                .unwrap(),
+        )
+        .add_field(
+            FieldSpec::builder("value", TypeName::primitive("String"))
+                .visibility(Visibility::Private)
+                .is_readonly()
+                .build()
+                .unwrap(),
+        )
+        .add_method(
+            FunSpec::builder("PetStatus")
+                .add_param(ParameterSpec::new("value", TypeName::primitive("String")).unwrap())
+                .body(CodeBlock::of("this.value = value;", ()).unwrap())
+                .build()
+                .unwrap(),
+        )
+        .add_method(
+            FunSpec::builder("getValue")
+                .visibility(Visibility::Public)
+                .returns(TypeName::primitive("String"))
+                .body(CodeBlock::of("return this.value;", ()).unwrap())
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
+
+    let file = FileSpec::builder_with("PetStatus.java", JavaLang::new())
+        .add_type(ts)
+        .build()
+        .unwrap();
+    let output = file.render(80).unwrap();
+
+    golden::assert_golden("java/enum_with_values.java", &output);
+}
+
+#[test]
 fn test_generic_class() {
     let tp = TypeParamSpec::new("T")
         .with_bound(TypeName::primitive("Comparable"))

--- a/tests/kotlin/builder_types.rs
+++ b/tests/kotlin/builder_types.rs
@@ -199,6 +199,46 @@ fn test_enum_class() {
 }
 
 #[test]
+fn test_enum_with_values() {
+    let ts = TypeSpec::builder("Status", TypeKind::Enum)
+        .add_variant(
+            EnumVariantSpec::builder("ACTIVE")
+                .value(CodeBlock::of("\"active\"", ()).unwrap())
+                .build()
+                .unwrap(),
+        )
+        .add_variant(
+            EnumVariantSpec::builder("INACTIVE")
+                .value(CodeBlock::of("\"inactive\"", ()).unwrap())
+                .build()
+                .unwrap(),
+        )
+        .add_field(
+            FieldSpec::builder("value", TypeName::primitive("String"))
+                .is_readonly()
+                .build()
+                .unwrap(),
+        )
+        .add_method(
+            FunSpec::builder("getValue")
+                .returns(TypeName::primitive("String"))
+                .body(CodeBlock::of("return value", ()).unwrap())
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
+
+    let file = FileSpec::builder_with("Status.kt", Kotlin::new())
+        .add_type(ts)
+        .build()
+        .unwrap();
+    let output = file.render(80).unwrap();
+
+    golden::assert_golden("kotlin/enum_with_values.kt", &output);
+}
+
+#[test]
 fn test_override_method() {
     let body = CodeBlock::of(
         "return %S",


### PR DESCRIPTION
## Summary

- Add `VariantValueFormat` enum (`Assignment` vs `ConstructorArg`) to control how variant values render: `NAME = val` vs `NAME(val)`.
- Add `variants_before_fields: bool` to emit variants before fields in the type body (Java/Kotlin pattern).
- Add `variant_section_terminator` to emit `;` after the last variant when fields/methods follow.
- Configure Java and Kotlin with all three new fields.

## Test plan

- [x] New integration test `test_enum_with_values` for Java — golden file verified
- [x] New integration test `test_enum_with_values` for Kotlin — golden file verified
- [x] New unit tests `test_enum_and_annotation_config` for Java and `test_enum_config` for Kotlin
- [x] All existing tests pass (509 unit + all integration suites)
- [x] `cargo clippy` clean
- [x] `cargo fmt` clean