### PR TITLE
feat: add Lua language support

### DIFF
--- a/macros/src/parse/statements.rs
+++ b/macros/src/parse/statements.rs
@@ -76,6 +76,18 @@ pub(super) fn parse_one_statement(
             // Check for $open("...") at end of collected tokens.
             let (condition_tokens, block_open_override) = try_extract_open_override(&collected)?;
 
+            // Distinguish control-flow `{` from literal `{` (e.g., Lua tables).
+            // Brace languages always use `{` for blocks, but end-delimited
+            // languages (Lua, Ruby, Elixir) use `{` for table/hash literals
+            // and can only detect control flow from surrounding keywords.
+            if !looks_like_control_flow_header(&condition_tokens) {
+                // Treat as a literal brace group — not control flow.
+                collected.push(tt.clone());
+                prev_end_line = Some(tt.span().end().line);
+                pos += 1;
+                continue;
+            }
+
             // Control flow detected.
             return parse_control_flow(tokens, &condition_tokens, g, pos, block_open_override);
         }
@@ -181,6 +193,84 @@ fn try_extract_open_override(
     Ok((condition_tokens, Some(text)))
 }
 
+/// Check whether the tokens before a `{` brace group look like a control-flow
+/// header (e.g. `if ... {`, `for ... {`, `function ... {`) rather than a
+/// literal brace expression (e.g. Lua table constructor `local t = { ... }`).
+///
+/// Returns `false` (→ literal) only for clear literal patterns: tokens ending
+/// with `=`, `,`, `return`, or a single identifier before `()` (function call
+/// with table argument, e.g. `foo(...) {`). Everything else defaults to
+/// `true` (→ control flow), which is correct for all brace languages.
+fn looks_like_control_flow_header(tokens: &[TokenTree]) -> bool {
+    if tokens.is_empty() {
+        return false;
+    }
+
+    let n = tokens.len();
+    let last = &tokens[n - 1];
+
+    // Control-flow keywords that always precede `{`
+    if is_ident(last, "then") || is_ident(last, "do") || is_ident(last, "else") {
+        return true;
+    }
+
+    // `=` → assignment of a table/object literal
+    if matches!(last, TokenTree::Punct(p) if p.as_char() == '=') {
+        return false;
+    }
+    // `,` → table entry separator (unlikely at statement level, but safe)
+    if matches!(last, TokenTree::Punct(p) if p.as_char() == ',') {
+        return false;
+    }
+    // `return` → returning a table
+    if is_ident(last, "return") {
+        return false;
+    }
+
+    // `(...)` group — check if it's a function call with table argument.
+    if matches!(last, TokenTree::Group(g) if g.delimiter() == Delimiter::Parenthesis) {
+        // Only one token before `()` and it's an ident → function call
+        // (e.g. `foo(...) {` with table arg). This is a literal.
+        if n == 2 && matches!(&tokens[0], TokenTree::Ident(_)) {
+            let s = tokens[0].to_string();
+            // Known control-flow keywords that appear as a single ident
+            // before `()` are NOT function calls.
+            if matches!(
+                s.as_str(),
+                "if" | "for"
+                    | "while"
+                    | "catch"
+                    | "switch"
+                    | "foreach"
+                    | "for_each"
+                    | "unless"
+                    | "until"
+                    | "match"
+                    | "try"
+                    | "synchronized"
+                    | "when"
+                    | "guard"
+                    | "function"
+            ) {
+                return true;
+            }
+            // Single ident (not a keyword) → function call → literal
+            return false;
+        }
+        // Multiple tokens before `()` or starts with keyword → control flow
+        return true;
+    }
+
+    // `repeat` starts a control-flow block
+    if is_ident(&tokens[0], "repeat") {
+        return true;
+    }
+
+    // Default: assume control flow — backward compatible with brace languages
+    // where `{` at statement level always denotes a block.
+    true
+}
+
 /// Parse a control flow chain starting from tokens that lead into a brace group.
 fn parse_control_flow(
     tokens: &[TokenTree],
@@ -204,11 +294,20 @@ fn parse_control_flow(
 
     // Check for else chain.
     while pos < tokens.len() {
-        if is_ident(&tokens[pos], "else") {
-            let else_span = tokens[pos].span();
-            pos += 1; // consume `else`
+        let is_else = is_ident(&tokens[pos], "else");
+        let is_elseif = is_ident(&tokens[pos], "elseif");
+        let is_elif = is_ident(&tokens[pos], "elif");
 
-            // Collect tokens until we find a brace group (handles `else if (...) {`).
+        if is_else || is_elseif || is_elif {
+            let kw_span = tokens[pos].span();
+            let keyword: String = tokens[pos].to_string();
+            pos += 1; // consume keyword
+
+            // For bare `else` with no condition tokens, use keyword as-is.
+            // For `elseif`/`elif`, collect tokens until `{` as condition.
+            let is_bare_else = is_else;
+
+            // Collect tokens until we find a brace group.
             let mut else_condition_tokens: Vec<TokenTree> = Vec::new();
             let mut found_brace = false;
 
@@ -219,12 +318,18 @@ fn parse_control_flow(
                     let body_toks: Vec<TokenTree> = g.stream().into_iter().collect();
                     let body = parse_body(&body_toks)?;
 
-                    let (cond_format, cond_args) = if else_condition_tokens.is_empty() {
-                        ("else".to_string(), Vec::new())
-                    } else {
-                        let (fmt, args) = tokens_to_format(&else_condition_tokens)?;
-                        (format!("else {fmt}"), args)
-                    };
+                    let (cond_format, cond_args) =
+                        if is_bare_else && else_condition_tokens.is_empty() {
+                            ("else".to_string(), Vec::new())
+                        } else if is_bare_else {
+                            let (fmt, args) = tokens_to_format(&else_condition_tokens)?;
+                            (format!("else {fmt}"), args)
+                        } else if else_condition_tokens.is_empty() {
+                            (keyword.clone(), Vec::new())
+                        } else {
+                            let (fmt, args) = tokens_to_format(&else_condition_tokens)?;
+                            (format!("{keyword} {fmt}"), args)
+                        };
 
                     branches.push(Branch {
                         condition_format: cond_format,
@@ -241,7 +346,10 @@ fn parse_control_flow(
             }
 
             if !found_brace {
-                return Err(CompileError::new(else_span, "expected `{` after `else`"));
+                return Err(CompileError::new(
+                    kw_span,
+                    "expected `{` after `else`/`elseif`/`elif`",
+                ));
             }
         } else {
             break;

--- a/src/code_renderer.rs
+++ b/src/code_renderer.rs
@@ -154,10 +154,10 @@ impl<'a> CodeRenderer<'a> {
                     }
                 }
                 CodeNode::BlockCloseTransition => {
-                    let close = self.lang.block_syntax().block_close;
-                    if !close.is_empty() {
+                    let cfg = self.lang.block_syntax();
+                    if !cfg.block_close.is_empty() && cfg.close_on_transition {
                         self.ensure_indent();
-                        self.emit(close);
+                        self.emit(cfg.block_close);
                         self.emit(" ");
                     }
                 }
@@ -235,11 +235,11 @@ impl<'a> CodeRenderer<'a> {
                     }
                 }
                 CodeNode::BlockCloseTransition => {
-                    let close = self.lang.block_syntax().block_close;
-                    if close.is_empty() {
+                    let cfg = self.lang.block_syntax();
+                    if cfg.block_close.is_empty() || !cfg.close_on_transition {
                         BoxDoc::nil()
                     } else {
-                        BoxDoc::text(format!("{} ", close))
+                        BoxDoc::text(format!("{} ", cfg.block_close))
                     }
                 }
                 CodeNode::Sequence(children) => self.nodes_to_doc(children),

--- a/src/lang/config.rs
+++ b/src/lang/config.rs
@@ -220,6 +220,10 @@ pub struct BlockSyntaxConfig<'a> {
     pub type_close_terminator: &'a str,
     /// Closing delimiter for base class / implements list (e.g. `")"` for Python).
     pub bases_close: &'a str,
+    /// Whether to emit `block_close` during control-flow transitions (e.g. `} else`).
+    /// Set to `false` for `end`-delimited languages (Lua, Ruby, Elixir) where
+    /// `else`/`elseif` should NOT be preceded by the closing delimiter.
+    pub close_on_transition: bool,
 }
 
 impl Default for BlockSyntaxConfig<'_> {
@@ -232,6 +236,7 @@ impl Default for BlockSyntaxConfig<'_> {
             field_terminator: ",",
             type_close_terminator: "",
             bases_close: "",
+            close_on_transition: true,
         }
     }
 }

--- a/src/lang/lua.rs
+++ b/src/lang/lua.rs
@@ -1,0 +1,291 @@
+//! Lua language implementation.
+//!
+//! Lua characteristics:
+//! - Dynamically typed (no type annotations)
+//! - `function` keyword, `end` for block close
+//! - `--` line comments, `---` doc comments
+//! - `then`/`do` after control flow conditions
+//! - `local` variable declarations
+//! - `require("module")` imports
+//! - 2-space indent by convention
+
+use crate::import::ImportGroup;
+use crate::lang::CodeLang;
+use crate::lang::config::{
+    BlockSyntaxConfig, EnumAndAnnotationConfig, FunctionSyntaxConfig, GenericSyntaxConfig,
+    TypeDeclSyntaxConfig, TypePresentationConfig,
+};
+use crate::spec::modifiers::{DeclarationContext, TypeKind, Visibility};
+
+/// Lua language implementation.
+#[derive(Debug, Clone)]
+pub struct Lua {
+    /// Indent with this string (default: `"  "` — 2 spaces by convention).
+    pub indent: String,
+    /// File extension (default: `"lua"`).
+    pub extension: String,
+}
+
+impl Default for Lua {
+    fn default() -> Self {
+        Self {
+            indent: "  ".to_string(),
+            extension: "lua".to_string(),
+        }
+    }
+}
+
+impl Lua {
+    /// Create a new Lua language instance with default settings.
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+/// Lua keywords (Lua 5.x).
+/// Contextual keyword `self` intentionally not included — treat as regular ident.
+const LUA_RESERVED: &[&str] = &[
+    "and", "break", "do", "else", "elseif", "end", "false", "for", "function", "goto", "if", "in",
+    "local", "nil", "not", "or", "repeat", "return", "then", "true", "until", "while",
+];
+
+impl CodeLang for Lua {
+    fn file_extension(&self) -> &str {
+        &self.extension
+    }
+
+    fn line_comment_prefix(&self) -> &str {
+        "--"
+    }
+
+    fn render_string_literal(&self, s: &str) -> String {
+        let escaped = s
+            .replace('\\', "\\\\")
+            .replace('"', "\\\"")
+            .replace('\n', "\\n")
+            .replace('\t', "\\t")
+            .replace('\r', "\\r");
+        format!("\"{}\"", escaped)
+    }
+
+    fn reserved_words(&self) -> &[&str] {
+        LUA_RESERVED
+    }
+
+    fn render_visibility(&self, _vis: Visibility, _ctx: DeclarationContext) -> &str {
+        ""
+    }
+
+    fn function_keyword(&self, _ctx: DeclarationContext) -> &str {
+        "function "
+    }
+
+    fn type_keyword(&self, _kind: TypeKind) -> &str {
+        // Lua has no class/struct/enum keywords — tables and metatables fill
+        // that role. TypeSpec should not be used with Lua; use CodeBlock
+        // directly for table constructors and function definitions instead.
+        // If TypeSpec IS used, this returns "" so the name emits as a bare
+        // identifier block (valid Lua, treated as a scope by the interpreter).
+        ""
+    }
+
+    fn module_separator(&self) -> Option<&str> {
+        Some(".")
+    }
+
+    fn escape_reserved(&self, name: &str) -> String {
+        // Lua doesn't support `@` or backtick escaping.
+        // Append `_` suffix (e.g., `function_` for `function`).
+        if LUA_RESERVED.contains(&name) {
+            format!("{}_", name)
+        } else {
+            name.to_string()
+        }
+    }
+
+    fn render_imports(&self, imports: &ImportGroup) -> String {
+        let mut lines = Vec::new();
+        for entry in imports.entries() {
+            let module = entry.module.replace('.', "/");
+            if entry.name.is_empty() || entry.is_side_effect {
+                lines.push(format!("require(\"{}\");", module));
+            } else {
+                let name = entry.resolved_name();
+                lines.push(format!("local {} = require(\"{}\");", name, module));
+            }
+        }
+        lines.join("\n")
+    }
+
+    fn render_doc_comment(&self, lines: &[&str]) -> String {
+        let mut out = String::new();
+        for line in lines {
+            if line.is_empty() {
+                out.push_str("---\n");
+            } else {
+                out.push_str(&format!("--- {}\n", line));
+            }
+        }
+        out
+    }
+
+    // ── Config accessors ──
+
+    fn block_syntax(&self) -> BlockSyntaxConfig<'_> {
+        BlockSyntaxConfig {
+            block_open: "",             // Lua opens bodies on next line
+            block_close: "end",         // ... and closes with `end`
+            close_on_transition: false, // `else`/`elseif` don't need `end` before them
+            indent_unit: &self.indent,
+            uses_semicolons: false,
+            field_terminator: ",",
+            ..Default::default()
+        }
+    }
+
+    fn fun_block_open(&self) -> &str {
+        "" // Function bodies start on the next line
+    }
+
+    fn type_header_block_open(&self, _kind: TypeKind) -> &str {
+        "" // Type bodies start on the next line
+    }
+
+    fn type_decl_syntax(&self) -> TypeDeclSyntaxConfig<'_> {
+        TypeDeclSyntaxConfig {
+            type_before_name: false,
+            return_type_is_prefix: false,
+            type_annotation_separator: "", // Lua has no type annotations
+            ..Default::default()
+        }
+    }
+
+    fn function_syntax(&self) -> FunctionSyntaxConfig<'_> {
+        FunctionSyntaxConfig {
+            return_type_separator: "", // No return type syntax in Lua
+            empty_body: "",
+            ..Default::default()
+        }
+    }
+
+    fn generic_syntax(&self) -> GenericSyntaxConfig<'_> {
+        GenericSyntaxConfig {
+            open: "",
+            close: "",
+            ..Default::default()
+        }
+    }
+
+    fn enum_and_annotation(&self) -> EnumAndAnnotationConfig<'_> {
+        EnumAndAnnotationConfig {
+            readonly_keyword: "",
+            ..Default::default()
+        }
+    }
+
+    fn type_presentation(&self) -> TypePresentationConfig<'_> {
+        TypePresentationConfig {
+            optional_absent_literal: "nil",
+            ..Default::default()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::import::ImportEntry;
+
+    use super::*;
+
+    #[test]
+    fn test_line_comment() {
+        let lua = Lua::new();
+        assert_eq!(lua.line_comment_prefix(), "--");
+    }
+
+    #[test]
+    fn test_render_string_literal() {
+        let lua = Lua::new();
+        assert_eq!(
+            lua.render_string_literal("hello 'world'"),
+            r#""hello 'world'""#
+        );
+        assert_eq!(lua.render_string_literal("say \"hi\""), r#""say \"hi\"""#);
+        assert_eq!(
+            lua.render_string_literal("line1\nline2"),
+            r#""line1\nline2""#
+        );
+    }
+
+    #[test]
+    fn test_escape_reserved() {
+        let lua = Lua::new();
+        assert_eq!(lua.escape_reserved("foo"), "foo");
+        assert_eq!(lua.escape_reserved("function"), "function_");
+        assert_eq!(lua.escape_reserved("end"), "end_");
+    }
+
+    #[test]
+    fn test_render_imports() {
+        let lua = Lua::new();
+        let entries = vec![
+            ImportEntry {
+                module: "path.to.mod".to_string(),
+                name: "Mod".to_string(),
+                alias: None,
+                is_type_only: false,
+                is_side_effect: false,
+                is_wildcard: false,
+            },
+            ImportEntry {
+                module: "some.lib".to_string(),
+                name: String::new(),
+                alias: None,
+                is_type_only: false,
+                is_side_effect: true,
+                is_wildcard: false,
+            },
+        ];
+        let group = ImportGroup::from(entries);
+        let out = lua.render_imports(&group);
+        assert!(out.contains(r#"local Mod = require("path/to/mod")"#));
+        assert!(out.contains(r#"require("some/lib")"#));
+        assert!(!out.ends_with('\n'), "no trailing newline");
+    }
+
+    #[test]
+    fn test_render_doc_comment() {
+        let lua = Lua::new();
+        let lines = &["Says hello.", "", "Returns a greeting."];
+        let rendered = lua.render_doc_comment(lines);
+        assert_eq!(rendered, "--- Says hello.\n---\n--- Returns a greeting.\n");
+    }
+
+    #[test]
+    fn test_block_syntax() {
+        let lua = Lua::new();
+        let bs = lua.block_syntax();
+        assert_eq!(bs.block_open, "");
+        assert_eq!(bs.block_close, "end");
+        assert!(!bs.uses_semicolons);
+        assert!(!bs.close_on_transition);
+    }
+
+    #[test]
+    fn test_no_visibility() {
+        let lua = Lua::new();
+        assert_eq!(
+            lua.render_visibility(Visibility::Public, DeclarationContext::TopLevel),
+            ""
+        );
+    }
+
+    #[test]
+    fn test_function_keyword() {
+        let lua = Lua::new();
+        assert_eq!(
+            lua.function_keyword(DeclarationContext::TopLevel),
+            "function "
+        );
+    }
+}

--- a/src/lang/mod.rs
+++ b/src/lang/mod.rs
@@ -20,6 +20,8 @@ pub mod java_lang;
 pub mod javascript;
 /// Kotlin language support.
 pub mod kotlin;
+/// Lua language support.
+pub mod lua;
 /// OCaml language support.
 pub mod ocaml;
 /// Python language support.
@@ -403,6 +405,7 @@ pub fn lang_from_extension(ext: &str) -> Option<Box<dyn CodeLang>> {
         "c" | "h" => Some(Box::new(c_lang::CLang::default())),
         "cpp" | "cxx" | "cc" | "hpp" | "hxx" => Some(Box::new(cpp_lang::CppLang::default())),
         "cs" => Some(Box::new(csharp::CSharp::default())),
+        "lua" => Some(Box::new(lua::Lua::default())),
         "sh" | "bash" => Some(Box::new(bash::Bash::default())),
         "zsh" => Some(Box::new(zsh::Zsh::default())),
         _ => None,

--- a/src/spec/fun_spec.rs
+++ b/src/spec/fun_spec.rs
@@ -398,12 +398,16 @@ impl FunSpec {
         }
 
         // Return type as suffix (TS/Rust/Go-style: `fn add(...) -> int`).
+        // Skip when separator is empty (e.g. Lua) — nothing to separate.
         if !lang.type_decl_syntax().return_type_is_prefix
             && let Some(ret) = &self.return_type
         {
-            sig.push_str(lang.function_syntax().return_type_separator);
-            sig.push_str("%T");
-            sig_args.push(Arg::TypeName(ret.clone()));
+            let sep = lang.function_syntax().return_type_separator;
+            if !sep.is_empty() {
+                sig.push_str(sep);
+                sig.push_str("%T");
+                sig_args.push(Arg::TypeName(ret.clone()));
+            }
         }
 
         // Constructor delegation — signature style (Kotlin: `constructor(x: Int) : this(x, 0)`).

--- a/test-goldens/lua/control_flow.lua
+++ b/test-goldens/lua/control_flow.lua
@@ -1,0 +1,7 @@
+if x > 0 then
+  return 'positive'
+elseif x < 0 then
+  return 'negative'
+else
+  return 'zero'
+end

--- a/test-goldens/lua/for_loop.lua
+++ b/test-goldens/lua/for_loop.lua
@@ -1,0 +1,3 @@
+for i = 1, 10 do
+  print(i)
+end

--- a/test-goldens/lua/function.lua
+++ b/test-goldens/lua/function.lua
@@ -1,0 +1,3 @@
+function greet(name)
+  return $"Hello, {name}!"
+end

--- a/test-goldens/lua/function_with_doc.lua
+++ b/test-goldens/lua/function_with_doc.lua
@@ -1,0 +1,4 @@
+--- Returns the user's name.
+function get_name(self)
+  return self.name
+end

--- a/test-goldens/lua/import.lua
+++ b/test-goldens/lua/import.lua
@@ -1,0 +1,4 @@
+local json = require("dkjson");
+local inspect = require("inspect");
+
+-- json inspect

--- a/test-goldens/lua/macro_basic.lua
+++ b/test-goldens/lua/macro_basic.lua
@@ -1,0 +1,3 @@
+local name = "Alice"
+local age = 30
+print(name, age)

--- a/test-goldens/lua/macro_control_flow.lua
+++ b/test-goldens/lua/macro_control_flow.lua
@@ -1,0 +1,7 @@
+if x > 0 then
+  return "positive"
+elseif x < 0 then
+  return "negative"
+else
+  return "zero"
+end

--- a/test-goldens/lua/macro_for_loop.lua
+++ b/test-goldens/lua/macro_for_loop.lua
@@ -1,0 +1,3 @@
+for i = 1, 10 do
+  print(i)
+end

--- a/test-goldens/lua/macro_function.lua
+++ b/test-goldens/lua/macro_function.lua
@@ -1,0 +1,3 @@
+function greet(name)
+  return "Hello, "..name
+end

--- a/test-goldens/lua/macro_table.lua
+++ b/test-goldens/lua/macro_table.lua
@@ -1,0 +1,2 @@
+local user = {name = "Bob", age = 42,}
+print(user.name)

--- a/test-goldens/lua/macro_while_loop.lua
+++ b/test-goldens/lua/macro_while_loop.lua
@@ -1,0 +1,3 @@
+while x > 0 do
+  x = x - 1
+end

--- a/test-goldens/lua/while_loop.lua
+++ b/test-goldens/lua/while_loop.lua
@@ -1,0 +1,3 @@
+while x > 0 do
+  x = x - 1
+end

--- a/tests/lua/builder_control_flow.rs
+++ b/tests/lua/builder_control_flow.rs
@@ -1,0 +1,67 @@
+use sigil_stitch::code_block::CodeBlock;
+use sigil_stitch::lang::lua::Lua;
+use sigil_stitch::spec::file_spec::FileSpec;
+
+use super::golden;
+
+#[test]
+fn test_if_else() {
+    let mut cb = CodeBlock::builder();
+    cb.begin_control_flow("if x > 0 then", ());
+    cb.add_statement("return 'positive'", ());
+    cb.next_control_flow("elseif x < 0 then", ());
+    cb.add_statement("return 'negative'", ());
+    cb.next_control_flow("else", ());
+    cb.add_statement("return 'zero'", ());
+    cb.end_control_flow();
+
+    let file = FileSpec::builder_with("test.lua", Lua::new())
+        .add_code(cb.build().unwrap())
+        .build()
+        .unwrap();
+    let output = file.render(80).unwrap();
+
+    golden::assert_golden("lua/control_flow.lua", &output);
+}
+
+#[test]
+fn test_for_loop() {
+    let mut cb = CodeBlock::builder();
+    cb.begin_control_flow("for i = 1, 10 do", ());
+    cb.add_statement("print(i)", ());
+    cb.end_control_flow();
+
+    let file = FileSpec::builder_with("test.lua", Lua::new())
+        .add_code(cb.build().unwrap())
+        .build()
+        .unwrap();
+    let output = file.render(80).unwrap();
+
+    golden::assert_golden("lua/for_loop.lua", &output);
+}
+
+#[test]
+fn test_while_loop() {
+    let mut cb = CodeBlock::builder();
+    cb.begin_control_flow("while x > 0 do", ());
+    cb.add_statement("x = x - 1", ());
+    cb.end_control_flow();
+
+    let file = FileSpec::builder_with("test.lua", Lua::new())
+        .add_code(cb.build().unwrap())
+        .build()
+        .unwrap();
+    let output = file.render(80).unwrap();
+
+    golden::assert_golden("lua/while_loop.lua", &output);
+}
+
+// Note: repeat/until is not supported via the control-flow API because
+// `end_control_flow()` emits `BlockClose` ("end"), but `repeat` blocks
+// are closed by `until`, not `end`. Use `$>`/`$<` indentation directives
+// or manually indented code strings instead.
+//
+// Example workaround:
+//   cb.add("repeat", ());
+//   cb.add_statement("  x = x - 1", ());
+//   cb.add_statement("until x == 0", ());

--- a/tests/lua/builder_functions.rs
+++ b/tests/lua/builder_functions.rs
@@ -1,0 +1,38 @@
+use sigil_stitch::code_block::CodeBlock;
+use sigil_stitch::lang::lua::Lua;
+use sigil_stitch::spec::file_spec::FileSpec;
+
+use super::golden;
+
+#[test]
+fn test_function() {
+    let mut b = CodeBlock::builder();
+    b.add_statement("function greet(name)", ());
+    b.add_statement("  return $\"Hello, {name}!\"", ());
+    b.add_statement("end", ());
+
+    let file = FileSpec::builder_with("greeter.lua", Lua::new())
+        .add_code(b.build().unwrap())
+        .build()
+        .unwrap();
+    let output = file.render(80).unwrap();
+
+    golden::assert_golden("lua/function.lua", &output);
+}
+
+#[test]
+fn test_function_with_doc() {
+    let mut b = CodeBlock::builder();
+    b.add_statement("--- Returns the user's name.", ());
+    b.add_statement("function get_name(self)", ());
+    b.add_statement("  return self.name", ());
+    b.add_statement("end", ());
+
+    let file = FileSpec::builder_with("user.lua", Lua::new())
+        .add_code(b.build().unwrap())
+        .build()
+        .unwrap();
+    let output = file.render(80).unwrap();
+
+    golden::assert_golden("lua/function_with_doc.lua", &output);
+}

--- a/tests/lua/builder_imports.rs
+++ b/tests/lua/builder_imports.rs
@@ -1,0 +1,24 @@
+use sigil_stitch::code_block::CodeBlock;
+use sigil_stitch::lang::lua::Lua;
+use sigil_stitch::spec::file_spec::FileSpec;
+use sigil_stitch::type_name::TypeName;
+
+use super::golden;
+
+#[test]
+fn test_import() {
+    let json = TypeName::importable("dkjson", "json");
+    let inspect = TypeName::importable("inspect", "inspect");
+
+    let mut b = CodeBlock::builder();
+    b.add_statement("-- %T %T", (json, inspect));
+    let block = b.build().unwrap();
+
+    let file = FileSpec::builder_with("test.lua", Lua::new())
+        .add_code(block)
+        .build()
+        .unwrap();
+    let output = file.render(80).unwrap();
+
+    golden::assert_golden("lua/import.lua", &output);
+}

--- a/tests/lua/main.rs
+++ b/tests/lua/main.rs
@@ -1,0 +1,8 @@
+#[path = "../golden.rs"]
+mod golden;
+
+mod builder_control_flow;
+mod builder_functions;
+mod builder_imports;
+mod quote_basic;
+mod quote_control_flow;

--- a/tests/lua/quote_basic.rs
+++ b/tests/lua/quote_basic.rs
@@ -1,0 +1,50 @@
+use sigil_stitch::code_block::CodeBlock;
+use sigil_stitch::lang::lua::Lua;
+use sigil_stitch::prelude::*;
+use sigil_stitch::spec::file_spec::FileSpec;
+
+use super::golden;
+
+fn render(block: &CodeBlock) -> String {
+    FileSpec::builder_with("test.lua", Lua::new())
+        .add_code(block.clone())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap()
+}
+
+#[test]
+fn test_basic() {
+    let block = sigil_quote!(Lua {
+        local name = $S("Alice")
+        local age = 30
+        print(name, age)
+    })
+    .unwrap();
+    golden::assert_golden("lua/macro_basic.lua", &render(&block));
+}
+
+#[test]
+fn test_function() {
+    let block = sigil_quote!(Lua {
+        function greet(name) {
+            return "Hello, "..name
+        }
+    })
+    .unwrap();
+    golden::assert_golden("lua/macro_function.lua", &render(&block));
+}
+
+#[test]
+fn test_table() {
+    let block = sigil_quote!(Lua {
+        local user = {
+            name = $S("Bob"),
+            age = 42,
+        }
+        print(user.name)
+    })
+    .unwrap();
+    golden::assert_golden("lua/macro_table.lua", &render(&block));
+}

--- a/tests/lua/quote_control_flow.rs
+++ b/tests/lua/quote_control_flow.rs
@@ -1,0 +1,58 @@
+use sigil_stitch::code_block::CodeBlock;
+use sigil_stitch::lang::lua::Lua;
+use sigil_stitch::prelude::*;
+use sigil_stitch::spec::file_spec::FileSpec;
+
+use super::golden;
+
+fn render(block: &CodeBlock) -> String {
+    FileSpec::builder_with("test.lua", Lua::new())
+        .add_code(block.clone())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap()
+}
+
+#[test]
+fn test_if_else() {
+    let block = sigil_quote!(Lua {
+        if x > 0 then {
+            return $S("positive")
+        } elseif x < 0 then {
+            return $S("negative")
+        } else {
+            return $S("zero")
+        }
+    })
+    .unwrap();
+    golden::assert_golden("lua/macro_control_flow.lua", &render(&block));
+}
+
+#[test]
+fn test_for_loop() {
+    let block = sigil_quote!(Lua {
+        for i = 1, 10 do {
+            print(i)
+        }
+    })
+    .unwrap();
+    golden::assert_golden("lua/macro_for_loop.lua", &render(&block));
+}
+
+#[test]
+fn test_while_loop() {
+    let block = sigil_quote!(Lua {
+        while x > 0 do {
+            x = x - 1
+        }
+    })
+    .unwrap();
+    golden::assert_golden("lua/macro_while_loop.lua", &render(&block));
+}
+
+// Note: repeat/until is not supported via sigil_quote! because `{...}` after
+// `repeat` is treated as control flow, and `end_control_flow()` emits
+// `BlockClose` ("end") instead of `until condition`. Use manual formatting:
+//   $>  x = x - 1
+//   $<until x == 0

--- a/tests/macro/cross_lang_spacing.rs
+++ b/tests/macro/cross_lang_spacing.rs
@@ -780,3 +780,87 @@ fn test_csharp_bitwise_operators() {
     assert!(output.contains("| c"), "bitwise OR spaced, got: {output}");
     assert!(output.contains("^ d"), "bitwise XOR spaced, got: {output}");
 }
+
+// =============================================================================
+// Lua — string concatenation, relational operators
+// =============================================================================
+
+#[test]
+fn test_lua_concat() {
+    let block = sigil_quote!(Lua {
+        local s = "Hello, "..name
+    })
+    .unwrap();
+
+    let output = render_lua(&block);
+    assert!(
+        output.contains("\"Hello, \"..name"),
+        "concat tight, got: {output}"
+    );
+}
+
+#[test]
+fn test_lua_not_equal() {
+    let block = sigil_quote!(Lua {
+        if x ~= 0 then
+            print(x)
+        end
+    })
+    .unwrap();
+
+    let output = render_lua(&block);
+    assert!(output.contains("x ~= 0"), "not-equal tight, got: {output}");
+}
+
+#[test]
+fn test_lua_length_operator() {
+    let block = sigil_quote!(Lua {
+        local n = #t
+    })
+    .unwrap();
+
+    let output = render_lua(&block);
+    assert!(
+        output.contains("#t"),
+        "length operator tight, got: {output}"
+    );
+}
+
+#[test]
+fn test_lua_exponent() {
+    let block = sigil_quote!(Lua {
+        local y = x ^ 2
+    })
+    .unwrap();
+
+    let output = render_lua(&block);
+    assert!(output.contains("x ^ 2"), "exponent spaced, got: {output}");
+}
+
+// =============================================================================
+// Python elif — verify the parser recognizes `elif` as control-flow continuation
+// =============================================================================
+
+#[test]
+fn test_python_elif() {
+    let block = sigil_quote!(Python {
+        if x > 0 {
+            return $S("positive")
+        } elif x < 0 {
+            return $S("negative")
+        } else {
+            return $S("zero")
+        }
+    })
+    .unwrap();
+
+    let output = render_py(&block);
+    assert!(
+        output.contains("elif x < 0"),
+        "elif recognized, got: {output}"
+    );
+    assert!(
+        !output.contains("elseif"),
+        "no elseif in Python, got: {output}"
+    );
+}

--- a/tests/macro/helpers.rs
+++ b/tests/macro/helpers.rs
@@ -6,6 +6,7 @@ pub use sigil_stitch::lang::dart::DartLang;
 pub use sigil_stitch::lang::haskell::Haskell;
 pub use sigil_stitch::lang::java_lang::JavaLang;
 pub use sigil_stitch::lang::kotlin::Kotlin;
+pub use sigil_stitch::lang::lua::Lua;
 pub use sigil_stitch::lang::ocaml::OCaml;
 pub use sigil_stitch::lang::scala::Scala;
 pub use sigil_stitch::lang::swift::Swift;
@@ -87,6 +88,14 @@ pub fn render_cpp(block: &CodeBlock) -> String {
 
 pub fn render_cs(block: &CodeBlock) -> String {
     let file = FileSpec::builder_with("Test.cs", CSharp::new())
+        .add_code(block.clone())
+        .build()
+        .unwrap();
+    file.render(80).unwrap()
+}
+
+pub fn render_lua(block: &CodeBlock) -> String {
+    let file = FileSpec::builder_with("test.lua", Lua::new())
         .add_code(block.clone())
         .build()
         .unwrap();


### PR DESCRIPTION
## Summary
- Adds Lua language support with `function`/`end` blocks, `--`/`---` comments, `require()` imports, and no type annotations
- Adds `close_on_transition` flag to `BlockSyntaxConfig` — fixes the `end else` bug for end-delimited languages (Lua, Ruby, Elixir). When `false`, `BlockCloseTransition` emits nothing instead of `end ` before `else`/`elseif`
- Fixes return type rendering: skips suffix when `return_type_separator` is empty
- Fixes `sigil_quote!` parser for end-delimited languages:
  - Recognizes `elseif`/`elif` as control-flow continuation keywords
  - Distinguishes control-flow `{` from literal `{` (table constructors) by inspecting preceding tokens
- 12 integration tests + 4 cross-lang spacing tests + 8 unit tests
- 12 golden files

## Test plan
- [x] `cargo test --all` — all tests pass
- [x] `cargo fmt --all --check` — clean
- [x] `cargo clippy --all-targets` — clean
- [x] Lua control flow: `end` does NOT appear before `else`/`elseif`
- [x] Lua control flow: `end` appears correctly at block close
- [x] Lua `sigil_quote!`: bodies properly indented, `elseif` works, table `{...}` renders correctly
- [x] Python `elif` recognized as control-flow continuation
- [x] C# `foreach` control flow unaffected
- [x] No regressions in existing languages

## Known limitations
- `repeat/until` is not supported via control-flow API — `end_control_flow()` emits `end` before `until`. Workaround: use `$>`/`$<` indentation directives or manual formatting