### PR TITLE
fix: C typedef fnptr, Haskell newtype deriving, macro spacing

### DIFF
--- a/macros/src/parse/format.rs
+++ b/macros/src/parse/format.rs
@@ -37,6 +37,8 @@ pub(super) enum PrevTokenKind {
     Literal,
     GroupOpen,
     Specifier,
+    /// `%W` soft-break — already provides a space, so suppress `maybe_space`.
+    SoftBreak,
 }
 
 /// Context for how `:` should be spaced.
@@ -58,6 +60,9 @@ pub(super) enum ColonContext {
 pub(super) struct SpacingState {
     pub prev: PrevTokenKind,
     pub colon_ctx: ColonContext,
+    /// End position (line, column) of the last specifier's closing group,
+    /// used to detect adjacent specifiers like `$L("a")$L("b")`.
+    pub prev_specifier_end: Option<(usize, usize)>,
 }
 
 impl SpacingState {
@@ -65,6 +70,7 @@ impl SpacingState {
         Self {
             prev: PrevTokenKind::None,
             colon_ctx: ColonContext::TypeAnnotation,
+            prev_specifier_end: None,
         }
     }
 }
@@ -295,6 +301,14 @@ fn tokens_to_format_inner(
         if let TokenTree::Punct(p) = tt
             && p.as_char() == '$'
         {
+            // Check if this `$` is immediately adjacent to the previous
+            // specifier's closing group (e.g. `$L("a")$L("b")` with no
+            // whitespace). Used to suppress unwanted space insertion.
+            let dollar_start = p.span().start();
+            let adjacent_to_prev_specifier = state
+                .prev_specifier_end
+                .is_some_and(|(line, col)| dollar_start.line == line && dollar_start.column == col);
+
             pos += 1;
             if pos >= tokens.len() {
                 return Err(CompileError::new(
@@ -309,14 +323,17 @@ fn tokens_to_format_inner(
             if let TokenTree::Punct(p2) = next
                 && p2.as_char() == '$'
             {
-                maybe_space(
-                    format,
-                    state,
-                    PrevTokenKind::Literal,
-                    TokenAnnotation::Normal,
-                );
+                if !adjacent_to_prev_specifier {
+                    maybe_space(
+                        format,
+                        state,
+                        PrevTokenKind::Literal,
+                        TokenAnnotation::Normal,
+                    );
+                }
                 format.push('$');
                 state.prev = PrevTokenKind::Literal;
+                state.prev_specifier_end = None;
                 pos += 1;
                 continue;
             }
@@ -327,6 +344,7 @@ fn tokens_to_format_inner(
             {
                 format.push_str("%>");
                 state.prev = PrevTokenKind::Specifier;
+                state.prev_specifier_end = None;
                 pos += 1;
                 continue;
             }
@@ -337,6 +355,7 @@ fn tokens_to_format_inner(
             {
                 format.push_str("%<");
                 state.prev = PrevTokenKind::Specifier;
+                state.prev_specifier_end = None;
                 pos += 1;
                 continue;
             }
@@ -345,6 +364,7 @@ fn tokens_to_format_inner(
             if let TokenTree::Punct(p2) = next
                 && p2.as_char() == '+'
             {
+                state.prev_specifier_end = None;
                 pos += 1;
                 continue;
             }
@@ -352,7 +372,8 @@ fn tokens_to_format_inner(
             // `$W` -> `%W` (no arg, no parens)
             if is_ident(next, "W") {
                 format.push_str("%W");
-                state.prev = PrevTokenKind::Specifier;
+                state.prev = PrevTokenKind::SoftBreak;
+                state.prev_specifier_end = None;
                 pos += 1;
                 continue;
             }
@@ -407,14 +428,18 @@ fn tokens_to_format_inner(
 
                 let (sep_expr, iter_expr) = split_join_args(group)?;
 
-                maybe_space(
-                    format,
-                    state,
-                    PrevTokenKind::Specifier,
-                    TokenAnnotation::Normal,
-                );
+                if !adjacent_to_prev_specifier {
+                    maybe_space(
+                        format,
+                        state,
+                        PrevTokenKind::Specifier,
+                        TokenAnnotation::Normal,
+                    );
+                }
                 format.push_str("%L");
                 state.prev = PrevTokenKind::Specifier;
+                let group_end = group.span().end();
+                state.prev_specifier_end = Some((group_end.line, group_end.column));
 
                 let join_expr: TokenStream = quote::quote! {
                     {
@@ -484,14 +509,18 @@ fn tokens_to_format_inner(
                     InterpolationKind::Literal | InterpolationKind::Code => "%L",
                 };
 
-                maybe_space(
-                    format,
-                    state,
-                    PrevTokenKind::Specifier,
-                    TokenAnnotation::Normal,
-                );
+                if !adjacent_to_prev_specifier {
+                    maybe_space(
+                        format,
+                        state,
+                        PrevTokenKind::Specifier,
+                        TokenAnnotation::Normal,
+                    );
+                }
                 format.push_str(specifier);
                 state.prev = PrevTokenKind::Specifier;
+                let group_end = group.span().end();
+                state.prev_specifier_end = Some((group_end.line, group_end.column));
 
                 args.push(TypedArg {
                     kind,
@@ -509,6 +538,9 @@ fn tokens_to_format_inner(
         }
 
         let annotation = annotations[pos];
+
+        // Regular (non-interpolation) token — clear specifier adjacency tracking.
+        state.prev_specifier_end = None;
 
         // Regular tokens.
         match tt {
@@ -657,6 +689,11 @@ pub(super) fn maybe_space(
     let prev = state.prev;
 
     if prev == PrevTokenKind::None || prev == PrevTokenKind::GroupOpen {
+        return;
+    }
+
+    // %W already provides a space (or newline), so don't add another.
+    if prev == PrevTokenKind::SoftBreak {
         return;
     }
 

--- a/src/spec/type_spec.rs
+++ b/src/spec/type_spec.rs
@@ -413,9 +413,24 @@ impl TypeSpec {
         };
 
         let fmt = if lang.type_decl_syntax().type_alias_target_first {
-            // C typedef: `typedef target name;`
-            args.push(Arg::TypeName(target));
-            format!("{kw} %T {}{tp_str}{semi}", self.name)
+            // C function pointer typedef: `typedef void (*Name)(int, char*);`
+            if let TypeName::Function {
+                params,
+                return_type,
+            } = &target
+            {
+                args.push(Arg::TypeName((**return_type).clone()));
+                for p in params {
+                    args.push(Arg::TypeName(p.clone()));
+                }
+                let param_placeholders: Vec<&str> = params.iter().map(|_| "%T").collect();
+                let params_str = param_placeholders.join(", ");
+                format!("{kw} %T (*{}{tp_str})({params_str}){semi}", self.name)
+            } else {
+                // Normal C typedef: `typedef target name;`
+                args.push(Arg::TypeName(target));
+                format!("{kw} %T {}{tp_str}{semi}", self.name)
+            }
         } else {
             // Normal: `{vis}type name<params> = target;`
             args.push(Arg::TypeName(target));
@@ -460,6 +475,15 @@ impl TypeSpec {
             cb.add(&line, tp_args);
         }
         cb.add_line();
+
+        let suffix = self.render_impl_type_suffix(lang);
+        if !suffix.is_empty() {
+            cb.add("%>", ());
+            cb.add("%L", suffix);
+            cb.add_line();
+            cb.add("%<", ());
+        }
+
         cb.build()
     }
 

--- a/test-goldens/c/builder_typedef_function_pointer.c
+++ b/test-goldens/c/builder_typedef_function_pointer.c
@@ -1,0 +1,1 @@
+typedef void (*Callback)(int, const char*);

--- a/test-goldens/c/builder_typedef_non_function.c
+++ b/test-goldens/c/builder_typedef_non_function.c
@@ -1,0 +1,1 @@
+typedef unsigned long Size;

--- a/test-goldens/c/quote_function_pointer.c
+++ b/test-goldens/c/quote_function_pointer.c
@@ -1,0 +1,3 @@
+typedef void(*Callback)(int, const char *);
+Callback cb = NULL;
+cb(42, "hello");

--- a/test-goldens/haskell/builder_newtype_deriving.hs
+++ b/test-goldens/haskell/builder_newtype_deriving.hs
@@ -1,0 +1,2 @@
+newtype UserId = UserId Int
+    deriving (Show, Eq, Ord)

--- a/test-goldens/haskell/quote_newtype.hs
+++ b/test-goldens/haskell/quote_newtype.hs
@@ -1,0 +1,2 @@
+newtype UserId = UserId Int
+newtype Email = Email String

--- a/test-goldens/macro/quote_consecutive_specifiers.txt
+++ b/test-goldens/macro/quote_consecutive_specifiers.txt
@@ -1,0 +1,1 @@
+const x = premidpost;

--- a/test-goldens/macro/quote_wrap_point.txt
+++ b/test-goldens/macro/quote_wrap_point.txt
@@ -1,0 +1,1 @@
+createUser( firstName, lastName);

--- a/test-goldens/typescript/builder_consecutive_specifiers.ts
+++ b/test-goldens/typescript/builder_consecutive_specifiers.ts
@@ -1,0 +1,1 @@
+const x = premidpost;

--- a/test-goldens/typescript/builder_wrap_point.ts
+++ b/test-goldens/typescript/builder_wrap_point.ts
@@ -1,0 +1,1 @@
+createUser( firstName: string, lastName: string)

--- a/tests/c/builder_types.rs
+++ b/tests/c/builder_types.rs
@@ -60,3 +60,41 @@ fn test_enum() {
 
     golden::assert_golden("c/enum.c", &output);
 }
+
+#[test]
+fn test_typedef_function_pointer() {
+    let callback = TypeSpec::builder("Callback", TypeKind::TypeAlias)
+        .extends(TypeName::function(
+            vec![
+                TypeName::primitive("int"),
+                TypeName::primitive("const char*"),
+            ],
+            TypeName::primitive("void"),
+        ))
+        .build()
+        .unwrap();
+
+    let file = FileSpec::builder_with("callback.h", CLang::header())
+        .add_type(callback)
+        .build()
+        .unwrap();
+    let output = file.render(80).unwrap();
+
+    golden::assert_golden("c/builder_typedef_function_pointer.c", &output);
+}
+
+#[test]
+fn test_typedef_non_function() {
+    let size = TypeSpec::builder("Size", TypeKind::TypeAlias)
+        .extends(TypeName::primitive("unsigned long"))
+        .build()
+        .unwrap();
+
+    let file = FileSpec::builder_with("types.h", CLang::header())
+        .add_type(size)
+        .build()
+        .unwrap();
+    let output = file.render(80).unwrap();
+
+    golden::assert_golden("c/builder_typedef_non_function.c", &output);
+}

--- a/tests/c/quote_basic.rs
+++ b/tests/c/quote_basic.rs
@@ -24,3 +24,14 @@ fn test_basic() {
     .unwrap();
     golden::assert_golden("c/macro_basic.c", &render(&block));
 }
+
+#[test]
+fn test_function_pointer_usage() {
+    let block = sigil_quote!(CLang {
+        typedef void (*Callback)(int, const char*);
+        Callback cb = NULL;
+        cb(42, $S("hello"));
+    })
+    .unwrap();
+    golden::assert_golden("c/quote_function_pointer.c", &render(&block));
+}

--- a/tests/haskell/builder_types.rs
+++ b/tests/haskell/builder_types.rs
@@ -161,3 +161,22 @@ fn test_data_with_deriving_record() {
 
     golden::assert_golden("haskell/data_deriving_record.hs", &output);
 }
+
+#[test]
+fn test_newtype_deriving() {
+    let ts = TypeSpec::builder("UserId", TypeKind::Newtype)
+        .extends(TypeName::primitive("Int"))
+        .implements(TypeName::primitive("Show"))
+        .implements(TypeName::primitive("Eq"))
+        .implements(TypeName::primitive("Ord"))
+        .build()
+        .unwrap();
+
+    let file = FileSpec::builder_with("UserId.hs", Haskell::new())
+        .add_type(ts)
+        .build()
+        .unwrap();
+    let output = file.render(80).unwrap();
+
+    golden::assert_golden("haskell/builder_newtype_deriving.hs", &output);
+}

--- a/tests/haskell/quote_basic.rs
+++ b/tests/haskell/quote_basic.rs
@@ -23,3 +23,13 @@ fn test_basic() {
     .unwrap();
     golden::assert_golden("haskell/macro_basic.hs", &render(&block));
 }
+
+#[test]
+fn test_newtype_declaration() {
+    let block = sigil_quote!(Haskell {
+        newtype UserId = UserId Int;
+        newtype Email = Email String;
+    })
+    .unwrap();
+    golden::assert_golden("haskell/quote_newtype.hs", &render(&block));
+}

--- a/tests/macro/interpolation.rs
+++ b/tests/macro/interpolation.rs
@@ -1,3 +1,4 @@
+use super::golden;
 use super::helpers::*;
 
 #[test]
@@ -105,4 +106,19 @@ fn test_mixed_arg_types_in_one_statement() {
     assert!(output.contains("User"), "got: {output}");
     assert!(output.contains("'hello'"), "got: {output}");
     assert!(output.contains("42"), "got: {output}");
+}
+
+#[test]
+fn test_consecutive_specifiers_no_space() {
+    let block = sigil_quote!(TypeScript {
+        const x = $L("pre")$L("mid")$L("post");
+    })
+    .unwrap();
+
+    let output = render_ts(&block);
+    assert!(
+        output.contains("premidpost"),
+        "consecutive $L should have no space between them, got: {output}"
+    );
+    golden::assert_golden("macro/quote_consecutive_specifiers.txt", &output);
 }

--- a/tests/macro/main.rs
+++ b/tests/macro/main.rs
@@ -1,5 +1,8 @@
 mod helpers;
 
+#[path = "../golden.rs"]
+mod golden;
+
 mod args_tuple;
 mod basic;
 mod blank_lines;

--- a/tests/macro/wrap_points.rs
+++ b/tests/macro/wrap_points.rs
@@ -1,3 +1,4 @@
+use super::golden;
 use super::helpers::*;
 
 #[test]
@@ -28,4 +29,25 @@ fn test_wrap_point_narrow_width() {
         .unwrap();
     let output = file.render(20).unwrap();
     assert!(output.contains("doSomething"), "got: {output}");
+}
+
+#[test]
+fn test_wrap_point_no_double_space() {
+    let block = sigil_quote!(TypeScript {
+        createUser($W firstName, $W lastName);
+    })
+    .unwrap();
+
+    let output = render_ts(&block);
+    // %W produces a single space (soft break) — there should not be a double
+    // space between the wrap point and the following token.
+    assert!(
+        output.contains("createUser( firstName"),
+        "should have single space after $W, got: {output}"
+    );
+    assert!(
+        !output.contains("createUser(  firstName"),
+        "double space after $W, got: {output}"
+    );
+    golden::assert_golden("macro/quote_wrap_point.txt", &output);
 }

--- a/tests/typescript/builder_edge_cases.rs
+++ b/tests/typescript/builder_edge_cases.rs
@@ -344,3 +344,39 @@ fn test_embedded_in_ts_interface() {
     let output = file.render(80).unwrap();
     golden::assert_golden("typescript/embedded_interface.ts", &output);
 }
+
+// ── %W wrap point produces single space, not double ───────────────
+
+#[test]
+fn test_wrap_point_single_space() {
+    let mut b = CodeBlock::builder();
+    b.add("createUser(%WfirstName: string,%WlastName: string)", ());
+    b.add_line();
+    let block = b.build().unwrap();
+
+    let file = FileSpec::builder("test.ts")
+        .add_code(block)
+        .build()
+        .unwrap();
+    let output = file.render(80).unwrap();
+
+    golden::assert_golden("typescript/builder_wrap_point.ts", &output);
+}
+
+// ── Consecutive %L specifiers join without spaces ───────────────
+
+#[test]
+fn test_consecutive_specifiers_no_space() {
+    let mut b = CodeBlock::builder();
+    b.add("const x = %L%L%L;", ("pre", "mid", "post"));
+    b.add_line();
+    let block = b.build().unwrap();
+
+    let file = FileSpec::builder("test.ts")
+        .add_code(block)
+        .build()
+        .unwrap();
+    let output = file.render(80).unwrap();
+
+    golden::assert_golden("typescript/builder_consecutive_specifiers.ts", &output);
+}


### PR DESCRIPTION
## Summary

- C typedef with function pointer now renders `typedef void (*Name)(params);` instead of placing the name after the parameter list (#51)
- Haskell newtype with `implements()` now emits the `deriving` clause (#63)
- `$W` no longer produces double spaces in `sigil_quote!` (#45)
- Consecutive specifiers (`$L$L`, `$T$T`) no longer insert unwanted spaces (#48)

## Test plan

- [x] Builder golden: `c/typedef_function_pointer.c`, `c/typedef_non_function.c`
- [x] Builder golden: `haskell/newtype_deriving.hs`
- [x] Quote golden: `c/macro_function_pointer.c`, `haskell/macro_newtype.hs`
- [x] Unit test: `test_wrap_point_no_double_space` (macro/wrap_points)
- [x] Unit test: `test_consecutive_specifiers_no_space` (macro/interpolation)
- [x] Full test suite passes (1350+ tests, 0 failures)
- [x] clippy + fmt clean

Closes #45, #48, #51, #63