### PR TITLE
test: add golden tests for macro meta-features and language edge cases

### DIFF
--- a/test-goldens/csharp/quote_null_conditional.cs
+++ b/test-goldens/csharp/quote_null_conditional.cs
@@ -1,0 +1,2 @@
+var name = user?.Profile?.DisplayName;
+var count = items?.Count ?? 0;

--- a/test-goldens/dart/quote_cascade.dart
+++ b/test-goldens/dart/quote_cascade.dart
@@ -1,0 +1,3 @@
+final builder = StringBuffer()
+..write("hello")
+..write(" world");

--- a/test-goldens/go/quote_imports.go
+++ b/test-goldens/go/quote_imports.go
@@ -1,0 +1,7 @@
+import (
+	"fmt"
+	"net/http"
+)
+
+srv := &http.Server{}
+fmt.Println(srv)

--- a/test-goldens/haskell/quote_imports.hs
+++ b/test-goldens/haskell/quote_imports.hs
@@ -1,0 +1,4 @@
+import Data.Map (Map)
+import Data.Text (Text)
+
+let users = Map.fromList[(Text.pack "alice", 1)]

--- a/test-goldens/java/quote_ternary.java
+++ b/test-goldens/java/quote_ternary.java
@@ -1,0 +1,2 @@
+String result = x != null ? x.toString() : "default";
+int value = flag ? 1 : 0;

--- a/test-goldens/kotlin/quote_elvis.kt
+++ b/test-goldens/kotlin/quote_elvis.kt
@@ -1,0 +1,2 @@
+val name: String = input ?: "default"
+val count = list?.size ?: 0

--- a/test-goldens/kotlin/quote_safe_call.kt
+++ b/test-goldens/kotlin/quote_safe_call.kt
@@ -1,0 +1,2 @@
+val name = response.body?.string()
+val length = name?.length

--- a/test-goldens/lua/builder_string_concat.lua
+++ b/test-goldens/lua/builder_string_concat.lua
@@ -1,0 +1,2 @@
+local greeting = "Hello, "..name.."!"
+local path = dir.."/"..file

--- a/test-goldens/lua/builder_table_constructor.lua
+++ b/test-goldens/lua/builder_table_constructor.lua
@@ -1,0 +1,5 @@
+local config = {
+  host = "localhost"
+  port = 8080
+  ["special-key"] = true
+}

--- a/test-goldens/lua/quote_imports.lua
+++ b/test-goldens/lua/quote_imports.lua
@@ -1,0 +1,5 @@
+local json = require("dkjson");
+local inspect = require("inspect");
+
+local data = json.decode(input)
+inspect(data)

--- a/test-goldens/lua/quote_local_function.lua
+++ b/test-goldens/lua/quote_local_function.lua
@@ -1,0 +1,4 @@
+local function add(a, b)
+  return a + b
+end
+local result = add(1, 2)

--- a/test-goldens/lua/quote_string_concat.lua
+++ b/test-goldens/lua/quote_string_concat.lua
@@ -1,0 +1,2 @@
+local greeting = "Hello, "..name.."!"
+local path = dir.."/"..file

--- a/test-goldens/macro/quote_c_each.txt
+++ b/test-goldens/macro/quote_c_each.txt
@@ -1,0 +1,4 @@
+const start = true;
+x = 1
+y = 2
+const end = true;

--- a/test-goldens/macro/quote_comment.txt
+++ b/test-goldens/macro/quote_comment.txt
@@ -1,0 +1,4 @@
+// Initialize values
+const x = 0;
+// Process result
+const y = x + 1;

--- a/test-goldens/macro/quote_continuation.txt
+++ b/test-goldens/macro/quote_continuation.txt
@@ -1,0 +1,1 @@
+mapM_ putStrLn items

--- a/test-goldens/macro/quote_continuation_kotlin.txt
+++ b/test-goldens/macro/quote_continuation_kotlin.txt
@@ -1,0 +1,1 @@
+val result = someFunction(arg1, arg2)

--- a/test-goldens/macro/quote_indent_dedent.txt
+++ b/test-goldens/macro/quote_indent_dedent.txt
@@ -1,0 +1,4 @@
+namespace Foo {
+    const x = 1;
+    const y = 2;
+}

