### PR TITLE
fix: interface visibility, Python static, Java @Override

### DIFF
--- a/src/lang/config.rs
+++ b/src/lang/config.rs
@@ -254,6 +254,17 @@ pub struct FunctionSyntaxConfig<'a> {
     pub async_suffix: &'a str,
     /// Keyword for abstract methods (e.g. `"abstract "`, `"virtual "`).
     pub abstract_keyword: &'a str,
+    /// Keyword for override methods as an inline modifier (e.g. `"override "`).
+    ///
+    /// Set to `""` for languages that use an annotation instead (e.g. Java `@Override`).
+    pub override_keyword: &'a str,
+    /// Annotation emitted on its own line when `is_override` is set and the
+    /// language uses an annotation instead of an inline keyword.
+    ///
+    /// For example, Java sets this to `"@Override"`. When non-empty, it is
+    /// emitted as a line before the function signature. Languages that use an
+    /// inline keyword (Kotlin, Swift, C#) leave this empty.
+    pub override_annotation: &'a str,
     /// How parameter lists are formatted (tupled vs curried).
     pub param_list_style: ParamListStyle,
     /// How signatures are rendered (merged vs split type signature).
@@ -273,6 +284,15 @@ pub struct FunctionSyntaxConfig<'a> {
     /// Most other languages place them after the function name:
     /// `fun <T> sortList(...)` or `fn sort_list<T>(...)`.
     pub type_params_before_return_type: bool,
+    /// Whether to suppress the `async` keyword for interface/trait member declarations.
+    ///
+    /// C# sets this to `true` because interface methods declare the contract
+    /// (return type `Task<T>`) without the `async` implementation detail.
+    /// Swift sets this to `false` because protocols include `async` in signatures.
+    pub suppress_async_in_interface: bool,
+    /// Keyword emitted for static methods/fields. Default `"static "`.
+    /// Python sets to `""` since static is expressed via decorators.
+    pub static_keyword: &'a str,
 }
 
 impl Default for FunctionSyntaxConfig<'_> {
@@ -282,6 +302,8 @@ impl Default for FunctionSyntaxConfig<'_> {
             async_keyword: "async ",
             async_suffix: "",
             abstract_keyword: "abstract ",
+            override_keyword: "override ",
+            override_annotation: "",
             param_list_style: ParamListStyle::Tupled,
             function_signature_style: FunctionSignatureStyle::Merged,
             constructor_keyword: "",
@@ -289,6 +311,8 @@ impl Default for FunctionSyntaxConfig<'_> {
             where_clause_style: WhereClauseStyle::Inline,
             empty_body: "",
             type_params_before_return_type: false,
+            suppress_async_in_interface: false,
+            static_keyword: "static ",
         }
     }
 }

--- a/src/lang/csharp.rs
+++ b/src/lang/csharp.rs
@@ -214,12 +214,16 @@ impl CodeLang for CSharp {
         "//"
     }
 
-    fn render_visibility(&self, vis: Visibility, _ctx: DeclarationContext) -> &str {
-        match vis {
-            Visibility::Public => "public ",
-            Visibility::Private => "private ",
-            Visibility::Protected => "protected ",
-            _ => "internal ",
+    fn render_visibility(&self, vis: Visibility, ctx: DeclarationContext) -> &str {
+        match ctx {
+            // Interface members are implicitly public in C#; no visibility keyword.
+            DeclarationContext::InterfaceMember => "",
+            _ => match vis {
+                Visibility::Public => "public ",
+                Visibility::Private => "private ",
+                Visibility::Protected => "protected ",
+                _ => "internal ",
+            },
         }
     }
 
@@ -283,6 +287,7 @@ impl CodeLang for CSharp {
         crate::lang::config::FunctionSyntaxConfig {
             return_type_separator: " ",
             async_keyword: "async ",
+            suppress_async_in_interface: true,
             ..Default::default()
         }
     }

--- a/src/lang/go_lang.rs
+++ b/src/lang/go_lang.rs
@@ -221,7 +221,7 @@ impl CodeLang for GoLang {
             // Top-level functions and receiver methods use `func`.
             DeclarationContext::TopLevel => "func",
             // Interface method signatures omit `func`.
-            DeclarationContext::Member => "",
+            DeclarationContext::Member | DeclarationContext::InterfaceMember => "",
         }
     }
 

--- a/src/lang/java_lang.rs
+++ b/src/lang/java_lang.rs
@@ -210,6 +210,8 @@ impl CodeLang for JavaLang {
                 Visibility::Protected => "protected ",
                 _ => "", // package-private
             },
+            // Interface members are implicitly public abstract in Java.
+            DeclarationContext::InterfaceMember => "",
         }
     }
 
