### PR TITLE
fix: don't escape reserved-word field names in TypeScript

### DIFF
--- a/src/lang/mod.rs
+++ b/src/lang/mod.rs
@@ -194,6 +194,12 @@ pub trait CodeLang: std::fmt::Debug + 'static {
         }
     }
 
+    /// Escape a field/property name. Languages where property names never
+    /// conflict with reserved words (e.g. TypeScript) can return the name as-is.
+    fn escape_field_name(&self, name: &str) -> String {
+        self.escape_reserved(name)
+    }
+
     // ── Optional — override only for unusual languages ────────────
 
     /// Qualify an import name for rendering in code.

--- a/src/lang/typescript.rs
+++ b/src/lang/typescript.rs
@@ -168,6 +168,10 @@ impl CodeLang for TypeScript {
         TS_RESERVED
     }
 
+    fn escape_field_name(&self, name: &str) -> String {
+        name.to_string()
+    }
+
     fn render_imports(&self, imports: &ImportGroup) -> String {
         let mut lines = Vec::new();
         let quote = self.quote_style.char();

--- a/src/spec/field_spec.rs
+++ b/src/spec/field_spec.rs
@@ -179,7 +179,7 @@ impl FieldSpec {
                 fmt.push(' ');
             }
             fmt.push_str(name_prefix);
-            fmt.push_str(&lang.escape_reserved(&self.name));
+            fmt.push_str(&lang.escape_field_name(&self.name));
             fmt.push_str(name_suffix);
         } else {
             // TS/Rust/Go/Python-style: name sep type
@@ -191,7 +191,7 @@ impl FieldSpec {
                     fmt.push_str(mk);
                 }
             }
-            fmt.push_str(&lang.escape_reserved(&self.name));
+            fmt.push_str(&lang.escape_field_name(&self.name));
             fmt.push_str(name_suffix);
 
             // Skip type annotation when the type is empty (e.g., Python enum members).

--- a/src/spec/property_spec.rs
+++ b/src/spec/property_spec.rs
@@ -210,7 +210,7 @@ impl PropertySpec {
             sig.push_str(lang.enum_and_annotation().readonly_keyword);
         }
 
-        sig.push_str(&lang.escape_reserved(&self.name));
+        sig.push_str(&lang.escape_field_name(&self.name));
 
         if !self.property_type.is_empty() {
             sig.push_str(lang.type_decl_syntax().type_annotation_separator);

--- a/tests/field_spec_tests.rs
+++ b/tests/field_spec_tests.rs
@@ -184,3 +184,23 @@ fn test_javascript_optional_field_is_ignored() {
         "JS output must not contain '?': {out:?}"
     );
 }
+
+#[test]
+fn test_ts_reserved_word_field_not_escaped() {
+    let field = FieldSpec::builder("type", TypeName::primitive("string"))
+        .is_readonly()
+        .build()
+        .unwrap();
+    let out = emit_field_ts(&field, DeclarationContext::Member);
+    assert_eq!(out.trim(), "readonly type: string;");
+}
+
+#[test]
+fn test_go_reserved_word_field_is_escaped() {
+    use sigil_stitch::lang::go_lang::GoLang;
+    let field = FieldSpec::builder("type", TypeName::primitive("string"))
+        .build()
+        .unwrap();
+    let out = emit_for(&GoLang::new(), &field, DeclarationContext::Member);
+    assert_eq!(out.trim(), "type_ string");
+}


### PR DESCRIPTION
## Summary

- Adds `escape_field_name` method to the `CodeLang` trait (defaults to `escape_reserved`)
- TypeScript overrides it to return names unchanged — property names in interfaces/objects never conflict with reserved words
- Updates `FieldSpec` and `PropertySpec` to use `escape_field_name` instead of `escape_reserved`
- Fixes: `{ readonly type: string }` no longer renders as `{ readonly type_: string }`

## Test plan

- [x] `test_ts_reserved_word_field_not_escaped` — asserts `readonly type: string;`
- [x] `test_go_reserved_word_field_is_escaped` — asserts Go still escapes to `type_ string`
- [x] Full test suite passes (1000+ tests, no regressions)