--- a/test-goldens/macro/quote_join.txt
+++ b/test-goldens/macro/quote_join.txt
@@ -1,0 +1,1 @@
+doSomething(x, y, z);

--- a/test-goldens/macro/quote_meta_for.txt
+++ b/test-goldens/macro/quote_meta_for.txt
@@ -1,0 +1,3 @@
+console.log(name);
+console.log(age);
+console.log(email);

--- a/test-goldens/macro/quote_meta_if_else.txt
+++ b/test-goldens/macro/quote_meta_if_else.txt
@@ -1,0 +1,1 @@
+const result = await fetch(url);

--- a/test-goldens/ocaml/quote_imports.ml
+++ b/test-goldens/ocaml/quote_imports.ml
@@ -1,0 +1,3 @@
+open List
+
+let result = t.map f xs

--- a/test-goldens/python/quote_imports.py
+++ b/test-goldens/python/quote_imports.py
@@ -1,0 +1,5 @@
+from json import dumps
+from os.path import join
+
+data = dumps(obj)
+full_path = join(base, name)

--- a/test-goldens/scala/quote_pattern_match.scala
+++ b/test-goldens/scala/quote_pattern_match.scala
@@ -1,0 +1,4 @@
+val result = x match {
+  case (1) => "one"
+  case (_) => "other"
+}

--- a/test-goldens/swift/quote_optional_chain.swift
+++ b/test-goldens/swift/quote_optional_chain.swift
@@ -1,0 +1,2 @@
+let name = user?.profile?.displayName
+let count = items?.count ?? 0

--- a/tests/csharp/main.rs
+++ b/tests/csharp/main.rs
@@ -7,4 +7,5 @@ mod builder_imports;
 mod builder_types;
 mod quote_basic;
 mod quote_control_flow;
+mod quote_edge_cases;
 mod quote_imports;

--- a/tests/csharp/quote_edge_cases.rs
+++ b/tests/csharp/quote_edge_cases.rs
@@ -1,0 +1,25 @@
+use sigil_stitch::code_block::CodeBlock;
+use sigil_stitch::lang::csharp::CSharp;
+use sigil_stitch::prelude::*;
+use sigil_stitch::spec::file_spec::FileSpec;
+
+use super::golden;
+
+fn render(block: &CodeBlock) -> String {
+    FileSpec::builder_with("Test.cs", CSharp::new())
+        .add_code(block.clone())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap()
+}
+
+#[test]
+fn test_null_conditional() {
+    let block = sigil_quote!(CSharp {
+        var name = user?.Profile?.DisplayName;
+        var count = items?.Count ?? 0;
+    })
+    .unwrap();
+    golden::assert_golden("csharp/quote_null_conditional.cs", &render(&block));
+}

--- a/tests/dart/main.rs
+++ b/tests/dart/main.rs
@@ -8,4 +8,5 @@ mod builder_imports;
 mod builder_types;
 mod quote_basic;
 mod quote_control_flow;
+mod quote_edge_cases;
 mod quote_imports;

--- a/tests/dart/quote_edge_cases.rs
+++ b/tests/dart/quote_edge_cases.rs
@@ -1,0 +1,26 @@
+use sigil_stitch::code_block::CodeBlock;
+use sigil_stitch::lang::dart::DartLang;
+use sigil_stitch::prelude::*;
+use sigil_stitch::spec::file_spec::FileSpec;
+
+use super::golden;
+
+fn render(block: &CodeBlock) -> String {
+    FileSpec::builder_with("test.dart", DartLang::new())
+        .add_code(block.clone())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap()
+}
+
+#[test]
+fn test_cascade() {
+    let block = sigil_quote!(DartLang {
+        final builder = StringBuffer()
+            ..write("hello")
+            ..write(" world");
+    })
+    .unwrap();
+    golden::assert_golden("dart/quote_cascade.dart", &render(&block));
+}

--- a/tests/go/main.rs
+++ b/tests/go/main.rs
@@ -9,3 +9,4 @@ mod builder_types;
 mod quote_basic;
 mod quote_control_flow;
 mod quote_edge_cases;
+mod quote_imports;

