### PR TITLE
docs: add C# and Lua to mdbook and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ See [Building Functions & Fields](docs/src/functions_and_fields.md), [Building T
 | OCaml      | `.ml`     | no         | `open` module      |
 | C          | `.c`      | yes        | `#include`         |
 | C++        | `.cpp`    | yes        | `#include`/`using` |
+| C#         | `.cs`     | yes        | `using` namespace  |
+| Lua        | `.lua`    | no         | `require()`        |
 | Bash       | `.bash`   | no         | `source`           |
 | Zsh        | `.zsh`    | no         | `source`           |
 

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -21,6 +21,8 @@
   - [Swift](cookbook_swift.md)
   - [C++](cookbook_cpp.md)
   - [C](cookbook_c.md)
+  - [C#](cookbook_csharp.md)
+  - [Lua](cookbook_lua.md)
   - [Scala](cookbook_scala.md)
   - [Haskell](cookbook_haskell.md)
   - [OCaml](cookbook_ocaml.md)

--- a/docs/src/cookbook_csharp.md
+++ b/docs/src/cookbook_csharp.md
@@ -1,0 +1,180 @@
+# C# Cookbook
+
+Practical, copy-paste-ready recipes for C# code generation. For the full API of each spec type, see [Building Functions & Fields](functions_and_fields.md), [Building Types & Enums](types_and_enums.md), and [Files & Projects](files_and_projects.md).
+
+## Class with XML doc
+
+```rust,ignore
+use sigil_stitch::prelude::*;
+use sigil_stitch::lang::csharp::CSharp;
+
+let body = CodeBlock::of("return $\"Hello, {name}!\";", ()).unwrap();
+
+let ts = TypeSpec::builder("Greeter", TypeKind::Class)
+    .visibility(Visibility::Public)
+    .add_method(
+        FunSpec::builder("Greet")
+            .visibility(Visibility::Public)
+            .returns(TypeName::primitive("string"))
+            .add_param(ParameterSpec::new("name", TypeName::primitive("string")).unwrap())
+            .doc("<summary>\nGreets a user by name.\n</summary>\n<param name=\"name\">The name to greet.</param>\n<returns>A greeting string.</returns>")
+            .body(body)
+            .build()
+            .unwrap(),
+    )
+    .build()
+    .unwrap();
+
+let file = FileSpec::builder_with("Greeter.cs", CSharp::new())
+    .add_type(ts)
+    .build()
+    .unwrap();
+let output = file.render(80).unwrap();
+```
+
+```csharp
+public class Greeter {
+    /// <summary>
+    /// Greets a user by name.
+    /// </summary>
+    /// <param name="name">The name to greet.</param>
+    /// <returns>A greeting string.</returns>
+    public string Greet(string name) {
+        return $"Hello, {name}!";
+    }
+}
+```
+
+## Interface
+
+```rust,ignore
+use sigil_stitch::prelude::*;
+use sigil_stitch::lang::csharp::CSharp;
+
+let ts = TypeSpec::builder("IRepository", TypeKind::Interface)
+    .visibility(Visibility::Public)
+    .add_type_param(TypeParamSpec::new("T"))
+    .doc("Generic data repository.")
+    .add_method(
+        FunSpec::builder("FindById")
+            .returns(TypeName::primitive("T"))
+            .add_param(ParameterSpec::new("id", TypeName::primitive("string")).unwrap())
+            .build()
+            .unwrap(),
+    )
+    .add_method(
+        FunSpec::builder("Save")
+            .returns(TypeName::primitive("void"))
+            .add_param(ParameterSpec::new("entity", TypeName::primitive("T")).unwrap())
+            .build()
+            .unwrap(),
+    )
+    .build()
+    .unwrap();
+
+let file = FileSpec::builder_with("IRepository.cs", CSharp::new())
+    .add_type(ts)
+    .build()
+    .unwrap();
+let output = file.render(80).unwrap();
+```
+
+```csharp
+/// Generic data repository.
+public interface IRepository<T> {
+    internal T FindById(string id);
+
+    internal void Save(T entity);
+}
+```
+
+## Enum
+
+```rust,ignore
+use sigil_stitch::prelude::*;
+use sigil_stitch::lang::csharp::CSharp;
+
+let ts = TypeSpec::builder("Direction", TypeKind::Enum)
+    .visibility(Visibility::Public)
+    .add_variant(EnumVariantSpec::new("North").unwrap())
+    .add_variant(
+        EnumVariantSpec::builder("South")
+            .value(CodeBlock::of("1", ()).unwrap())
+            .build()
+            .unwrap(),
+    )
+    .add_variant(
+        EnumVariantSpec::builder("East")
+            .value(CodeBlock::of("2", ()).unwrap())
+            .build()
+            .unwrap(),
+    )
+    .add_variant(
+        EnumVariantSpec::builder("West")
+            .value(CodeBlock::of("3", ()).unwrap())
+            .build()
+            .unwrap(),
+    )
+    .build()
+    .unwrap();
+
+let file = FileSpec::builder_with("Direction.cs", CSharp::new())
+    .add_type(ts)
+    .build()
+    .unwrap();
+let output = file.render(80).unwrap();
+```
+
+```csharp
+public enum Direction {
+    North,
+    South = 1,
+    East = 2,
+    West = 3
+}
+```
+
+## Async method with imports
+
+```rust,ignore
+use sigil_stitch::prelude::*;
+use sigil_stitch::lang::csharp::CSharp;
+
+let task_user = TypeName::importable("System.Threading.Tasks", "Task<User>");
+let user = TypeName::importable("MyApp.Models", "User");
+
+let body = CodeBlock::of("return await repo.GetByIdAsync(id);", ()).unwrap();
+
+let fun = FunSpec::builder("GetUserAsync")
+    .visibility(Visibility::Public)
+    .is_async()
+    .returns(task_user)
+    .add_param(ParameterSpec::new("id", TypeName::primitive("string")).unwrap())
+    .body(body)
+    .build()
+    .unwrap();
+
+let ts = TypeSpec::builder("UserService", TypeKind::Class)
+    .visibility(Visibility::Public)
+    .add_method(fun)
+    .build()
+    .unwrap();
+
+let file = FileSpec::builder_with("UserService.cs", CSharp::new())
+    .add_type(ts)
+    .build()
+    .unwrap();
+let output = file.render(80).unwrap();
+```
+
+```csharp
+using System.Threading.Tasks;
+
+using MyApp.Models;
+
+public class UserService {
+    public async Task<User> GetUserAsync(string id) {
+        return await repo.GetByIdAsync(id);
+    }
+}
+```

--- a/docs/src/cookbook_lua.md
+++ b/docs/src/cookbook_lua.md
@@ -1,0 +1,122 @@
+# Lua Cookbook
+
+Practical, copy-paste-ready recipes for Lua code generation. For the full API of each spec type, see [Building Functions & Fields](functions_and_fields.md), [Building Types & Enums](types_and_enums.md), and [Files & Projects](files_and_projects.md).
+
+Lua is an end-delimited language (`end` instead of `}`). sigil-stitch handles this via `close_on_transition: false` in its block syntax config -- you get correct `if/elseif/else ... end` without spurious `end` before `else`. Since Lua has no type system, you'll mostly use `CodeBlock` directly and `sigil_quote!` rather than `TypeSpec`.
+
+## Function
+
+```rust,ignore
+use sigil_stitch::prelude::*;
+use sigil_stitch::lang::lua::Lua;
+
+let body = sigil_quote!(Lua {
+    function greet(name) {
+        return "Hello, "..name
+    }
+}).unwrap();
+
+let file = FileSpec::builder_with("greeter.lua", Lua::new())
+    .add_code(body)
+    .build()
+    .unwrap();
+let output = file.render(80).unwrap();
+```
+
+```lua
+function greet(name)
+  return "Hello, "..name
+end
+```
+
+## Module with require
+
+Use `TypeName::importable` to track Lua `require()` imports. The module path is converted to a slash-separated path in the `require()` call.
+
+```rust,ignore
+use sigil_stitch::prelude::*;
+use sigil_stitch::lang::lua::Lua;
+
+let json = TypeName::importable("dkjson", "json");
+let inspect = TypeName::importable("inspect", "inspect");
+
+let mut cb = CodeBlock::builder();
+cb.add_statement("-- %T %T", (json, inspect));
+let block = cb.build().unwrap();
+
+let file = FileSpec::builder_with("app.lua", Lua::new())
+    .add_code(block)
+    .build()
+    .unwrap();
+let output = file.render(80).unwrap();
+```
+
+```lua
+local json = require("dkjson");
+local inspect = require("inspect");
+
+-- json inspect
+```
+
+## Control flow with sigil_quote!
+
+`sigil_quote!` supports `if/elseif/else`, `for/do`, and `while/do` blocks. Use `{` and `}` in the macro to delimit bodies -- they render as indented blocks closed by `end`.
+
+```rust,ignore
+use sigil_stitch::prelude::*;
+use sigil_stitch::lang::lua::Lua;
+
+let block = sigil_quote!(Lua {
+    if x > 0 then {
+        return $S("positive")
+    } elseif x < 0 then {
+        return $S("negative")
+    } else {
+        return $S("zero")
+    }
+}).unwrap();
+
+let file = FileSpec::builder_with("classify.lua", Lua::new())
+    .add_code(block)
+    .build()
+    .unwrap();
+let output = file.render(80).unwrap();
+```
+
+```lua
+if x > 0 then
+  return "positive"
+elseif x < 0 then
+  return "negative"
+else
+  return "zero"
+end
+```
+
+## Table constructor with sigil_quote!
+
+Braces after `=` or in assignments are recognized as table constructors (not control flow). No `end` is emitted -- the braces render as literal `{...}`.
+
+```rust,ignore
+use sigil_stitch::prelude::*;
+use sigil_stitch::lang::lua::Lua;
+
+let block = sigil_quote!(Lua {
+    local user = {
+        name = $S("Bob"),
+        age = 42,
+    }
+    print(user.name)
+}).unwrap();
+
+let file = FileSpec::builder_with("user.lua", Lua::new())
+    .add_code(block)
+    .build()
+    .unwrap();
+let output = file.render(80).unwrap();
+```
+
+```lua
+local user = {name = "Bob", age = 42,}
+print(user.name)
+```

--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -154,6 +154,8 @@ let ts = TypeScript::new()
 | `Kotlin`     | n/a | yes | n/a | yes (e.g. `kts`) |
 | `Swift`      | n/a | yes | n/a | yes |
 | `DartLang`   | n/a | yes | n/a | yes |
+| `CSharp`     | n/a | yes | n/a | yes |
+| `Lua`        | n/a | yes | n/a | yes |
 | `CLang`      | n/a | yes | n/a | yes (e.g. `h`) |
 | `CppLang`    | n/a | yes | n/a | yes (e.g. `hpp`, `cxx`) |
 | `Bash`       | n/a | yes | n/a | yes (e.g. `sh`) |

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -43,7 +43,7 @@ and the same code blocks produce different layouts for different widths.
 languages: string delimiters, statement terminators, import syntax, visibility keywords,
 type formatting, annotation style, and more. sigil-stitch ships with implementations
 for TypeScript, JavaScript, Rust, Go, Python, Java, Kotlin, Swift, Dart, Scala,
-Haskell, OCaml, C, C++, Bash, and Zsh.
+Haskell, OCaml, C, C++, C#, Lua, Bash, and Zsh.
 The same `CodeBlock`, `TypeName`, and `Spec` types work across all of them -- only the
 language passed to `render()` changes.
 

--- a/docs/src/language_cookbook.md
+++ b/docs/src/language_cookbook.md
@@ -13,6 +13,8 @@ This chapter collects practical, copy-paste-ready recipes for each supported lan
 - [Swift](cookbook_swift.md) -- struct with protocol conformance, enum, enum with associated values, protocol
 - [C++](cookbook_cpp.md) -- class with template, using alias, enum class, virtual method, namespace wrapping
 - [C](cookbook_c.md) -- typedef, struct with fields, function declaration, enum
+- [C#](cookbook_csharp.md) -- class with XML doc, interface, enum, record with imports
+- [Lua](cookbook_lua.md) -- function, module with require, control flow, table constructor
 - [Scala](cookbook_scala.md) -- case class, trait with type parameter, enum, bounded type parameter, newtype
 - [Haskell](cookbook_haskell.md) -- data record with deriving, type class, function with split signature, newtype, type alias
 - [OCaml](cookbook_ocaml.md) -- record type, function with curried params, module block, type alias, pattern match
@@ -27,6 +29,8 @@ The same logical concept -- a simple data type with two fields -- rendered acros
 | Rust       | `pub struct Point { pub x: f64, pub y: f64, }` + separate `impl` block |
 | Go         | `type Point struct { X float64; Y float64 }` |
 | Python     | `class Point: x: float; y: float` |
+| C#         | `public class Point { public double X; public double Y; }` |
+| Lua        | (no type system -- use `CodeBlock` directly for table constructors) |
 | Scala      | `case class Point(x: Double, y: Double)` |
 | Haskell    | `data Point = Point { pointX :: Double, pointY :: Double }` |
 | OCaml      | `type point = { x : float; y : float }` |


### PR DESCRIPTION
## Summary

- Add `cookbook_csharp.md` (4 recipes: class with XML doc, interface, enum, async method with imports)
- Add `cookbook_lua.md` (4 recipes: function, module with require, control flow, table constructor)
- Update supported-languages table in README (add C# and Lua rows)
- Update `introduction.md`, `getting_started.md`, `SUMMARY.md`, and `language_cookbook.md` to list both new languages

## Test plan

- [x] `mdbook build` succeeds with no errors
- [x] All SUMMARY.md links resolve to existing files
- [x] Full test suite passes (no golden file regressions)