### PR TITLE
chore: release 0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## 0.4.2
+
+### Added
+
+- `$for(pat in expr) { body }` meta-loop in `sigil_quote!` — compile-time
+  iteration with full nesting, destructuring patterns, and all interpolation
+  markers.
+- `Emittable` trait and `FileMember::Spec` variant for third-party spec types
+  to participate in `FileSpec` rendering and import collection.
+- `ProjectSpec::build()` rejects duplicate filenames (returns
+  `SigilStitchError::DuplicateFileName`).
+
+### Fixed
+
+- `FileSpec` serde round-trip no longer panics on render (deserialized files
+  now retain their language).
+
+### Changed (internal, non-breaking)
+
+- `CodeLang` required methods reduced from 10 to 3 (config accessors +
+  format specifiers consolidated).
+- TypeName rendering and import collection extracted into separate modules.
+- Import collection consolidated into a single walker.
+- Format specifier definitions unified into `Specifier` enum.
+- Architecture deepened: import resolution deduplication, `ImportGroup.entries`
+  privatized, `EnumVariantSpec` self-contained emit.
+
 ## 0.4.1
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,7 +100,7 @@ dependencies = [
 
 [[package]]
 name = "sigil-stitch"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "pretty",
  "serde",
@@ -111,7 +111,7 @@ dependencies = [
 
 [[package]]
 name = "sigil-stitch-macros"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["macros"]
 resolver = "3"
 
 [workspace.package]
-version = "0.4.1"
+version = "0.4.2"
 edition = "2024"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"
@@ -35,7 +35,7 @@ exclude = [
 [dependencies]
 pretty = "0.12"
 snafu = "0.9"
-sigil-stitch-macros = { path = "macros", version = "0.4.1" }
+sigil-stitch-macros = { path = "macros", version = "0.4.2" }
 serde = { version = "1", features = ["derive"] }
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ let body = sigil_quote!(TypeScript {
 The macro uses `$T`/`$S`/`$N`/`$L`/`$C`/`$W` interpolation markers that expand to
 the equivalent `%T`/`%S`/`%N`/`%L` format specifiers at compile time. It also
 supports `$C_each` for splicing iterables of code blocks, `$if`/`$else_if`/`$else`
-for meta-conditionals, `$join` for separator-joined lists, and `$+` for line
-continuation in multi-line expressions.
+for meta-conditionals, `$for` for compile-time iteration, `$join` for
+separator-joined lists, and `$+` for line continuation in multi-line expressions.
 
 ## Format Specifiers
 

--- a/docs/src/sigil_quote.md
+++ b/docs/src/sigil_quote.md
@@ -44,6 +44,7 @@ It returns `Result<CodeBlock, SigilStitchError>`.
 | `$$` | `$` | (none) | Literal dollar sign |
 | `$C_each(expr)` | — | `impl IntoIterator<Item: Into<CodeBlock>>` | Splice each code block from iterable |
 | `$if(cond) { ... }` | — | Rust expression | Meta-conditional (runtime codegen control) |
+| `$for(pat in expr) { ... }` | — | Rust pattern + iterable | Meta-loop (emit body per iteration) |
 | `$join(sep, iter)` | `%L` | separator + `impl IntoIterator<Item: ToString>` | Separator-joined list |
 | `$+` | — | (none) | Line continuation (suppress line-break split) |
 
@@ -393,6 +394,74 @@ sigil_quote!(TypeScript {
         if (!user) {
             throw new Error($S("unauthorized"));
         }
+    }
+})
+```
+
+## Meta-Loops (`$for`)
+
+`$for` iterates over a Rust collection at compile time, emitting the body statements
+once per iteration. Like `$if`, it controls **which builder calls are made** — it
+does not produce target-language loop syntax.
+
+```rust,ignore
+let fields = vec!["name", "age", "email"];
+
+sigil_quote!(TypeScript {
+    $for(f in &fields) {
+        this.$N(*f) = null;
+    }
+})
+// Output:
+// this.name = null;
+// this.age = null;
+// this.email = null;
+```
+
+### Destructuring Patterns
+
+Any Rust `for` pattern works:
+
+```rust,ignore
+let entries = vec![("x", "number"), ("y", "string")];
+
+sigil_quote!(TypeScript {
+    $for((name, ty) in &entries) {
+        let $N(*name): $L(*ty);
+    }
+})
+// Output:
+// let x: number;
+// let y: string;
+```
+
+### Nesting
+
+`$for` can nest inside `$if` and vice versa, and can contain target-language
+control flow:
+
+```rust,ignore
+let variants = vec!["A", "B", "C"];
+
+sigil_quote!(TypeScript {
+    $for(v in &variants) {
+        case $S(*v):
+            return $S(*v);
+    }
+})
+```
+
+### Combining with Interpolation Markers
+
+All interpolation markers (`$T`, `$N`, `$S`, `$L`, `$C`, `$W`, `$join`) work
+inside `$for` bodies, and the loop variable is in scope:
+
+```rust,ignore
+let types: Vec<TypeName> = get_types();
+
+sigil_quote!(TypeScript {
+    $for(t in &types) {
+        import type { $T(t.clone()) };
     }
 })
 ```


### PR DESCRIPTION
## Summary

- Bump version from 0.4.1 → 0.4.2 in workspace Cargo.toml (2 places)
- Add `## 0.4.2` changelog section covering 9 commits (3 features, 1 fix, 5 refactors)
- Add `$for` to README macro features paragraph
- Add `$for` row to docs interpolation table + full "Meta-Loops" documentation section

## Test plan

- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --all-targets` passes
- [x] `cargo test --all` passes