--- a/tests/go/quote_imports.rs
+++ b/tests/go/quote_imports.rs
@@ -1,0 +1,28 @@
+use sigil_stitch::code_block::CodeBlock;
+use sigil_stitch::lang::go_lang::GoLang;
+use sigil_stitch::prelude::*;
+use sigil_stitch::spec::file_spec::FileSpec;
+use sigil_stitch::type_name::TypeName;
+
+use super::golden;
+
+fn render(block: &CodeBlock) -> String {
+    FileSpec::builder_with("test.go", GoLang::new())
+        .add_code(block.clone())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap()
+}
+
+#[test]
+fn test_imports() {
+    let fmt_println = TypeName::importable("fmt", "Println");
+    let http_server = TypeName::importable("net/http", "Server");
+    let block = sigil_quote!(GoLang {
+        srv := &$T(http_server){};
+        $T(fmt_println)(srv);
+    })
+    .unwrap();
+    golden::assert_golden("go/quote_imports.go", &render(&block));
+}

--- a/tests/haskell/main.rs
+++ b/tests/haskell/main.rs
@@ -9,3 +9,4 @@ mod builder_types;
 mod quote_basic;
 mod quote_control_flow;
 mod quote_edge_cases;
+mod quote_imports;

--- a/tests/haskell/quote_imports.rs
+++ b/tests/haskell/quote_imports.rs
@@ -1,0 +1,27 @@
+use sigil_stitch::code_block::CodeBlock;
+use sigil_stitch::lang::haskell::Haskell;
+use sigil_stitch::prelude::*;
+use sigil_stitch::spec::file_spec::FileSpec;
+use sigil_stitch::type_name::TypeName;
+
+use super::golden;
+
+fn render(block: &CodeBlock) -> String {
+    FileSpec::builder_with("test.hs", Haskell::new())
+        .add_code(block.clone())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap()
+}
+
+#[test]
+fn test_imports() {
+    let map_type = TypeName::importable("Data.Map", "Map");
+    let text_type = TypeName::importable("Data.Text", "Text");
+    let block = sigil_quote!(Haskell {
+        let users = $T(map_type).fromList [($T(text_type).pack "alice", 1)]
+    })
+    .unwrap();
+    golden::assert_golden("haskell/quote_imports.hs", &render(&block));
+}

--- a/tests/java/main.rs
+++ b/tests/java/main.rs
@@ -8,4 +8,5 @@ mod builder_imports;
 mod builder_types;
 mod quote_basic;
 mod quote_control_flow;
+mod quote_edge_cases;
 mod quote_imports;

--- a/tests/java/quote_edge_cases.rs
+++ b/tests/java/quote_edge_cases.rs
@@ -1,0 +1,25 @@
+use sigil_stitch::code_block::CodeBlock;
+use sigil_stitch::lang::java_lang::JavaLang;
+use sigil_stitch::prelude::*;
+use sigil_stitch::spec::file_spec::FileSpec;
+
+use super::golden;
+
+fn render(block: &CodeBlock) -> String {
+    FileSpec::builder_with("Test.java", JavaLang::new())
+        .add_code(block.clone())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap()
+}
+
+#[test]
+fn test_ternary() {
+    let block = sigil_quote!(JavaLang {
+        String result = x != null ? x.toString() : "default";
+        int value = flag ? 1 : 0;
+    })
+    .unwrap();
+    golden::assert_golden("java/quote_ternary.java", &render(&block));
+}

--- a/tests/kotlin/main.rs
+++ b/tests/kotlin/main.rs
@@ -8,4 +8,5 @@ mod builder_imports;
 mod builder_types;
 mod quote_basic;
 mod quote_control_flow;
+mod quote_edge_cases;
 mod quote_imports;

