### PR TITLE
feat: add $for meta-loop to sigil_quote!()

### DIFF
--- a/macros/src/codegen.rs
+++ b/macros/src/codegen.rs
@@ -104,6 +104,18 @@ fn generate_statements(statements: &[Statement]) -> Vec<TokenStream> {
                 let meta_if = generate_meta_if(branches);
                 calls.push(meta_if);
             }
+            Statement::MetaFor {
+                pat,
+                iter_expr,
+                body,
+            } => {
+                let body_calls = generate_statements(body);
+                calls.push(quote! {
+                    for #pat in #iter_expr {
+                        #(#body_calls)*
+                    }
+                });
+            }
         }
     }
     calls

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -47,6 +47,22 @@ use proc_macro::TokenStream;
 /// - `$comment("text")` becomes `add_comment("text")`
 /// - `$>` / `$<` increase / decrease indent level
 ///
+/// ## Meta-Conditionals and Meta-Loops
+///
+/// Use `$if`/`$else_if`/`$else` to conditionally emit builder calls at runtime,
+/// and `$for` to loop over a collection and emit per-item statements:
+///
+/// ```ignore
+/// sigil_quote!(TypeScript {
+///     $if(use_strict) {
+///         "use strict";
+///     }
+///     $for((name, ty) in &fields) {
+///         let $N(*name): $L(*ty);
+///     }
+/// })
+/// ```
+///
 /// ## Control Flow
 ///
 /// The macro detects `if`/`else`/`else if` chains, `for`, `while`, `try`/`catch`,

--- a/macros/src/parse/format.rs
+++ b/macros/src/parse/format.rs
@@ -160,11 +160,15 @@ fn tokens_to_format_inner(
                 ));
             }
 
-            // `$if`/`$else_if`/`$else` should have been caught earlier (statement-level).
-            if is_ident(next, "if") || is_ident(next, "else_if") || is_ident(next, "else") {
+            // `$if`/`$else_if`/`$else`/`$for` should have been caught earlier (statement-level).
+            if is_ident(next, "if")
+                || is_ident(next, "else_if")
+                || is_ident(next, "else")
+                || is_ident(next, "for")
+            {
                 return Err(CompileError::new(
                     next.span(),
-                    "$if/$else_if/$else must appear at the start of a line",
+                    "$if/$else_if/$else/$for must appear at the start of a line",
                 ));
             }
 
@@ -276,7 +280,7 @@ fn tokens_to_format_inner(
 
             return Err(CompileError::new(
                 next.span(),
-                "expected interpolation kind after `$`: $T, $N, $S, $L, $C, $W, $join, $C_each, or $$",
+                "expected interpolation kind after `$`: $T, $N, $S, $L, $C, $W, $join, $C_each, $for, or $$",
             ));
         }
 

--- a/macros/src/parse/statements.rs
+++ b/macros/src/parse/statements.rs
@@ -31,6 +31,11 @@ pub(super) fn parse_one_statement(
         return Ok((stmt, next));
     }
 
+    // Check for $for(pat in expr) { ... }
+    if let Some((stmt, next)) = try_parse_meta_for(tokens, start)? {
+        return Ok((stmt, next));
+    }
+
     // Collect tokens for this statement, looking for `;` or a brace group.
     let mut pos = start;
     let mut collected: Vec<TokenTree> = Vec::new();
@@ -425,6 +430,88 @@ fn try_parse_meta_if(
     }
 
     Ok(Some((Statement::MetaIf { branches }, pos)))
+}
+
+/// Try to parse `$for(pat in expr) { ... }` at position `start`.
+/// Produces `Statement::MetaFor` which expands to a Rust `for` loop at compile time.
+fn try_parse_meta_for(
+    tokens: &[TokenTree],
+    start: usize,
+) -> Result<Option<(Statement, usize)>, CompileError> {
+    // Need at least 4 tokens: `$`, `for`, `(pat in expr)`, `{ body }`
+    if start + 3 >= tokens.len() {
+        return Ok(None);
+    }
+
+    let is_dollar = matches!(&tokens[start], TokenTree::Punct(p) if p.as_char() == '$');
+    if !is_dollar {
+        return Ok(None);
+    }
+
+    if !is_ident(&tokens[start + 1], "for") {
+        return Ok(None);
+    }
+
+    let paren_group = match &tokens[start + 2] {
+        TokenTree::Group(g) if g.delimiter() == Delimiter::Parenthesis => g.clone(),
+        _ => {
+            return Err(CompileError::new(
+                tokens[start + 2].span(),
+                "$for requires a parenthesized pattern: $for(pat in expr) { ... }",
+            ));
+        }
+    };
+
+    let body_group = match &tokens[start + 3] {
+        TokenTree::Group(g) if g.delimiter() == Delimiter::Brace => g.clone(),
+        _ => {
+            return Err(CompileError::new(
+                tokens[start + 3].span(),
+                "$for requires a brace body: $for(pat in expr) { ... }",
+            ));
+        }
+    };
+
+    // Split paren contents on the first `in` keyword.
+    let paren_tokens: Vec<TokenTree> = paren_group.stream().into_iter().collect();
+    let in_pos = paren_tokens.iter().position(|tt| is_ident(tt, "in"));
+    let in_pos = match in_pos {
+        Some(p) => p,
+        None => {
+            return Err(CompileError::new(
+                paren_group.span(),
+                "$for requires `in` keyword: $for(pat in expr) { ... }",
+            ));
+        }
+    };
+
+    if in_pos == 0 {
+        return Err(CompileError::new(
+            paren_group.span(),
+            "$for pattern cannot be empty: $for(pat in expr) { ... }",
+        ));
+    }
+    if in_pos + 1 >= paren_tokens.len() {
+        return Err(CompileError::new(
+            paren_group.span(),
+            "$for iterator expression cannot be empty: $for(pat in expr) { ... }",
+        ));
+    }
+
+    let pat: proc_macro2::TokenStream = paren_tokens[..in_pos].iter().cloned().collect();
+    let iter_expr: proc_macro2::TokenStream = paren_tokens[in_pos + 1..].iter().cloned().collect();
+
+    let body_tokens: Vec<TokenTree> = body_group.stream().into_iter().collect();
+    let body = parse_body(&body_tokens)?;
+
+    Ok(Some((
+        Statement::MetaFor {
+            pat,
+            iter_expr,
+            body,
+        },
+        start + 4,
+    )))
 }
 
 /// Strip a trailing `$+` continuation marker from collected tokens.

