### PR TITLE
feat: context-aware block delimiters for Bash/Lua control flow

### DIFF
--- a/docs/src/cookbook_ocaml.md
+++ b/docs/src/cookbook_ocaml.md
@@ -102,7 +102,7 @@ type string_list = string list
 
 ## Pattern match
 
-Pattern matching is built using `CodeBlock` control-flow methods. Use `begin_control_flow` for the outer binding, then `begin_control_flow_with_open` to open the `match` expression with no trailing brace.
+Pattern matching is built using `CodeBlock` control-flow methods. Use `begin_control_flow` for the outer binding and for the `match` expression — the OCaml backend's `block_open_for` automatically suppresses the block opener for `match ... with`.
 
 ```rust
 # extern crate sigil_stitch;
@@ -111,7 +111,7 @@ Pattern matching is built using `CodeBlock` control-flow methods. Use `begin_con
 # fn main() {
 let mut b = CodeBlock::builder();
 b.begin_control_flow("let describe color", ());
-b.begin_control_flow_with_open("match color with", (), "");
+b.begin_control_flow("match color with", ());
 b.add("| Red -> \"red\"", ());
 b.add_line();
 b.add("| Green -> \"green\"", ());

--- a/docs/src/sigil_quote.md
+++ b/docs/src/sigil_quote.md
@@ -40,7 +40,6 @@ It returns `Result<CodeBlock, SigilStitchError>`.
 | `$L(expr)` | `%L` | `impl Into<Arg>` | Literal value or nested code |
 | `$C(expr)` | `%L` | `CodeBlock` | Nested code block |
 | `$W` | `%W` | (none) | Soft line-break point |
-| `$open("text")` | — | (none) | Custom block opener override |
 | `$>` | `%>` | (none) | Increase indent level |
 | `$<` | `%<` | (none) | Decrease indent level |
 | `$$` | `$` | (none) | Literal dollar sign |