--- a/tests/kotlin/quote_edge_cases.rs
+++ b/tests/kotlin/quote_edge_cases.rs
@@ -1,0 +1,35 @@
+use sigil_stitch::code_block::CodeBlock;
+use sigil_stitch::lang::kotlin::Kotlin;
+use sigil_stitch::prelude::*;
+use sigil_stitch::spec::file_spec::FileSpec;
+
+use super::golden;
+
+fn render(block: &CodeBlock) -> String {
+    FileSpec::builder_with("test.kt", Kotlin::new())
+        .add_code(block.clone())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap()
+}
+
+#[test]
+fn test_safe_call() {
+    let block = sigil_quote!(Kotlin {
+        val name = response.body?.string();
+        val length = name?.length;
+    })
+    .unwrap();
+    golden::assert_golden("kotlin/quote_safe_call.kt", &render(&block));
+}
+
+#[test]
+fn test_elvis() {
+    let block = sigil_quote!(Kotlin {
+        val name: String = input ?: "default";
+        val count = list?.size ?: 0;
+    })
+    .unwrap();
+    golden::assert_golden("kotlin/quote_elvis.kt", &render(&block));
+}

--- a/tests/lua/builder_edge_cases.rs
+++ b/tests/lua/builder_edge_cases.rs
@@ -1,0 +1,44 @@
+use sigil_stitch::code_block::CodeBlock;
+use sigil_stitch::lang::lua::Lua;
+use sigil_stitch::spec::file_spec::FileSpec;
+
+use super::golden;
+
+#[test]
+fn test_string_concat() {
+    let mut b = CodeBlock::builder();
+    b.add_statement("local greeting = \"Hello, \"..name..\"!\"", ());
+    b.add_statement("local path = dir..\"/\"..file", ());
+    let block = b.build().unwrap();
+
+    let file = FileSpec::builder_with("test.lua", Lua::new())
+        .add_code(block)
+        .build()
+        .unwrap();
+    let output = file.render(80).unwrap();
+
+    golden::assert_golden("lua/builder_string_concat.lua", &output);
+}
+
+#[test]
+fn test_table_constructor() {
+    let mut b = CodeBlock::builder();
+    b.add("local config = {", ());
+    b.add_line();
+    b.add("%>", ());
+    b.add_statement("host = \"localhost\"", ());
+    b.add_statement("port = 8080", ());
+    b.add_statement("[\"special-key\"] = true", ());
+    b.add("%<", ());
+    b.add("}", ());
+    b.add_line();
+    let block = b.build().unwrap();
+
+    let file = FileSpec::builder_with("test.lua", Lua::new())
+        .add_code(block)
+        .build()
+        .unwrap();
+    let output = file.render(80).unwrap();
+
+    golden::assert_golden("lua/builder_table_constructor.lua", &output);
+}

--- a/tests/lua/main.rs
+++ b/tests/lua/main.rs
@@ -2,7 +2,10 @@
 mod golden;
 
 mod builder_control_flow;
+mod builder_edge_cases;
 mod builder_functions;
 mod builder_imports;
 mod quote_basic;
 mod quote_control_flow;
+mod quote_edge_cases;
+mod quote_imports;

--- a/tests/lua/quote_edge_cases.rs
+++ b/tests/lua/quote_edge_cases.rs
@@ -1,0 +1,37 @@
+use sigil_stitch::code_block::CodeBlock;
+use sigil_stitch::lang::lua::Lua;
+use sigil_stitch::prelude::*;
+use sigil_stitch::spec::file_spec::FileSpec;
+
+use super::golden;
+
+fn render(block: &CodeBlock) -> String {
+    FileSpec::builder_with("test.lua", Lua::new())
+        .add_code(block.clone())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap()
+}
+
+#[test]
+fn test_string_concat() {
+    let block = sigil_quote!(Lua {
+        local greeting = "Hello, "..name.."!"
+        local path = dir.."/"..file
+    })
+    .unwrap();
+    golden::assert_golden("lua/quote_string_concat.lua", &render(&block));
+}
+
+#[test]
+fn test_local_function() {
+    let block = sigil_quote!(Lua {
+        local function add(a, b) {
+            return a + b
+        }
+        local result = add(1, 2)
+    })
+    .unwrap();
+    golden::assert_golden("lua/quote_local_function.lua", &render(&block));
+}