@@ -276,6 +278,8 @@ impl CodeLang for JavaLang {
         crate::lang::config::FunctionSyntaxConfig {
             return_type_separator: " ",
             async_keyword: "",
+            override_keyword: "",
+            override_annotation: "@Override",
             type_params_before_return_type: true,
             ..Default::default()
         }

--- a/src/lang/javascript.rs
+++ b/src/lang/javascript.rs
@@ -226,14 +226,14 @@ impl CodeLang for JavaScript {
             },
             // JavaScript has no member visibility keywords.
             // Use #name convention for private fields.
-            DeclarationContext::Member => "",
+            DeclarationContext::Member | DeclarationContext::InterfaceMember => "",
         }
     }
 
     fn function_keyword(&self, ctx: DeclarationContext) -> &str {
         match ctx {
             DeclarationContext::TopLevel => "function",
-            DeclarationContext::Member => "",
+            DeclarationContext::Member | DeclarationContext::InterfaceMember => "",
         }
     }
 

--- a/src/lang/kotlin.rs
+++ b/src/lang/kotlin.rs
@@ -272,6 +272,8 @@ impl CodeLang for Kotlin {
                 Visibility::Protected => "protected ",
                 _ => "internal ",
             },
+            // Interface members are implicitly public in Kotlin — no visibility modifier.
+            DeclarationContext::InterfaceMember => "",
         }
     }
 

--- a/src/lang/python.rs
+++ b/src/lang/python.rs
@@ -385,6 +385,7 @@ impl CodeLang for Python {
             return_type_separator: " -> ",
             constructor_keyword: "def",
             empty_body: "...",
+            static_keyword: "",
             ..Default::default()
         }
     }

--- a/src/lang/typescript.rs
+++ b/src/lang/typescript.rs
@@ -275,7 +275,7 @@ impl CodeLang for TypeScript {
                 Visibility::Public => "export ",
                 _ => "",
             },
