### PR TITLE
fix: $C_each trailing blank line when used as FunSpec body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.4.1
+
+### Fixed
+
+- `$C_each` trailing blank line when used as `FunSpec` body inside a `TypeSpec` —
+  `ends_with_newline_or_block_close()` now recurses into `Nested` nodes, fixing
+  the unwanted blank line before the closing `}` in generated constructors/methods.
+
 ## 0.4.0
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,7 +100,7 @@ dependencies = [
 
 [[package]]
 name = "sigil-stitch"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "pretty",
  "serde",
@@ -111,7 +111,7 @@ dependencies = [
 
 [[package]]
 name = "sigil-stitch-macros"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["macros"]
 resolver = "3"
 
 [workspace.package]
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"
@@ -35,7 +35,7 @@ exclude = [
 [dependencies]
 pretty = "0.12"
 snafu = "0.9"
-sigil-stitch-macros = { path = "macros", version = "0.4.0" }
+sigil-stitch-macros = { path = "macros", version = "0.4.1" }
 serde = { version = "1", features = ["derive"] }
 
 [dev-dependencies]

--- a/src/code_block.rs
+++ b/src/code_block.rs
@@ -117,6 +117,7 @@ impl CodeBlock {
             match nodes.last() {
                 Some(CodeNode::Newline | CodeNode::BlockClose) => true,
                 Some(CodeNode::Sequence(children)) => check_last(children),
+                Some(CodeNode::Nested(inner)) => check_last(&inner.nodes),
                 _ => false,
             }
         }

--- a/tests/macro/c_each.rs
+++ b/tests/macro/c_each.rs
@@ -337,3 +337,45 @@ fn test_c_each_in_control_flow_no_blank_lines() {
     assert!(output.contains("this.x = x;"), "got: {output}");
     assert!(output.contains("this.y = y;"), "got: {output}");
 }
+
+#[test]
+fn test_c_each_no_trailing_blank_line_in_fun_spec_body() {
+    use sigil_stitch::lang::java_lang::JavaLang;
+
+    let fields = ["statusCode", "raw", "status200"];
+    let assignments: Vec<CodeBlock> = fields
+        .iter()
+        .map(|f| {
+            sigil_quote!(JavaLang {
+                this.$L(*f) = $L(*f);
+            })
+            .unwrap()
+        })
+        .collect();
+
+    let ctor_body = sigil_quote!(JavaLang {
+        $C_each(assignments);
+    })
+    .unwrap();
+
+    let mut cls = TypeSpec::builder("TestClass", TypeKind::Struct).visibility(Visibility::Public);
+    let mut ctor = FunSpec::builder("TestClass");
+    ctor = ctor.visibility(Visibility::Public);
+    ctor = ctor.body(ctor_body);
+    cls = cls.add_method(ctor.build().unwrap());
+
+    let file = FileSpec::builder_with("TestClass.java", JavaLang::new())
+        .add_type(cls.build().unwrap())
+        .build()
+        .unwrap();
+    let output = file.render(100).unwrap();
+
+    assert!(
+        !output.contains("status200;\n\n    }"),
+        "trailing blank line before closing brace. got:\n{output}"
+    );
+    assert!(
+        output.contains("this.statusCode = statusCode;"),
+        "got:\n{output}"
+    );
+}


### PR DESCRIPTION
## Summary

- `ends_with_newline_or_block_close()` now recurses into `Nested` nodes, matching the existing `Sequence` recursion
- Fixes unwanted blank line before closing `}` when a `$C_each`-produced `CodeBlock` is embedded as a method body via `FunSpec::body()` inside a `TypeSpec`
- Bumps version to 0.4.1

## Test plan

- [x] Regression test added in `tests/macro/c_each.rs` — `$C_each` assignments as constructor body inside a class, asserts no blank line before `}`
- [x] `just check` passes (fmt + clippy + 1066 tests)