--- a/tests/lua/quote_imports.rs
+++ b/tests/lua/quote_imports.rs
@@ -1,0 +1,28 @@
+use sigil_stitch::code_block::CodeBlock;
+use sigil_stitch::lang::lua::Lua;
+use sigil_stitch::prelude::*;
+use sigil_stitch::spec::file_spec::FileSpec;
+use sigil_stitch::type_name::TypeName;
+
+use super::golden;
+
+fn render(block: &CodeBlock) -> String {
+    FileSpec::builder_with("test.lua", Lua::new())
+        .add_code(block.clone())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap()
+}
+
+#[test]
+fn test_imports() {
+    let json = TypeName::importable("dkjson", "json");
+    let inspect = TypeName::importable("inspect", "inspect");
+    let block = sigil_quote!(Lua {
+        local data = $T(json).decode(input)
+        $T(inspect)(data)
+    })
+    .unwrap();
+    golden::assert_golden("lua/quote_imports.lua", &render(&block));
+}

--- a/tests/macro/c_each.rs
+++ b/tests/macro/c_each.rs
@@ -1,3 +1,4 @@
+use super::golden;
 use super::helpers::*;
 
 // --- Basic $C_each ---
@@ -378,4 +379,22 @@ fn test_c_each_no_trailing_blank_line_in_fun_spec_body() {
         output.contains("this.statusCode = statusCode;"),
         "got:\n{output}"
     );
+}
+
+#[test]
+fn test_c_each_golden() {
+    let items = vec![
+        CodeBlock::of("x = 1", ()).unwrap(),
+        CodeBlock::of("y = 2", ()).unwrap(),
+    ];
+
+    let block = sigil_quote!(TypeScript {
+        const start = true;
+        $C_each(items);
+        const end = true;
+    })
+    .unwrap();
+
+    let output = render_ts(&block);
+    golden::assert_golden("macro/quote_c_each.txt", &output);
 }

--- a/tests/macro/comments.rs
+++ b/tests/macro/comments.rs
@@ -1,3 +1,4 @@
+use super::golden;
 use super::helpers::*;
 
 #[test]
@@ -86,4 +87,18 @@ fn test_comment_with_backslash_escape() {
 
     let output = render_ts(&block);
     assert!(output.contains("path\\to\\file"), "got: {output}");
+}
+
+#[test]
+fn test_comment_golden() {
+    let block = sigil_quote!(TypeScript {
+        $comment("Initialize values");
+        const x = 0;
+        $comment("Process result");
+        const y = x + 1;
+    })
+    .unwrap();
+
+    let output = render_ts(&block);
+    golden::assert_golden("macro/quote_comment.txt", &output);
 }

--- a/tests/macro/indent_dedent.rs
+++ b/tests/macro/indent_dedent.rs
@@ -1,3 +1,4 @@
+use super::golden;
 use super::helpers::*;
 
 #[test]
@@ -21,4 +22,18 @@ fn test_manual_indent_dedent() {
         "expected indented y, got: {output}"
     );
     assert!(output.contains("}"), "got: {output}");
+}
+
+#[test]
+fn test_indent_dedent_golden() {
+    let block = sigil_quote!(TypeScript {
+        namespace Foo {$>
+        const x = 1;
+        const y = 2;
+        $<}
+    })
+    .unwrap();
+
+    let output = render_ts(&block);
+    golden::assert_golden("macro/quote_indent_dedent.txt", &output);
 }

--- a/tests/macro/join.rs
+++ b/tests/macro/join.rs
@@ -1,3 +1,4 @@
+use super::golden;
 use super::helpers::*;
 
 // --- Basic $join ---
@@ -181,4 +182,17 @@ fn test_join_combined_with_c_each() {
     assert!(output.contains("handle(a, b, c)"), "got: {output}");
     assert!(output.contains("validate(input)"), "got: {output}");
     assert!(output.contains("process(input)"), "got: {output}");
+}
+
+#[test]
+fn test_join_golden() {
+    let args = vec!["x", "y", "z"];
+
+    let block = sigil_quote!(TypeScript {
+        doSomething($join(", ", args));
+    })
+    .unwrap();
+
+    let output = render_ts(&block);
+    golden::assert_golden("macro/quote_join.txt", &output);
 }

--- a/tests/macro/line_splitting.rs
+++ b/tests/macro/line_splitting.rs
@@ -1,3 +1,4 @@
+use super::golden;
 use super::helpers::*;
 
 #[test]
