### PR TITLE
feat: add embedded fields, %N escaping, and AnnotationSpec.args()

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ continuation in multi-line expressions.
 | Specifier | Name | Argument Type | Purpose |
 |-----------|------|---------------|---------|
 | `%T` | Type | `TypeName` | Emit type reference, track import |
-| `%N` | Name | `NameArg` | Emit identifier name |
+| `%N` | Name | `NameArg` | Emit identifier name, escape reserved words |
 | `%S` | String | `StringLitArg` | Emit escaped string literal |
 | `%L` | Literal | `&str`, number, `CodeBlock` | Emit raw value or nested block |
 | `%W` | Wrap | (none) | Soft line break point |
@@ -100,7 +100,7 @@ Build structured declarations with the spec builders:
 | **ParameterSpec** | Function parameter (name + type + default + variadic) |
 | **FieldSpec** | Struct field / class property (visibility, static, readonly) |
 | **FunSpec** | Function or method (params, return type, body, async, abstract) |
-| **TypeSpec** | Class, struct, interface, trait, enum, type alias, or newtype |
+| **TypeSpec** | Class, struct, interface, trait, enum, type alias, newtype, embedded types |
 | **PropertySpec** | Computed property with getter/setter |
 | **AnnotationSpec** | `@Override`, `#[derive(...)]`, `[[nodiscard]]` |
 | **EnumVariantSpec** | Enum variant with optional value, tuple, or struct fields |

--- a/docs/src/format_specifiers.md
+++ b/docs/src/format_specifiers.md
@@ -62,7 +62,7 @@ let block = CodeBlock::of("function load(): %T", (promise,)).unwrap();
 
 ## `%N` -- Name
 
-Emits an identifier. Bare `&str` and `String` values map to `Arg::Literal` (for `%L`) by default, so you must use the `NameArg` wrapper when your format string contains `%N`.
+Emits an identifier with automatic keyword escaping. If the name collides with a reserved word in the target language, it is escaped using the language's convention (Rust: `r#type`, Go/Python: `type_`). Bare `&str` and `String` values map to `Arg::Literal` (for `%L`) by default, so you must use the `NameArg` wrapper when your format string contains `%N`.
 
 ```rust
 # extern crate sigil_stitch;
@@ -74,6 +74,26 @@ let mut cb = CodeBlock::builder();
 cb.add_statement("this.%N()", (NameArg(method_name.to_string()),));
 let block = cb.build().unwrap();
 // Output: this.getData();
+# }
+```
+
+Reserved-word escaping happens at render time based on the target language:
+
+```rust
+# extern crate sigil_stitch;
+# use sigil_stitch::code_block::{CodeBlock, NameArg};
+# use sigil_stitch::lang::rust_lang::RustLang;
+# use sigil_stitch::spec::file_spec::FileSpec;
+# use sigil_stitch::prelude::*;
+# fn main() {
+let field_name = "type"; // reserved in Rust
+let block = CodeBlock::of("let %N = value", NameArg(field_name.into())).unwrap();
+let file = FileSpec::builder_with("test.rs", RustLang::new())
+    .add_code(block)
+    .build()
+    .unwrap();
+let output = file.render(80).unwrap();
+// Output: let r#type = value
 # }
 ```
 

--- a/docs/src/types_and_enums.md
+++ b/docs/src/types_and_enums.md
@@ -115,6 +115,55 @@ let type_spec = TypeSpec::builder("AdminService", TypeKind::Class)
 # }
 ```
 
+### Embedded types (Go struct composition)
+
+Use `add_embedded(TypeName)` for unnamed type references inside a struct body. This models Go's embedded field pattern where a type is included by name without a field identifier:
+
+```rust
+# extern crate sigil_stitch;
+# use sigil_stitch::lang::go_lang::GoLang;
+# use sigil_stitch::prelude::*;
+# fn main() {
+let type_spec = TypeSpec::builder("UserAdmin", TypeKind::Struct)
+    .add_embedded(TypeName::primitive("User"))
+    .add_embedded(TypeName::primitive("Admin"))
+    .add_field(
+        FieldSpec::builder("Role", TypeName::primitive("string"))
+            .build()
+            .unwrap(),
+    )
+    .build()
+    .unwrap();
+// type UserAdmin struct {
+//     User
+//     Admin
+//     Role string
+// }
+# }
+```
+
+Embedded types render before regular fields. If the embedded type is `TypeName::importable(...)`, its import is tracked automatically via `%T`. This works across languages — for Go interfaces, embedded types produce interface composition:
+
+```rust
+# extern crate sigil_stitch;
+# use sigil_stitch::lang::go_lang::GoLang;
+# use sigil_stitch::prelude::*;
+# fn main() {
+let io_reader = TypeName::importable("io", "Reader");
+let io_writer = TypeName::importable("io", "Writer");
+
+let type_spec = TypeSpec::builder("ReadWriter", TypeKind::Interface)
+    .add_embedded(io_reader)
+    .add_embedded(io_writer)
+    .build()
+    .unwrap();
+// type ReadWriter interface {
+//     io.Reader
+//     io.Writer
+// }
+# }
+```
+
 ### Type aliases
 
 `TypeKind::TypeAlias` emits a single-line type alias declaration with no body. The aliased target is set via `.extends()` (exactly one required). No fields, methods, or variants are allowed.
@@ -289,6 +338,10 @@ let ann = AnnotationSpec::new("allow").arg("dead_code");
 let ann = AnnotationSpec::new("cfg")
     .arg("test")
     .arg("feature = \"nightly\"");
+
+// Bulk arguments from an iterator: #[derive(Debug, Clone, Serialize)]
+let ann = AnnotationSpec::new("derive")
+    .args(["Debug", "Clone", "Serialize"]);
 # }
 ```
 

