### PR TITLE
refactor: unify format specifier definitions into a single Specifier enum

### DIFF
--- a/src/code_block.rs
+++ b/src/code_block.rs
@@ -3,19 +3,67 @@ use crate::import::ImportRef;
 use crate::lang::CodeLang;
 use crate::type_name::TypeName;
 
+/// Argument-consuming format specifier kinds.
+///
+/// This is the single source of truth for what interpolation specifiers exist.
+/// Both the library's `parse_format()` and the `sigil_quote!` macro's codegen
+/// map to these same logical kinds. The macro crate cannot import this type
+/// (proc-macro dependency cycle), but the format characters are shared: the
+/// macro emits `%T`/`%N`/`%S`/`%L` strings that `parse_format` then parses
+/// via [`Specifier::from_format_char`].
+///
+/// Adding a variant here without handling it in `parse_format` and
+/// `parts_args_to_nodes` will cause exhaustiveness errors.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum Specifier {
+    /// `%T` / `$T` — type reference (consumes `Arg::TypeName`).
+    Type,
+    /// `%N` / `$N` — name identifier (consumes `Arg::Name`).
+    Name,
+    /// `%S` / `$S` — string literal (consumes `Arg::StringLit`).
+    StringLit,
+    /// `%L` / `$L` / `$C` — literal value or nested code block (consumes `Arg::Literal` or `Arg::Code`).
+    Literal,
+}
+
+impl Specifier {
+    /// Map a format-string character to a specifier.
+    ///
+    /// Returns `None` for characters that are not argument-consuming specifiers
+    /// (e.g. `W`, `>`, `<`, `[`, `]`, `%`).
+    pub fn from_format_char(ch: char) -> Option<Self> {
+        match ch {
+            'T' => Some(Self::Type),
+            'N' => Some(Self::Name),
+            'S' => Some(Self::StringLit),
+            'L' => Some(Self::Literal),
+            _ => None,
+        }
+    }
+
+    /// The format-string character for this specifier.
+    pub fn format_char(self) -> char {
+        match self {
+            Self::Type => 'T',
+            Self::Name => 'N',
+            Self::StringLit => 'S',
+            Self::Literal => 'L',
+        }
+    }
+
+    /// All defined specifier variants.
+    pub fn all() -> &'static [Self] {
+        &[Self::Type, Self::Name, Self::StringLit, Self::Literal]
+    }
+}
+
 /// A parsed format specifier from a format string.
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub(crate) enum FormatPart {
     /// Literal text (no interpolation).
     Literal(String),
-    /// `%T` - type reference (consumes an Arg::TypeName).
-    Type,
-    /// `%N` - name reference (consumes an Arg::Name).
-    Name,
-    /// `%S` - string literal (consumes an Arg::StringLit).
-    StringLit,
-    /// `%L` - literal/nested code block (consumes an Arg::Literal or Arg::Code).
-    Literal_,
+    /// An argument-consuming specifier (`%T`, `%N`, `%S`, `%L`).
+    Arg(Specifier),
     /// `%W` - soft line break point (no argument consumed).
     Wrap,
     /// `%>` - increase indent (no argument consumed).
@@ -208,10 +256,7 @@ impl CodeBlockBuilder {
         let consuming_specifiers: Vec<String> = parsed
             .iter()
             .filter_map(|p| match p {
-                FormatPart::Type => Some("%T".to_string()),
-                FormatPart::Name => Some("%N".to_string()),
-                FormatPart::StringLit => Some("%S".to_string()),
-                FormatPart::Literal_ => Some("%L".to_string()),
+                FormatPart::Arg(s) => Some(format!("%{}", s.format_char())),
                 _ => None,
             })
             .collect();
@@ -367,10 +412,6 @@ fn parse_format(format: &str) -> Result<Vec<FormatPart>, crate::error::SigilStit
             if let Some(&(_, spec)) = chars.peek() {
                 chars.next();
                 let part = match spec {
-                    'T' => Some(FormatPart::Type),
-                    'N' => Some(FormatPart::Name),
-                    'S' => Some(FormatPart::StringLit),
-                    'L' => Some(FormatPart::Literal_),
                     'W' => Some(FormatPart::Wrap),
                     '>' => Some(FormatPart::Indent),
                     '<' => Some(FormatPart::Dedent),
@@ -380,12 +421,15 @@ fn parse_format(format: &str) -> Result<Vec<FormatPart>, crate::error::SigilStit
                         current_literal.push('%');
                         continue;
                     }
-                    _ => {
-                        return Err(crate::error::SigilStitchError::InvalidFormatSpecifier {
-                            format: format.to_string(),
-                            specifier: spec,
-                        });
-                    }
+                    _ => match Specifier::from_format_char(spec) {
+                        Some(s) => Some(FormatPart::Arg(s)),
+                        None => {
+                            return Err(crate::error::SigilStitchError::InvalidFormatSpecifier {
+                                format: format.to_string(),
+                                specifier: spec,
+                            });
+                        }
+                    },
                 };
                 if let Some(part) = part {
                     if !current_literal.is_empty() {
@@ -580,10 +624,10 @@ mod tests {
     #[test]
     fn test_parse_all_specifiers() {
         let parts = parse_format("hello %T world %N %S %L %W %> %< %[ %]").unwrap();
-        assert!(parts.contains(&FormatPart::Type));
-        assert!(parts.contains(&FormatPart::Name));
-        assert!(parts.contains(&FormatPart::StringLit));
-        assert!(parts.contains(&FormatPart::Literal_));
+        assert!(parts.contains(&FormatPart::Arg(Specifier::Type)));
+        assert!(parts.contains(&FormatPart::Arg(Specifier::Name)));
+        assert!(parts.contains(&FormatPart::Arg(Specifier::StringLit)));
+        assert!(parts.contains(&FormatPart::Arg(Specifier::Literal)));
         assert!(parts.contains(&FormatPart::Wrap));
         assert!(parts.contains(&FormatPart::Indent));
         assert!(parts.contains(&FormatPart::Dedent));

--- a/src/code_node.rs
+++ b/src/code_node.rs
@@ -5,7 +5,7 @@
 //! stored inline rather than in a separate argument vector. This enables natural
 //! tree traversal for import collection, structural transformation, and rendering.
 
-use crate::code_block::{Arg, CodeBlock, FormatPart};
+use crate::code_block::{Arg, CodeBlock, FormatPart, Specifier};
 use crate::type_name::TypeName;
 
 /// A single node in the code generation tree.
@@ -68,36 +68,15 @@ pub(crate) fn parts_args_to_nodes(parts: &[FormatPart], args: &[Arg]) -> Vec<Cod
     for part in parts {
         let node = match part {
             FormatPart::Literal(text) => CodeNode::Literal(text.clone()),
-            FormatPart::Type => {
+            FormatPart::Arg(spec) => {
                 let arg = &args[arg_index];
                 arg_index += 1;
-                match arg {
-                    Arg::TypeName(tn) => CodeNode::TypeRef(tn.clone()),
-                    _ => CodeNode::Literal(String::new()),
-                }
-            }
-            FormatPart::Name => {
-                let arg = &args[arg_index];
-                arg_index += 1;
-                match arg {
-                    Arg::Name(n) => CodeNode::NameRef(n.clone()),
-                    _ => CodeNode::Literal(String::new()),
-                }
-            }
-            FormatPart::StringLit => {
-                let arg = &args[arg_index];
-                arg_index += 1;
-                match arg {
-                    Arg::StringLit(s) => CodeNode::StringLit(s.clone()),
-                    _ => CodeNode::Literal(String::new()),
-                }
-            }
-            FormatPart::Literal_ => {
-                let arg = &args[arg_index];
-                arg_index += 1;
-                match arg {
-                    Arg::Literal(s) => CodeNode::InlineLiteral(s.clone()),
-                    Arg::Code(block) => CodeNode::Nested(block.clone()),
+                match (spec, arg) {
+                    (Specifier::Type, Arg::TypeName(tn)) => CodeNode::TypeRef(tn.clone()),
+                    (Specifier::Name, Arg::Name(n)) => CodeNode::NameRef(n.clone()),
+                    (Specifier::StringLit, Arg::StringLit(s)) => CodeNode::StringLit(s.clone()),
+                    (Specifier::Literal, Arg::Literal(s)) => CodeNode::InlineLiteral(s.clone()),
+                    (Specifier::Literal, Arg::Code(block)) => CodeNode::Nested(block.clone()),
                     _ => CodeNode::Literal(String::new()),
                 }
             }
@@ -136,7 +115,10 @@ mod tests {
     #[test]
     fn test_type_ref_conversion() {
         let tn = TypeName::primitive("string");
-        let parts = vec![FormatPart::Literal("x: ".to_string()), FormatPart::Type];
+        let parts = vec![
+            FormatPart::Literal("x: ".to_string()),
+            FormatPart::Arg(Specifier::Type),
+        ];
         let args = vec![Arg::TypeName(tn)];
         let nodes = parts_args_to_nodes(&parts, &args);
         assert_eq!(nodes.len(), 2);
@@ -147,7 +129,7 @@ mod tests {
     #[test]
     fn test_nested_block_conversion() {
         let inner = CodeBlock::of("inner()", ()).unwrap();
-        let parts = vec![FormatPart::Literal_];
+        let parts = vec![FormatPart::Arg(Specifier::Literal)];
         let args = vec![Arg::Code(inner)];
         let nodes = parts_args_to_nodes(&parts, &args);
         assert_eq!(nodes.len(), 1);
@@ -206,11 +188,11 @@ mod tests {
         let tn = TypeName::primitive("number");
         let parts = vec![
             FormatPart::Literal("let ".to_string()),
-            FormatPart::Name,
+            FormatPart::Arg(Specifier::Name),
             FormatPart::Literal(": ".to_string()),
-            FormatPart::Type,
+            FormatPart::Arg(Specifier::Type),
             FormatPart::Literal(" = ".to_string()),
-            FormatPart::StringLit,
+            FormatPart::Arg(Specifier::StringLit),
         ];
         let args = vec![
             Arg::Name("x".to_string()),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,7 +96,7 @@ pub(crate) mod type_name_render;
 
 /// Common re-exports for convenient usage.
 pub mod prelude {
-    pub use crate::code_block::{CodeBlock, CodeBlockBuilder, NameArg, StringLitArg};
+    pub use crate::code_block::{CodeBlock, CodeBlockBuilder, NameArg, Specifier, StringLitArg};
     pub use crate::code_template::{CodeTemplate, ParamKind};
     pub use crate::error::SigilStitchError;
     pub use crate::lang::CodeLang;


### PR DESCRIPTION
## Summary

- Extracts argument-consuming specifier kinds (`%T`, `%N`, `%S`, `%L`) into a public `Specifier` enum as the single source of truth
- `FormatPart` now uses `FormatPart::Arg(Specifier)` instead of separate `Type`/`Name`/`StringLit`/`Literal_` variants
- `parse_format()` delegates to `Specifier::from_format_char()` for argument-consuming specifiers
- Adding a new specifier variant causes exhaustiveness errors in both `parse_format` and `parts_args_to_nodes`
- `Specifier` is re-exported in the prelude

Closes #21

## Test plan

- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --all-targets` passes
- [x] All 1071 tests pass (`cargo test --all`)
- [x] Existing `sigil_quote!` and `CodeBlockBuilder` usage unchanged