@@ -99,4 +100,29 @@ fn test_continuation_mid_line_is_noop() {
     let output = render_kt(&block);
     assert!(output.contains("val x = 1"), "got: {output}");
     assert!(!output.contains('+'), "got: {output}");
+}
+
+#[test]
+fn test_continuation_golden() {
+    let block = sigil_quote!(Haskell {
+        mapM_ $+
+            putStrLn $+
+            items
+    })
+    .unwrap();
+
+    let output = render_hs(&block);
+    golden::assert_golden("macro/quote_continuation.txt", &output);
+}
+
+#[test]
+fn test_continuation_kotlin_golden() {
+    let block = sigil_quote!(Kotlin {
+        val result = someFunction( $+
+            arg1, arg2);
+    })
+    .unwrap();
+
+    let output = render_kt(&block);
+    golden::assert_golden("macro/quote_continuation_kotlin.txt", &output);
 }

--- a/tests/macro/meta_for.rs
+++ b/tests/macro/meta_for.rs
@@ -1,3 +1,4 @@
+use super::golden;
 use super::helpers::*;
 
 // --- Basic $for loop ---
@@ -189,4 +190,19 @@ fn test_meta_for_enum_variants() {
     assert!(output.contains("Red = 0,"), "got: {output}");
     assert!(output.contains("Green = 1,"), "got: {output}");
     assert!(output.contains("Blue = 2,"), "got: {output}");
+}
+
+#[test]
+fn test_meta_for_golden() {
+    let fields = vec!["name", "age", "email"];
+
+    let block = sigil_quote!(TypeScript {
+        $for(field in &fields) {
+            console.log($L(*field));
+        }
+    })
+    .unwrap();
+
+    let output = render_ts(&block);
+    golden::assert_golden("macro/quote_meta_for.txt", &output);
 }

--- a/tests/macro/meta_if.rs
+++ b/tests/macro/meta_if.rs
@@ -1,3 +1,4 @@
+use super::golden;
 use super::helpers::*;
 
 // --- Basic meta-conditionals ---
@@ -236,4 +237,21 @@ fn test_meta_if_only_else_if_true() {
     assert!(!output.contains("\"a\""), "got: {output}");
     assert!(output.contains("\"b\""), "got: {output}");
     assert!(!output.contains("\"none\""), "got: {output}");
+}
+
+#[test]
+fn test_meta_if_else_golden() {
+    let use_async = true;
+
+    let block = sigil_quote!(TypeScript {
+        $if(use_async) {
+            const result = await fetch(url);
+        } $else {
+            const result = fetchSync(url);
+        }
+    })
+    .unwrap();
+
+    let output = render_ts(&block);
+    golden::assert_golden("macro/quote_meta_if_else.txt", &output);
 }

--- a/tests/ocaml/main.rs
+++ b/tests/ocaml/main.rs
@@ -9,3 +9,4 @@ mod builder_types;
 mod quote_basic;
 mod quote_control_flow;
 mod quote_edge_cases;
+mod quote_imports;

--- a/tests/ocaml/quote_imports.rs
+++ b/tests/ocaml/quote_imports.rs
@@ -1,0 +1,26 @@
+use sigil_stitch::code_block::CodeBlock;
+use sigil_stitch::lang::ocaml::OCaml;
+use sigil_stitch::prelude::*;
+use sigil_stitch::spec::file_spec::FileSpec;
+use sigil_stitch::type_name::TypeName;
+
+use super::golden;
+
+fn render(block: &CodeBlock) -> String {
+    FileSpec::builder_with("test.ml", OCaml::new())
+        .add_code(block.clone())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap()
+}
+
+#[test]
+fn test_imports() {
+    let list_mod = TypeName::importable("List", "t");
+    let block = sigil_quote!(OCaml {
+        let result = $T(list_mod).map f xs
+    })
+    .unwrap();
+    golden::assert_golden("ocaml/quote_imports.ml", &render(&block));
+}

--- a/tests/python/main.rs
+++ b/tests/python/main.rs
@@ -8,3 +8,4 @@ mod builder_imports;
 mod builder_types;
 mod quote_basic;
 mod quote_control_flow;
