### PR TITLE
fix: context-aware colon spacing and $C_each trailing blank line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 0.3.4
+
+### Changed
+
+- Colon spacing in `sigil_quote!` redesigned with a `ColonContext` enum
+  (`TypeAnnotation`, `MapEntry`, `Ternary`, `PathSeparator`, `WalrusAssign`)
+  and `SpacingState` struct. All colon spacing decisions now go through the
+  enum via exhaustive match, replacing the previous unconditional suppress.
+
+### Fixed
+
+- Ternary `? :` colon spacing — `x ? y : z` now renders with a space before
+  `:` instead of `x ? y: z`. Context resets at statement boundaries.
+- Go/walrus `:=` spacing — `x := 42` now renders with a space before `:`
+  instead of `x:= 42`. Detected via one-token lookahead.
+- `$C_each` trailing blank line — spliced blocks that already end with a
+  newline (from `add_statement`) no longer produce an extra blank line before
+  the next statement.
+
 ## 0.3.3
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,7 +100,7 @@ dependencies = [
 
 [[package]]
 name = "sigil-stitch"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "pretty",
  "serde",
@@ -111,7 +111,7 @@ dependencies = [
 
 [[package]]
 name = "sigil-stitch-macros"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["macros"]
 resolver = "3"
 
 [workspace.package]
-version = "0.3.3"
+version = "0.3.4"
 edition = "2024"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"
@@ -35,7 +35,7 @@ exclude = [
 [dependencies]
 pretty = "0.12"
 snafu = "0.9"
-sigil-stitch-macros = { path = "macros", version = "0.3.3" }
+sigil-stitch-macros = { path = "macros", version = "0.3.4" }
 serde = { version = "1", features = ["derive"] }
 
 [dev-dependencies]

--- a/docs/src/sigil_quote.md
+++ b/docs/src/sigil_quote.md
@@ -336,6 +336,11 @@ Each item in the iterable is converted via `Into<CodeBlock>`, so you can pass an
 type that implements the conversion. An optional trailing `;` after `$C_each(expr)`
 is consumed silently.
 
+`$C_each` is newline-aware: blocks that already end with a newline (e.g., from
+`add_statement`) are spliced as-is, while blocks that don't (e.g., from
+`CodeBlock::of`) get an automatic line break appended. This prevents double blank
+lines when splicing statement-built blocks.
+
 ## Meta-Conditionals (`$if` / `$else_if` / `$else`)
 
 Meta-conditionals control which builder calls are emitted **at Rust runtime**, as
@@ -460,25 +465,43 @@ as Rust tokens, not as the target language's tokens. This creates some edge case
 1. **Single-quoted strings don't work.** `'hello'` is tokenized as a Rust lifetime.
    Use `$S("hello")` instead.
 
-2. **Spacing around operators.** Multi-character operators like `:=`, `::`, `===`
-   are tokenized as separate punctuation characters. The macro reconstructs them
-   but spacing may differ slightly:
-   - `x := 42` may render as `x:= 42` (`:` suppresses leading space)
-   - `std::mem::size_of` works but `<u32>` may get extra spaces around `<` and `>`
+2. **Colon spacing is context-aware.** The macro tracks a `ColonContext` to decide
+   whether `:` gets a space before it:
 
-3. **Keyword spacing before `(`.** Control-flow keywords (`if`, `for`, `while`,
+   | Context | Example | Space before `:` |
+   |---------|---------|-------------------|
+   | Type annotation | `name: string` | no |
+   | Map entry | `{ key: value }` | no |
+   | Path separator | `std::mem` | no |
+   | Ternary | `x ? y : z` | yes |
+   | Walrus assign | `x := 42` | yes |
+
+   The context is set automatically: `?` (standalone) enters ternary mode,
+   `:` and `;` reset to type-annotation mode, `{` enters map-entry mode,
+   and `:=` / `::` are detected via one-token lookahead. The `::` pair is
+   always glued (`std::mem`), but because proc_macro2 tokenizes the second
+   `:` as standalone, a space appears before the following identifier
+   (`std:: mem`). This is a tokenization artifact common to all multi-char
+   punctuation.
+
+3. **Other multi-character operators.** Operators like `===`, `!==`, `->`
+   are tokenized as separate punctuation characters. The macro reconstructs
+   them via proc_macro2's `Spacing::Joint` flag, but spacing may differ
+   slightly — `<u32>` may get extra spaces around `<` and `>`.
+
+4. **Keyword spacing before `(`.** Control-flow keywords (`if`, `for`, `while`,
    `else`, `match`, `return`, `try`, `catch`, etc.) automatically get a space
    before `(`. Regular identifiers do not, so `myFunc(x)` stays tight while
    `if (x)` gets the expected space. This covers the common case but isn't
    configurable per-language.
 
-4. **Negative number literals.** `-1` tokenizes as `-` then `1`, so it renders as
+5. **Negative number literals.** `-1` tokenizes as `-` then `1`, so it renders as
    `- 1` with a space. Functionally identical in all target languages.
 
-5. **Template literals.** Backtick strings (`` `${expr}` ``) aren't representable.
+6. **Template literals.** Backtick strings (`` `${expr}` ``) aren't representable.
    Use `$L(expr)` for dynamic content.
 
-6. **Percent signs.** Literal `%` in your code is auto-escaped to `%%` in the
+7. **Percent signs.** Literal `%` in your code is auto-escaped to `%%` in the
    format string, so it renders correctly.
 
 ### Comments

--- a/macros/src/codegen.rs
+++ b/macros/src/codegen.rs
@@ -89,9 +89,14 @@ fn generate_statements(statements: &[Statement]) -> Vec<TokenStream> {
             Statement::SpliceEach { expr } => {
                 calls.push(quote! {
                     for __sigil_item in #expr {
-                        __sigil_builder.add_code(
-                            ::std::convert::Into::<::sigil_stitch::code_block::CodeBlock>::into(__sigil_item)
-                        );
+                        let __sigil_block: ::sigil_stitch::code_block::CodeBlock =
+                            ::std::convert::Into::into(__sigil_item);
+                        let __sigil_needs_nl =
+                            !__sigil_block.ends_with_newline_or_block_close();
+                        __sigil_builder.add_code(__sigil_block);
+                        if __sigil_needs_nl {
+                            __sigil_builder.add_line();
+                        }
                     }
                 });
             }

--- a/macros/src/parse/format.rs
+++ b/macros/src/parse/format.rs
@@ -15,6 +15,36 @@ pub(super) enum PrevTokenKind {
     Specifier,
 }
 
+/// Context for how `:` should be spaced.
+#[derive(Clone, Copy, PartialEq)]
+pub(super) enum ColonContext {
+    /// `name: Type`, `param: Type` — no space before `:`.
+    TypeAnnotation,
+    /// `key: value` in map/object literals — no space before `:`.
+    MapEntry,
+    /// `cond ? a : b` — space before `:`.
+    Ternary,
+    /// `std::mem` — no space before `:`.
+    PathSeparator,
+    /// `x := 42` — space before `:`.
+    WalrusAssign,
+}
+
+/// Accumulated state threaded through the format-string builder.
+pub(super) struct SpacingState {
+    pub prev: PrevTokenKind,
+    pub colon_ctx: ColonContext,
+}
+
+impl SpacingState {
+    pub fn new() -> Self {
+        Self {
+            prev: PrevTokenKind::None,
+            colon_ctx: ColonContext::TypeAnnotation,
+        }
+    }
+}
+
 #[rustfmt::skip]
 pub(super) const CONTROL_FLOW_KEYWORDS: &[&str] = &[
     "if", "else", "for", "while", "do", "switch", "catch",
@@ -33,9 +63,9 @@ pub(crate) fn tokens_to_format(
 ) -> Result<(String, Vec<TypedArg>), CompileError> {
     let mut format = String::new();
     let mut args: Vec<TypedArg> = Vec::new();
-    let mut prev_kind = PrevTokenKind::None;
+    let mut state = SpacingState::new();
 
-    tokens_to_format_inner(tokens, &mut format, &mut args, &mut prev_kind)?;
+    tokens_to_format_inner(tokens, &mut format, &mut args, &mut state)?;
 
     Ok((format, args))
 }
@@ -44,7 +74,7 @@ fn tokens_to_format_inner(
     tokens: &[TokenTree],
     format: &mut String,
     args: &mut Vec<TypedArg>,
-    prev_kind: &mut PrevTokenKind,
+    state: &mut SpacingState,
 ) -> Result<(), CompileError> {
     let mut pos = 0;
 
@@ -69,9 +99,9 @@ fn tokens_to_format_inner(
             if let TokenTree::Punct(p2) = next
                 && p2.as_char() == '$'
             {
-                maybe_space(format, *prev_kind, PrevTokenKind::Literal);
+                maybe_space(format, state, PrevTokenKind::Literal);
                 format.push('$');
-                *prev_kind = PrevTokenKind::Literal;
+                state.prev = PrevTokenKind::Literal;
                 pos += 1;
                 continue;
             }
@@ -81,7 +111,7 @@ fn tokens_to_format_inner(
                 && p2.as_char() == '>'
             {
                 format.push_str("%>");
-                *prev_kind = PrevTokenKind::Specifier;
+                state.prev = PrevTokenKind::Specifier;
                 pos += 1;
                 continue;
             }
@@ -91,7 +121,7 @@ fn tokens_to_format_inner(
                 && p2.as_char() == '<'
             {
                 format.push_str("%<");
-                *prev_kind = PrevTokenKind::Specifier;
+                state.prev = PrevTokenKind::Specifier;
                 pos += 1;
                 continue;
             }
@@ -99,7 +129,7 @@ fn tokens_to_format_inner(
             // `$W` -> `%W` (no arg, no parens)
             if is_ident(next, "W") {
                 format.push_str("%W");
-                *prev_kind = PrevTokenKind::Specifier;
+                state.prev = PrevTokenKind::Specifier;
                 pos += 1;
                 continue;
             }
@@ -149,9 +179,9 @@ fn tokens_to_format_inner(
 
                 let (sep_expr, iter_expr) = split_join_args(group)?;
 
-                maybe_space(format, *prev_kind, PrevTokenKind::Specifier);
+                maybe_space(format, state, PrevTokenKind::Specifier);
                 format.push_str("%L");
-                *prev_kind = PrevTokenKind::Specifier;
+                state.prev = PrevTokenKind::Specifier;
 
                 let join_expr: TokenStream = quote::quote! {
                     {
@@ -221,9 +251,9 @@ fn tokens_to_format_inner(
                     InterpolationKind::Literal | InterpolationKind::Code => "%L",
                 };
 
-                maybe_space(format, *prev_kind, PrevTokenKind::Specifier);
+                maybe_space(format, state, PrevTokenKind::Specifier);
                 format.push_str(specifier);
-                *prev_kind = PrevTokenKind::Specifier;
+                state.prev = PrevTokenKind::Specifier;
 
                 args.push(TypedArg {
                     kind,
@@ -249,26 +279,48 @@ fn tokens_to_format_inner(
                 } else {
                     PrevTokenKind::Ident
                 };
-                maybe_space(format, *prev_kind, kind);
+                maybe_space(format, state, kind);
                 format.push_str(&s.replace('%', "%%"));
-                *prev_kind = kind;
+                state.prev = kind;
             }
             TokenTree::Punct(p) => {
                 let ch = p.as_char();
                 let new_kind = PrevTokenKind::Punct(ch, p.spacing());
-                maybe_space(format, *prev_kind, new_kind);
+
+                // Set colon context before spacing decision so `maybe_space`
+                // can use it for the current `:` token.
+                if ch == ':'
+                    && p.spacing() == Spacing::Joint
+                    && pos + 1 < tokens.len()
+                    && let TokenTree::Punct(next_p) = &tokens[pos + 1]
+                {
+                    match next_p.as_char() {
+                        '=' => state.colon_ctx = ColonContext::WalrusAssign,
+                        ':' => state.colon_ctx = ColonContext::PathSeparator,
+                        _ => {}
+                    }
+                }
+
+                maybe_space(format, state, new_kind);
                 if ch == '%' {
                     format.push_str("%%");
                 } else {
                     format.push(ch);
                 }
-                *prev_kind = new_kind;
+                // Context transitions after emitting the token.
+                match (ch, p.spacing()) {
+                    ('?', Spacing::Alone) => state.colon_ctx = ColonContext::Ternary,
+                    (':', _) => state.colon_ctx = ColonContext::TypeAnnotation,
+                    (';', _) => state.colon_ctx = ColonContext::TypeAnnotation,
+                    _ => {}
+                }
+                state.prev = new_kind;
             }
             TokenTree::Literal(lit) => {
-                maybe_space(format, *prev_kind, PrevTokenKind::Literal);
+                maybe_space(format, state, PrevTokenKind::Literal);
                 let s = lit.to_string();
                 format.push_str(&s.replace('%', "%%"));
-                *prev_kind = PrevTokenKind::Literal;
+                state.prev = PrevTokenKind::Literal;
             }
             TokenTree::Group(g) => {
                 let (open, close) = match g.delimiter() {
@@ -278,15 +330,21 @@ fn tokens_to_format_inner(
                     Delimiter::None => ("", ""),
                 };
                 let new_kind = PrevTokenKind::GroupOpen;
-                maybe_space(format, *prev_kind, new_kind);
+                maybe_space(format, state, new_kind);
                 format.push_str(open);
-                *prev_kind = PrevTokenKind::GroupOpen;
+
+                let saved_ctx = state.colon_ctx;
+                if g.delimiter() == Delimiter::Brace {
+                    state.colon_ctx = ColonContext::MapEntry;
+                }
+                state.prev = PrevTokenKind::GroupOpen;
 
                 let inner: Vec<TokenTree> = g.stream().into_iter().collect();
-                tokens_to_format_inner(&inner, format, args, prev_kind)?;
+                tokens_to_format_inner(&inner, format, args, state)?;
 
+                state.colon_ctx = saved_ctx;
                 format.push_str(close);
-                *prev_kind = PrevTokenKind::Literal;
+                state.prev = PrevTokenKind::Literal;
             }
         }
         pos += 1;
@@ -341,7 +399,9 @@ pub(super) fn split_join_args(
 }
 
 /// Insert a space between the previous and current tokens if needed.
-pub(super) fn maybe_space(format: &mut String, prev: PrevTokenKind, current: PrevTokenKind) {
+pub(super) fn maybe_space(format: &mut String, state: &SpacingState, current: PrevTokenKind) {
+    let prev = state.prev;
+
     if prev == PrevTokenKind::None || prev == PrevTokenKind::GroupOpen {
         return;
     }
@@ -350,9 +410,12 @@ pub(super) fn maybe_space(format: &mut String, prev: PrevTokenKind, current: Pre
     if let PrevTokenKind::Punct(ch, _) = current {
         match ch {
             ',' | ';' | ')' | ']' | '.' => return,
-            ':' => {
-                return;
-            }
+            ':' => match state.colon_ctx {
+                ColonContext::Ternary | ColonContext::WalrusAssign => {}
+                ColonContext::TypeAnnotation
+                | ColonContext::MapEntry
+                | ColonContext::PathSeparator => return,
+            },
             _ => {}
         }
     }

--- a/src/code_block.rs
+++ b/src/code_block.rs
@@ -112,7 +112,7 @@ impl CodeBlock {
     }
 
     /// Check if this code block ends with a newline or block close.
-    pub(crate) fn ends_with_newline_or_block_close(&self) -> bool {
+    pub fn ends_with_newline_or_block_close(&self) -> bool {
         fn check_last(nodes: &[CodeNode]) -> bool {
             match nodes.last() {
                 Some(CodeNode::Newline | CodeNode::BlockClose) => true,

--- a/test-goldens/go/macro_basic.go
+++ b/test-goldens/go/macro_basic.go
@@ -1,3 +1,3 @@
-x:= 42
-name:= "Alice"
+x := 42
+name := "Alice"
 fmt.Println(name, x)

--- a/tests/macro_tests.rs
+++ b/tests/macro_tests.rs
@@ -3,6 +3,8 @@
 use sigil_stitch::code_block::{CodeBlock, NameArg, StringLitArg};
 use sigil_stitch::import_collector;
 use sigil_stitch::lang::haskell::Haskell;
+use sigil_stitch::lang::java_lang::JavaLang;
+use sigil_stitch::lang::kotlin::Kotlin;
 use sigil_stitch::lang::ocaml::OCaml;
 use sigil_stitch::prelude::*;
 use sigil_stitch::spec::file_spec::FileSpec;
@@ -695,9 +697,8 @@ fn test_go_language() {
     .unwrap();
 
     let output = render_go(&block);
-    // `:` is in the "no space before" set, so `x:= 42` is expected.
-    // Go doesn't emit semicolons.
-    assert!(output.contains("x:= 42"), "got: {output}");
+    // Go doesn't emit semicolons. `:=` is recognized as walrus operator.
+    assert!(output.contains("x := 42"), "got: {output}");
 }
 
 // ════════════════════════════════════════════════════════
@@ -2124,4 +2125,654 @@ fn test_meta_if_with_join_in_both_branches() {
         "got: {output}"
     );
     assert!(!output.contains("string, number"), "got: {output}");
+}
+
+// ════════════════════════════════════════════════════════
+// Render helpers: Java, Kotlin
+// ════════════════════════════════════════════════════════
+
+fn render_java(block: &CodeBlock) -> String {
+    let file = FileSpec::builder_with("Test.java", JavaLang::new())
+        .add_code(block.clone())
+        .build()
+        .unwrap();
+    file.render(80).unwrap()
+}
+
+fn render_kt(block: &CodeBlock) -> String {
+    let file = FileSpec::builder_with("test.kt", Kotlin::new())
+        .add_code(block.clone())
+        .build()
+        .unwrap();
+    file.render(80).unwrap()
+}
+
+// ════════════════════════════════════════════════════════
+// Colon spacing: ternary, elvis, type annotations
+// ════════════════════════════════════════════════════════
+
+#[test]
+fn test_java_ternary_colon_spacing() {
+    let block = sigil_quote!(JavaLang {
+        String result = x != null ? x.toString() : "default";
+    })
+    .unwrap();
+
+    let output = render_java(&block);
+    assert!(
+        output.contains("? x.toString() : \"default\""),
+        "ternary colon should have space before it. got: {output}"
+    );
+}
+
+#[test]
+fn test_simple_ternary_colon_spacing() {
+    let block = sigil_quote!(TypeScript {
+        const y = x > 0 ? x : 0;
+    })
+    .unwrap();
+
+    let output = render_ts(&block);
+    assert!(
+        output.contains("? x : 0"),
+        "ternary colon should have space before it. got: {output}"
+    );
+}
+
+#[test]
+fn test_kotlin_elvis_spacing() {
+    let block = sigil_quote!(Kotlin {
+        val result = x ?: "default";
+    })
+    .unwrap();
+
+    let output = render_kt(&block);
+    assert!(
+        output.contains("x ?: \"default\""),
+        "elvis operator should stay glued. got: {output}"
+    );
+}
+
+#[test]
+fn test_type_annotation_colon_no_space() {
+    let block = sigil_quote!(TypeScript {
+        const name: string = "foo";
+    })
+    .unwrap();
+
+    let output = render_ts(&block);
+    assert!(
+        output.contains("name: string"),
+        "type annotation colon should have no space before it. got: {output}"
+    );
+    assert!(
+        !output.contains("name : string"),
+        "should not have space before colon in type annotation. got: {output}"
+    );
+}
+
+#[test]
+fn test_go_walrus_spacing() {
+    let block = sigil_quote!(GoLang {
+        x := 42;
+    })
+    .unwrap();
+
+    let output = render_go(&block);
+    assert!(
+        output.contains("x := 42"),
+        "Go := should have space before colon. got: {output}"
+    );
+}
+
+#[test]
+fn test_ternary_resets_after_colon() {
+    let block = sigil_quote!(TypeScript {
+        const a = x ? 1 : 2;
+        const b: number = 3;
+    })
+    .unwrap();
+
+    let output = render_ts(&block);
+    assert!(
+        output.contains("? 1 : 2"),
+        "ternary should have space before colon. got: {output}"
+    );
+    assert!(
+        output.contains("b: number"),
+        "type annotation after ternary should suppress space. got: {output}"
+    );
+}
+
+// ════════════════════════════════════════════════════════
+// $C_each trailing blank line
+// ════════════════════════════════════════════════════════
+
+#[test]
+fn test_c_each_with_add_statement_no_trailing_blank_line() {
+    let fields = ["name", "age"];
+    let blocks: Vec<CodeBlock> = fields
+        .iter()
+        .map(|f| {
+            let mut cb = CodeBlock::builder();
+            cb.add_statement(&format!("this.{f} = null"), ());
+            cb.build().unwrap()
+        })
+        .collect();
+
+    let block = sigil_quote!(TypeScript {
+        $C_each(blocks);
+        return this;
+    })
+    .unwrap();
+
+    let output = render_ts(&block);
+    assert!(
+        !output.contains("this.age = null;\n\nreturn"),
+        "should not have blank line between spliced blocks and next statement. got: {output}"
+    );
+    assert!(output.contains("this.name = null;"), "got: {output}");
+    assert!(output.contains("this.age = null;"), "got: {output}");
+    assert!(output.contains("return this;"), "got: {output}");
+}
+
+#[test]
+fn test_c_each_with_code_block_of() {
+    let fields = ["name", "age"];
+    let blocks: Vec<CodeBlock> = fields
+        .iter()
+        .map(|f| CodeBlock::of(&format!("this.{f} = null"), ()).unwrap())
+        .collect();
+
+    let block = sigil_quote!(TypeScript {
+        $C_each(blocks);
+        return this;
+    })
+    .unwrap();
+
+    let output = render_ts(&block);
+    assert!(output.contains("this.name = null"), "got: {output}");
+    assert!(output.contains("this.age = null"), "got: {output}");
+    assert!(output.contains("return this;"), "got: {output}");
+}
+
+// ════════════════════════════════════════════════════════
+// Colon context: comprehensive ColonContext coverage
+// ════════════════════════════════════════════════════════
+
+// --- TypeAnnotation context ---
+
+#[test]
+fn test_colon_type_annotation_in_function_param() {
+    let block = sigil_quote!(TypeScript {
+        function greet(name: string, age: number) {
+            return name;
+        }
+    })
+    .unwrap();
+
+    let output = render_ts(&block);
+    assert!(output.contains("name: string"), "got: {output}");
+    assert!(output.contains("age: number"), "got: {output}");
+}
+
+#[test]
+fn test_colon_type_annotation_with_interpolated_type() {
+    let t = TypeName::primitive("string");
+    let block = sigil_quote!(TypeScript {
+        const x: $T(t) = "hello";
+    })
+    .unwrap();
+
+    let output = render_ts(&block);
+    assert!(output.contains("x: string"), "got: {output}");
+    assert!(!output.contains("x : string"), "got: {output}");
+}
+
+#[test]
+fn test_colon_type_annotation_resets_after_semicolon() {
+    let block = sigil_quote!(TypeScript {
+        const a = x ? 1 : 2;
+        const b: string = "hi";
+    })
+    .unwrap();
+
+    let output = render_ts(&block);
+    assert!(output.contains("? 1 : 2"), "ternary space. got: {output}");
+    assert!(
+        output.contains("b: string"),
+        "type annotation after semicolon. got: {output}"
+    );
+}
+
+#[test]
+fn test_colon_type_annotation_multiple_per_line() {
+    let block = sigil_quote!(TypeScript {
+        const fn = (a: number, b: string) => a;
+    })
+    .unwrap();
+
+    let output = render_ts(&block);
+    assert!(output.contains("a: number"), "got: {output}");
+    assert!(output.contains("b: string"), "got: {output}");
+}
+
+// --- MapEntry context ---
+
+#[test]
+fn test_colon_map_entry_in_object_literal() {
+    let block = sigil_quote!(TypeScript {
+        const config = { timeout: 5000, retries: 3 };
+    })
+    .unwrap();
+
+    let output = render_ts(&block);
+    assert!(output.contains("timeout: 5000"), "got: {output}");
+    assert!(output.contains("retries: 3"), "got: {output}");
+    assert!(!output.contains("timeout : 5000"), "got: {output}");
+}
+
+#[test]
+fn test_colon_map_entry_restores_after_brace_group() {
+    let block = sigil_quote!(TypeScript {
+        const config = { timeout: 5000 };
+        const x: number = 1;
+    })
+    .unwrap();
+
+    let output = render_ts(&block);
+    assert!(output.contains("timeout: 5000"), "got: {output}");
+    assert!(
+        output.contains("x: number"),
+        "type annotation after object literal. got: {output}"
+    );
+}
+
+#[test]
+fn test_colon_ternary_inside_object_literal() {
+    let block = sigil_quote!(TypeScript {
+        const config = { value: x ? 1 : 0 };
+    })
+    .unwrap();
+
+    let output = render_ts(&block);
+    assert!(output.contains("value:"), "map entry colon. got: {output}");
+    assert!(
+        output.contains("? 1 : 0"),
+        "ternary inside object should have space. got: {output}"
+    );
+}
+
+// --- Ternary context ---
+
+#[test]
+fn test_colon_ternary_with_function_calls() {
+    let block = sigil_quote!(TypeScript {
+        const result = isValid(x) ? getValue(x) : getDefault();
+    })
+    .unwrap();
+
+    let output = render_ts(&block);
+    assert!(
+        output.contains("? getValue(x) : getDefault()"),
+        "got: {output}"
+    );
+}
+
+#[test]
+fn test_colon_nested_ternary() {
+    let block = sigil_quote!(TypeScript {
+        const r = a ? 1 : b ? 2 : 3;
+    })
+    .unwrap();
+
+    let output = render_ts(&block);
+    assert!(output.contains("a ? 1 : b"), "first ternary. got: {output}");
+    assert!(
+        output.contains("b ? 2 : 3"),
+        "nested ternary. got: {output}"
+    );
+}
+
+#[test]
+fn test_colon_ternary_with_interpolation() {
+    let default_val = "fallback";
+    let block = sigil_quote!(TypeScript {
+        const x = cond ? value : $L(default_val);
+    })
+    .unwrap();
+
+    let output = render_ts(&block);
+    assert!(
+        output.contains("? value : fallback"),
+        "ternary with interpolation. got: {output}"
+    );
+}
+
+#[test]
+fn test_colon_ternary_resets_at_statement_boundary() {
+    let block = sigil_quote!(TypeScript {
+        const a = x ? y : z;
+        const b: string = "ok";
+        const c = p ? q : r;
+    })
+    .unwrap();
+
+    let output = render_ts(&block);
+    assert!(output.contains("? y : z"), "first ternary. got: {output}");
+    assert!(
+        output.contains("b: string"),
+        "type annotation between ternaries. got: {output}"
+    );
+    assert!(output.contains("? q : r"), "second ternary. got: {output}");
+}
+
+#[test]
+fn test_colon_ternary_in_java_error_handling() {
+    let block = sigil_quote!(JavaLang {
+        String msg = error != null ? error.getMessage() : "unknown";
+    })
+    .unwrap();
+
+    let output = render_java(&block);
+    assert!(
+        output.contains("? error.getMessage() : \"unknown\""),
+        "got: {output}"
+    );
+}
+
+// --- PathSeparator context ---
+
+#[test]
+fn test_colon_path_separator_rust() {
+    let block = sigil_quote!(RustLang {
+        let v = std::collections::HashMap::new();
+    })
+    .unwrap();
+
+    let output = render_rs(&block);
+    // `::` is glued (no space between the two colons), but proc_macro2
+    // tokenizes the second `:` as Alone so a space appears before the next ident.
+    assert!(output.contains("std::"), "got: {output}");
+    assert!(output.contains("HashMap::"), "got: {output}");
+    assert!(
+        !output.contains("std ::"),
+        "no space before first colon. got: {output}"
+    );
+}
+
+#[test]
+fn test_colon_path_separator_cpp() {
+    let block = sigil_quote!(CppLang {
+        auto v = std::make_unique(42);
+    })
+    .unwrap();
+
+    let file = FileSpec::builder_with("test.cpp", sigil_stitch::lang::cpp_lang::CppLang::new())
+        .add_code(block)
+        .build()
+        .unwrap();
+    let output = file.render(80).unwrap();
+    assert!(output.contains("std::"), "got: {output}");
+    assert!(
+        !output.contains("std ::"),
+        "no space before first colon. got: {output}"
+    );
+}
+
+#[test]
+fn test_colon_path_then_type_annotation() {
+    let block = sigil_quote!(RustLang {
+        let x: std::string::String = String::new();
+    })
+    .unwrap();
+
+    let output = render_rs(&block);
+    // Type annotation colon suppresses space; `::` path separators are glued.
+    assert!(output.contains("x: std::"), "got: {output}");
+    assert!(!output.contains("x : std"), "got: {output}");
+}
+
+// --- WalrusAssign context ---
+
+#[test]
+fn test_colon_walrus_with_expression() {
+    let block = sigil_quote!(GoLang {
+        result := computeValue(42);
+    })
+    .unwrap();
+
+    let output = render_go(&block);
+    assert!(
+        output.contains("result := computeValue(42)"),
+        "got: {output}"
+    );
+}
+
+#[test]
+fn test_colon_walrus_multiple_assignments() {
+    let block = sigil_quote!(GoLang {
+        x := 1;
+        y := 2;
+        z := x + y;
+    })
+    .unwrap();
+
+    let output = render_go(&block);
+    assert!(output.contains("x := 1"), "got: {output}");
+    assert!(output.contains("y := 2"), "got: {output}");
+    assert!(output.contains("z := x + y"), "got: {output}");
+}
+
+#[test]
+fn test_colon_walrus_in_control_flow() {
+    let block = sigil_quote!(GoLang {
+        if err := doSomething() {
+            return err;
+        }
+    })
+    .unwrap();
+
+    let output = render_go(&block);
+    assert!(output.contains("err := doSomething()"), "got: {output}");
+}
+
+// --- Context interactions and transitions ---
+
+#[test]
+fn test_colon_context_walrus_then_type_annotation() {
+    let block = sigil_quote!(TypeScript {
+        const x = { a: 1 };
+        const y: number = 2;
+    })
+    .unwrap();
+
+    let output = render_ts(&block);
+    assert!(output.contains("a: 1"), "map entry. got: {output}");
+    assert!(
+        output.contains("y: number"),
+        "type annotation. got: {output}"
+    );
+}
+
+#[test]
+fn test_colon_context_all_in_sequence() {
+    let block = sigil_quote!(TypeScript {
+        const a: string = x ? "y" : "z";
+        const b = { key: a };
+    })
+    .unwrap();
+
+    let output = render_ts(&block);
+    assert!(
+        output.contains("a: string"),
+        "type annotation. got: {output}"
+    );
+    assert!(
+        output.contains("? \"y\" : \"z\"") || output.contains("? 'y' : 'z'"),
+        "ternary. got: {output}"
+    );
+    assert!(output.contains("key: a"), "map entry. got: {output}");
+}
+
+#[test]
+fn test_colon_context_kotlin_full_scenario() {
+    let block = sigil_quote!(Kotlin {
+        val name: String = value ?: "default";
+    })
+    .unwrap();
+
+    let output = render_kt(&block);
+    assert!(
+        output.contains("name: String"),
+        "type annotation. got: {output}"
+    );
+    assert!(output.contains("?: \"default\""), "elvis. got: {output}");
+}
+
+#[test]
+fn test_colon_switch_case_label() {
+    let block = sigil_quote!(JavaLang {
+        switch(x) {
+            case(1):
+            return "one";
+        }
+    })
+    .unwrap();
+
+    let output = render_java(&block);
+    // `case` is a keyword so it gets a space before `(`.
+    assert!(output.contains("case (1):"), "got: {output}");
+}
+
+// ════════════════════════════════════════════════════════
+// $C_each: comprehensive newline/blank-line coverage
+// ════════════════════════════════════════════════════════
+
+#[test]
+fn test_c_each_add_statement_blocks_no_double_newline() {
+    let blocks: Vec<CodeBlock> = (0..3)
+        .map(|i| {
+            let mut cb = CodeBlock::builder();
+            cb.add_statement(&format!("step{i}()"), ());
+            cb.build().unwrap()
+        })
+        .collect();
+
+    let block = sigil_quote!(TypeScript {
+        $C_each(blocks);
+    })
+    .unwrap();
+
+    let output = render_ts(&block);
+    assert!(output.contains("step0();"), "got: {output}");
+    assert!(output.contains("step1();"), "got: {output}");
+    assert!(output.contains("step2();"), "got: {output}");
+    assert!(
+        !output.contains("\n\n"),
+        "no blank lines between add_statement blocks. got: {output}"
+    );
+}
+
+#[test]
+fn test_c_each_code_block_of_gets_newlines() {
+    let blocks: Vec<CodeBlock> = (0..3)
+        .map(|i| CodeBlock::of(&format!("step{i}()"), ()).unwrap())
+        .collect();
+
+    let block = sigil_quote!(TypeScript {
+        $C_each(blocks);
+    })
+    .unwrap();
+
+    let output = render_ts(&block);
+    assert!(output.contains("step0()"), "got: {output}");
+    assert!(output.contains("step1()"), "got: {output}");
+    assert!(output.contains("step2()"), "got: {output}");
+}
+
+#[test]
+fn test_c_each_mixed_block_types() {
+    let mut blocks: Vec<CodeBlock> = Vec::new();
+
+    let mut cb = CodeBlock::builder();
+    cb.add_statement("statement_block()", ());
+    blocks.push(cb.build().unwrap());
+
+    blocks.push(CodeBlock::of("of_block()", ()).unwrap());
+
+    let mut cb = CodeBlock::builder();
+    cb.add_statement("another_statement()", ());
+    blocks.push(cb.build().unwrap());
+
+    let block = sigil_quote!(TypeScript {
+        $C_each(blocks);
+    })
+    .unwrap();
+
+    let output = render_ts(&block);
+    assert!(output.contains("statement_block();"), "got: {output}");
+    assert!(output.contains("of_block()"), "got: {output}");
+    assert!(output.contains("another_statement();"), "got: {output}");
+}
+
+#[test]
+fn test_c_each_before_and_after_statements() {
+    let blocks: Vec<CodeBlock> = vec![CodeBlock::of("middle()", ()).unwrap()];
+
+    let block = sigil_quote!(TypeScript {
+        const before = 1;
+        $C_each(blocks);
+        const after = 2;
+    })
+    .unwrap();
+
+    let output = render_ts(&block);
+    assert!(output.contains("const before = 1;"), "got: {output}");
+    assert!(output.contains("middle()"), "got: {output}");
+    assert!(output.contains("const after = 2;"), "got: {output}");
+}
+
+#[test]
+fn test_c_each_single_add_statement_block() {
+    let mut cb = CodeBlock::builder();
+    cb.add_statement("only_one()", ());
+    let blocks = vec![cb.build().unwrap()];
+
+    let block = sigil_quote!(TypeScript {
+        $C_each(blocks);
+        done();
+    })
+    .unwrap();
+
+    let output = render_ts(&block);
+    assert!(output.contains("only_one();"), "got: {output}");
+    assert!(output.contains("done();"), "got: {output}");
+    assert!(
+        !output.contains("only_one();\n\ndone"),
+        "no blank line between single spliced block and next. got: {output}"
+    );
+}
+
+#[test]
+fn test_c_each_in_control_flow_no_blank_lines() {
+    let assignments: Vec<CodeBlock> = ["x", "y"]
+        .iter()
+        .map(|f| {
+            let mut cb = CodeBlock::builder();
+            cb.add_statement(&format!("this.{f} = {f}"), ());
+            cb.build().unwrap()
+        })
+        .collect();
+
+    let block = sigil_quote!(TypeScript {
+        if(init) {
+            $C_each(assignments);
+        }
+    })
+    .unwrap();
+
+    let output = render_ts(&block);
+    assert!(output.contains("this.x = x;"), "got: {output}");
+    assert!(output.contains("this.y = y;"), "got: {output}");
 }


### PR DESCRIPTION
## Summary

- Redesign colon spacing in `sigil_quote!` with a `ColonContext` enum (`TypeAnnotation`, `MapEntry`, `Ternary`, `PathSeparator`, `WalrusAssign`) and `SpacingState` struct. All colon spacing decisions go through exhaustive match — no special-case bypasses.
- Fix `$C_each` to check `ends_with_newline_or_block_close()` before adding a line break, preventing double blank lines when splicing statement-built blocks.
- Bump version to 0.3.4.

## What was broken

| Bug | Before | After |
|-----|--------|-------|
| Ternary colon | `x ? y: z` | `x ? y : z` |
| Go walrus | `x:= 42` | `x := 42` |
| `$C_each` trailing blank | extra blank line between spliced blocks and next statement | no blank line |

## Test plan

- [x] 28 new tests covering all 5 `ColonContext` variants and `$C_each` newline behavior
- [x] All 1053 tests pass (`just check` — fmt + clippy + nextest + doctests)
- [x] Go golden file updated for `:=` spacing fix