### PR TITLE
fix: annotation-based spacing for sigil_quote tokenizer

### DIFF
--- a/macros/src/parse/format.rs
+++ b/macros/src/parse/format.rs
@@ -21,6 +21,14 @@ pub(super) enum TokenAnnotation {
     MacroBang,
     /// `?` in `?.` safe-call — suppress space before it.
     SafeCallQ,
+    /// First `+` of `++` or first `-` of `--` used as postfix — suppress space before.
+    PostfixIncDec,
+    /// `*` used as postfix pointer marker (e.g. `Config*`) — suppress space before.
+    PostfixStar,
+    /// `-` starting `->` when adjacent to preceding token (member access, not type arrow).
+    ArrowOp,
+    /// First `:` of `::` used as operator (not path separator) — space before it.
+    DoubleColonOp,
 }
 
 /// What kind of token was just emitted (for spacing decisions).
@@ -39,6 +47,8 @@ pub(super) enum PrevTokenKind {
     Specifier,
     /// `%W` soft-break — already provides a space, so suppress `maybe_space`.
     SoftBreak,
+    /// `$$` literal dollar — suppress space after it so `$$1` renders as `$1`.
+    DollarLiteral,
 }
 
 /// Context for how `:` should be spaced.
@@ -150,13 +160,26 @@ fn annotate_tokens(tokens: &[TokenTree]) -> Vec<TokenAnnotation> {
                 let ch = p.as_char();
                 match ch {
                     ':' => {
-                        // PathSepComplete: first `:` is Joint and next is `:`
+                        // PathSepComplete: first `:` is Joint, next is `:`, and
+                        // the `::` is span-adjacent to the preceding token
+                        // (no whitespace before `::` → path separator like `std::fmt`).
+                        // When user writes `fmap :: Type` with space, it's an operator.
                         if p.spacing() == Spacing::Joint
                             && i + 1 < tokens.len()
                             && let TokenTree::Punct(next_p) = &tokens[i + 1]
                             && next_p.as_char() == ':'
                         {
-                            annotations[i + 1] = TokenAnnotation::PathSepComplete;
+                            let is_path_sep = i > 0 && {
+                                let prev_end = tokens[i - 1].span().end();
+                                let colon_start = p.span().start();
+                                prev_end.line == colon_start.line
+                                    && prev_end.column == colon_start.column
+                            };
+                            if is_path_sep {
+                                annotations[i + 1] = TokenAnnotation::PathSepComplete;
+                            } else {
+                                annotations[i] = TokenAnnotation::DoubleColonOp;
+                            }
                         }
                     }
                     '!' if p.spacing() == Spacing::Alone
@@ -165,7 +188,66 @@ fn annotate_tokens(tokens: &[TokenTree]) -> Vec<TokenAnnotation> {
                     {
                         annotations[i] = TokenAnnotation::MacroBang;
                     }
+                    '+' | '-'
+                        if p.spacing() == Spacing::Joint
+                            && i + 1 < tokens.len()
+                            && matches!(&tokens[i + 1], TokenTree::Punct(np) if np.as_char() == ch) =>
+                    {
+                        // ++ or -- : check if postfix (preceded by ident, literal, or group close)
+                        let is_postfix = if i == 0 {
+                            false
+                        } else {
+                            match &tokens[i - 1] {
+                                TokenTree::Ident(id) => {
+                                    let s = id.to_string();
+                                    !CONTROL_FLOW_KEYWORDS.contains(&s.as_str())
+                                }
+                                TokenTree::Literal(_) => true,
+                                TokenTree::Group(g) => matches!(
+                                    g.delimiter(),
+                                    Delimiter::Parenthesis | Delimiter::Bracket
+                                ),
+                                _ => false,
+                            }
+                        };
+                        if is_postfix {
+                            annotations[i] = TokenAnnotation::PostfixIncDec;
+                        }
+                    }
                     '&' | '*' | '-' => {
+                        // ArrowOp: `-` that forms `->` and is span-adjacent to
+                        // preceding token (member access like `cfg->host`).
+                        if ch == '-'
+                            && p.spacing() == Spacing::Joint
+                            && i + 1 < tokens.len()
+                            && matches!(&tokens[i + 1], TokenTree::Punct(np) if np.as_char() == '>')
+                            && i > 0
+                        {
+                            let prev_end = tokens[i - 1].span().end();
+                            let cur_start = p.span().start();
+                            if prev_end.line == cur_start.line
+                                && prev_end.column == cur_start.column
+                            {
+                                annotations[i] = TokenAnnotation::ArrowOp;
+                                annotations[i + 1] = TokenAnnotation::ArrowOp;
+                                i += 2;
+                                continue;
+                            }
+                        }
+
+                        // PostfixStar: `*` span-adjacent to preceding ident (pointer type like `Config*`).
+                        if ch == '*' && i > 0 && matches!(&tokens[i - 1], TokenTree::Ident(_)) {
+                            let prev_end = tokens[i - 1].span().end();
+                            let star_start = p.span().start();
+                            if prev_end.line == star_start.line
+                                && prev_end.column == star_start.column
+                            {
+                                annotations[i] = TokenAnnotation::PostfixStar;
+                                i += 1;
+                                continue;
+                            }
+                        }
+
                         // PrefixOp: NOT preceded by non-keyword ident, literal, `)`, or `]`
                         // After keywords like `return`, `-` is prefix (unary minus)
                         let is_prefix = if i == 0 {
@@ -327,12 +409,12 @@ fn tokens_to_format_inner(
                     maybe_space(
                         format,
                         state,
-                        PrevTokenKind::Literal,
+                        PrevTokenKind::DollarLiteral,
                         TokenAnnotation::Normal,
                     );
                 }
                 format.push('$');
-                state.prev = PrevTokenKind::Literal;
+                state.prev = PrevTokenKind::DollarLiteral;
                 state.prev_specifier_end = None;
                 pos += 1;
                 continue;
@@ -570,7 +652,9 @@ fn tokens_to_format_inner(
                 {
                     match next_p.as_char() {
                         '=' => state.colon_ctx = ColonContext::WalrusAssign,
-                        ':' => state.colon_ctx = ColonContext::PathSeparator,
+                        ':' if annotations[pos + 1] == TokenAnnotation::PathSepComplete => {
+                            state.colon_ctx = ColonContext::PathSeparator;
+                        }
                         _ => {}
                     }
                 }
@@ -593,6 +677,7 @@ fn tokens_to_format_inner(
                     TokenAnnotation::PathSepComplete => PrevTokenKind::PathSep,
                     TokenAnnotation::GenericOpen => PrevTokenKind::GenericOpen,
                     TokenAnnotation::PrefixOp => PrevTokenKind::PrefixOp(ch),
+                    TokenAnnotation::ArrowOp => PrevTokenKind::PathSep,
                     _ => new_kind,
                 };
             }
@@ -702,14 +787,20 @@ pub(super) fn maybe_space(
         TokenAnnotation::MacroBang
         | TokenAnnotation::GenericOpen
         | TokenAnnotation::GenericClose
-        | TokenAnnotation::SafeCallQ => return,
+        | TokenAnnotation::SafeCallQ
+        | TokenAnnotation::PostfixIncDec
+        | TokenAnnotation::PostfixStar
+        | TokenAnnotation::ArrowOp => return,
         _ => {}
     }
 
     // No space after prefix operators, path separators, or generic openers.
     if matches!(
         prev,
-        PrevTokenKind::PrefixOp(_) | PrevTokenKind::PathSep | PrevTokenKind::GenericOpen
+        PrevTokenKind::PrefixOp(_)
+            | PrevTokenKind::PathSep
+            | PrevTokenKind::GenericOpen
+            | PrevTokenKind::DollarLiteral
     ) {
         return;
     }
@@ -718,7 +809,7 @@ pub(super) fn maybe_space(
     if let PrevTokenKind::Punct(ch, _) = current {
         match ch {
             ',' | ';' | ')' | ']' | '.' => return,
-            ':' => match state.colon_ctx {
+            ':' if annotation != TokenAnnotation::DoubleColonOp => match state.colon_ctx {
                 ColonContext::Ternary | ColonContext::WalrusAssign => {}
                 ColonContext::TypeAnnotation
                 | ColonContext::MapEntry

--- a/macros/src/parse/statements.rs
+++ b/macros/src/parse/statements.rs
@@ -46,12 +46,27 @@ pub(super) fn parse_one_statement(
     let mut collected: Vec<TokenTree> = Vec::new();
     let mut prev_end_line: Option<usize> = None;
 
+    // Track whether we're inside a control-flow header that allows embedded
+    // semicolons (Go: `if init; cond {`, `for init; cond; post {`,
+    // `switch init; expr {`). Semicolons before the opening `{` are part of
+    // the header, not statement terminators.
+    let mut in_cf_header = false;
+
     while pos < tokens.len() {
         let tt = &tokens[pos];
 
-        // Check for `;` — statement terminator.
+        if collected.is_empty()
+            && let TokenTree::Ident(id) = tt
+        {
+            let s = id.to_string();
+            if matches!(s.as_str(), "if" | "for" | "switch") {
+                in_cf_header = true;
+            }
+        }
+
+        // Check for `;` — statement terminator, unless inside a CF header.
         // (Any trailing `$+` in collected is handled by tokens_to_format_inner.)
-        if is_semicolon(tt) {
+        if is_semicolon(tt) && !in_cf_header {
             let (format, args) = tokens_to_format(&collected)?;
             return Ok((Statement::Statement { format, args }, pos + 1));
         }

--- a/test-goldens/bash/builder_dollar_escape.bash
+++ b/test-goldens/bash/builder_dollar_escape.bash
@@ -1,0 +1,2 @@
+local level=$1
+echo $level

--- a/test-goldens/bash/quote_dollar_escape.bash
+++ b/test-goldens/bash/quote_dollar_escape.bash
@@ -1,0 +1,2 @@
+local level =$1
+echo $level

--- a/test-goldens/c/builder_arrow_pointer.c
+++ b/test-goldens/c/builder_arrow_pointer.c
@@ -1,0 +1,3 @@
+struct Config* cfg = create_config();
+cfg->host = "localhost";
+cfg->port = 8080;

--- a/test-goldens/c/macro_imports.c
+++ b/test-goldens/c/macro_imports.c
@@ -2,4 +2,4 @@
 #include <stdlib.h>
 
 printf("hello");
-void * p = malloc(sizeof(int));
+void* p = malloc(sizeof(int));

--- a/test-goldens/c/quote_arrow_pointer.c
+++ b/test-goldens/c/quote_arrow_pointer.c
@@ -1,0 +1,3 @@
+struct Config* cfg = create_config();
+cfg->host = "localhost";
+cfg->port = 8080;

--- a/test-goldens/c/quote_function_pointer.c
+++ b/test-goldens/c/quote_function_pointer.c
@@ -1,3 +1,3 @@
-typedef void(*Callback)(int, const char *);
+typedef void(*Callback)(int, const char*);
 Callback cb = NULL;
 cb(42, "hello");

--- a/test-goldens/csharp/macro_for_loop.cs
+++ b/test-goldens/csharp/macro_for_loop.cs
@@ -1,3 +1,3 @@
-for (var i = 0; i < items.Length; i ++) {
+for (var i = 0; i < items.Length; i++) {
     Console.WriteLine(items[i]);
 }

--- a/test-goldens/go/builder_if_init.go
+++ b/test-goldens/go/builder_if_init.go
@@ -1,0 +1,3 @@
+if err := doStuff(); err != nil {
+	return err
+}

--- a/test-goldens/go/quote_for_init.go
+++ b/test-goldens/go/quote_for_init.go
@@ -1,0 +1,3 @@
+for i := 0; i < 10; i++ {
+	fmt.Println(i)
+}

--- a/test-goldens/go/quote_if_init.go
+++ b/test-goldens/go/quote_if_init.go
@@ -1,0 +1,3 @@
+if err := doStuff(); err != nil {
+	return err
+}

--- a/test-goldens/go/quote_switch_init.go
+++ b/test-goldens/go/quote_switch_init.go
@@ -1,0 +1,3 @@
+switch v := getValue(); v {
+	fmt.Println(v)
+}

--- a/test-goldens/haskell/builder_type_annotation.hs
+++ b/test-goldens/haskell/builder_type_annotation.hs
@@ -1,0 +1,2 @@
+map :: (a -> b) -> f a -> f b
+id :: a -> a

--- a/test-goldens/haskell/macro_open_where.hs
+++ b/test-goldens/haskell/macro_open_where.hs
@@ -1,2 +1,2 @@
 class Functor f where
-  fmap::(a -> b) -> f a -> f b
+  fmap :: (a -> b) -> f a -> f b

--- a/test-goldens/haskell/quote_type_annotation.hs
+++ b/test-goldens/haskell/quote_type_annotation.hs
@@ -1,0 +1,2 @@
+map :: (a -> b) -> f a -> f b
+id :: a -> a

--- a/test-goldens/javascript/builder_postfix_increment.js
+++ b/test-goldens/javascript/builder_postfix_increment.js
@@ -1,0 +1,3 @@
+for (let i = 0; i < 10; i++) {
+  count++;
+}

--- a/test-goldens/javascript/quote_postfix_increment.js
+++ b/test-goldens/javascript/quote_postfix_increment.js
@@ -1,0 +1,3 @@
+for (let i = 0; i < 10; i++) {
+  count++;
+}

--- a/tests/bash/builder_edge_cases.rs
+++ b/tests/bash/builder_edge_cases.rs
@@ -58,3 +58,19 @@ fn test_string_escaping() {
     let output = file.render(80).unwrap();
     golden::assert_golden("bash/string_escaping.bash", &output);
 }
+
+#[test]
+fn test_dollar_escape_no_space() {
+    let mut b = CodeBlock::builder();
+    b.add_statement("local level=$1", ());
+    b.add_statement("echo $level", ());
+    let block = b.build().unwrap();
+
+    let file = FileSpec::builder("test.bash")
+        .add_code(block)
+        .build()
+        .unwrap();
+
+    let output = file.render(80).unwrap();
+    golden::assert_golden("bash/builder_dollar_escape.bash", &output);
+}

--- a/tests/bash/quote_basic.rs
+++ b/tests/bash/quote_basic.rs
@@ -23,3 +23,14 @@ fn test_basic() {
     .unwrap();
     golden::assert_golden("bash/macro_basic.bash", &render(&block));
 }
+
+#[test]
+fn test_dollar_escape_no_space() {
+    // `$$` followed by an identifier or number should NOT insert a space.
+    let block = sigil_quote!(Bash {
+        local level=$$1;
+        echo $$level;
+    })
+    .unwrap();
+    golden::assert_golden("bash/quote_dollar_escape.bash", &render(&block));
+}

--- a/tests/c/builder_edge_cases.rs
+++ b/tests/c/builder_edge_cases.rs
@@ -12,6 +12,23 @@ use sigil_stitch::type_name::TypeName;
 use super::golden;
 
 #[test]
+fn test_arrow_and_pointer_spacing() {
+    let mut b = CodeBlock::builder();
+    b.add_statement("struct Config* cfg = create_config()", ());
+    b.add_statement("cfg->host = %S", (StringLitArg("localhost".to_string()),));
+    b.add_statement("cfg->port = 8080", ());
+    let block = b.build().unwrap();
+
+    let file = FileSpec::builder_with("test.c", CLang::new())
+        .add_code(block)
+        .build()
+        .unwrap();
+    let output = file.render(80).unwrap();
+
+    golden::assert_golden("c/builder_arrow_pointer.c", &output);
+}
+
+#[test]
 fn test_struct_basic() {
     let mut b = CodeBlock::builder();
     b.add("struct Point", ());

--- a/tests/c/quote_basic.rs
+++ b/tests/c/quote_basic.rs
@@ -35,3 +35,14 @@ fn test_function_pointer_usage() {
     .unwrap();
     golden::assert_golden("c/quote_function_pointer.c", &render(&block));
 }
+
+#[test]
+fn test_arrow_and_pointer_spacing() {
+    let block = sigil_quote!(CLang {
+        struct Config* cfg = create_config();
+        cfg->host = $S("localhost");
+        cfg->port = 8080;
+    })
+    .unwrap();
+    golden::assert_golden("c/quote_arrow_pointer.c", &render(&block));
+}

--- a/tests/go/builder_control_flow.rs
+++ b/tests/go/builder_control_flow.rs
@@ -31,3 +31,20 @@ fn test_control_flow() {
     let output = file.render(80).unwrap();
     golden::assert_golden("go/control_flow.go", &output);
 }
+
+#[test]
+fn test_if_init_semicolon() {
+    let mut b = CodeBlock::builder();
+    b.begin_control_flow("if err := doStuff(); err != nil", ());
+    b.add_statement("return err", ());
+    b.end_control_flow();
+    let block = b.build().unwrap();
+
+    let file = FileSpec::builder_with("test.go", GoLang::new())
+        .add_code(block)
+        .build()
+        .unwrap();
+
+    let output = file.render(80).unwrap();
+    golden::assert_golden("go/builder_if_init.go", &output);
+}

--- a/tests/go/quote_control_flow.rs
+++ b/tests/go/quote_control_flow.rs
@@ -26,3 +26,36 @@ fn test_control_flow() {
     .unwrap();
     golden::assert_golden("go/macro_control_flow.go", &render(&block));
 }
+
+#[test]
+fn test_if_init_semicolon() {
+    let block = sigil_quote!(GoLang {
+        if err := doStuff(); err != nil {
+            return err;
+        }
+    })
+    .unwrap();
+    golden::assert_golden("go/quote_if_init.go", &render(&block));
+}
+
+#[test]
+fn test_for_init_semicolon() {
+    let block = sigil_quote!(GoLang {
+        for i := 0; i < 10; i++ {
+            fmt.Println(i);
+        }
+    })
+    .unwrap();
+    golden::assert_golden("go/quote_for_init.go", &render(&block));
+}
+
+#[test]
+fn test_switch_init_semicolon() {
+    let block = sigil_quote!(GoLang {
+        switch v := getValue(); v {
+            fmt.Println(v);
+        }
+    })
+    .unwrap();
+    golden::assert_golden("go/quote_switch_init.go", &render(&block));
+}

--- a/tests/haskell/builder_edge_cases.rs
+++ b/tests/haskell/builder_edge_cases.rs
@@ -1,2 +1,21 @@
-// Haskell builder edge-case tests.
-// Currently all edge-case-like tests are covered in other modules.
+use sigil_stitch::code_block::CodeBlock;
+use sigil_stitch::lang::haskell::Haskell;
+use sigil_stitch::spec::file_spec::FileSpec;
+
+use super::golden;
+
+#[test]
+fn test_type_annotation() {
+    let mut b = CodeBlock::builder();
+    b.add_statement("map :: (a -> b) -> f a -> f b", ());
+    b.add_statement("id :: a -> a", ());
+    let block = b.build().unwrap();
+
+    let file = FileSpec::builder_with("test.hs", Haskell::new())
+        .add_code(block)
+        .build()
+        .unwrap();
+
+    let output = file.render(80).unwrap();
+    golden::assert_golden("haskell/builder_type_annotation.hs", &output);
+}

--- a/tests/haskell/quote_edge_cases.rs
+++ b/tests/haskell/quote_edge_cases.rs
@@ -24,3 +24,13 @@ fn test_open_where() {
     .unwrap();
     golden::assert_golden("haskell/macro_open_where.hs", &render(&block));
 }
+
+#[test]
+fn test_type_annotation() {
+    let block = sigil_quote!(Haskell {
+        map :: (a -> b) -> f a -> f b;
+        id :: a -> a;
+    })
+    .unwrap();
+    golden::assert_golden("haskell/quote_type_annotation.hs", &render(&block));
+}

--- a/tests/javascript/builder_edge_cases.rs
+++ b/tests/javascript/builder_edge_cases.rs
@@ -78,3 +78,20 @@ fn test_full_module() {
 
     golden::assert_golden("javascript/full_module.js", &output);
 }
+
+#[test]
+fn test_postfix_increment() {
+    let mut b = CodeBlock::builder();
+    b.begin_control_flow("for (let i = 0; i < 10; i++)", ());
+    b.add_statement("count++", ());
+    b.end_control_flow();
+    let block = b.build().unwrap();
+
+    let file = FileSpec::builder_with("test.js", JavaScript::new())
+        .add_code(block)
+        .build()
+        .unwrap();
+    let output = file.render(80).unwrap();
+
+    golden::assert_golden("javascript/builder_postfix_increment.js", &output);
+}

--- a/tests/javascript/quote_basic.rs
+++ b/tests/javascript/quote_basic.rs
@@ -24,3 +24,14 @@ fn test_basic() {
     .unwrap();
     golden::assert_golden("javascript/macro_basic.js", &render(&block));
 }
+
+#[test]
+fn test_postfix_increment() {
+    let block = sigil_quote!(JavaScript {
+        for (let i = 0; i < 10; i++) {
+            count++;
+        }
+    })
+    .unwrap();
+    golden::assert_golden("javascript/quote_postfix_increment.js", &render(&block));
+}

--- a/tests/macro/helpers.rs
+++ b/tests/macro/helpers.rs
@@ -1,5 +1,6 @@
 pub use sigil_stitch::code_block::{CodeBlock, NameArg, StringLitArg};
 pub use sigil_stitch::import_collector;
+pub use sigil_stitch::lang::c_lang::CLang;
 pub use sigil_stitch::lang::cpp_lang::CppLang;
 pub use sigil_stitch::lang::csharp::CSharp;
 pub use sigil_stitch::lang::dart::DartLang;
@@ -14,8 +15,25 @@ pub use sigil_stitch::prelude::*;
 pub use sigil_stitch::spec::file_spec::FileSpec;
 pub use sigil_stitch::type_name::TypeName;
 
+pub fn render_js(block: &CodeBlock) -> String {
+    use sigil_stitch::lang::javascript::JavaScript;
+    let file = FileSpec::builder_with("test.js", JavaScript::new())
+        .add_code(block.clone())
+        .build()
+        .unwrap();
+    file.render(80).unwrap()
+}
+
 pub fn render_ts(block: &CodeBlock) -> String {
     let file = FileSpec::builder("test.ts")
+        .add_code(block.clone())
+        .build()
+        .unwrap();
+    file.render(80).unwrap()
+}
+
+pub fn render_c(block: &CodeBlock) -> String {
+    let file = FileSpec::builder_with("test.c", CLang::new())
         .add_code(block.clone())
         .build()
         .unwrap();

--- a/tests/macro/spacing.rs
+++ b/tests/macro/spacing.rs
@@ -602,3 +602,119 @@ fn test_elvis_no_space_before_question() {
     let output = render_kt(&block);
     assert!(output.contains("x ?: \"default\""), "got: {output}");
 }
+
+// --- Postfix pointer (`*`) spacing (Issue #44) ---
+
+#[test]
+fn test_postfix_star_pointer_type() {
+    let block = sigil_quote!(CppLang {
+        Config* cfg = get_config();
+    })
+    .unwrap();
+
+    let output = render_cpp(&block);
+    assert!(
+        output.contains("Config*"),
+        "no space before * in pointer type. got: {output}"
+    );
+}
+
+#[test]
+fn test_postfix_star_const_pointer() {
+    let block = sigil_quote!(CppLang {
+        const char* host = get_host();
+    })
+    .unwrap();
+
+    let output = render_cpp(&block);
+    assert!(
+        output.contains("char*"),
+        "no space before * after type name. got: {output}"
+    );
+}
+
+#[test]
+fn test_multiplication_still_spaced() {
+    // After a group close, `*` should still be multiplication
+    let block = sigil_quote!(TypeScript {
+        const x = (a + b) * c;
+    })
+    .unwrap();
+
+    let output = render_ts(&block);
+    assert!(
+        output.contains("(a + b) * c"),
+        "multiplication should keep spaces. got: {output}"
+    );
+}
+
+// --- Postfix `++` and `--` spacing ---
+
+#[test]
+fn test_postfix_increment() {
+    let block = sigil_quote!(JavaScript {
+        for (let i = 0; i < 10; i++) {
+            count++;
+        }
+    })
+    .unwrap();
+
+    let output = render_js(&block);
+    assert!(output.contains("i++"), "got: {output}");
+    assert!(output.contains("count++"), "got: {output}");
+}
+
+#[test]
+fn test_postfix_decrement() {
+    let block = sigil_quote!(JavaScript {
+        while (n > 0) {
+            n--;
+        }
+    })
+    .unwrap();
+
+    let output = render_js(&block);
+    assert!(output.contains("n--"), "got: {output}");
+}
+
+#[test]
+fn test_binary_plus_still_spaced() {
+    let block = sigil_quote!(JavaScript {
+        const x = a + b;
+    })
+    .unwrap();
+
+    let output = render_js(&block);
+    assert!(
+        output.contains("a + b"),
+        "binary + should keep spaces. got: {output}"
+    );
+}
+
+#[test]
+fn test_binary_minus_still_spaced() {
+    let block = sigil_quote!(JavaScript {
+        const x = a - b;
+    })
+    .unwrap();
+
+    let output = render_js(&block);
+    assert!(
+        output.contains("a - b"),
+        "binary - should keep spaces. got: {output}"
+    );
+}
+
+#[test]
+fn test_binary_star_still_spaced() {
+    let block = sigil_quote!(CLang {
+        int x = a * b;
+    })
+    .unwrap();
+
+    let output = render_c(&block);
+    assert!(
+        output.contains("a * b"),
+        "binary * should keep spaces. got: {output}"
+    );
+}


### PR DESCRIPTION
## Summary

- Fix 5 proc-macro tokenizer spacing issues using the existing `TokenAnnotation` system with **span adjacency** heuristics — no language config threading needed
- `ArrowOp`: suppress space around `->` when span-adjacent (C member access `cfg->host`), preserve when user writes spaces (Haskell `a -> b`)
- `PostfixStar`: suppress space before `*` when span-adjacent to ident (`Config*`, `void*`)
- `PostfixIncDec`: suppress space before `++`/`--` when postfix (`i++`)
- `DoubleColonOp`: use span adjacency to distinguish path separator (`std::fmt`) from type operator (`fmap ::`)
- `DollarLiteral`: suppress space after `$$` literal dollar (`$$var` → `$var`)
- `in_cf_header`: don't split on `;` inside `if`/`for`/`switch` headers (Go init-semicolons)

## Test plan

- [x] All existing tests pass (700+ across 15+ languages)
- [x] Both `builder_*` and `quote_*` golden tests for each fix
- [x] Regression tests: binary `*`, `+`, `-` still get spaces
- [x] clippy clean, fmt clean

Closes #44, #46, #47, #49, #53