+mod quote_imports;

--- a/tests/python/quote_imports.rs
+++ b/tests/python/quote_imports.rs
@@ -1,0 +1,27 @@
+use sigil_stitch::code_block::CodeBlock;
+use sigil_stitch::prelude::*;
+use sigil_stitch::spec::file_spec::FileSpec;
+use sigil_stitch::type_name::TypeName;
+
+use super::golden;
+
+fn render(block: &CodeBlock) -> String {
+    FileSpec::builder("test.py")
+        .add_code(block.clone())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap()
+}
+
+#[test]
+fn test_imports() {
+    let json_dumps = TypeName::importable("json", "dumps");
+    let path_join = TypeName::importable("os.path", "join");
+    let block = sigil_quote!(Python {
+        data = $T(json_dumps)(obj);
+        full_path = $T(path_join)(base, name);
+    })
+    .unwrap();
+    golden::assert_golden("python/quote_imports.py", &render(&block));
+}

--- a/tests/scala/main.rs
+++ b/tests/scala/main.rs
@@ -8,4 +8,5 @@ mod builder_imports;
 mod builder_types;
 mod quote_basic;
 mod quote_control_flow;
+mod quote_edge_cases;
 mod quote_imports;

--- a/tests/scala/quote_edge_cases.rs
+++ b/tests/scala/quote_edge_cases.rs
@@ -1,0 +1,27 @@
+use sigil_stitch::code_block::CodeBlock;
+use sigil_stitch::lang::scala::Scala;
+use sigil_stitch::prelude::*;
+use sigil_stitch::spec::file_spec::FileSpec;
+
+use super::golden;
+
+fn render(block: &CodeBlock) -> String {
+    FileSpec::builder_with("test.scala", Scala::new())
+        .add_code(block.clone())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap()
+}
+
+#[test]
+fn test_pattern_match() {
+    let block = sigil_quote!(Scala {
+        val result = x match {
+            case(1) => "one"
+            case(_) => "other"
+        }
+    })
+    .unwrap();
+    golden::assert_golden("scala/quote_pattern_match.scala", &render(&block));
+}

--- a/tests/swift/main.rs
+++ b/tests/swift/main.rs
@@ -8,4 +8,5 @@ mod builder_imports;
 mod builder_types;
 mod quote_basic;
 mod quote_control_flow;
+mod quote_edge_cases;
 mod quote_imports;

--- a/tests/swift/quote_edge_cases.rs
+++ b/tests/swift/quote_edge_cases.rs
@@ -1,0 +1,25 @@
+use sigil_stitch::code_block::CodeBlock;
+use sigil_stitch::lang::swift::Swift;
+use sigil_stitch::prelude::*;
+use sigil_stitch::spec::file_spec::FileSpec;
+
+use super::golden;
+
+fn render(block: &CodeBlock) -> String {
+    FileSpec::builder_with("test.swift", Swift::new())
+        .add_code(block.clone())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap()
+}
+
+#[test]
+fn test_optional_chaining() {
+    let block = sigil_quote!(Swift {
+        let name = user?.profile?.displayName;
+        let count = items?.count ?? 0;
+    })
+    .unwrap();
+    golden::assert_golden("swift/quote_optional_chain.swift", &render(&block));
+}


### PR DESCRIPTION
## Summary

- Add golden anchors for 7 macro meta-features (`$+`, `$comment`, `$>/$<`, `$C_each`, `$join`, `$for`, `$if/$else`) that previously had only substring assertions
- Add `quote_imports` golden tests for Go, Python, Lua, Haskell, OCaml (previously only builder-side coverage)
- Add `quote_edge_cases` golden tests for Lua, Kotlin, Swift, Java, C#, Dart, Scala (pin spacing for `?.`, `?:`, `..`, ternary, null-conditional, cascade, pattern match)
- Add Lua `builder_edge_cases` (string concat, table constructor)
- 24 new golden files across 12 languages, 55 files changed

## Test plan

- [x] `BLESS=1 cargo test --all` generates all goldens
- [x] `cargo test --all` passes (1385+ tests, 0 failures)
- [x] `cargo clippy --all-targets` clean
- [x] `cargo fmt --check` clean