### PR TITLE
fix: OCaml optional, C# annotations, Dart async, Java generic params

### DIFF
--- a/src/lang/config.rs
+++ b/src/lang/config.rs
@@ -246,8 +246,12 @@ impl Default for BlockSyntaxConfig<'_> {
 pub struct FunctionSyntaxConfig<'a> {
     /// Separator between parameters and return type (e.g. `" -> "`, `": "`).
     pub return_type_separator: &'a str,
-    /// Keyword for async functions (e.g. `"async "`).
+    /// Keyword for async functions as a prefix (e.g. `"async "`).
     pub async_keyword: &'a str,
+    /// Keyword for async functions as a suffix after the parameter list
+    /// (e.g. Dart: `" async"`). Emitted when `is_async` is set, placed
+    /// after the closing `)` and before the block-open brace.
+    pub async_suffix: &'a str,
     /// Keyword for abstract methods (e.g. `"abstract "`, `"virtual "`).
     pub abstract_keyword: &'a str,
     /// How parameter lists are formatted (tupled vs curried).
@@ -262,6 +266,13 @@ pub struct FunctionSyntaxConfig<'a> {
     pub where_clause_style: WhereClauseStyle,
     /// Content emitted for abstract methods with no body (e.g. `""`, `"..."`).
     pub empty_body: &'a str,
+    /// Whether type parameters appear before the return type instead of after the name.
+    ///
+    /// Java places generic type parameters between modifiers and return type:
+    /// `public static <T extends Comparable> List<T> sortList(...)`.
+    /// Most other languages place them after the function name:
+    /// `fun <T> sortList(...)` or `fn sort_list<T>(...)`.
+    pub type_params_before_return_type: bool,
 }
 
 impl Default for FunctionSyntaxConfig<'_> {
@@ -269,6 +280,7 @@ impl Default for FunctionSyntaxConfig<'_> {
         Self {
             return_type_separator: ": ",
             async_keyword: "async ",
+            async_suffix: "",
             abstract_keyword: "abstract ",
             param_list_style: ParamListStyle::Tupled,
             function_signature_style: FunctionSignatureStyle::Merged,
@@ -276,6 +288,7 @@ impl Default for FunctionSyntaxConfig<'_> {
             constructor_delegation_style: ConstructorDelegationStyle::Body,
             where_clause_style: WhereClauseStyle::Inline,
             empty_body: "",
+            type_params_before_return_type: false,
         }
     }
 }