-            DeclarationContext::Member => match vis {
+            DeclarationContext::Member | DeclarationContext::InterfaceMember => match vis {
                 Visibility::Public => "public ",
                 Visibility::Private => "private ",
                 Visibility::Protected => "protected ",
@@ -287,7 +287,7 @@ impl CodeLang for TypeScript {
     fn function_keyword(&self, ctx: DeclarationContext) -> &str {
         match ctx {
             DeclarationContext::TopLevel => "function",
-            DeclarationContext::Member => "",
+            DeclarationContext::Member | DeclarationContext::InterfaceMember => "",
         }
     }
 

--- a/src/spec/field_spec.rs
+++ b/src/spec/field_spec.rs
@@ -135,7 +135,7 @@ impl FieldSpec {
 
         fmt.push_str(vis);
         if self.modifiers.is_static {
-            fmt.push_str("static ");
+            fmt.push_str(lang.function_syntax().static_keyword);
         }
 
         // Resolve the optional-field style (only applied when `is_optional` is set).

--- a/src/spec/fun_spec.rs
+++ b/src/spec/fun_spec.rs
@@ -310,6 +310,16 @@ impl FunSpec {
             cb.add_line();
         }
 
+        // Override annotation (e.g., Java `@Override`) -- emitted as an annotation line
+        // rather than an inline keyword when the language uses annotation style.
+        if self.modifiers.is_override {
+            let override_ann = lang.function_syntax().override_annotation;
+            if !override_ann.is_empty() {
+                cb.add("%L", override_ann.to_string());
+                cb.add_line();
+            }
+        }
+
         if !lang.doc_before_annotations()
             && let Some(doc_str) = emit_doc()
         {
@@ -333,15 +343,28 @@ impl FunSpec {
 
         sig.push_str(vis);
         if self.modifiers.is_abstract {
-            sig.push_str(lang.function_syntax().abstract_keyword);
+            let kw = lang.function_syntax().abstract_keyword;
+            if !kw.is_empty() {
+                sig.push_str(kw);
+            }
         }
         if self.modifiers.is_static {
-            sig.push_str("static ");
+            let kw = lang.function_syntax().static_keyword;
+            if !kw.is_empty() {
+                sig.push_str(kw);
+            }
         }
         if self.modifiers.is_override {
-            sig.push_str("override ");
+            let kw = lang.function_syntax().override_keyword;
+            if !kw.is_empty() {
+                sig.push_str(kw);
+            }
         }
-        if self.modifiers.is_async {
+        // Some languages (C#) suppress `async` for interface members because
+        // interfaces declare the contract (return type), not the implementation.
+        let suppress_async = ctx == DeclarationContext::InterfaceMember
+            && lang.function_syntax().suppress_async_in_interface;
+        if self.modifiers.is_async && !suppress_async {
             sig.push_str(lang.function_syntax().async_keyword);
         }
 
@@ -437,7 +460,7 @@ impl FunSpec {
         };
 
         // Async suffix (Dart: `Future<T> foo() async { ... }`).
-        if self.modifiers.is_async {
+        if self.modifiers.is_async && !suppress_async {
             sig.push_str(lang.function_syntax().async_suffix);
         }
 

--- a/src/spec/modifiers.rs
+++ b/src/spec/modifiers.rs
@@ -7,6 +7,13 @@ pub enum DeclarationContext {
     TopLevel,
     /// Inside a type body: e.g., `private name: string` (TS), `pub name: String` (Rust).
     Member,
+    /// Inside an interface or trait body.
+    ///
+    /// Some languages suppress modifiers for interface members:
+    /// - Kotlin: no visibility (implicitly public).
+    /// - Java: interface methods are implicitly `public abstract`.
+    /// - C#: no visibility (implicitly public), no `async` keyword.
+    InterfaceMember,
 }
 
 /// Visibility level for declarations.

--- a/src/spec/property_spec.rs
+++ b/src/spec/property_spec.rs
@@ -110,7 +110,7 @@ impl PropertySpec {
 
             sig.push_str(vis);
             if self.modifiers.is_static {
-                sig.push_str("static ");
+                sig.push_str(lang.function_syntax().static_keyword);
             }
             sig.push_str("get ");
             sig.push_str(&self.name);
@@ -148,7 +148,7 @@ impl PropertySpec {
 
             sig.push_str(vis);
             if self.modifiers.is_static {
-                sig.push_str("static ");
+                sig.push_str(lang.function_syntax().static_keyword);
             }
             sig.push_str("set ");
             sig.push_str(&self.name);
@@ -201,7 +201,7 @@ impl PropertySpec {
 
         sig.push_str(vis);
         if self.modifiers.is_static {
-            sig.push_str("static ");
+            sig.push_str(lang.function_syntax().static_keyword);
         }
 
         if has_setter {

--- a/src/spec/type_spec.rs
+++ b/src/spec/type_spec.rs
@@ -131,6 +131,13 @@ impl TypeSpec {
     ) -> Result<CodeBlock, crate::error::SigilStitchError> {
         let mut cb = CodeBlock::builder();
 
+        // Use InterfaceMember context for interface/trait bodies so that
+        // languages can suppress visibility modifiers and async keywords.
+        let member_ctx = match self.kind {
+            TypeKind::Interface | TypeKind::Trait => DeclarationContext::InterfaceMember,
+            _ => DeclarationContext::Member,
+        };
+
         self.emit_preamble(&mut cb, lang)?;
         self.emit_header(&mut cb, lang)?;
 
@@ -171,7 +178,7 @@ impl TypeSpec {
                 if i == 0 && !self.variants.is_empty() {
                     cb.add_line();
                 }
-                cb.add_code(field.emit(lang, DeclarationContext::Member)?);
+                cb.add_code(field.emit(lang, member_ctx)?);
             }
         } else {
             // Fields first, then variants (default).
@@ -179,7 +186,7 @@ impl TypeSpec {
                 if i > 0 {
                     // No extra blank line between fields.
                 }
-                cb.add_code(field.emit(lang, DeclarationContext::Member)?);
+                cb.add_code(field.emit(lang, member_ctx)?);
             }
             if !self.variants.is_empty() {
                 if !self.fields.is_empty() {
@@ -199,7 +206,7 @@ impl TypeSpec {
                 if i > 0 {
                     cb.add_line();
                 }
-                for block in prop.emit(lang, DeclarationContext::Member)? {
+                for block in prop.emit(lang, member_ctx)? {
                     cb.add_code(block);
                 }
             }
@@ -212,7 +219,7 @@ impl TypeSpec {
             if i > 0 {
                 cb.add_line();
             }
-            cb.add_code(method.emit(lang, DeclarationContext::Member)?);
+            cb.add_code(method.emit(lang, member_ctx)?);
         }
         for extra in &self.extra_members {
             cb.add_code(extra.clone());

--- a/test-goldens/csharp/async_interface.cs
+++ b/test-goldens/csharp/async_interface.cs
@@ -1,0 +1,5 @@
+public interface IUserService {
+    Task<User> GetUserAsync(string id);
+
+    Task SaveUserAsync(User user);
+}

--- a/test-goldens/csharp/interface.cs
+++ b/test-goldens/csharp/interface.cs
@@ -1,6 +1,6 @@
 /// Generic data repository.
 public interface IRepository<T> {
-    internal T FindById(string id);
+    T FindById(string id);
 
-    internal void Save(T entity);
+    void Save(T entity);
 }

--- a/test-goldens/csharp/macro_interface_methods.cs
+++ b/test-goldens/csharp/macro_interface_methods.cs
@@ -1,0 +1,3 @@
+Task<User> GetUserAsync(string id);
+Task SaveUserAsync(User user);
+void Delete(string id);

--- a/test-goldens/java/generic_params_before_return.java
+++ b/test-goldens/java/generic_params_before_return.java
@@ -1,0 +1,5 @@
+public class Utils {
+    public static <T extends Comparable> List<T> sortList(List<T> list) {
+        return Collections.sort(list);
+    }
+}

--- a/test-goldens/java/macro_generic_static.java
+++ b/test-goldens/java/macro_generic_static.java
@@ -1,0 +1,4 @@
+public static < T extends Comparable > List<T> sortList(List<T> list) {
+    Collections.sort(list);
+    return list;
+}

--- a/test-goldens/java/macro_override_method.java
+++ b/test-goldens/java/macro_override_method.java
@@ -1,0 +1,4 @@
+@Override
+public String speak() {
+    return "Woof!";
+}

--- a/test-goldens/java/override_method.java
+++ b/test-goldens/java/override_method.java
@@ -1,0 +1,6 @@
+public class Dog extends Animal {
+    @Override
+    public String speak() {
+        return "Woof!";
+    }
+}

--- a/test-goldens/kotlin/full_module.kt
+++ b/test-goldens/kotlin/full_module.kt
@@ -3,9 +3,9 @@ import kotlin.collections.List
 import kotlin.collections.MutableList
 
 internal interface UserRepository {
-    internal fun findById(id: String): User?
+    fun findById(id: String): User?
 
-    internal fun findAll(): List<User>
+    fun findAll(): List<User>
 }
 
 /**

--- a/test-goldens/kotlin/interface.kt
+++ b/test-goldens/kotlin/interface.kt
@@ -2,9 +2,9 @@
  * Generic data repository.
  */
 internal interface Repository<T> {
-    internal fun findById(id: String): T?
+    fun findById(id: String): T?
 
-    internal fun save(entity: T)
+    fun save(entity: T)
 
-    internal fun delete(id: String)
+    fun delete(id: String)
 }

--- a/test-goldens/python/macro_classmethod.py
+++ b/test-goldens/python/macro_classmethod.py
@@ -1,0 +1,3 @@
+@classmethod
+def from_dict(cls, data: dict) -> "User"::
+    return cls(data["name"], data["age"])

--- a/test-goldens/python/static_method.py
+++ b/test-goldens/python/static_method.py
@@ -1,0 +1,4 @@
+class User:
+    @classmethod
+    def from_dict(cls, name: str, age: int) -> User:
+        return cls(name, age)

--- a/tests/csharp/builder_functions.rs
+++ b/tests/csharp/builder_functions.rs
@@ -155,3 +155,35 @@ fn test_function_with_doc() {
 
     golden::assert_golden("csharp/function_with_doc.cs", &output);
 }
+
+#[test]
+fn test_async_suppressed_in_interface() {
+    let ts = TypeSpec::builder("IUserService", TypeKind::Interface)
+        .visibility(Visibility::Public)
+        .add_method(
+            FunSpec::builder("GetUserAsync")
+                .is_async()
+                .returns(TypeName::primitive("Task<User>"))
+                .add_param(ParameterSpec::new("id", TypeName::primitive("string")).unwrap())
+                .build()
+                .unwrap(),
+        )
+        .add_method(
+            FunSpec::builder("SaveUserAsync")
+                .is_async()
+                .returns(TypeName::primitive("Task"))
+                .add_param(ParameterSpec::new("user", TypeName::primitive("User")).unwrap())
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
+
+    let file = FileSpec::builder_with("IUserService.cs", CSharp::new())
+        .add_type(ts)
+        .build()
+        .unwrap();
+    let output = file.render(80).unwrap();
+
+    golden::assert_golden("csharp/async_interface.cs", &output);
+}

--- a/tests/csharp/quote_basic.rs
+++ b/tests/csharp/quote_basic.rs
@@ -46,3 +46,14 @@ fn test_method_calls() {
     .unwrap();
     golden::assert_golden("csharp/macro_method_calls.cs", &render(&block));
 }
+
+#[test]
+fn test_interface_method_signatures() {
+    let block = sigil_quote!(CSharp {
+        Task<User> GetUserAsync(string id);
+        Task SaveUserAsync(User user);
+        void Delete(string id);
+    })
+    .unwrap();
+    golden::assert_golden("csharp/macro_interface_methods.cs", &render(&block));
+}

--- a/tests/java/builder_functions.rs
+++ b/tests/java/builder_functions.rs
@@ -1,9 +1,10 @@
 use sigil_stitch::code_block::CodeBlock;
 use sigil_stitch::lang::java_lang::JavaLang;
 use sigil_stitch::spec::file_spec::FileSpec;
-use sigil_stitch::spec::fun_spec::FunSpec;
-use sigil_stitch::spec::modifiers::Visibility;
+use sigil_stitch::spec::fun_spec::{FunSpec, TypeParamSpec};
+use sigil_stitch::spec::modifiers::{TypeKind, Visibility};
 use sigil_stitch::spec::parameter_spec::ParameterSpec;
+use sigil_stitch::spec::type_spec::TypeSpec;
 use sigil_stitch::type_name::TypeName;
 
 use super::golden;
@@ -58,4 +59,62 @@ fn test_generic_type_params_before_return_type() {
         !output.contains("sortList<T"),
         "should NOT put type params after function name, got:\n{output}"
     );
+}
+
+#[test]
+fn test_override_annotation() {
+    let body = CodeBlock::of("return \"Woof!\";", ()).unwrap();
+
+    let ts = TypeSpec::builder("Dog", TypeKind::Class)
+        .visibility(Visibility::Public)
+        .extends(TypeName::primitive("Animal"))
+        .add_method(
+            FunSpec::builder("speak")
+                .visibility(Visibility::Public)
+                .is_override()
+                .returns(TypeName::primitive("String"))
+                .body(body)
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
+
+    let file = FileSpec::builder_with("Dog.java", JavaLang::new())
+        .add_type(ts)
+        .build()
+        .unwrap();
+    let output = file.render(80).unwrap();
+
+    golden::assert_golden("java/override_method.java", &output);
+}
+
+#[test]
+fn test_generic_params_before_return_golden() {
+    let tp = TypeParamSpec::new("T").with_bound(TypeName::primitive("Comparable"));
+    let body = CodeBlock::of("return Collections.sort(list);", ()).unwrap();
+
+    let ts = TypeSpec::builder("Utils", TypeKind::Class)
+        .visibility(Visibility::Public)
+        .add_method(
+            FunSpec::builder("sortList")
+                .visibility(Visibility::Public)
+                .is_static()
+                .add_type_param(tp)
+                .add_param(ParameterSpec::new("list", TypeName::primitive("List<T>")).unwrap())
+                .returns(TypeName::primitive("List<T>"))
+                .body(body)
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
+
+    let file = FileSpec::builder_with("Utils.java", JavaLang::new())
+        .add_type(ts)
+        .build()
+        .unwrap();
+    let output = file.render(80).unwrap();
+
+    golden::assert_golden("java/generic_params_before_return.java", &output);
 }

--- a/tests/java/quote_basic.rs
+++ b/tests/java/quote_basic.rs
@@ -24,3 +24,27 @@ fn test_basic() {
     .unwrap();
     golden::assert_golden("java/macro_basic.java", &render(&block));
 }
+
+#[test]
+fn test_override_method() {
+    let block = sigil_quote!(JavaLang {
+        @Override
+        public String speak() {
+            return "Woof!";
+        }
+    })
+    .unwrap();
+    golden::assert_golden("java/macro_override_method.java", &render(&block));
+}
+
+#[test]
+fn test_generic_static_method() {
+    let block = sigil_quote!(JavaLang {
+        public static <T extends Comparable> List<T> sortList(List<T> list) {
+            Collections.sort(list);
+            return list;
+        }
+    })
+    .unwrap();
+    golden::assert_golden("java/macro_generic_static.java", &render(&block));
+}

--- a/tests/python/builder_functions.rs
+++ b/tests/python/builder_functions.rs
@@ -2,7 +2,9 @@ use sigil_stitch::code_block::CodeBlock;
 use sigil_stitch::lang::python::Python;
 use sigil_stitch::spec::file_spec::FileSpec;
 use sigil_stitch::spec::fun_spec::FunSpec;
+use sigil_stitch::spec::modifiers::TypeKind;
 use sigil_stitch::spec::parameter_spec::ParameterSpec;
+use sigil_stitch::spec::type_spec::TypeSpec;
 use sigil_stitch::type_name::TypeName;
 
 use super::golden;
@@ -46,4 +48,33 @@ fn test_function_with_doc() {
     let output = file.render(80).unwrap();
 
     golden::assert_golden("python/function_with_doc.py", &output);
+}
+
+#[test]
+fn test_static_method_no_keyword() {
+    let body = CodeBlock::of("return cls(name, age)", ()).unwrap();
+
+    let ts = TypeSpec::builder("User", TypeKind::Class)
+        .add_method(
+            FunSpec::builder("from_dict")
+                .is_static()
+                .annotation(CodeBlock::of("@classmethod", ()).unwrap())
+                .add_param(ParameterSpec::new("cls", TypeName::primitive("")).unwrap())
+                .add_param(ParameterSpec::new("name", TypeName::primitive("str")).unwrap())
+                .add_param(ParameterSpec::new("age", TypeName::primitive("int")).unwrap())
+                .returns(TypeName::primitive("User"))
+                .body(body)
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
+
+    let file = FileSpec::builder_with("user.py", Python::new())
+        .add_type(ts)
+        .build()
+        .unwrap();
+    let output = file.render(80).unwrap();
+
+    golden::assert_golden("python/static_method.py", &output);
 }

--- a/tests/python/quote_basic.rs
+++ b/tests/python/quote_basic.rs
@@ -23,3 +23,15 @@ fn test_basic() {
     .unwrap();
     golden::assert_golden("python/macro_basic.py", &render(&block));
 }
+
+#[test]
+fn test_classmethod_decorator() {
+    let block = sigil_quote!(Python {
+        @classmethod
+        def from_dict(cls, data: dict) -> "User": {
+            return cls(data["name"], data["age"])
+        }
+    })
+    .unwrap();
+    golden::assert_golden("python/macro_classmethod.py", &render(&block));
+}


### PR DESCRIPTION
## Summary

- **#55** — C# interface methods: suppress `internal` visibility and `async` keyword on interface member declarations
- **#57** — Kotlin interface methods: suppress `internal` visibility (implicitly public)
- **#58** — Python: suppress `static` keyword (behavior expressed via `@staticmethod` decorator)
- **#59** — Java: emit `@Override` annotation instead of `override` keyword

## Changes

- Add `DeclarationContext::InterfaceMember` variant; `type_spec.rs` passes it for Interface/Trait bodies
- Add `suppress_async_in_interface` to `FunctionSyntaxConfig` (C# opts in)
- Add `static_keyword` to `FunctionSyntaxConfig` (Python sets to `""`)
- Add `override_keyword` / `override_annotation` to `FunctionSyntaxConfig` (Java uses annotation)
- All keyword emissions (`abstract`, `static`, `override`) consistently guard with `!kw.is_empty()`
- Propagate `InterfaceMember` to Go, JS, TS, Java, Kotlin backends

## Test plan

- [x] `cargo test` — all pass
- [x] `cargo clippy --all-targets` — clean
- [x] C# golden: `T FindById(string id)` (no `internal`)
- [x] Kotlin golden: `fun findById(id: String)` (no `internal`)
- [x] Python: no `static` keyword emitted
- [x] Java: `@Override` annotation on its own line