### PR TITLE
chore: release 0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 0.3.3
+
+### Added
+
+- `$C_each(iter)` in `sigil_quote!` — splice each `CodeBlock` from an iterable
+  into the builder sequentially.
+- `$if(cond) { ... } $else_if(cond) { ... } $else { ... }` in `sigil_quote!` —
+  meta-conditionals that control which builder calls are emitted at runtime.
+- `$join(sep, iter)` in `sigil_quote!` — inline separator-joined list rendering.
+- Keyword spacing in `sigil_quote!` — control-flow keywords (`if`, `for`,
+  `while`, etc.) now emit a space before `(` in the format string.
+
+### Changed
+
+- `macros/src/parse.rs` split into `parse/{mod,types,statements,format,util}.rs`
+  for navigability.
+- CI workflows now use `just` commands from the Justfile.
+- Justfile recipes aligned with CI (`--workspace`, `--all-targets`).
+
 ## 0.3.2
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,7 +100,7 @@ dependencies = [
 
 [[package]]
 name = "sigil-stitch"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "pretty",
  "serde",
@@ -111,7 +111,7 @@ dependencies = [
 
 [[package]]
 name = "sigil-stitch-macros"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["macros"]
 resolver = "3"
 
 [workspace.package]
-version = "0.3.2"
+version = "0.3.3"
 edition = "2024"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"
@@ -35,7 +35,7 @@ exclude = [
 [dependencies]
 pretty = "0.12"
 snafu = "0.9"
-sigil-stitch-macros = { path = "macros", version = "0.3.2" }
+sigil-stitch-macros = { path = "macros", version = "0.3.3" }
 serde = { version = "1", features = ["derive"] }
 
 [dev-dependencies]

--- a/Justfile
+++ b/Justfile
@@ -66,3 +66,8 @@ book:
 # Serve the mdbook with live reload
 book-serve:
     mdbook serve docs --open
+
+# Publish to crates.io (macros crate first, then main crate)
+publish:
+    cargo publish -p sigil-stitch-macros
+    cargo publish -p sigil-stitch

--- a/README.md
+++ b/README.md
@@ -68,7 +68,9 @@ let body = sigil_quote!(TypeScript {
 ```
 
 The macro uses `$T`/`$S`/`$N`/`$L`/`$C`/`$W` interpolation markers that expand to
-the equivalent `%T`/`%S`/`%N`/`%L` format specifiers at compile time.
+the equivalent `%T`/`%S`/`%N`/`%L` format specifiers at compile time. It also
+supports `$C_each` for splicing iterables of code blocks, `$if`/`$else_if`/`$else`
+for meta-conditionals, and `$join` for separator-joined lists.
 
 ## Format Specifiers
 
@@ -142,7 +144,7 @@ The [sigil-stitch book](docs/src/SUMMARY.md) covers everything in depth:
 - [Building Functions & Fields](docs/src/functions_and_fields.md) -- ParameterSpec, FieldSpec, FunSpec
 - [Building Types & Enums](docs/src/types_and_enums.md) -- TypeSpec, PropertySpec, AnnotationSpec, EnumVariantSpec
 - [Files & Projects](docs/src/files_and_projects.md) -- ImportSpec, FileSpec, ProjectSpec
-- [sigil_quote! Macro](docs/src/sigil_quote.md) -- inline code with `$T`/`$S`/`$N`/`$L` interpolation
+- [sigil_quote! Macro](docs/src/sigil_quote.md) -- inline code with `$T`/`$S`/`$N`/`$L`/`$C_each`/`$if`/`$join` interpolation
 - [Code Templates](docs/src/code_templates.md) -- reusable `#{name:K}` templates
 - [Language Cookbook](docs/src/language_cookbook.md) -- idiomatic recipes per language
 

--- a/docs/src/sigil_quote.md
+++ b/docs/src/sigil_quote.md
@@ -42,6 +42,9 @@ It returns `Result<CodeBlock, SigilStitchError>`.
 | `$>` | `%>` | (none) | Increase indent level |
 | `$<` | `%<` | (none) | Decrease indent level |
 | `$$` | `$` | (none) | Literal dollar sign |
+| `$C_each(expr)` | — | `impl IntoIterator<Item: Into<CodeBlock>>` | Splice each code block from iterable |
+| `$if(cond) { ... }` | — | Rust expression | Meta-conditional (runtime codegen control) |
+| `$join(sep, iter)` | `%L` | separator + `impl IntoIterator<Item: ToString>` | Separator-joined list |
 
 ### Types (`$T`)
 
@@ -310,6 +313,114 @@ sigil_quote!(TypeScript {
 
 These map to the `%>` and `%<` format specifiers in `CodeBlockBuilder`.
 
+## Splicing Code Block Iterables (`$C_each`)
+
+`$C_each(expr)` iterates over a collection of `CodeBlock` values and splices each
+one into the builder sequentially. It must appear at the start of a line.
+
+```rust,ignore
+let blocks: Vec<CodeBlock> = fields
+    .iter()
+    .map(|f| CodeBlock::of(&format!("this.{f} = null"), ()).unwrap())
+    .collect();
+
+sigil_quote!(TypeScript {
+    $C_each(blocks);
+})
+// Output:
+// this.name = null;
+// this.age = null;
+```
+
+Each item in the iterable is converted via `Into<CodeBlock>`, so you can pass any
+type that implements the conversion. An optional trailing `;` after `$C_each(expr)`
+is consumed silently.
+
+## Meta-Conditionals (`$if` / `$else_if` / `$else`)
+
+Meta-conditionals control which builder calls are emitted **at Rust runtime**, as
+opposed to target-language `if`/`else` which emits control flow in the generated
+code. Use them when the structure of the output depends on a Rust-side condition.
+
+```rust,ignore
+let include_debug = true;
+
+sigil_quote!(TypeScript {
+    const x = 1;
+    $if(include_debug) {
+        console.log($S("debug: x ="), x);
+    }
+})
+// When include_debug is true, output includes the console.log line.
+// When false, it's omitted entirely.
+```
+
+### `$else_if` and `$else`
+
+```rust,ignore
+let mode = "production";
+
+sigil_quote!(TypeScript {
+    $if(mode == "debug") {
+        console.log($S("debug mode"));
+    } $else_if(mode == "test") {
+        console.log($S("test mode"));
+    } $else {
+        console.log($S("production mode"));
+    }
+})
+```
+
+The conditions are arbitrary Rust expressions evaluated at runtime. The braces
+delimit which `sigil_quote!` statements are conditionally included — they do **not**
+produce target-language block syntax.
+
+### Nesting with Target-Language Control Flow
+
+Meta-conditionals can wrap target-language control flow and vice versa:
+
+```rust,ignore
+let use_guard = true;
+
+sigil_quote!(TypeScript {
+    $if(use_guard) {
+        if (!user) {
+            throw new Error($S("unauthorized"));
+        }
+    }
+})
+```
+
+## Separator-Joined Lists (`$join`)
+
+`$join(sep, iter)` joins the string representations of an iterable's items with
+a separator. It expands to a `%L` specifier internally.
+
+```rust,ignore
+let items = vec!["a", "b", "c"];
+
+sigil_quote!(TypeScript {
+    const values = [$join(", ", items)];
+})
+// Output: const values = [a, b, c];
+```
+
+The separator is any Rust expression that evaluates to something accepted by
+`Vec<String>::join()` (typically a `&str`). Each item is converted via `ToString`.
+
+```rust,ignore
+let fields = vec!["name", "age", "email"];
+let assignments: Vec<String> = fields.iter().map(|f| format!("this.{f} = {f}")).collect();
+
+sigil_quote!(TypeScript {
+    $join(";\n", assignments)
+})
+// Output:
+// this.name = name;
+// this.age = age;
+// this.email = email
+```
+
 ## Multi-Language Support
 
 The same syntax works with any language type:
@@ -355,9 +466,11 @@ as Rust tokens, not as the target language's tokens. This creates some edge case
    - `x := 42` may render as `x:= 42` (`:` suppresses leading space)
    - `std::mem::size_of` works but `<u32>` may get extra spaces around `<` and `>`
 
-3. **No space before `(` after identifiers.** The macro can't distinguish keywords
-   from function calls, so `if(x)` and `fn(x)` are treated the same. Both are valid
-   in all supported languages.
+3. **Keyword spacing before `(`.** Control-flow keywords (`if`, `for`, `while`,
+   `else`, `match`, `return`, `try`, `catch`, etc.) automatically get a space
+   before `(`. Regular identifiers do not, so `myFunc(x)` stays tight while
+   `if (x)` gets the expected space. This covers the common case but isn't
+   configurable per-language.
 
 4. **Negative number literals.** `-1` tokenizes as `-` then `1`, so it renders as
    `- 1` with a space. Functionally identical in all target languages.


### PR DESCRIPTION
## Summary

- Bump workspace version `0.3.2` → `0.3.3`
- Update CHANGELOG with new features: `$C_each`, `$if`/`$else_if`/`$else`, `$join`, keyword spacing, parse module split, CI/Justfile alignment
- Update README interpolation markers description and docs table entry
- Add `sigil_quote.md` sections for `$C_each`, meta-conditionals, `$join`, and updated keyword spacing behavior in known limitations

## Test plan

- [x] `cargo build --workspace` compiles at 0.3.3
- [x] `mdbook build docs` succeeds
- [x] No code changes — version bump, changelog, and docs only