--- a/src/lang/csharp.rs
+++ b/src/lang/csharp.rs
@@ -298,6 +298,8 @@ impl CodeLang for CSharp {
 
     fn enum_and_annotation(&self) -> crate::lang::config::EnumAndAnnotationConfig<'_> {
         crate::lang::config::EnumAndAnnotationConfig {
+            annotation_prefix: "[",
+            annotation_suffix: "]",
             readonly_keyword: "readonly ",
             ..Default::default()
         }

--- a/src/lang/dart.rs
+++ b/src/lang/dart.rs
@@ -19,7 +19,7 @@ use crate::spec::modifiers::{DeclarationContext, TypeKind, Visibility};
 /// - `///` dartdoc comments
 /// - `<T extends Bound>` generics (same as Java/TS)
 /// - `@override`, `@required` annotations via `annotation()`
-/// - No `async` prefix — Dart's `async` is a body modifier, not a signature modifier
+/// - `async` as a body modifier suffix (`Future<int> foo() async { ... }`)
 ///
 /// # Import conventions
 ///
@@ -44,9 +44,11 @@ use crate::spec::modifiers::{DeclarationContext, TypeKind, Visibility};
 /// # Async functions
 ///
 /// Dart's `async` is a body modifier (`Future<int> foo() async { ... }`),
-/// not a signature prefix. Use `Future<T>` as the return type:
+/// not a signature prefix. Set `is_async()` on the builder and use
+/// `Future<T>` as the return type:
 /// ```text
-/// fb.returns(TypeName::primitive("Future<User>"));
+/// fb.returns(TypeName::primitive("Future<User>"))
+///   .is_async();
 /// ```
 #[derive(Debug, Clone)]
 pub struct DartLang {
@@ -271,6 +273,7 @@ impl CodeLang for DartLang {
         crate::lang::config::FunctionSyntaxConfig {
             return_type_separator: " ",
             async_keyword: "",
+            async_suffix: " async",
             ..Default::default()
         }
     }
@@ -508,6 +511,12 @@ mod tests {
     fn test_no_async_keyword() {
         let d = DartLang::new();
         assert_eq!(d.function_syntax().async_keyword, "");
+    }
+
+    #[test]
+    fn test_async_suffix() {
+        let d = DartLang::new();
+        assert_eq!(d.function_syntax().async_suffix, " async");
     }
 
     #[test]

--- a/src/lang/java_lang.rs
+++ b/src/lang/java_lang.rs
@@ -276,6 +276,7 @@ impl CodeLang for JavaLang {
         crate::lang::config::FunctionSyntaxConfig {
             return_type_separator: " ",
             async_keyword: "",
+            type_params_before_return_type: true,
             ..Default::default()
         }
     }

--- a/src/lang/ocaml.rs
+++ b/src/lang/ocaml.rs
@@ -251,9 +251,9 @@ impl CodeLang for OCaml {
 
     fn type_presentation(&self) -> TypePresentationConfig<'_> {
         TypePresentationConfig {
-            array: TypePresentation::GenericWrap { name: "list" },
-            readonly_array: Some(TypePresentation::GenericWrap { name: "list" }),
-            optional: TypePresentation::GenericWrap { name: "option" },
+            array: TypePresentation::Postfix { suffix: " list" },
+            readonly_array: Some(TypePresentation::Postfix { suffix: " list" }),
+            optional: TypePresentation::Postfix { suffix: " option" },
             map: TypePresentation::Delimited {
                 open: "(",
                 sep: ", ",

--- a/src/spec/fun_spec.rs
+++ b/src/spec/fun_spec.rs
@@ -345,6 +345,15 @@ impl FunSpec {
             sig.push_str(lang.function_syntax().async_keyword);
         }
 
+        // Type parameters before return type (Java-style: `public static <T> List<T> sort(...)`).
+        if lang.function_syntax().type_params_before_return_type {
+            let tp_str = render_type_params(&self.type_params, lang, &mut sig_args);
+            if !tp_str.is_empty() {
+                sig.push_str(&tp_str);
+                sig.push(' ');
+            }
+        }
+
         // Return type as prefix (C-style: `int add(...)`).
         if lang.type_decl_syntax().return_type_is_prefix
             && let Some(ret) = &self.return_type
@@ -371,9 +380,11 @@ impl FunSpec {
 
         sig.push_str(&self.name);
 
-        // Type parameters.
-        let tp_str = render_type_params(&self.type_params, lang, &mut sig_args);
-        sig.push_str(&tp_str);
+        // Type parameters after name (most languages: `fn sort<T>(...)`).
+        if !lang.function_syntax().type_params_before_return_type {
+            let tp_str = render_type_params(&self.type_params, lang, &mut sig_args);
+            sig.push_str(&tp_str);
+        }
 
         // Parameters — build as a sub-block for %W support.
         if lang.function_syntax().param_list_style == ParamListStyle::Curried {
@@ -424,6 +435,11 @@ impl FunSpec {
         } else {
             false
         };
+
+        // Async suffix (Dart: `Future<T> foo() async { ... }`).
+        if self.modifiers.is_async {
+            sig.push_str(lang.function_syntax().async_suffix);
+        }
 
         // Body or abstract.
         if let Some(body) = &self.body {

--- a/test-goldens/dart/async_function.dart
+++ b/test-goldens/dart/async_function.dart
@@ -2,6 +2,6 @@ import 'package:myapp/models/user.dart';
 
 // User
 
-Future<User> fetchUser(String id) {
+Future<User> fetchUser(String id) async {
   return await api.fetchUser(id);
 }

--- a/tests/csharp/builder_types.rs
+++ b/tests/csharp/builder_types.rs
@@ -221,3 +221,32 @@ fn test_enum() {
 
     golden::assert_golden("csharp/enum.cs", &output);
 }
+
+#[test]
+fn test_annotation_bracket_syntax() {
+    use sigil_stitch::spec::annotation_spec::AnnotationSpec;
+
+    let ts = TypeSpec::builder("Entity", TypeKind::Class)
+        .visibility(Visibility::Public)
+        .annotate(AnnotationSpec::new("Serializable"))
+        .add_field(
+            FieldSpec::builder("id", TypeName::primitive("int"))
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
+    let file = FileSpec::builder_with("Entity.cs", CSharp::new())
+        .add_type(ts)
+        .build()
+        .unwrap();
+    let output = file.render(80).unwrap();
+    assert!(
+        output.contains("[Serializable]"),
+        "C# annotations should use bracket syntax, got:\n{output}"
+    );
+    assert!(
+        !output.contains("@Serializable"),
+        "should NOT use @-prefix annotation style, got:\n{output}"
+    );
+}

--- a/tests/dart/builder_functions.rs
+++ b/tests/dart/builder_functions.rs
@@ -17,6 +17,7 @@ fn test_async_function() {
     let fun = FunSpec::builder("fetchUser")
         .returns(TypeName::primitive("Future<User>"))
         .add_param(ParameterSpec::new("id", TypeName::primitive("String")).unwrap())
+        .is_async()
         .body(body)
         .build()
         .unwrap();

--- a/tests/java/builder_functions.rs
+++ b/tests/java/builder_functions.rs
@@ -28,3 +28,34 @@ fn test_function_with_doc() {
 
     golden::assert_golden("java/function_with_doc.java", &output);
 }
+
+#[test]
+fn test_generic_type_params_before_return_type() {
+    use sigil_stitch::spec::fun_spec::TypeParamSpec;
+
+    let tp = TypeParamSpec::new("T").with_bound(TypeName::primitive("Comparable"));
+    let body = CodeBlock::of("return Collections.sort(list);", ()).unwrap();
+    let fun = FunSpec::builder("sortList")
+        .visibility(Visibility::Public)
+        .is_static()
+        .add_type_param(tp)
+        .add_param(ParameterSpec::new("list", TypeName::primitive("List<T>")).unwrap())
+        .returns(TypeName::primitive("List<T>"))
+        .body(body)
+        .build()
+        .unwrap();
+
+    let file = FileSpec::builder_with("Sort.java", JavaLang::new())
+        .add_function(fun)
+        .build()
+        .unwrap();
+    let output = file.render(80).unwrap();
+    assert!(
+        output.contains("<T extends Comparable> List<T> sortList"),
+        "Java type params should appear before return type, got:\n{output}"
+    );
+    assert!(
+        !output.contains("sortList<T"),
+        "should NOT put type params after function name, got:\n{output}"
+    );
+}

--- a/tests/ocaml/builder_types.rs
+++ b/tests/ocaml/builder_types.rs
@@ -117,3 +117,34 @@ fn test_module_sig_block() {
 
     golden::assert_golden("ocaml/module_sig.ml", &output);
 }
+
+#[test]
+fn test_optional_type_postfix() {
+    let ml = OCaml::new();
+    let ts = TypeSpec::builder("person", TypeKind::Struct)
+        .add_field(
+            FieldSpec::builder("name", TypeName::primitive("string"))
+                .build()
+                .unwrap(),
+        )
+        .add_field(
+            FieldSpec::builder("email", TypeName::optional(TypeName::primitive("string")))
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
+    let file = FileSpec::builder_with("person.ml", ml)
+        .add_type(ts)
+        .build()
+        .unwrap();
+    let output = file.render(80).unwrap();
+    assert!(
+        output.contains("string option"),
+        "OCaml optional should render postfix: `string option`, got:\n{output}"
+    );
+    assert!(
+        !output.contains("option(string)"),
+        "should NOT render prefix-style option(string), got:\n{output}"
+    );
+}


### PR DESCRIPTION
## Summary

- **#50** — OCaml optional type renders postfix `string option` instead of `option(string)`. Switched from `GenericWrap` to `Postfix` presentation for optional/array types.
- **#56** — C# annotations render as `[Attribute]` instead of `@Attribute`. Set `annotation_prefix: "["` and `annotation_suffix: "]"` in C# backend.
- **#54** — Dart `is_async()` now renders `async` after parameter list. Added `async_suffix` field to `FunctionSyntaxConfig`.
- **#60** — Java generic type params render before return type: `<T> List<T> sort(...)`. Added `type_params_before_return_type` field to `FunctionSyntaxConfig`.

## Test plan

- [x] `cargo test` — all pass (0 failures)
- [x] `cargo clippy --all-targets` — clean
- [x] New integration tests: OCaml postfix optional, C# bracket annotations, Java generic param position
- [x] Dart: golden updated, builder test uses `.is_async()`, unit test for config