@@ -330,23 +329,21 @@ sigil_quote!(TypeScript {
 # }
 ```
 
-## Custom Block Openers (`$open`)
+## Context-Aware Block Delimiters
 
-By default, `{ ... }` in `sigil_quote!` uses the language's `block_syntax().block_open`:
-- Brace languages (TypeScript, Go, etc.): `" {"`
-- Python: `":"`
-- Haskell: `" ="`
-
-Use `$open("text")` immediately before `{` to override the opener for that block:
+By default, `{ ... }` in `sigil_quote!` uses the language's `block_syntax().block_open`.
+Language backends can override the opener and closer per condition via `block_open_for`
+and `block_close_for`. For example, Bash maps `if` → `then`/`fi` and `for` → `do`/`done`,
+while Haskell maps `class` → `where`:
 
 ```rust
 # extern crate sigil_stitch;
 # use sigil_stitch::lang::haskell::Haskell;
 # use sigil_stitch::prelude::*;
 # fn main() -> Result<(), Box<dyn std::error::Error>> {
-// Haskell type class needs " where" instead of the default " ="
+// Haskell type class — block_open_for returns " where" for "class ..."
 sigil_quote!(Haskell {
-    class Functor f $open(" where") {
+    class Functor f {
         fmap :: (a -> b) -> f a -> f b;
     }
 })?;
@@ -361,9 +358,9 @@ sigil_quote!(Haskell {
 # use sigil_stitch::lang::ocaml::OCaml;
 # use sigil_stitch::prelude::*;
 # fn main() -> Result<(), Box<dyn std::error::Error>> {
-// OCaml module block needs " = struct" opener
+// OCaml module — block_open_for returns " = struct" for "module ..."
 sigil_quote!(OCaml {
-    module Foo $open(" = struct") {
+    module Foo {
         let x = 42;
     }
 })?;
@@ -372,8 +369,6 @@ sigil_quote!(OCaml {
 # Ok(())
 # }
 ```
-
-Pass `$open("")` to suppress the block opener entirely.
 
 ## Manual Indent / Dedent (`$>` / `$<`)
 

--- a/examples/bash_codegen.rs
+++ b/examples/bash_codegen.rs
@@ -1,7 +1,9 @@
 //! Generate a Bash script — builder API vs `sigil_quote!` comparison.
 //!
-//! Demonstrates: functions with manual control flow (`if/then/fi`, `for/do/done`),
+//! Demonstrates: functions with control flow (`if/then/fi`, `for/do/done`),
 //! shebang header, `set -euo pipefail`, `source` imports, and string escaping.
+//! The macro approach uses `{ }` blocks that the Bash backend automatically
+//! converts to the correct delimiters (`then`/`fi`, `do`/`done`).
 //!
 //! Run: `cargo run --example bash_codegen`
 
@@ -100,38 +102,27 @@ fn macro_approach() -> String {
         .build()
         .unwrap();
 
-    // Bash control flow (if/then/fi, for/do/done) doesn't map to { } blocks,
-    // so we use CodeBlock::builder with manual indent markers.
+    // With context-aware block delimiters, Bash control flow works with
+    // begin_control_flow/end_control_flow — the backend emits then/fi,
+    // do/done automatically based on the condition text.
     let mut deploy_body = CodeBlock::builder();
-    deploy_body.add("local env=$$1", ());
+    deploy_body.add("local env=$1", ());
     deploy_body.add_line();
     deploy_body.add_line();
-    deploy_body.add("%<", ());
-    deploy_body.add("if [ -z \"$$env\" ]; then", ());
-    deploy_body.add_line();
-    deploy_body.add("%>", ());
+    deploy_body.begin_control_flow("if [ -z \"$env\" ];", ());
     deploy_body.add("log_message \"ERROR\" \"No environment specified\"", ());
     deploy_body.add_line();
     deploy_body.add("return 1", ());
     deploy_body.add_line();
-    deploy_body.add("%<", ());
-    deploy_body.add("fi", ());
+    deploy_body.end_control_flow();
     deploy_body.add_line();
-    deploy_body.add("%>", ());
-    deploy_body.add_line();
-    deploy_body.add("log_message \"INFO\" \"Deploying to $$env\"", ());
+    deploy_body.add("log_message \"INFO\" \"Deploying to $env\"", ());
     deploy_body.add_line();
     deploy_body.add_line();
-    deploy_body.add("%<", ());
-    deploy_body.add("for service in api worker scheduler; do", ());
+    deploy_body.begin_control_flow("for service in api worker scheduler;", ());
+    deploy_body.add("log_message \"INFO\" \"Starting $service\"", ());
     deploy_body.add_line();
-    deploy_body.add("%>", ());
-    deploy_body.add("log_message \"INFO\" \"Starting $$service\"", ());
-    deploy_body.add_line();
-    deploy_body.add("%<", ());
-    deploy_body.add("done", ());
-    deploy_body.add_line();
-    deploy_body.add("%>", ());
+    deploy_body.end_control_flow();
 
     let deploy_fn = FunSpec::builder("deploy")
         .doc("Deploy services to the given environment.")

--- a/examples/lua_codegen.rs
+++ b/examples/lua_codegen.rs
@@ -2,6 +2,8 @@
 //!
 //! Demonstrates: functions with `end` block close, table constructors via
 //! raw CodeBlock, `require` imports, and control flow (`if/then/end`).
+//! The macro approach uses `{ }` blocks that the Lua backend automatically
+//! converts to the correct delimiters (`then`/`end`, `do`/`end`).
 //!
 //! Run: `cargo run --example lua_codegen`
 
@@ -96,33 +98,25 @@ fn macro_approach() -> String {
         .build()
         .unwrap();
 
-    // Lua control flow (if/then/end, for/do/end) doesn't use { } blocks,
-    // so we use CodeBlock::builder with manual indent markers.
-    let mut create_body = CodeBlock::builder();
-    create_body.add("local config = {}", ());
-    create_body.add_line();
-    create_body.add("config.host = host or \"localhost\"", ());
-    create_body.add_line();
-    create_body.add("config.port = port or 8080", ());
-    create_body.add_line();
-    create_body.add_line();
-    create_body.add("%<", ());
-    create_body.add("if config.port < 1024 then", ());
-    create_body.add_line();
-    create_body.add("%>", ());
-    create_body.add("print(\"Warning: privileged port\")", ());
-    create_body.add_line();
-    create_body.add("%<", ());
-    create_body.add("end", ());
-    create_body.add_line();
-    create_body.add("%>", ());
-    create_body.add_line();
-    create_body.add("return config", ());
+    // With context-aware block delimiters, Lua control flow now uses { }
+    // in sigil_quote! — the backend emits then/end, do/end automatically.
+    let create_body = sigil_quote!(Lua {
+        local config = {}
+        config.host = host or "localhost"
+        config.port = port or 8080
+
+        if config.port < 1024 {
+            print("Warning: privileged port")
+        }
+
+        return config
+    })
+    .unwrap();
 
     let create_fn = FunSpec::builder("create_config")
         .add_param(ParameterSpec::new("host", TypeName::primitive("")).unwrap())
         .add_param(ParameterSpec::new("port", TypeName::primitive("")).unwrap())
-        .body(create_body.build().unwrap())
+        .body(create_body)
         .build()
         .unwrap();
 

--- a/examples/macro_features.rs
+++ b/examples/macro_features.rs
@@ -174,11 +174,11 @@ fn line_continuation() {
     println!("{output}");
 }
 
-/// `$open("text")` — custom block opener override.
+/// Context-aware block delimiters — Haskell `class` uses `where` via `block_open_for`.
 fn open_override() {
-    println!("--- $open: Custom Block Opener ---\n");
+    println!("--- Context-Aware Block Opener ---\n");
     let block = sigil_quote!(Haskell {
-        class Functor f $open(" where") {
+        class Functor f {
             fmap :: (a -> b) -> f a -> f b;
         }
     })

--- a/macros/src/codegen.rs
+++ b/macros/src/codegen.rs
@@ -65,15 +65,9 @@ fn generate_statements(statements: &[Statement]) -> Vec<TokenStream> {
                     let body_calls = generate_statements(&branch.body);
 
                     if i == 0 {
-                        if let Some(ref custom_open) = branch.block_open_override {
-                            calls.push(quote! {
-                                __sigil_builder.begin_control_flow_with_open(#fmt, #args_tuple, #custom_open);
-                            });
-                        } else {
-                            calls.push(quote! {
-                                __sigil_builder.begin_control_flow(#fmt, #args_tuple);
-                            });
-                        }
+                        calls.push(quote! {
+                            __sigil_builder.begin_control_flow(#fmt, #args_tuple);
+                        });
                     } else {
                         calls.push(quote! {
                             __sigil_builder.next_control_flow(#fmt, #args_tuple);

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -33,7 +33,6 @@ use proc_macro::TokenStream;
 /// | `$L(expr)` | `%L` | Literal or nested code |
 /// | `$C(expr)` | `%L` | Nested `CodeBlock` |
 /// | `$W` | `%W` | Soft line-break point |
-/// | `$open("text")` | — | Custom block opener (see below) |
 /// | `$>` | `%>` | Increase indent |
 /// | `$<` | `%<` | Decrease indent |
 /// | `$$` | `$` | Literal dollar sign |
@@ -80,19 +79,20 @@ use proc_macro::TokenStream;
 /// })
 /// ```
 ///
-/// ## Custom Block Openers (`$open`)
+/// ## Context-Aware Block Delimiters
 ///
-/// By default, `{ ... }` uses the language's `block_syntax().block_open` (e.g., `" {"` for
-/// brace languages, `":"` for Python, `" ="` for Haskell). Use `$open("text")`
-/// before `{` to override the opener for that block:
+/// By default, `{ ... }` uses the language's `block_syntax().block_open`. Language
+/// backends can override the opener and closer per condition via `block_open_for`
+/// and `block_close_for`. For example, Bash maps `if` → `then`/`fi` and
+/// `for` → `do`/`done`, while Haskell maps `class` → `where`:
 ///
 /// ```ignore
-/// // Haskell type class: "class Functor f where" instead of "class Functor f ="
-/// sigil_quote!(Haskell {
-///     class Functor f $open(" where") {
-///         fmap :: (a -> b) -> f a -> f b;
+/// sigil_quote!(Bash {
+///     if [ -f "$$file" ]; {
+///         echo "found"
 ///     }
 /// })
+/// // renders: if [ -f "$file" ]; then\n    echo "found"\nfi
 /// ```
 ///
 /// ## Limitations

--- a/macros/src/parse/statements.rs
+++ b/macros/src/parse/statements.rs
@@ -73,14 +73,11 @@ pub(super) fn parse_one_statement(
 
             // (Any trailing `$+` in collected is handled by tokens_to_format_inner.)
 
-            // Check for $open("...") at end of collected tokens.
-            let (condition_tokens, block_open_override) = try_extract_open_override(&collected)?;
-
             // Distinguish control-flow `{` from literal `{` (e.g., Lua tables).
             // Brace languages always use `{` for blocks, but end-delimited
             // languages (Lua, Ruby, Elixir) use `{` for table/hash literals
             // and can only detect control flow from surrounding keywords.
-            if !looks_like_control_flow_header(&condition_tokens) {
+            if !looks_like_control_flow_header(&collected) {
                 // Treat as a literal brace group — not control flow.
                 collected.push(tt.clone());
                 prev_end_line = Some(tt.span().end().line);
@@ -89,7 +86,7 @@ pub(super) fn parse_one_statement(
             }
 
             // Control flow detected.
-            return parse_control_flow(tokens, &condition_tokens, g, pos, block_open_override);
+            return parse_control_flow(tokens, &collected, g, pos);
         }
 
         // Line-break detection: split statement when tokens span multiple lines.
@@ -125,72 +122,6 @@ pub(super) fn parse_one_statement(
         let (format, args) = tokens_to_format(&collected)?;
         Ok((Statement::Line { format, args }, pos))
     }
-}
-
-/// Check if the last tokens in `collected` form `$open("text")`.
-/// Returns the remaining condition tokens and the optional override string.
-fn try_extract_open_override(
-    collected: &[TokenTree],
-) -> Result<(Vec<TokenTree>, Option<String>), CompileError> {
-    let n = collected.len();
-    if n < 3 {
-        return Ok((collected.to_vec(), None));
-    }
-
-    // Check for pattern: Punct($) Ident(open) Group(Paren containing string literal)
-    let dollar = &collected[n - 3];
-    let ident = &collected[n - 2];
-    let group = &collected[n - 1];
-
-    let is_dollar = matches!(dollar, TokenTree::Punct(p) if p.as_char() == '$');
-    let is_open = is_ident(ident, "open");
-    let paren_group = if let TokenTree::Group(g) = group
-        && g.delimiter() == Delimiter::Parenthesis
-    {
-        Some(g)
-    } else {
-        None
-    };
-
-    if !is_dollar || !is_open || paren_group.is_none() {
-        return Ok((collected.to_vec(), None));
-    }
-
-    let g = paren_group.unwrap();
-    let inner: Vec<TokenTree> = g.stream().into_iter().collect();
-    if inner.len() != 1 {
-        return Err(CompileError::new(
-            g.span(),
-            "$open requires a single string literal: $open(\"text\")",
-        ));
-    }
-
-    let text = match &inner[0] {
-        TokenTree::Literal(lit) => {
-            let s = lit.to_string();
-            if s.starts_with('"') && s.ends_with('"') && s.len() >= 2 {
-                let raw = &s[1..s.len() - 1];
-                match unescape_string(raw) {
-                    Ok(text) => text,
-                    Err(msg) => return Err(CompileError::new(lit.span(), &msg)),
-                }
-            } else {
-                return Err(CompileError::new(
-                    lit.span(),
-                    "$open requires a string literal",
-                ));
-            }
-        }
-        _ => {
-            return Err(CompileError::new(
-                inner[0].span(),
-                "$open requires a string literal",
-            ));
-        }
-    };
-
-    let condition_tokens = collected[..n - 3].to_vec();
-    Ok((condition_tokens, Some(text)))
 }
 
 /// Check whether the tokens before a `{` brace group look like a control-flow
@@ -277,7 +208,6 @@ fn parse_control_flow(
     condition_tokens: &[TokenTree],
     first_brace: &proc_macro2::Group,
     brace_pos: usize,
-    block_open_override: Option<String>,
 ) -> Result<(Statement, usize), CompileError> {
     let (cond_format, cond_args) = tokens_to_format(condition_tokens)?;
     let body_tokens: Vec<TokenTree> = first_brace.stream().into_iter().collect();
@@ -287,7 +217,6 @@ fn parse_control_flow(
         condition_format: cond_format,
         condition_args: cond_args,
         body,
-        block_open_override,
     }];
 
     let mut pos = brace_pos + 1;
@@ -335,7 +264,6 @@ fn parse_control_flow(
                         condition_format: cond_format,
                         condition_args: cond_args,
                         body,
-                        block_open_override: None,
                     });
                     pos += 1;
                     found_brace = true;

--- a/macros/src/parse/types.rs
+++ b/macros/src/parse/types.rs
@@ -50,8 +50,6 @@ pub(crate) struct Branch {
     pub condition_args: Vec<TypedArg>,
     /// Body statements inside the braces.
     pub body: Vec<Statement>,
-    /// Custom block opener override from `$open("...")`, only on the first branch.
-    pub block_open_override: Option<String>,
 }
 
 /// A branch in a `$if` / `$else_if` / `$else` meta-conditional.

--- a/src/code_block.rs
+++ b/src/code_block.rs
@@ -76,21 +76,21 @@ pub(crate) enum FormatPart {
     StatementEnd,
     /// Newline.
     Newline,
-    /// Block open delimiter — resolved at render time via `lang.block_syntax().block_open`.
-    /// Emitted by control-flow builders; braces for TS/Rust/Go, colon for Python.
-    BlockOpen,
-    /// Block open with an overridden delimiter (not resolved via `lang.block_syntax().block_open`).
-    /// Emitted by `begin_control_flow_with_open` for constructs that need a
-    /// different opener than the language default (e.g., Haskell `where` vs `=`).
-    BlockOpenOverride(String),
-    /// Block close delimiter (terminal) — resolved at render time via `lang.block_syntax().block_close`.
-    /// Emitted by `end_control_flow`. When non-empty, also emits a trailing newline.
-    /// When empty (indent-only languages like OCaml/Haskell/Python), emits nothing.
-    BlockClose,
-    /// Block close delimiter (transitional) — resolved at render time via
-    /// `lang.block_syntax().block_close` + `" "`. Used by `next_control_flow` to emit `} else`.
-    /// When `block_close()` is empty, emits nothing (Python: dedent-only transition).
-    BlockCloseTransition,
+    /// Block open delimiter — resolved at render time via `lang.block_open_for(condition)`
+    /// falling back to `lang.block_syntax().block_open`. Carries the condition text
+    /// from `begin_control_flow` (e.g., `"if x > 0"`, `"for i in range(10)"`).
+    /// Empty string means no condition (e.g., a bare `{ }` block).
+    BlockOpen(String),
+    /// Terminal block close delimiter — resolved at render time via
+    /// `lang.block_close_for(condition)` falling back to `lang.block_syntax().block_close`.
+    /// Carries the condition from the matching `begin_control_flow`.
+    /// Emits: closer + newline.
+    BlockClose(String),
+    /// Non-terminal block close before a branch keyword (`else`, `elif`, `catch`).
+    /// Like `BlockClose` but emits closer + space (not newline) so the branch
+    /// keyword continues on the same line (e.g., `} else {`).
+    /// Suppressed when `block_syntax().close_on_transition` is `false`.
+    BranchClose(String),
 }
 
 /// An argument to a CodeBlock format string.
@@ -163,7 +163,7 @@ impl CodeBlock {
     pub fn ends_with_newline_or_block_close(&self) -> bool {
         fn check_last(nodes: &[CodeNode]) -> bool {
             match nodes.last() {
-                Some(CodeNode::Newline | CodeNode::BlockClose) => true,
+                Some(CodeNode::Newline | CodeNode::BlockClose(_)) => true,
                 Some(CodeNode::Sequence(children)) => check_last(children),
                 Some(CodeNode::Nested(inner)) => check_last(&inner.nodes),
                 _ => false,
@@ -218,6 +218,7 @@ impl CodeBlock {
 pub struct CodeBlockBuilder {
     nodes: Vec<CodeNode>,
     indent_depth: i32,
+    block_stack: Vec<String>,
     errors: Vec<crate::error::SigilStitchError>,
 }
 
@@ -227,6 +228,7 @@ impl CodeBlockBuilder {
         Self {
             nodes: Vec::new(),
             indent_depth: 0,
+            block_stack: Vec::new(),
             errors: Vec::new(),
         }
     }
@@ -289,31 +291,21 @@ impl CodeBlockBuilder {
     }
 
     /// Begin a control flow block (e.g., "if foo" -> "if foo {\n" + indent).
-    pub fn begin_control_flow(&mut self, format: &str, args: impl IntoArgs) -> &mut Self {
-        self.add(format, args);
-        self.nodes.push(CodeNode::BlockOpen);
-        self.nodes.push(CodeNode::Newline);
-        self.nodes.push(CodeNode::Indent);
-        self.indent_depth += 1;
-        self
-    }
-
-    /// Begin a control flow block with a custom block-open string.
     ///
-    /// Like [`begin_control_flow`](Self::begin_control_flow), but uses
-    /// `custom_open` instead of the language's `block_open()`. Pass `""`
-    /// to suppress the block opener entirely (e.g., OCaml `match x with`).
-    pub fn begin_control_flow_with_open(
-        &mut self,
-        format: &str,
-        args: impl IntoArgs,
-        custom_open: &str,
-    ) -> &mut Self {
+    /// The **raw format string** (not the interpolated result) is stored as
+    /// the condition text and passed to `block_open_for` / `block_close_for`
+    /// at render time, enabling language backends to emit context-aware
+    /// delimiters (e.g., Bash `then`/`fi` for `if`, `do`/`done` for `for`).
+    ///
+    /// Because backends pattern-match on the stored condition (e.g.,
+    /// `condition.starts_with("if ")`), avoid interpolating into the keyword
+    /// prefix — `begin_control_flow("if %L", expr)` works, but
+    /// `begin_control_flow("%L x", some_keyword)` would not be recognized.
+    pub fn begin_control_flow(&mut self, format: &str, args: impl IntoArgs) -> &mut Self {
+        let condition = format.to_string();
+        self.block_stack.push(condition.clone());
         self.add(format, args);
-        if !custom_open.is_empty() {
-            self.nodes
-                .push(CodeNode::BlockOpenOverride(custom_open.to_string()));
-        }
+        self.nodes.push(CodeNode::BlockOpen(condition));
         self.nodes.push(CodeNode::Newline);
         self.nodes.push(CodeNode::Indent);
         self.indent_depth += 1;
@@ -322,22 +314,25 @@ impl CodeBlockBuilder {
 
     /// Add an else/else-if clause (e.g., "} else {" or "elif ...:" for Python).
     pub fn next_control_flow(&mut self, format: &str, args: impl IntoArgs) -> &mut Self {
+        let condition = self.block_stack.last().cloned().unwrap_or_default();
         self.nodes.push(CodeNode::Dedent);
         self.indent_depth -= 1;
-        self.nodes.push(CodeNode::BlockCloseTransition);
+        self.nodes.push(CodeNode::BranchClose(condition));
         self.add(format, args);
-        self.nodes.push(CodeNode::BlockOpen);
+        let new_condition = format.to_string();
+        self.nodes.push(CodeNode::BlockOpen(new_condition));
         self.nodes.push(CodeNode::Newline);
         self.nodes.push(CodeNode::Indent);
         self.indent_depth += 1;
         self
     }
 
-    /// End a control flow block (emits "}" or nothing for Python, and decreases indent).
+    /// End a control flow block (emits "}" or language-specific closer, and decreases indent).
     pub fn end_control_flow(&mut self) -> &mut Self {
+        let condition = self.block_stack.pop().unwrap_or_default();
         self.nodes.push(CodeNode::Dedent);
         self.indent_depth -= 1;
-        self.nodes.push(CodeNode::BlockClose);
+        self.nodes.push(CodeNode::BlockClose(condition));
         self
     }
 
@@ -820,41 +815,36 @@ mod tests {
     }
 
     #[test]
-    fn test_begin_control_flow_with_open_non_empty() {
+    fn test_begin_control_flow_stores_condition() {
         let mut b = CodeBlock::builder();
-        b.begin_control_flow_with_open("class Functor f", (), " where");
+        b.begin_control_flow("class Functor f", ());
         b.add_statement("fmap :: (a -> b) -> f a -> f b", ());
         b.end_control_flow();
         let block = b.build().unwrap();
-        let has_override = block
+        let has_open = block
             .nodes
             .iter()
-            .any(|n| matches!(n, CodeNode::BlockOpenOverride(s) if s == " where"));
-        assert!(has_override, "should contain BlockOpenOverride(\" where\")");
-        let has_block_open = block.nodes.iter().any(|n| matches!(n, CodeNode::BlockOpen));
-        assert!(
-            !has_block_open,
-            "should NOT contain BlockOpen when override is used"
-        );
+            .any(|n| matches!(n, CodeNode::BlockOpen(s) if s == "class Functor f"));
+        assert!(has_open, "should contain BlockOpen with condition text");
+        let has_close = block
+            .nodes
+            .iter()
+            .any(|n| matches!(n, CodeNode::BlockClose(s) if s == "class Functor f"));
+        assert!(has_close, "should contain BlockClose with condition text");
     }
 
     #[test]
-    fn test_begin_control_flow_with_open_empty() {
+    fn test_begin_control_flow_match_empty_open() {
         let mut b = CodeBlock::builder();
-        b.begin_control_flow_with_open("match x with", (), "");
+        b.begin_control_flow("match x with", ());
         b.add("| Red -> red", ());
         b.add_line();
         b.end_control_flow();
         let block = b.build().unwrap();
-        let has_override = block
+        let has_open = block
             .nodes
             .iter()
-            .any(|n| matches!(n, CodeNode::BlockOpenOverride(_)));
-        assert!(
-            !has_override,
-            "empty custom_open should skip BlockOpenOverride"
-        );
-        let has_block_open = block.nodes.iter().any(|n| matches!(n, CodeNode::BlockOpen));
-        assert!(!has_block_open, "should NOT contain BlockOpen either");
+            .any(|n| matches!(n, CodeNode::BlockOpen(s) if s == "match x with"));
+        assert!(has_open, "should contain BlockOpen(\"match x with\")");
     }
 }

--- a/src/code_node.rs
+++ b/src/code_node.rs
@@ -44,15 +44,24 @@ pub enum CodeNode {
     StatementEnd,
     /// Hard newline.
     Newline,
-    /// Block open delimiter, resolved at render time via `lang.block_syntax().block_open`.
-    BlockOpen,
-    /// Block open with an overridden delimiter string.
-    BlockOpenOverride(String),
-    /// Terminal block close delimiter, resolved via `lang.block_syntax().block_close`.
-    BlockClose,
-    /// Transitional block close delimiter (e.g. `} else`), resolved via
-    /// `lang.block_syntax().block_close` + `" "`.
-    BlockCloseTransition,
+    /// Block open delimiter. Carries the control-flow condition text (e.g.,
+    /// `"if x > 0"`, `"for i in range(10)"`). At render time the renderer calls
+    /// `lang.block_open_for(condition)` — if it returns `Some(s)`, emit `s`;
+    /// otherwise fall back to `lang.block_syntax().block_open`.
+    /// Empty string means no condition (e.g., a bare `{ }` block).
+    BlockOpen(String),
+    /// Terminal block close delimiter. Carries the condition from the matching
+    /// `begin_control_flow` call. At render time the renderer calls
+    /// `lang.block_close_for(condition)` — if it returns `Some(s)`, emit `s`;
+    /// otherwise fall back to `lang.block_syntax().block_close`.
+    /// Emits: closer + newline.
+    BlockClose(String),
+    /// Non-terminal block close before a branch keyword (`else`, `elif`, `catch`).
+    /// Like `BlockClose` but emits closer + space (not newline) so the branch
+    /// keyword continues on the same line (e.g., `} else {`).
+    /// Suppressed when `block_syntax().close_on_transition` is `false`
+    /// (Lua, Bash — where `else`/`elif` sit between opener and closer).
+    BranchClose(String),
     /// A sequence of nodes (for grouping, e.g. a statement or control flow block).
     Sequence(Vec<CodeNode>),
 }
@@ -86,10 +95,9 @@ pub(crate) fn parts_args_to_nodes(parts: &[FormatPart], args: &[Arg]) -> Vec<Cod
             FormatPart::StatementBegin => CodeNode::StatementBegin,
             FormatPart::StatementEnd => CodeNode::StatementEnd,
             FormatPart::Newline => CodeNode::Newline,
-            FormatPart::BlockOpen => CodeNode::BlockOpen,
-            FormatPart::BlockOpenOverride(s) => CodeNode::BlockOpenOverride(s.clone()),
-            FormatPart::BlockClose => CodeNode::BlockClose,
-            FormatPart::BlockCloseTransition => CodeNode::BlockCloseTransition,
+            FormatPart::BlockOpen(s) => CodeNode::BlockOpen(s.clone()),
+            FormatPart::BlockClose(s) => CodeNode::BlockClose(s.clone()),
+            FormatPart::BranchClose(s) => CodeNode::BranchClose(s.clone()),
         };
         nodes.push(node);
     }
@@ -170,17 +178,15 @@ mod tests {
     #[test]
     fn test_block_open_close_conversion() {
         let parts = vec![
-            FormatPart::BlockOpen,
-            FormatPart::BlockClose,
-            FormatPart::BlockOpenOverride("where".to_string()),
-            FormatPart::BlockCloseTransition,
+            FormatPart::BlockOpen("if x".to_string()),
+            FormatPart::BlockClose("if x".to_string()),
+            FormatPart::BranchClose("if x".to_string()),
         ];
         let nodes = parts_args_to_nodes(&parts, &[]);
-        assert_eq!(nodes.len(), 4);
-        assert!(matches!(nodes[0], CodeNode::BlockOpen));
-        assert!(matches!(nodes[1], CodeNode::BlockClose));
-        assert!(matches!(&nodes[2], CodeNode::BlockOpenOverride(s) if s == "where"));
-        assert!(matches!(nodes[3], CodeNode::BlockCloseTransition));
+        assert_eq!(nodes.len(), 3);
+        assert!(matches!(&nodes[0], CodeNode::BlockOpen(s) if s == "if x"));
+        assert!(matches!(&nodes[1], CodeNode::BlockClose(s) if s == "if x"));
+        assert!(matches!(&nodes[2], CodeNode::BranchClose(s) if s == "if x"));
     }
 
     #[test]

--- a/src/code_renderer.rs
+++ b/src/code_renderer.rs
@@ -140,26 +140,35 @@ impl<'a> CodeRenderer<'a> {
                 CodeNode::Newline => {
                     self.emit_newline();
                 }
-                CodeNode::BlockOpen => {
-                    self.emit(self.lang.block_syntax().block_open);
+                CodeNode::BlockOpen(cond) => {
+                    let open = self
+                        .lang
+                        .block_open_for(cond)
+                        .unwrap_or(self.lang.block_syntax().block_open);
+                    if !open.is_empty() {
+                        self.emit(open);
+                    }
                 }
-                CodeNode::BlockOpenOverride(s) => {
-                    self.emit(s);
-                }
-                CodeNode::BlockClose => {
-                    let close = self.lang.block_syntax().block_close;
+                CodeNode::BlockClose(cond) => {
+                    let close = self
+                        .lang
+                        .block_close_for(cond)
+                        .unwrap_or(self.lang.block_syntax().block_close);
                     if !close.is_empty() {
                         self.ensure_indent();
                         self.emit(close);
                         self.emit_newline();
                     }
                 }
-                CodeNode::BlockCloseTransition => {
+                CodeNode::BranchClose(cond) => {
                     let cfg = self.lang.block_syntax();
-                    if !cfg.block_close.is_empty() && cfg.close_on_transition {
-                        self.ensure_indent();
-                        self.emit(cfg.block_close);
-                        self.emit(" ");
+                    if cfg.close_on_transition {
+                        let close = self.lang.block_close_for(cond).unwrap_or(cfg.block_close);
+                        if !close.is_empty() {
+                            self.ensure_indent();
+                            self.emit(close);
+                            self.emit(" ");
+                        }
                     }
                 }
                 CodeNode::Sequence(children) => {
@@ -223,24 +232,39 @@ impl<'a> CodeRenderer<'a> {
                     }
                 }
                 CodeNode::Newline => BoxDoc::hardline(),
-                CodeNode::BlockOpen => {
-                    BoxDoc::text(self.lang.block_syntax().block_open.to_string())
+                CodeNode::BlockOpen(cond) => {
+                    let open = self
+                        .lang
+                        .block_open_for(cond)
+                        .unwrap_or(self.lang.block_syntax().block_open);
+                    if open.is_empty() {
+                        BoxDoc::nil()
+                    } else {
+                        BoxDoc::text(open.to_string())
+                    }
                 }
-                CodeNode::BlockOpenOverride(s) => BoxDoc::text(s.clone()),
-                CodeNode::BlockClose => {
-                    let close = self.lang.block_syntax().block_close;
+                CodeNode::BlockClose(cond) => {
+                    let close = self
+                        .lang
+                        .block_close_for(cond)
+                        .unwrap_or(self.lang.block_syntax().block_close);
                     if close.is_empty() {
                         BoxDoc::nil()
                     } else {
                         BoxDoc::text(close.to_string()).append(BoxDoc::hardline())
                     }
                 }
-                CodeNode::BlockCloseTransition => {
+                CodeNode::BranchClose(cond) => {
                     let cfg = self.lang.block_syntax();
-                    if cfg.block_close.is_empty() || !cfg.close_on_transition {
+                    if !cfg.close_on_transition {
                         BoxDoc::nil()
                     } else {
-                        BoxDoc::text(format!("{} ", cfg.block_close))
+                        let close = self.lang.block_close_for(cond).unwrap_or(cfg.block_close);
+                        if close.is_empty() {
+                            BoxDoc::nil()
+                        } else {
+                            BoxDoc::text(format!("{close} "))
+                        }
                     }
                 }
                 CodeNode::Sequence(children) => self.nodes_to_doc(children),
@@ -478,20 +502,20 @@ mod tests {
     }
 
     #[test]
-    fn test_block_open_override() {
+    fn test_block_open_for_override() {
+        use crate::lang::haskell::Haskell;
+        let hs = Haskell::new();
+        let imports = ImportGroup::new();
         let mut b = CodeBlock::builder();
-        b.begin_control_flow_with_open("class Functor f", (), " where");
+        b.begin_control_flow("class Functor f", ());
         b.add_statement("fmap :: a -> b", ());
         b.end_control_flow();
         let block = b.build().unwrap();
-        let output = render_block(&block, 80);
+        let mut renderer = CodeRenderer::new(&hs, &imports, 80);
+        let output = renderer.render(&block).unwrap();
         assert!(
             output.contains("class Functor f where"),
-            "should use custom opener, got:\n{output}"
-        );
-        assert!(
-            !output.contains(" {"),
-            "should NOT contain default block_open, got:\n{output}"
+            "Haskell backend should emit 'where' via block_open_for, got:\n{output}"
         );
     }
 }

--- a/src/lang/bash.rs
+++ b/src/lang/bash.rs
@@ -21,60 +21,22 @@ use crate::spec::modifiers::{DeclarationContext, TypeKind, Visibility};
 ///
 /// # Control Flow
 ///
-/// Bash uses keyword-based block closers that vary per construct (`fi`, `done`,
-/// `esac`). The `begin_control_flow`/`end_control_flow` helpers auto-append
-/// `block_open()`/`block_close()` (i.e., `{`/`}`), which is wrong for shell
-/// control flow. Instead, use manual `add()` with explicit indent/dedent:
+/// Bash uses keyword-based block delimiters that vary per construct (`then`/`fi`,
+/// `do`/`done`, `in`/`esac`). The `block_open_for`/`block_close_for` methods
+/// automatically map conditions to the correct delimiters:
 ///
 /// ```text
-/// // if/then/fi
-/// b.add("if [ -f \"$file\" ]; then\n", ());
-/// b.add("%>", ());
+/// // Builder API — begin_control_flow/end_control_flow work directly:
+/// b.begin_control_flow("if [ -f \"$file\" ];", ());   // emits "; then"
 /// b.add_statement("echo \"found\"", ());
-/// b.add("%<", ());
-/// b.add("fi\n", ());
+/// b.end_control_flow();                                // emits "fi"
 ///
-/// // for/do/done
-/// b.add("for f in *.txt; do\n", ());
-/// b.add("%>", ());
-/// b.add_statement("process \"$f\"", ());
-/// b.add("%<", ());
-/// b.add("done\n", ());
-///
-/// // while/do/done
-/// b.add("while read -r line; do\n", ());
-/// b.add("%>", ());
-/// b.add_statement("echo \"$line\"", ());
-/// b.add("%<", ());
-/// b.add("done\n", ());
-///
-/// // case/esac
-/// b.add("case \"$1\" in\n", ());
-/// b.add("%>", ());
-/// b.add("start)\n", ());
-/// b.add("%>", ());
-/// b.add_statement("start_service", ());
-/// b.add("%<", ());
-/// b.add(";;\n", ());
-/// b.add("*)\n", ());
-/// b.add("%>", ());
-/// b.add_statement("echo \"unknown\"", ());
-/// b.add("%<", ());
-/// b.add(";;\n", ());
-/// b.add("%<", ());
-/// b.add("esac\n", ());
-/// ```
-///
-/// The `begin_control_flow`/`end_control_flow` helpers **do** work for function
-/// bodies since functions use `{ }` braces:
-///
-/// ```text
-/// let mut fb = FunSpec::builder("greet");
-/// fb.body(body);
-/// let fun = fb.build().unwrap();
-/// // function greet {
-/// //     echo "hello"
-/// // }
+/// // sigil_quote! — use { } and the backend handles the rest:
+/// sigil_quote!(Bash {
+///     if [ -f "$$file" ]; {
+///         echo "found"
+///     }
+/// })
 /// ```
 ///
 /// # Shebang
@@ -230,7 +192,50 @@ impl CodeLang for Bash {
             indent_unit: &self.indent,
             uses_semicolons: false,
             field_terminator: "",
+            close_on_transition: false,
             ..Default::default()
+        }
+    }
+
+    fn block_open_for(&self, condition: &str) -> Option<&str> {
+        let raw = condition.trim();
+        let t = raw.trim_end_matches(';').trim();
+        if t.ends_with("; then")
+            || t.ends_with("; do")
+            || t.ends_with(" in")
+            || t == "else"
+            || t == "elif"
+        {
+            Some("")
+        } else if t.starts_with("if ") || t.starts_with("elif ") {
+            if raw.ends_with(';') {
+                Some(" then")
+            } else {
+                Some("; then")
+            }
+        } else if t.starts_with("for ") || t.starts_with("while ") || t.starts_with("until ") {
+            if raw.ends_with(';') {
+                Some(" do")
+            } else {
+                Some("; do")
+            }
+        } else if t.starts_with("case ") {
+            Some(" in")
+        } else {
+            None
+        }
+    }
+
+    fn block_close_for(&self, condition: &str) -> Option<&str> {
+        let t = condition.trim().trim_end_matches(';').trim();
+        if t.starts_with("if ") || t.starts_with("elif ") || t == "else" {
+            Some("fi")
+        } else if t.starts_with("for ") || t.starts_with("while ") || t.starts_with("until ") {
+            Some("done")
+        } else if t.starts_with("case ") {
+            Some("esac")
+        } else {
+            None
         }
     }
 

--- a/src/lang/haskell.rs
+++ b/src/lang/haskell.rs
@@ -40,8 +40,8 @@ use crate::spec::modifiers::{DeclarationContext, TypeKind, Visibility};
 /// # Known limitations
 ///
 /// - `block_open` returns `" ="` which works for function definitions and type
-///   aliases, but type class declarations need `" where"`. Use
-///   `begin_control_flow_with_open("class Functor f", (), " where")` for type classes.
+///   aliases. Type class declarations automatically get `" where"` via
+///   `block_open_for("class ...")` / `block_open_for("instance ...")`.
 /// - Complex multi-param type class constraints (e.g., `MonadReader Env m`) are not
 ///   directly modeled. Use `TypeName::primitive("(MonadIO m, MonadReader Env m) => m String")`
 ///   for complex constrained return types.
@@ -339,6 +339,17 @@ impl CodeLang for Haskell {
             uses_semicolons: false,
             field_terminator: ",",
             ..Default::default()
+        }
+    }
+
+    fn block_open_for(&self, condition: &str) -> Option<&str> {
+        let t = condition.trim();
+        if t.starts_with("class ") || t.starts_with("instance ") {
+            Some(" where")
+        } else if t.starts_with("do") {
+            Some("")
+        } else {
+            None
         }
     }
 

--- a/src/lang/lua.rs
+++ b/src/lang/lua.rs
@@ -133,13 +133,26 @@ impl CodeLang for Lua {
 
     fn block_syntax(&self) -> BlockSyntaxConfig<'_> {
         BlockSyntaxConfig {
-            block_open: "",             // Lua opens bodies on next line
-            block_close: "end",         // ... and closes with `end`
-            close_on_transition: false, // `else`/`elseif` don't need `end` before them
+            block_open: "",
+            block_close: "end",
+            close_on_transition: false,
             indent_unit: &self.indent,
             uses_semicolons: false,
             field_terminator: ",",
             ..Default::default()
+        }
+    }
+
+    fn block_open_for(&self, condition: &str) -> Option<&str> {
+        let t = condition.trim();
+        if t.ends_with(" then") || t.ends_with(" do") || t == "else" {
+            Some("")
+        } else if t.starts_with("if ") || t.starts_with("elseif ") {
+            Some(" then")
+        } else if t.starts_with("for ") || t.starts_with("while ") {
+            Some(" do")
+        } else {
+            None
         }
     }
 

--- a/src/lang/mod.rs
+++ b/src/lang/mod.rs
@@ -355,6 +355,33 @@ pub trait CodeLang: std::fmt::Debug + 'static {
         config::BlockSyntaxConfig::default()
     }
 
+    /// Map a control-flow condition to its block-opening delimiter.
+    ///
+    /// Called at render time with the condition text from `begin_control_flow`.
+    /// Return `Some("...")` to override the default `block_syntax().block_open`.
+    ///
+    /// # Examples
+    ///
+    /// Bash maps `"if [ -f ... ];"` → `Some("; then")` and
+    /// `"for f in *.txt;"` → `Some("; do")`.
+    /// Haskell maps `"class Functor f"` → `Some(" where")`.
+    fn block_open_for(&self, _condition: &str) -> Option<&str> {
+        None
+    }
+
+    /// Map a control-flow condition to its block-closing delimiter.
+    ///
+    /// Called at render time with the condition text from `begin_control_flow`.
+    /// Return `Some("...")` to override the default `block_syntax().block_close`.
+    ///
+    /// # Examples
+    ///
+    /// Bash maps `"if ..."` → `Some("fi")`, `"for ..."` → `Some("done")`,
+    /// `"case ..."` → `Some("esac")`.
+    fn block_close_for(&self, _condition: &str) -> Option<&str> {
+        None
+    }
+
     /// Function signature syntax.
     fn function_syntax(&self) -> config::FunctionSyntaxConfig<'_> {
         config::FunctionSyntaxConfig::default()

--- a/src/lang/ocaml.rs
+++ b/src/lang/ocaml.rs
@@ -93,7 +93,7 @@ impl OCaml {
         body: crate::code_block::CodeBlock,
     ) -> Result<crate::code_block::CodeBlock, crate::error::SigilStitchError> {
         let mut cb = crate::code_block::CodeBlock::builder();
-        cb.begin_control_flow_with_open(&format!("module {name}"), (), " = struct");
+        cb.begin_control_flow(&format!("module {name}"), ());
         cb.add_code(body);
         cb.end_control_flow();
         cb.add("end", ());
@@ -106,7 +106,7 @@ impl OCaml {
         body: crate::code_block::CodeBlock,
     ) -> Result<crate::code_block::CodeBlock, crate::error::SigilStitchError> {
         let mut cb = crate::code_block::CodeBlock::builder();
-        cb.begin_control_flow_with_open(&format!("module type {name}"), (), " = sig");
+        cb.begin_control_flow(&format!("module type {name}"), ());
         cb.add_code(body);
         cb.end_control_flow();
         cb.add("end", ());
@@ -296,6 +296,19 @@ impl CodeLang for OCaml {
             uses_semicolons: false,
             field_terminator: ";",
             ..Default::default()
+        }
+    }
+
+    fn block_open_for(&self, condition: &str) -> Option<&str> {
+        let t = condition.trim();
+        if t.starts_with("module type ") {
+            Some(" = sig")
+        } else if t.starts_with("module ") {
+            Some(" = struct")
+        } else if t.starts_with("match ") {
+            Some("")
+        } else {
+            None
         }
     }
 

--- a/test-goldens/bash/macro_control_flow.bash
+++ b/test-goldens/bash/macro_control_flow.bash
@@ -1,5 +1,5 @@
-if [$x - gt 0] {
+if [$x - gt 0]; then
     echo "positive"
-} else {
+else
     echo "negative"
-}
+fi

--- a/tests/haskell/builder_control_flow.rs
+++ b/tests/haskell/builder_control_flow.rs
@@ -24,7 +24,7 @@ fn test_where_block() {
 #[test]
 fn test_type_class_where() {
     let mut b = CodeBlock::builder();
-    b.begin_control_flow_with_open("class Functor f", (), " where");
+    b.begin_control_flow("class Functor f", ());
     b.add_statement("fmap :: (a -> b) -> f a -> f b", ());
     b.end_control_flow();
     let block = b.build().unwrap();

--- a/tests/haskell/quote_edge_cases.rs
+++ b/tests/haskell/quote_edge_cases.rs
@@ -17,7 +17,7 @@ fn render(block: &CodeBlock) -> String {
 #[test]
 fn test_open_where() {
     let block = sigil_quote!(Haskell {
-        class Functor f $open(" where") {
+        class Functor f {
             fmap :: (a -> b) -> f a -> f b;
         }
     })

--- a/tests/macro/open_override.rs
+++ b/tests/macro/open_override.rs
@@ -1,45 +1,85 @@
+use sigil_stitch::code_block::CodeBlock;
+use sigil_stitch::code_renderer::CodeRenderer;
+use sigil_stitch::import::ImportGroup;
+
 use super::helpers::*;
 
 #[test]
-fn test_open_haskell_where() {
+fn test_haskell_class_where_via_block_open_for() {
     let block = sigil_quote!(Haskell {
-        class Functor f $open(" where") {
+        class Functor f {
             fmap :: (a -> b) -> f a -> f b;
         }
     })
     .unwrap();
 
     let output = render_hs(&block);
-    assert!(output.contains("class Functor f where"), "got: {output}");
+    assert!(
+        output.contains("class Functor f where"),
+        "Haskell block_open_for should emit 'where' for class, got: {output}"
+    );
     assert!(output.contains("fmap"), "got: {output}");
-    assert!(!output.contains("class Functor f ="), "got: {output}");
+    assert!(
+        !output.contains("class Functor f ="),
+        "should NOT use default block_open, got: {output}"
+    );
 }
 
 #[test]
-fn test_open_ocaml_module() {
+fn test_ocaml_module_struct_via_block_open_for() {
     let block = sigil_quote!(OCaml {
-        module Foo $open(" = struct") {
+        module Foo {
             let x = 42;
         }
     })
     .unwrap();
 
     let output = render_ml(&block);
-    assert!(output.contains("module Foo = struct"), "got: {output}");
+    assert!(
+        output.contains("module Foo = struct"),
+        "OCaml block_open_for should emit '= struct' for module, got: {output}"
+    );
     assert!(output.contains("let x = 42"), "got: {output}");
 }
 
 #[test]
-fn test_open_empty_suppresses_block_opener() {
-    let block = sigil_quote!(TypeScript {
-        something $open("") {
-            body;
+fn test_ocaml_match_suppresses_block_opener() {
+    let block = sigil_quote!(OCaml {
+        match x with {
+            | Red -> "red";
         }
     })
     .unwrap();
 
-    let output = render_ts(&block);
-    assert!(output.contains("something"), "got: {output}");
-    assert!(output.contains("body;"), "got: {output}");
-    assert!(!output.contains("something {"), "got: {output}");
+    let output = render_ml(&block);
+    assert!(
+        output.contains("match x with"),
+        "OCaml block_open_for should return empty for match, got: {output}"
+    );
+    assert!(
+        !output.contains("match x with ="),
+        "should NOT emit default block_open after match, got: {output}"
+    );
+}
+
+#[test]
+fn test_empty_opener_via_builder_block_open_for() {
+    let ocaml = sigil_stitch::lang::ocaml::OCaml::new();
+    let imports = ImportGroup::new();
+    let mut b = CodeBlock::builder();
+    b.begin_control_flow("match color with", ());
+    b.add("| Red -> \"red\"", ());
+    b.add_line();
+    b.end_control_flow();
+    let block = b.build().unwrap();
+    let mut renderer = CodeRenderer::new(&ocaml, &imports, 80);
+    let output = renderer.render(&block).unwrap();
+    assert!(
+        output.contains("match color with\n"),
+        "block_open_for returning Some(\"\") should suppress opener, got: {output}"
+    );
+    assert!(
+        !output.contains("match color with ="),
+        "should NOT contain default block_open, got: {output}"
+    );
 }

--- a/tests/ocaml/builder_control_flow.rs
+++ b/tests/ocaml/builder_control_flow.rs
@@ -25,7 +25,7 @@ fn test_let_binding() {
 fn test_pattern_match() {
     let mut b = CodeBlock::builder();
     b.begin_control_flow("let describe color", ());
-    b.begin_control_flow_with_open("match color with", (), "");
+    b.begin_control_flow("match color with", ());
     b.add("| Red -> \"red\"", ());
     b.add_line();
     b.add("| Green -> \"green\"", ());

--- a/tests/ocaml/quote_edge_cases.rs
+++ b/tests/ocaml/quote_edge_cases.rs
@@ -17,7 +17,7 @@ fn render(block: &CodeBlock) -> String {
 #[test]
 fn test_open_struct() {
     let block = sigil_quote!(OCaml {
-        module Foo $open(" = struct") {
+        module Foo {
             let x = 42;
             let name = $S("Alice");
         }


### PR DESCRIPTION
## Summary

- Add `block_open_for` / `block_close_for` to the `CodeLang` trait so language backends can map control-flow conditions to the correct block delimiters at render time (e.g., Bash `if` → `then`/`fi`, `for` → `do`/`done`, `case` → `in`/`esac`)
- Simplify `CodeNode` from 4 block variants (`BlockOpen`, `BlockOpenOverride`, `BlockClose`, `BlockCloseTransition`) to 3 condition-carrying variants (`BlockOpen(String)`, `BlockClose(String)`, `BranchClose(String)`)
- Remove the `$open("text")` proc macro directive and `begin_control_flow_with_open` — language backends are now the single source of truth for delimiter mapping
- Implement `block_open_for` / `block_close_for` for Bash, Lua, Haskell, and OCaml

Users can now write natural `sigil_quote!` with `{ }` blocks for Bash and Lua control flow:

```rust
sigil_quote!(Bash {
    if [ -f "$$file" ]; {
        echo "found"
    }
})
// renders: if [ -f "$file" ]; then\n    echo "found"\nfi
```

## Breaking changes

- `begin_control_flow_with_open` removed — callers should rely on the backend's `block_open_for` instead
- `$open("text")` no longer parsed by `sigil_quote!` — use `block_open_for` in the language backend
- `CodeNode::BlockOpenOverride` and `CodeNode::BlockCloseTransition` replaced by `BlockOpen(String)`, `BlockClose(String)`, `BranchClose(String)`

## Test plan

- [x] `cargo test` — all pass (33 suites, 0 failures)
- [x] `cargo clippy --all-targets` — clean
- [x] `cargo fmt --check` — clean
- [x] All examples run correctly: `bash_codegen`, `lua_codegen`, `macro_features`
- [x] Bash golden updated to show correct `then`/`fi`/`else` output
- [x] New tests for empty-opener suppression via `block_open_for`