### PR TITLE
fix: Lua double space, Haskell MaybeString, Rust where brace

### DIFF
--- a/src/lang/lua.rs
+++ b/src/lang/lua.rs
@@ -77,7 +77,7 @@ impl CodeLang for Lua {
     }
 
     fn function_keyword(&self, _ctx: DeclarationContext) -> &str {
-        "function "
+        "function"
     }
 
     fn type_keyword(&self, _kind: TypeKind) -> &str {
@@ -298,7 +298,7 @@ mod tests {
         let lua = Lua::new();
         assert_eq!(
             lua.function_keyword(DeclarationContext::TopLevel),
-            "function "
+            "function"
         );
     }
 }

--- a/src/spec/fun_spec.rs
+++ b/src/spec/fun_spec.rs
@@ -521,12 +521,15 @@ impl FunSpec {
     }
 
     fn emit_where_and_open(&self, sig: &mut String, sig_args: &mut Vec<Arg>, lang: &dyn CodeLang) {
-        if !self.where_constraints.is_empty()
-            && lang.function_syntax().where_clause_style == WhereClauseStyle::WhereBlock
-        {
+        let has_where = !self.where_constraints.is_empty()
+            && lang.function_syntax().where_clause_style == WhereClauseStyle::WhereBlock;
+        if has_where {
             emit_where_block(sig, sig_args, &self.where_constraints, lang);
+            // After a where clause, put the block-open brace on its own line.
+            sig.push_str("\n{");
+        } else {
+            sig.push_str(lang.fun_block_open());
         }
-        sig.push_str(lang.fun_block_open());
     }
 
     /// Emit a function with separate type signature and definition (Haskell style).

--- a/src/spec/type_spec.rs
+++ b/src/spec/type_spec.rs
@@ -340,8 +340,10 @@ impl TypeSpec {
                 && lang.function_syntax().where_clause_style == WhereClauseStyle::WhereBlock
             {
                 emit_where_block(&mut impl_fmt, &mut impl_args, &self.where_constraints, lang);
+                impl_fmt.push_str("\n{");
+            } else {
+                impl_fmt.push_str(lang.block_syntax().block_open);
             }
-            impl_fmt.push_str(lang.block_syntax().block_open);
             impl_cb.add(&impl_fmt, impl_args);
             impl_cb.add_line();
 
@@ -615,9 +617,10 @@ impl TypeSpec {
             && lang.function_syntax().where_clause_style == WhereClauseStyle::WhereBlock
         {
             emit_where_block(&mut fmt, &mut args, &self.where_constraints, lang);
+            fmt.push_str("\n{");
+        } else {
+            fmt.push_str(lang.type_header_block_open(self.kind));
         }
-
-        fmt.push_str(lang.type_header_block_open(self.kind));
         cb.add(&fmt, args);
         cb.add_line();
         Ok(())

--- a/src/type_name_render.rs
+++ b/src/type_name_render.rs
@@ -13,10 +13,18 @@ pub(crate) fn render_presentation(
 ) -> BoxDoc<'static, ()> {
     match pres {
         TypePresentation::GenericWrap { name } => {
+            // When generic delimiters are empty (e.g., Haskell prefix juxtaposition),
+            // insert a space between the wrapper name and the parameters so that
+            // `Maybe String` renders correctly instead of `MaybeString`.
+            let open = if gs.open.is_empty() && !name.is_empty() {
+                " ".to_string()
+            } else {
+                gs.open.to_string()
+            };
             let sep = BoxDoc::text(",").append(BoxDoc::softline());
             let params = BoxDoc::intersperse(inner_docs, sep);
             BoxDoc::text(name.to_string())
-                .append(BoxDoc::text(gs.open.to_string()))
+                .append(BoxDoc::text(open))
                 .append(params.nest(2).group())
                 .append(BoxDoc::text(gs.close.to_string()))
         }

--- a/tests/fun_spec_tests.rs
+++ b/tests/fun_spec_tests.rs
@@ -136,7 +136,10 @@ fn test_where_clause_rust_function() {
         output.contains("where\n    T: Clone + Send,\n    U: Debug,"),
         "where: {output}"
     );
-    assert!(output.contains(" {"), "block_open: {output}");
+    assert!(
+        output.contains("U: Debug,\n{"),
+        "block_open on new line after where: {output}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- **#52** — Lua `function_keyword()` had a trailing space, causing `function  greet()` (double space). Removed to match all other backends.
- **#62** — `TypeName::optional("String")` rendered `MaybeString` in Haskell. `GenericWrap` now inserts a space when generic delimiters are empty.
- **#61** — Rust where clause had `{` on the same line as the last constraint. Now emits `\n{` after where blocks in `fun_spec` and `type_spec` (3 sites).

## Test plan

- [x] `cargo test` — all pass
- [x] `cargo clippy --all-targets` — clean
- [x] Lua: `function greet(name)` (single space)
- [x] Haskell: `Maybe String` (with space)
- [x] Rust: `{` on new line after where clause