### PR TITLE
refactor: consolidate import collection into a single walker

### DIFF
--- a/src/code_block.rs
+++ b/src/code_block.rs
@@ -174,7 +174,7 @@ impl CodeBlock {
 
     /// Collect all import references from this code block.
     pub fn collect_imports(&self, out: &mut Vec<ImportRef>) {
-        collect_imports_from_nodes(&self.nodes, out);
+        crate::import_collector::walk_nodes(&self.nodes, out);
     }
 
     /// Render this code block to a string without import resolution.
@@ -190,17 +190,6 @@ impl CodeBlock {
         let imports = crate::import::ImportGroup::new();
         let mut renderer = crate::code_renderer::CodeRenderer::new(lang, &imports, width);
         renderer.render(self)
-    }
-}
-
-fn collect_imports_from_nodes(nodes: &[CodeNode], out: &mut Vec<ImportRef>) {
-    for node in nodes {
-        match node {
-            CodeNode::TypeRef(tn) => tn.collect_imports(out),
-            CodeNode::Nested(block) => block.collect_imports(out),
-            CodeNode::Sequence(children) => collect_imports_from_nodes(children, out),
-            _ => {}
-        }
     }
 }
 

--- a/src/import_collector.rs
+++ b/src/import_collector.rs
@@ -12,7 +12,12 @@ pub fn collect_imports(block: &CodeBlock) -> Vec<ImportRef> {
     refs
 }
 
-fn walk_nodes(nodes: &[CodeNode], refs: &mut Vec<ImportRef>) {
+/// Walk a slice of `CodeNode`s, collecting import references.
+///
+/// Recurses into `Nested(CodeBlock)`, `Sequence`, and `TypeRef(TypeName)`.
+/// This is the single import-collection walker for `CodeNode` trees;
+/// all other import-collection entry points delegate here.
+pub(crate) fn walk_nodes(nodes: &[CodeNode], refs: &mut Vec<ImportRef>) {
     for node in nodes {
         match node {
             CodeNode::TypeRef(tn) => {

--- a/src/type_name.rs
+++ b/src/type_name.rs
@@ -551,7 +551,11 @@ impl TypeName {
     }
 
     /// Collect import references from this type name (recursive).
-    pub fn collect_imports(&self, out: &mut Vec<ImportRef>) {
+    ///
+    /// Callers working with `CodeBlock` or `CodeNode` trees should use
+    /// [`import_collector::collect_imports`](crate::import_collector::collect_imports)
+    /// instead, which handles the full tree walk including nested blocks.
+    pub(crate) fn collect_imports(&self, out: &mut Vec<ImportRef>) {
         crate::type_name_import::collect_imports(self, out)
     }
 


### PR DESCRIPTION
## Summary

- Removes duplicate `collect_imports_from_nodes` from `code_block.rs`; `CodeBlock::collect_imports` now delegates to `import_collector::walk_nodes`
- Makes `walk_nodes` `pub(crate)` as the single `CodeNode`-level import walker
- Demotes `TypeName::collect_imports` from `pub` to `pub(crate)` — callers should use `import_collector::collect_imports` for full tree walks

Closes #22

## Test plan

- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --all-targets` passes
- [x] All 1071 tests pass (`cargo test --all`)