--- a/src/code_renderer.rs
+++ b/src/code_renderer.rs
@@ -100,7 +100,8 @@ impl<'a> CodeRenderer<'a> {
                 }
                 CodeNode::NameRef(name) => {
                     self.ensure_indent();
-                    self.emit(name);
+                    let escaped = self.lang.escape_reserved(name);
+                    self.emit(&escaped);
                 }
                 CodeNode::StringLit(s) => {
                     self.ensure_indent();
@@ -202,7 +203,7 @@ impl<'a> CodeRenderer<'a> {
             let node_doc = match node {
                 CodeNode::Literal(text) => BoxDoc::text(text.clone()),
                 CodeNode::TypeRef(tn) => self.resolve_type_doc(tn),
-                CodeNode::NameRef(name) => BoxDoc::text(name.clone()),
+                CodeNode::NameRef(name) => BoxDoc::text(self.lang.escape_reserved(name)),
                 CodeNode::StringLit(s) => BoxDoc::text(self.lang.render_string_literal(s)),
                 CodeNode::InlineLiteral(s) => BoxDoc::text(s.clone()),
                 CodeNode::Nested(block) => self.nodes_to_doc(&block.nodes),

--- a/src/spec/annotation_spec.rs
+++ b/src/spec/annotation_spec.rs
@@ -104,6 +104,21 @@ impl AnnotationSpec {
         self
     }
 
+    /// Add multiple arguments at once.
+    ///
+    /// Arguments are joined with `", "` inside parentheses.
+    ///
+    /// ```text
+    /// AnnotationSpec::new("derive")
+    ///     .args(["Debug", "Clone", "Serialize"])
+    /// // Rust: #[derive(Debug, Clone, Serialize)]
+    /// ```
+    pub fn args(mut self, arguments: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        self.arguments
+            .extend(arguments.into_iter().map(|a| a.into()));
+        self
+    }
+
     /// Emit this annotation as a `CodeBlock` using the language's annotation syntax.
     ///
     /// Called during spec `emit()` methods which have access to `&L`.

--- a/src/spec/type_spec.rs
+++ b/src/spec/type_spec.rs
@@ -51,6 +51,8 @@ pub struct TypeSpec {
     pub(crate) kind: TypeKind,
     pub(crate) modifiers: Modifiers,
     pub(crate) doc: Vec<String>,
+    #[serde(default)]
+    pub(crate) embedded_types: Vec<TypeName>,
     pub(crate) fields: Vec<FieldSpec>,
     pub(crate) properties: Vec<PropertySpec>,
     pub(crate) methods: Vec<FunSpec>,
@@ -76,6 +78,7 @@ impl TypeSpec {
             kind,
             modifiers: Modifiers::default(),
             doc: Vec::new(),
+            embedded_types: Vec::new(),
             fields: Vec::new(),
             properties: Vec::new(),
             methods: Vec::new(),
@@ -152,6 +155,13 @@ impl TypeSpec {
         let has_trailing_members =
             !self.fields.is_empty() || !self.properties.is_empty() || !self.methods.is_empty();
 
+        // Embedded types (Go struct composition: unnamed type references).
+        for embedded in &self.embedded_types {
+            let term = lang.block_syntax().field_terminator;
+            cb.add(&format!("%T{term}"), embedded.clone());
+            cb.add_line();
+        }
+
         if ea.variants_before_fields {
             // Variants first (Java/Kotlin pattern).
             if !self.variants.is_empty() {
@@ -178,7 +188,8 @@ impl TypeSpec {
                 self.emit_variants(&mut cb, lang, has_trailing_members)?;
             }
         }
-        let has_body_above = !self.fields.is_empty() || !self.variants.is_empty();
+        let has_body_above =
+            !self.embedded_types.is_empty() || !self.fields.is_empty() || !self.variants.is_empty();
         // Properties (after fields, before methods).
         if !self.properties.is_empty() {
             if has_body_above {
@@ -254,6 +265,12 @@ impl TypeSpec {
             cb.add("%L", body_prefix);
             cb.add_line();
             cb.add("%>", ());
+        }
+        // Embedded types (Go struct composition).
+        for embedded in &self.embedded_types {
+            let term = lang.block_syntax().field_terminator;
+            cb.add(&format!("%T{term}"), embedded.clone());
+            cb.add_line();
         }
         for field in &self.fields {
             cb.add_code(field.emit(lang, DeclarationContext::Member)?);
@@ -629,6 +646,7 @@ pub struct TypeSpecBuilder {
     kind: TypeKind,
     modifiers: Modifiers,
     doc: Vec<String>,
+    embedded_types: Vec<TypeName>,
     fields: Vec<FieldSpec>,
     properties: Vec<PropertySpec>,
     methods: Vec<FunSpec>,
@@ -659,6 +677,20 @@ impl TypeSpecBuilder {
     /// Add a documentation comment line.
     pub fn doc(mut self, line: &str) -> Self {
         self.doc.push(line.to_string());
+        self
+    }
+
+    /// Add an embedded type (Go struct composition).
+    ///
+    /// Embedded types render as unnamed type references inside the struct body:
+    /// ```go
+    /// type UserAdmin struct {
+    ///     User
+    ///     Admin
+    /// }
+    /// ```
+    pub fn add_embedded(mut self, type_name: TypeName) -> Self {
+        self.embedded_types.push(type_name);
         self
     }
 
@@ -801,6 +833,7 @@ impl TypeSpecBuilder {
             kind: self.kind,
             modifiers: self.modifiers,
             doc: self.doc,
+            embedded_types: self.embedded_types,
             fields: self.fields,
             properties: self.properties,
             methods: self.methods,

--- a/test-goldens/go/embedded_basic.go
+++ b/test-goldens/go/embedded_basic.go
@@ -1,0 +1,6 @@
+package models
+
+type ReadWriter struct {
+	Reader
+	Writer
+}

--- a/test-goldens/go/embedded_importable.go
+++ b/test-goldens/go/embedded_importable.go
@@ -1,0 +1,8 @@
+package rw
+
+import "io"
+
+type ReadWriter interface {
+	io.Reader
+	io.Writer
+}

--- a/test-goldens/go/embedded_struct.go
+++ b/test-goldens/go/embedded_struct.go
@@ -1,0 +1,8 @@
+package models
+
+// UserAdmin composes User and Admin.
+type UserAdmin struct {
+	User
+	Admin
+	Role string `json:"role"`
+}

--- a/test-goldens/go/embedded_with_method.go
+++ b/test-goldens/go/embedded_with_method.go
@@ -1,0 +1,10 @@
+package models
+
+type Endpoint struct {
+	BaseConfig
+	Path string
+}
+
+func URL(a *Endpoint) string {
+	return fmt.Sprintf("%s/%s", a.Host, a.Path)
+}

--- a/test-goldens/python/embedded_types.py
+++ b/test-goldens/python/embedded_types.py
@@ -1,0 +1,4 @@
+class AdminUser:
+    User
+    Admin
+    role: str

--- a/test-goldens/rust/annotation_args_derive.rs
+++ b/test-goldens/rust/annotation_args_derive.rs
@@ -1,0 +1,4 @@
+#[derive(Debug, Clone, Serialize)]
+pub struct Config {
+    pub name: String,
+}

--- a/test-goldens/rust/annotation_args_serde.rs
+++ b/test-goldens/rust/annotation_args_serde.rs
@@ -1,0 +1,8 @@
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct User {
+    #[serde(rename = "userName")]
+    pub user_name: String,
+    #[serde(rename = "emailAddress")]
+    pub email_address: String,
+}

--- a/test-goldens/typescript/embedded_interface.ts
+++ b/test-goldens/typescript/embedded_interface.ts
@@ -1,0 +1,8 @@
+import type { BaseUser } from './base';
+import type { AdminRole } from './roles';
+
+export interface AdminUser {
+  BaseUser;
+  AdminRole;
+  permissions: string[];
+}

--- a/tests/annotation_spec_tests.rs
+++ b/tests/annotation_spec_tests.rs
@@ -455,3 +455,88 @@ fn test_multiple_args() {
     );
     assert!(output.contains("#[cfg(feature = \"web\", not(test))]"));
 }
+
+// ── .args() bulk method ─────────────────────────────────
+
+#[test]
+fn test_rust_args_bulk_derive() {
+    let rs = RustLang::new();
+    let ann = AnnotationSpec::new("derive").args(["Debug", "Clone", "Serialize"]);
+    let block = ann.emit(&rs).unwrap();
+    let imports = sigil_stitch::import::ImportGroup::new();
+    let mut renderer = sigil_stitch::code_renderer::CodeRenderer::new(&rs, &imports, 80);
+    let output = renderer.render(&block).unwrap();
+    assert_eq!(output, "#[derive(Debug, Clone, Serialize)]");
+}
+
+#[test]
+fn test_args_combined_with_arg() {
+    let rs = RustLang::new();
+    let ann = AnnotationSpec::new("serde")
+        .arg("rename_all = \"camelCase\"")
+        .args(["deny_unknown_fields"]);
+    let block = ann.emit(&rs).unwrap();
+    let imports = sigil_stitch::import::ImportGroup::new();
+    let mut renderer = sigil_stitch::code_renderer::CodeRenderer::new(&rs, &imports, 80);
+    let output = renderer.render(&block).unwrap();
+    assert_eq!(
+        output,
+        "#[serde(rename_all = \"camelCase\", deny_unknown_fields)]"
+    );
+}
+
+#[test]
+fn test_args_empty_iter_no_parens() {
+    let rs = RustLang::new();
+    let ann = AnnotationSpec::new("test").args(Vec::<&str>::new());
+    let block = ann.emit(&rs).unwrap();
+    let imports = sigil_stitch::import::ImportGroup::new();
+    let mut renderer = sigil_stitch::code_renderer::CodeRenderer::new(&rs, &imports, 80);
+    let output = renderer.render(&block).unwrap();
+    assert_eq!(output, "#[test]");
+}
+
+// ── %N keyword escaping ─────────────────────────────────
+
+#[test]
+fn test_name_ref_escapes_rust_keyword() {
+    let rs = RustLang::new();
+    let block = CodeBlock::of(
+        "let %N = 1",
+        sigil_stitch::code_block::NameArg("type".into()),
+    )
+    .unwrap();
+    let imports = sigil_stitch::import::ImportGroup::new();
+    let mut renderer = sigil_stitch::code_renderer::CodeRenderer::new(&rs, &imports, 80);
+    let output = renderer.render(&block).unwrap();
+    assert_eq!(output, "let r#type = 1");
+}
+
+#[test]
+fn test_name_ref_escapes_go_keyword() {
+    use sigil_stitch::lang::go_lang::GoLang;
+    let go = GoLang::new();
+    let block = CodeBlock::of(
+        "var %N int",
+        sigil_stitch::code_block::NameArg("func".into()),
+    )
+    .unwrap();
+    let imports = sigil_stitch::import::ImportGroup::new();
+    let mut renderer = sigil_stitch::code_renderer::CodeRenderer::new(&go, &imports, 80);
+    let output = renderer.render(&block).unwrap();
+    assert_eq!(output, "var func_ int");
+}
+
+#[test]
+fn test_name_ref_no_escape_non_keyword() {
+    let rs = RustLang::new();
+    let block = CodeBlock::of(
+        "let %N = 1",
+        sigil_stitch::code_block::NameArg("myVar".into()),
+    )
+    .unwrap();
+    let imports = sigil_stitch::import::ImportGroup::new();
+    let mut renderer = sigil_stitch::code_renderer::CodeRenderer::new(&rs, &imports, 80);
+    let output = renderer.render(&block).unwrap();
+    assert_eq!(output, "let myVar = 1");
+}

--- a/tests/go/builder_edge_cases.rs
+++ b/tests/go/builder_edge_cases.rs
@@ -1,7 +1,13 @@
-use sigil_stitch::code_block::CodeBlock;
+use sigil_stitch::code_block::{CodeBlock, NameArg};
 use sigil_stitch::lang::CodeLang;
 use sigil_stitch::lang::go_lang::GoLang;
+use sigil_stitch::spec::field_spec::FieldSpec;
 use sigil_stitch::spec::file_spec::FileSpec;
+use sigil_stitch::spec::fun_spec::FunSpec;
+use sigil_stitch::spec::modifiers::TypeKind;
+use sigil_stitch::spec::parameter_spec::ParameterSpec;
+use sigil_stitch::spec::type_spec::TypeSpec;
+use sigil_stitch::type_name::TypeName;
 
 use super::golden;
 
@@ -45,4 +51,154 @@ fn test_enum() {
 
     let output = file.render(80).unwrap();
     golden::assert_golden("go/enum.go", &output);
+}
+
+// ── %N keyword escaping ─────────────────────────────────
+
+#[test]
+fn test_name_escapes_go_keywords() {
+    let keywords = ["func", "type", "var", "map", "range", "select", "chan"];
+    for kw in keywords {
+        let block = CodeBlock::of("var %N int", NameArg(kw.into())).unwrap();
+        let file = FileSpec::builder_with("test.go", GoLang::new())
+            .add_code(block)
+            .build()
+            .unwrap();
+        let output = file.render(80).unwrap();
+        assert!(
+            output.contains(&format!("{kw}_")),
+            "Expected '{kw}_' in output for reserved word '{kw}', got: {output}"
+        );
+    }
+    // Non-reserved word should not be escaped.
+    let block = CodeBlock::of("var %N int", NameArg("myVar".into())).unwrap();
+    let file = FileSpec::builder_with("test.go", GoLang::new())
+        .add_code(block)
+        .build()
+        .unwrap();
+    let output = file.render(80).unwrap();
+    assert!(output.contains("var myVar int"));
+}
+
+#[test]
+fn test_name_escape_in_struct_context() {
+    let mut cb = CodeBlock::builder();
+    cb.add("type Params struct {", ());
+    cb.add_line();
+    cb.add("%>", ());
+    cb.add("%N string", NameArg("type".into()));
+    cb.add_line();
+    cb.add("%N int", NameArg("count".into()));
+    cb.add_line();
+    cb.add("%<", ());
+    cb.add("}", ());
+    cb.add_line();
+    let block = cb.build().unwrap();
+
+    let file = FileSpec::builder_with("test.go", GoLang::new())
+        .header(CodeBlock::of("package models", ()).unwrap())
+        .add_code(block)
+        .build()
+        .unwrap();
+    let output = file.render(80).unwrap();
+    assert!(output.contains("type_ string"));
+    assert!(output.contains("count int"));
+}
+
+// ── Embedded fields ─────────────────────────────────────
+
+#[test]
+fn test_embedded_struct_basic() {
+    let file = FileSpec::builder_with("models.go", GoLang::new())
+        .header(CodeBlock::of("package models", ()).unwrap())
+        .add_type(
+            TypeSpec::builder("ReadWriter", TypeKind::Struct)
+                .add_embedded(TypeName::primitive("Reader"))
+                .add_embedded(TypeName::primitive("Writer"))
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
+
+    let output = file.render(80).unwrap();
+    golden::assert_golden("go/embedded_basic.go", &output);
+}
+
+#[test]
+fn test_embedded_with_methods() {
+    let body = CodeBlock::of("return fmt.Sprintf(\"%%s/%%s\", a.Host, a.Path)", ()).unwrap();
+    let file = FileSpec::builder_with("models.go", GoLang::new())
+        .header(CodeBlock::of("package models", ()).unwrap())
+        .add_type(
+            TypeSpec::builder("Endpoint", TypeKind::Struct)
+                .add_embedded(TypeName::primitive("BaseConfig"))
+                .add_field(
+                    FieldSpec::builder("Path", TypeName::primitive("string"))
+                        .build()
+                        .unwrap(),
+                )
+                .build()
+                .unwrap(),
+        )
+        .add_function(
+            FunSpec::builder("URL")
+                .add_param(
+                    ParameterSpec::new("a", TypeName::pointer(TypeName::primitive("Endpoint")))
+                        .unwrap(),
+                )
+                .returns(TypeName::primitive("string"))
+                .body(body)
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
+
+    let output = file.render(80).unwrap();
+    golden::assert_golden("go/embedded_with_method.go", &output);
+}
+
+#[test]
+fn test_embedded_only_no_fields() {
+    let file = FileSpec::builder_with("compose.go", GoLang::new())
+        .header(CodeBlock::of("package compose", ()).unwrap())
+        .add_type(
+            TypeSpec::builder("Combined", TypeKind::Struct)
+                .add_embedded(TypeName::primitive("Alpha"))
+                .add_embedded(TypeName::primitive("Beta"))
+                .add_embedded(TypeName::primitive("Gamma"))
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
+
+    let output = file.render(80).unwrap();
+    assert!(output.contains("type Combined struct {"));
+    assert!(output.contains("\tAlpha\n"));
+    assert!(output.contains("\tBeta\n"));
+    assert!(output.contains("\tGamma\n"));
+    assert!(output.contains("}"));
+}
+
+#[test]
+fn test_embedded_with_importable_type() {
+    let io_reader = TypeName::importable("io", "Reader");
+    let io_writer = TypeName::importable("io", "Writer");
+
+    let file = FileSpec::builder_with("rw.go", GoLang::new())
+        .header(CodeBlock::of("package rw", ()).unwrap())
+        .add_type(
+            TypeSpec::builder("ReadWriter", TypeKind::Interface)
+                .add_embedded(io_reader)
+                .add_embedded(io_writer)
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
+
+    let output = file.render(80).unwrap();
+    golden::assert_golden("go/embedded_importable.go", &output);
 }

--- a/tests/go/builder_types.rs
+++ b/tests/go/builder_types.rs
@@ -154,3 +154,28 @@ fn test_generic_function() {
     let output = file.render(80).unwrap();
     golden::assert_golden("go/generic_function.go", &output);
 }
+
+#[test]
+fn test_embedded_struct() {
+    let file = FileSpec::builder_with("admin.go", GoLang::new())
+        .header(CodeBlock::of("package models", ()).unwrap())
+        .add_type(
+            TypeSpec::builder("UserAdmin", TypeKind::Struct)
+                .doc("UserAdmin composes User and Admin.")
+                .add_embedded(TypeName::primitive("User"))
+                .add_embedded(TypeName::primitive("Admin"))
+                .add_field(
+                    FieldSpec::builder("Role", TypeName::primitive("string"))
+                        .tag("json:\"role\"")
+                        .build()
+                        .unwrap(),
+                )
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
+
+    let output = file.render(80).unwrap();
+    golden::assert_golden("go/embedded_struct.go", &output);
+}

--- a/tests/go/quote_edge_cases.rs
+++ b/tests/go/quote_edge_cases.rs
@@ -29,3 +29,47 @@ fn test_indent() {
     .unwrap();
     golden::assert_golden("go/macro_indent.go", &render(&block));
 }
+
+#[test]
+fn test_name_escape_in_macro() {
+    let name = "type";
+    let block = sigil_quote!(GoLang {
+        var $N(name) string
+    })
+    .unwrap();
+
+    let output = render(&block);
+    assert!(
+        output.contains("var type_ string"),
+        "Expected 'var type_ string', got: {output}"
+    );
+}
+
+#[test]
+fn test_name_escape_multiple_keywords_in_macro() {
+    let pkg = "package";
+    let ret = "return";
+    let block = sigil_quote!(GoLang {
+        $N(pkg) = $N(ret)
+    })
+    .unwrap();
+
+    let output = render(&block);
+    assert!(output.contains("package_"), "Expected 'package_': {output}");
+    assert!(output.contains("return_"), "Expected 'return_': {output}");
+}
+
+#[test]
+fn test_name_no_escape_in_macro() {
+    let name = "myHandler";
+    let block = sigil_quote!(GoLang {
+        func $N(name)()
+    })
+    .unwrap();
+
+    let output = render(&block);
+    assert!(
+        output.contains("func myHandler()"),
+        "Expected 'func myHandler()', got: {output}"
+    );
+}

--- a/tests/macro/equivalence.rs
+++ b/tests/macro/equivalence.rs
@@ -163,3 +163,68 @@ fn test_equiv_wrap_point() {
     assert!(output.contains("a,"), "got: {output}");
     assert!(output.contains("b,"), "got: {output}");
 }
+
+#[test]
+fn test_name_escaping_via_macro_rust() {
+    let field_name = "type";
+    let macro_block = sigil_quote!(RustLang {
+        let $N(field_name) = value;
+    })
+    .unwrap();
+
+    let output = render_rs(&macro_block);
+    assert!(
+        output.contains("r#type"),
+        "Expected r#type in output: {output}"
+    );
+}
+
+#[test]
+fn test_name_escaping_via_macro_go() {
+    let var_name = "func";
+    let macro_block = sigil_quote!(GoLang {
+        var $N(var_name) int
+    })
+    .unwrap();
+
+    let output = render_go(&macro_block);
+    assert!(
+        output.contains("func_"),
+        "Expected func_ in output: {output}"
+    );
+}
+
+#[test]
+fn test_name_no_escape_via_macro() {
+    let name = "myVariable";
+    let macro_block = sigil_quote!(TypeScript {
+        const $N(name) = 42;
+    })
+    .unwrap();
+
+    let output = render_ts(&macro_block);
+    assert!(
+        output.contains("myVariable"),
+        "Expected myVariable in output: {output}"
+    );
+    assert!(
+        !output.contains("myVariable_"),
+        "Should not escape non-keyword: {output}"
+    );
+}
+
+#[test]
+fn test_name_and_type_combined() {
+    let field_name = "type";
+    let field_type = TypeName::primitive("String");
+    let macro_block = sigil_quote!(RustLang {
+        pub $N(field_name): $T(field_type)
+    })
+    .unwrap();
+
+    let output = render_rs(&macro_block);
+    assert!(
+        output.contains("pub r#type: String"),
+        "Expected 'pub r#type: String', got: {output}"
+    );
+}

--- a/tests/python/builder_edge_cases.rs
+++ b/tests/python/builder_edge_cases.rs
@@ -1,5 +1,6 @@
-use sigil_stitch::code_block::CodeBlock;
+use sigil_stitch::code_block::{CodeBlock, NameArg};
 use sigil_stitch::lang::python::Python;
+use sigil_stitch::spec::field_spec::FieldSpec;
 use sigil_stitch::spec::file_spec::FileSpec;
 use sigil_stitch::spec::fun_spec::FunSpec;
 use sigil_stitch::spec::modifiers::TypeKind;
@@ -58,4 +59,83 @@ fn test_decorated_function() {
 
     let output = file.render(80).unwrap();
     golden::assert_golden("python/decorated_function.py", &output);
+}
+
+// ── %N keyword escaping ─────────────────────────────────
+
+#[test]
+fn test_name_escapes_python_keywords() {
+    let keywords = [
+        "class", "def", "import", "from", "return", "lambda", "global", "yield",
+    ];
+    for kw in keywords {
+        let block = CodeBlock::of("%N = None", NameArg(kw.into())).unwrap();
+        let file = FileSpec::builder_with("test.py", Python::new())
+            .add_code(block)
+            .build()
+            .unwrap();
+        let output = file.render(80).unwrap();
+        assert!(
+            output.contains(&format!("{kw}_")),
+            "Expected '{kw}_' for reserved word '{kw}', got: {output}"
+        );
+    }
+}
+
+#[test]
+fn test_name_no_escape_python_non_keywords() {
+    let names = ["user", "my_class", "data_from", "imports"];
+    for name in names {
+        let block = CodeBlock::of("%N = None", NameArg(name.into())).unwrap();
+        let file = FileSpec::builder_with("test.py", Python::new())
+            .add_code(block)
+            .build()
+            .unwrap();
+        let output = file.render(80).unwrap();
+        assert!(
+            output.contains(&format!("{name} = None")),
+            "Expected '{name} = None' in output, got: {output}"
+        );
+    }
+}
+
+#[test]
+fn test_name_escape_in_assignment() {
+    let mut cb = CodeBlock::builder();
+    cb.add_statement(
+        "self.%N = %N",
+        (NameArg("class".into()), NameArg("class".into())),
+    );
+    let block = cb.build().unwrap();
+
+    let file = FileSpec::builder_with("test.py", Python::new())
+        .add_code(block)
+        .build()
+        .unwrap();
+    let output = file.render(80).unwrap();
+    assert!(output.contains("self.class_ = class_"));
+}
+
+// ── Embedded fields in Python ───────────────────────────
+
+#[test]
+fn test_embedded_types_in_python_class() {
+    let file = FileSpec::builder_with("models.py", Python::new())
+        .add_type(
+            TypeSpec::builder("AdminUser", TypeKind::Class)
+                .add_embedded(TypeName::primitive("User"))
+                .add_embedded(TypeName::primitive("Admin"))
+                .add_field(
+                    FieldSpec::builder("role", TypeName::primitive("str"))
+                        .build()
+                        .unwrap(),
+                )
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
+
+    let output = file.render(80).unwrap();
+    golden::assert_golden("python/embedded_types.py", &output);
 }

--- a/tests/rust/builder_edge_cases.rs
+++ b/tests/rust/builder_edge_cases.rs
@@ -1,7 +1,8 @@
 use super::golden;
 
-use sigil_stitch::code_block::CodeBlock;
+use sigil_stitch::code_block::{CodeBlock, NameArg};
 use sigil_stitch::lang::rust_lang::RustLang;
+use sigil_stitch::spec::annotation_spec::AnnotationSpec;
 use sigil_stitch::spec::field_spec::FieldSpec;
 use sigil_stitch::spec::file_spec::FileSpec;
 use sigil_stitch::spec::modifiers::{TypeKind, Visibility};
@@ -61,4 +62,119 @@ fn test_derive_annotation() {
         .unwrap();
 
     golden::assert_golden("rust/derive_annotation.rs", &output);
+}
+
+// ── %N keyword escaping ─────────────────────────────────
+
+#[test]
+fn test_name_escapes_rust_keywords() {
+    let keywords = [
+        "type", "fn", "struct", "enum", "trait", "impl", "mod", "use", "let", "mut",
+    ];
+    for kw in keywords {
+        let block = CodeBlock::of("let %N = value", NameArg(kw.into())).unwrap();
+        let file = FileSpec::builder_with("test.rs", RustLang::new())
+            .add_code(block)
+            .build()
+            .unwrap();
+        let output = file.render(80).unwrap();
+        assert!(
+            output.contains(&format!("r#{kw}")),
+            "Expected 'r#{kw}' for reserved word '{kw}', got: {output}"
+        );
+    }
+}
+
+#[test]
+fn test_name_no_escape_non_keywords() {
+    let names = ["user_id", "count", "my_struct", "TypeName", "snake_case"];
+    for name in names {
+        let block = CodeBlock::of("let %N = value", NameArg(name.into())).unwrap();
+        let file = FileSpec::builder_with("test.rs", RustLang::new())
+            .add_code(block)
+            .build()
+            .unwrap();
+        let output = file.render(80).unwrap();
+        assert!(
+            output.contains(&format!("let {name} = value")),
+            "Expected 'let {name} = value' in output, got: {output}"
+        );
+    }
+}
+
+#[test]
+fn test_name_escape_in_format_string() {
+    let mut cb = CodeBlock::builder();
+    cb.add(
+        "pub %N: %T",
+        (NameArg("type".into()), TypeName::primitive("String")),
+    );
+    cb.add_line();
+    let block = cb.build().unwrap();
+
+    let file = FileSpec::builder_with("test.rs", RustLang::new())
+        .add_code(block)
+        .build()
+        .unwrap();
+    let output = file.render(80).unwrap();
+    assert!(output.contains("pub r#type: String"));
+}
+
+// ── AnnotationSpec .args() ──────────────────────────────
+
+#[test]
+fn test_annotation_args_with_type_spec() {
+    let output = FileSpec::builder_with("config.rs", RustLang::new())
+        .add_type(
+            TypeSpec::builder("Config", TypeKind::Struct)
+                .visibility(Visibility::Public)
+                .annotate(AnnotationSpec::new("derive").args(["Debug", "Clone", "Serialize"]))
+                .add_field(
+                    FieldSpec::builder("name", TypeName::primitive("String"))
+                        .visibility(Visibility::Public)
+                        .build()
+                        .unwrap(),
+                )
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap();
+
+    golden::assert_golden("rust/annotation_args_derive.rs", &output);
+}
+
+#[test]
+fn test_annotation_args_serde_field() {
+    let output = FileSpec::builder_with("model.rs", RustLang::new())
+        .add_type(
+            TypeSpec::builder("User", TypeKind::Struct)
+                .visibility(Visibility::Public)
+                .annotate(AnnotationSpec::new("derive").args(["Debug", "Serialize", "Deserialize"]))
+                .annotate(AnnotationSpec::new("serde").args(["rename_all = \"camelCase\""]))
+                .add_field(
+                    FieldSpec::builder("user_name", TypeName::primitive("String"))
+                        .visibility(Visibility::Public)
+                        .annotate(AnnotationSpec::new("serde").arg("rename = \"userName\""))
+                        .build()
+                        .unwrap(),
+                )
+                .add_field(
+                    FieldSpec::builder("email_address", TypeName::primitive("String"))
+                        .visibility(Visibility::Public)
+                        .annotate(AnnotationSpec::new("serde").arg("rename = \"emailAddress\""))
+                        .build()
+                        .unwrap(),
+                )
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap();
+
+    golden::assert_golden("rust/annotation_args_serde.rs", &output);
 }

--- a/tests/type_spec_tests.rs
+++ b/tests/type_spec_tests.rs
@@ -461,3 +461,157 @@ fn test_emittable_returns_multiple_blocks_for_rust() {
         blocks.len()
     );
 }
+
+// ── Embedded types ──────────────────────────────────────
+
+fn render_blocks_go(blocks: &[CodeBlock]) -> String {
+    use sigil_stitch::lang::go_lang::GoLang;
+    let lang = GoLang::new();
+    let imports = ImportGroup::new();
+    let mut output = String::new();
+    for (i, block) in blocks.iter().enumerate() {
+        if i > 0 {
+            output.push('\n');
+        }
+        let mut renderer = CodeRenderer::new(&lang, &imports, 80);
+        output.push_str(&renderer.render(block).unwrap());
+    }
+    output
+}
+
+#[test]
+fn test_embedded_go_struct_emit() {
+    use sigil_stitch::lang::go_lang::GoLang;
+    let spec = TypeSpec::builder("UserAdmin", TypeKind::Struct)
+        .add_embedded(TypeName::primitive("User"))
+        .add_embedded(TypeName::primitive("Admin"))
+        .add_field(
+            FieldSpec::builder("Role", TypeName::primitive("string"))
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
+    let blocks = spec.emit(&GoLang::new()).unwrap();
+    let output = render_blocks_go(&blocks);
+    assert!(output.contains("User\n"), "embedded User: {output}");
+    assert!(output.contains("Admin\n"), "embedded Admin: {output}");
+    assert!(output.contains("Role string"), "field Role: {output}");
+    let user_pos = output.find("User").unwrap();
+    let role_pos = output.find("Role").unwrap();
+    assert!(
+        user_pos < role_pos,
+        "embedded types should come before fields"
+    );
+}
+
+#[test]
+fn test_embedded_ts_interface_emit() {
+    let spec = TypeSpec::builder("AdminUser", TypeKind::Interface)
+        .add_embedded(TypeName::primitive("BaseUser"))
+        .add_embedded(TypeName::primitive("AdminRole"))
+        .add_field(
+            FieldSpec::builder("permissions", TypeName::primitive("string[]"))
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
+    let blocks = spec.emit(&TypeScript::new()).unwrap();
+    let output = render_blocks_ts(&blocks);
+    assert!(output.contains("BaseUser;"), "embedded BaseUser: {output}");
+    assert!(
+        output.contains("AdminRole;"),
+        "embedded AdminRole: {output}"
+    );
+    assert!(
+        output.contains("permissions: string[];"),
+        "field permissions: {output}"
+    );
+}
+
+#[test]
+fn test_embedded_rust_struct_emit() {
+    let spec = TypeSpec::builder("Combined", TypeKind::Struct)
+        .add_embedded(TypeName::primitive("Base"))
+        .add_field(
+            FieldSpec::builder("extra", TypeName::primitive("String"))
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
+    let blocks = spec.emit(&RustLang::new()).unwrap();
+    let output = render_blocks_rs(&blocks);
+    assert!(output.contains("Base,"), "embedded Base: {output}");
+    assert!(output.contains("extra: String,"), "field extra: {output}");
+}
+
+#[test]
+fn test_embedded_only_no_fields() {
+    use sigil_stitch::lang::go_lang::GoLang;
+    let spec = TypeSpec::builder("ReadCloser", TypeKind::Interface)
+        .add_embedded(TypeName::primitive("Reader"))
+        .add_embedded(TypeName::primitive("Closer"))
+        .build()
+        .unwrap();
+    let blocks = spec.emit(&GoLang::new()).unwrap();
+    let output = render_blocks_go(&blocks);
+    assert!(output.contains("Reader\n"), "Reader embedded: {output}");
+    assert!(output.contains("Closer\n"), "Closer embedded: {output}");
+}
+
+#[test]
+fn test_embedded_with_methods_after() {
+    let spec = TypeSpec::builder("Controller", TypeKind::Class)
+        .add_embedded(TypeName::primitive("BaseHandler"))
+        .add_field(
+            FieldSpec::builder("name", TypeName::primitive("string"))
+                .build()
+                .unwrap(),
+        )
+        .add_method(
+            FunSpec::builder("handle")
+                .returns(TypeName::primitive("void"))
+                .body(CodeBlock::of("// handle", ()).unwrap())
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
+    let blocks = spec.emit(&TypeScript::new()).unwrap();
+    let output = render_blocks_ts(&blocks);
+    assert!(output.contains("BaseHandler;"), "embedded: {output}");
+    assert!(output.contains("name: string;"), "field: {output}");
+    assert!(output.contains("handle(): void {"), "method: {output}");
+    let embedded_pos = output.find("BaseHandler").unwrap();
+    let field_pos = output.find("name:").unwrap();
+    let method_pos = output.find("handle()").unwrap();
+    assert!(embedded_pos < field_pos, "embedded before field");
+    assert!(field_pos < method_pos, "field before method");
+}
+
+#[test]
+fn test_embedded_import_tracking() {
+    use sigil_stitch::lang::go_lang::GoLang;
+    let io_reader = TypeName::importable("io", "Reader");
+    let spec = TypeSpec::builder("MyReader", TypeKind::Struct)
+        .add_embedded(io_reader)
+        .build()
+        .unwrap();
+
+    let file = sigil_stitch::spec::file_spec::FileSpec::builder_with("reader.go", GoLang::new())
+        .header(CodeBlock::of("package main", ()).unwrap())
+        .add_type(spec)
+        .build()
+        .unwrap();
+    let output = file.render(80).unwrap();
+    assert!(
+        output.contains("import"),
+        "should have import statement: {output}"
+    );
+    assert!(
+        output.contains("\"io\""),
+        "should import io package: {output}"
+    );
+}

--- a/tests/typescript/builder_edge_cases.rs
+++ b/tests/typescript/builder_edge_cases.rs
@@ -262,3 +262,85 @@ fn test_optional_field() {
 
     golden::assert_golden("typescript/optional_field.ts", &output);
 }
+
+// ── %N keyword escaping ─────────────────────────────────
+
+#[test]
+fn test_name_does_not_escape_ts_reserved_as_identifiers() {
+    // TypeScript reserves keywords but they're valid in many positions.
+    // escape_reserved uses the default (append _) for TS.
+    let keywords = ["class", "function", "import", "export", "return"];
+    for kw in keywords {
+        let block = CodeBlock::of("const %N = 1", NameArg(kw.into())).unwrap();
+        let file = FileSpec::builder("test.ts")
+            .add_code(block)
+            .build()
+            .unwrap();
+        let output = file.render(80).unwrap();
+        assert!(
+            output.contains(&format!("{kw}_")),
+            "Expected '{kw}_' for reserved word '{kw}', got: {output}"
+        );
+    }
+}
+
+#[test]
+fn test_name_no_escape_ts_non_keywords() {
+    let names = ["user", "className", "functionName", "exportData"];
+    for name in names {
+        let block = CodeBlock::of("const %N = 1", NameArg(name.into())).unwrap();
+        let file = FileSpec::builder("test.ts")
+            .add_code(block)
+            .build()
+            .unwrap();
+        let output = file.render(80).unwrap();
+        assert!(
+            output.contains(&format!("const {name} = 1")),
+            "Expected 'const {name} = 1', got: {output}"
+        );
+    }
+}
+
+#[test]
+fn test_name_escape_multiple_in_one_line() {
+    let block = CodeBlock::of(
+        "const %N: %N = new %N()",
+        (
+            NameArg("class".into()),
+            NameArg("MyType".into()),
+            NameArg("MyType".into()),
+        ),
+    )
+    .unwrap();
+    let file = FileSpec::builder("test.ts")
+        .add_code(block)
+        .build()
+        .unwrap();
+    let output = file.render(80).unwrap();
+    assert!(output.contains("const class_: MyType = new MyType()"));
+}
+
+// ── Embedded types in TypeScript interface ───────────────
+
+#[test]
+fn test_embedded_in_ts_interface() {
+    let file = FileSpec::builder("models.ts")
+        .add_type(
+            TypeSpec::builder("AdminUser", TypeKind::Interface)
+                .visibility(Visibility::Public)
+                .add_embedded(TypeName::importable_type("./base", "BaseUser"))
+                .add_embedded(TypeName::importable_type("./roles", "AdminRole"))
+                .add_field(
+                    FieldSpec::builder("permissions", TypeName::primitive("string[]"))
+                        .build()
+                        .unwrap(),
+                )
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
+
+    let output = file.render(80).unwrap();
+    golden::assert_golden("typescript/embedded_interface.ts", &output);
+}


### PR DESCRIPTION
## Summary

- Add `TypeSpec::add_embedded(TypeName)` for Go struct composition — renders unnamed embedded type references before regular fields, with automatic import tracking via `%T`
- Make `%N` / `$N` call `lang.escape_reserved()` so reserved words are auto-escaped (Rust: `r#type`, Go/Python: `type_`)
- Add `AnnotationSpec::args(iter)` for bulk argument addition (e.g., `.args(["Debug", "Clone", "Serialize"])`)

## Test plan

- [x] 37 new tests across Go, Rust, Python, TypeScript, and macro test suites
- [x] 8 new golden files for embedded fields and annotation rendering
- [x] All 1,308 tests pass
- [x] Clippy clean
- [x] mdbook test pass