--- a/macros/src/parse/types.rs
+++ b/macros/src/parse/types.rs
@@ -32,6 +32,12 @@ pub(crate) enum Statement {
     SpliceEach { expr: TokenStream },
     /// `$if(cond) { ... } $else_if(cond) { ... } $else { ... }` — meta-conditional.
     MetaIf { branches: Vec<MetaBranch> },
+    /// `$for(pat in expr) { ... }` — meta-loop that emits body once per iteration.
+    MetaFor {
+        pat: TokenStream,
+        iter_expr: TokenStream,
+        body: Vec<Statement>,
+    },
 }
 
 /// A single branch in a control flow chain.

--- a/tests/macro/main.rs
+++ b/tests/macro/main.rs
@@ -16,6 +16,7 @@ mod interpolation;
 mod join;
 mod keyword_spacing;
 mod line_splitting;
+mod meta_for;
 mod meta_if;
 mod multi_language;
 mod non_brace_langs;

--- a/tests/macro/meta_for.rs
+++ b/tests/macro/meta_for.rs
@@ -1,0 +1,192 @@
+use super::helpers::*;
+
+// --- Basic $for loop ---
+
+#[test]
+fn test_meta_for_simple() {
+    let fields = vec!["name", "age", "email"];
+
+    let block = sigil_quote!(TypeScript {
+        $for(field in &fields) {
+            console.log($L(*field));
+        }
+    })
+    .unwrap();
+
+    let output = render_ts(&block);
+    assert!(output.contains("console.log(name)"), "got: {output}");
+    assert!(output.contains("console.log(age)"), "got: {output}");
+    assert!(output.contains("console.log(email)"), "got: {output}");
+}
+
+#[test]
+fn test_meta_for_with_interpolation() {
+    let fields = vec!["name", "age"];
+
+    let block = sigil_quote!(TypeScript {
+        $for(field in &fields) {
+            this.$N(*field) = $N(*field);
+        }
+    })
+    .unwrap();
+
+    let output = render_ts(&block);
+    assert!(output.contains("this.name = name;"), "got: {output}");
+    assert!(output.contains("this.age = age;"), "got: {output}");
+}
+
+#[test]
+fn test_meta_for_with_string_literal() {
+    let items = vec!["hello", "world"];
+
+    let block = sigil_quote!(TypeScript {
+        $for(item in &items) {
+            console.log($S(*item));
+        }
+    })
+    .unwrap();
+
+    let output = render_ts(&block);
+    assert!(output.contains("console.log('hello')"), "got: {output}");
+    assert!(output.contains("console.log('world')"), "got: {output}");
+}
+
+#[test]
+fn test_meta_for_with_type_interpolation() {
+    let types = vec![TypeName::primitive("string"), TypeName::primitive("number")];
+
+    let block = sigil_quote!(TypeScript {
+        $for(ty in &types) {
+            let x: $T(ty.clone());
+        }
+    })
+    .unwrap();
+
+    let output = render_ts(&block);
+    assert!(output.contains("let x: string;"), "got: {output}");
+    assert!(output.contains("let x: number;"), "got: {output}");
+}
+
+// --- Destructuring patterns ---
+
+#[test]
+fn test_meta_for_destructuring() {
+    let pairs = vec![("x", "number"), ("y", "string")];
+
+    let block = sigil_quote!(TypeScript {
+        $for((name, ty) in &pairs) {
+            let $N(*name): $L(*ty);
+        }
+    })
+    .unwrap();
+
+    let output = render_ts(&block);
+    assert!(output.contains("let x: number;"), "got: {output}");
+    assert!(output.contains("let y: string;"), "got: {output}");
+}
+
+// --- Nesting ---
+
+#[test]
+fn test_meta_for_nested_in_meta_if() {
+    let include_fields = true;
+    let fields = vec!["a", "b"];
+
+    let block = sigil_quote!(TypeScript {
+        $if(include_fields) {
+            $for(field in &fields) {
+                this.$N(*field) = null;
+            }
+        }
+    })
+    .unwrap();
+
+    let output = render_ts(&block);
+    assert!(output.contains("this.a = null;"), "got: {output}");
+    assert!(output.contains("this.b = null;"), "got: {output}");
+}
+
+#[test]
+fn test_meta_if_nested_in_meta_for() {
+    let fields: Vec<(&str, bool)> = vec![("name", true), ("age", false)];
+
+    let block = sigil_quote!(TypeScript {
+        $for((field, required) in &fields) {
+            $if(*required) {
+                this.$N(*field) = validate($L(*field));
+            } $else {
+                this.$N(*field) = $L(*field);
+            }
+        }
+    })
+    .unwrap();
+
+    let output = render_ts(&block);
+    assert!(
+        output.contains("this.name = validate(name);"),
+        "got: {output}"
+    );
+    assert!(output.contains("this.age = age;"), "got: {output}");
+}
+
+#[test]
+fn test_meta_for_nested_for() {
+    let outer = vec!["A", "B"];
+    let inner = vec!["1", "2"];
+
+    let block = sigil_quote!(TypeScript {
+        $for(o in &outer) {
+            $for(i in &inner) {
+                const $N(format!("{}_{}", o, i)) = true;
+            }
+        }
+    })
+    .unwrap();
+
+    let output = render_ts(&block);
+    assert!(output.contains("const A_1 = true;"), "got: {output}");
+    assert!(output.contains("const A_2 = true;"), "got: {output}");
+    assert!(output.contains("const B_1 = true;"), "got: {output}");
+    assert!(output.contains("const B_2 = true;"), "got: {output}");
+}
+
+// --- Empty iteration ---
+
+#[test]
+fn test_meta_for_empty_iter() {
+    let fields: Vec<&str> = vec![];
+
+    let block = sigil_quote!(TypeScript {
+        const before = 1;
+        $for(field in &fields) {
+            const $N(*field) = null;
+        }
+        const after = 2;
+    })
+    .unwrap();
+
+    let output = render_ts(&block);
+    assert!(output.contains("const before = 1;"), "got: {output}");
+    assert!(output.contains("const after = 2;"), "got: {output}");
+    // No field lines should appear.
+    assert!(!output.contains("null"), "got: {output}");
+}
+
+// --- Real-world pattern: enum variant generation ---
+
+#[test]
+fn test_meta_for_enum_variants() {
+    let variants = vec![("Red", "0"), ("Green", "1"), ("Blue", "2")];
+
+    let block = sigil_quote!(TypeScript {
+        $for((name, value) in &variants) {
+            $L(*name) = $L(*value),
+        }
+    })
+    .unwrap();
+
+    let output = render_ts(&block);
+    assert!(output.contains("Red = 0,"), "got: {output}");
+    assert!(output.contains("Green = 1,"), "got: {output}");
+    assert!(output.contains("Blue = 2,"), "got: {output}");
+}


### PR DESCRIPTION
## Summary

- Adds `$for(pat in expr) { body }` as a compile-time meta-loop in `sigil_quote!()`, expanding to a Rust `for` loop wrapping the body's builder calls
- Supports destructuring patterns, all interpolation markers (`$T`/`$N`/`$S`/`$L`/`$C`), and arbitrary nesting with `$if` and other `$for` loops
- Eliminates the most common reason to fall back from declarative `sigil_quote!()` to imperative `CodeBlock::builder()` — iterating a collection to emit per-item statements

## Test plan

- [x] 10 integration tests covering: simple iteration, interpolation markers, destructuring, nesting ($if inside $for, $for inside $if, $for inside $for), empty iteration, real-world enum variant generation
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets`
- [x] `cargo test --all` (455+ tests pass)
- [x] `RUSTDOCFLAGS="-Dwarnings" cargo doc --workspace --no-deps`