### PR TITLE
test: add comprehensive golden tests for all 18 languages

### DIFF
--- a/test-goldens/bash/quote_array.bash
+++ b/test-goldens/bash/quote_array.bash
@@ -1,0 +1,4 @@
+declare - a ITEMS
+ITEMS = (one two three)
+echo ${ITEMS[@]}
+echo ${#ITEMS[@]}

--- a/test-goldens/bash/quote_function_local.bash
+++ b/test-goldens/bash/quote_function_local.bash
@@ -1,0 +1,4 @@
+function greet() {
+    local name =$1
+    echo "Hello, \${name}\!"
+}

--- a/test-goldens/bash/quote_here_string.bash
+++ b/test-goldens/bash/quote_here_string.bash
@@ -1,0 +1,2 @@
+read - r line <<< "hello world"
+echo $line

--- a/test-goldens/bash/quote_imports.bash
+++ b/test-goldens/bash/quote_imports.bash
@@ -1,0 +1,5 @@
+source "./lib/config.sh"
+source "./lib/log.sh"
+
+load_config
+log_info "started"

--- a/test-goldens/bash/quote_parameter_expansion.bash
+++ b/test-goldens/bash/quote_parameter_expansion.bash
@@ -1,0 +1,3 @@
+DEFAULT =${NAME:-guest}
+UPPER =${NAME^^}
+SUBSTR =${NAME:0:3}

--- a/test-goldens/c/quote_cast_sizeof.c
+++ b/test-goldens/c/quote_cast_sizeof.c
@@ -1,0 +1,2 @@
+size_t size = sizeof(struct Node);
+int* arr = (int*) malloc(size * sizeof(int));

--- a/test-goldens/c/quote_for_loop.c
+++ b/test-goldens/c/quote_for_loop.c
@@ -1,0 +1,3 @@
+for (int i = 0; i < n; i++) {
+    arr[i] = i * 2;
+}

--- a/test-goldens/c/quote_pointer_decl.c
+++ b/test-goldens/c/quote_pointer_decl.c
@@ -1,0 +1,3 @@
+int* ptr = malloc(sizeof(int));
+const char* msg = "hello";
+void* data = NULL;

--- a/test-goldens/c/quote_preprocessor.c
+++ b/test-goldens/c/quote_preprocessor.c
@@ -1,0 +1,2 @@
+#define MAX_SIZE 1024
+#define MIN(a, b)((a) < (b) ? (a) : (b))

--- a/test-goldens/c/quote_struct_access.c
+++ b/test-goldens/c/quote_struct_access.c
@@ -1,0 +1,3 @@
+node->next = NULL;
+node->data = value;
+result.x = node->point.x;

--- a/test-goldens/cpp/quote_lambda.cpp
+++ b/test-goldens/cpp/quote_lambda.cpp
@@ -1,0 +1,2 @@
+auto fn = [&](int x){return x * 2;};
+auto result = fn(21);

--- a/test-goldens/cpp/quote_range_for.cpp
+++ b/test-goldens/cpp/quote_range_for.cpp
@@ -1,0 +1,3 @@
+for (const auto & item: items) {
+    std::cout << item << std::endl;
+}

--- a/test-goldens/cpp/quote_smart_pointers.cpp
+++ b/test-goldens/cpp/quote_smart_pointers.cpp
@@ -1,0 +1,3 @@
+auto ptr = std::make_unique<Config>();
+auto shared = std::make_shared<Node>(42);
+std::weak_ptr<Node> weak = shared;

--- a/test-goldens/cpp/quote_template_angle.cpp
+++ b/test-goldens/cpp/quote_template_angle.cpp
@@ -1,0 +1,2 @@
+std::vector<std::pair<int, std::string>> items;
+std::map<std::string, std::vector<int>> index;

--- a/test-goldens/csharp/quote_async_await.cs
+++ b/test-goldens/csharp/quote_async_await.cs
@@ -1,0 +1,5 @@
+async Task<string> FetchDataAsync(string url) {
+    using var client = new HttpClient();
+    var response = await client.GetAsync(url);
+    return await response.Content.ReadAsStringAsync();
+}

--- a/test-goldens/csharp/quote_linq.cs
+++ b/test-goldens/csharp/quote_linq.cs
@@ -1,0 +1,4 @@
+var results = items
+.Where(x => x.IsActive)
+.Select(x => x.Name)
+.ToList();

--- a/test-goldens/csharp/quote_nullable.cs
+++ b/test-goldens/csharp/quote_nullable.cs
@@ -1,0 +1,3 @@
+string ? name = null;
+int ? count = GetCount();
+var value = name ?? "default";

--- a/test-goldens/csharp/quote_pattern_matching.cs
+++ b/test-goldens/csharp/quote_pattern_matching.cs
@@ -1,0 +1,1 @@
+var result = shape switch {Circle(c) => c.Radius * c.Radius * Math.PI, Rectangle(r) => r.Width * r.Height, _ => 0,};

--- a/test-goldens/dart/quote_async_await.dart
+++ b/test-goldens/dart/quote_async_await.dart
@@ -1,0 +1,4 @@
+Future<String> fetchData(String url) async {
+  final response = await http.get(Uri.parse(url));
+  return response.body;
+}

--- a/test-goldens/dart/quote_named_params.dart
+++ b/test-goldens/dart/quote_named_params.dart
@@ -1,0 +1,3 @@
+void configure({required String host, int port = 8080}) {
+  print(host);
+}

--- a/test-goldens/dart/quote_null_aware.dart
+++ b/test-goldens/dart/quote_null_aware.dart
@@ -1,0 +1,3 @@
+String name = user?.name ?? 'anonymous';
+list ??= [];
+final length = items?.length ?? 0;

--- a/test-goldens/go/quote_channel.go
+++ b/test-goldens/go/quote_channel.go
@@ -1,0 +1,3 @@
+ch := make(chan int, 10)
+ch <-42
+val := <-ch

--- a/test-goldens/go/quote_defer.go
+++ b/test-goldens/go/quote_defer.go
@@ -1,0 +1,2 @@
+f, err := os.Open(path)
+defer f.Close()

--- a/test-goldens/go/quote_goroutine.go
+++ b/test-goldens/go/quote_goroutine.go
@@ -1,0 +1,4 @@
+go func() {
+	fmt.Println("hello from goroutine")
+}
+()

--- a/test-goldens/go/quote_interface.go
+++ b/test-goldens/go/quote_interface.go
@@ -1,0 +1,3 @@
+type Reader interface {
+	Read(p[] byte)(int, error)
+}

--- a/test-goldens/go/quote_keyword_escape.go
+++ b/test-goldens/go/quote_keyword_escape.go
@@ -1,0 +1,1 @@
+var type_ string

--- a/test-goldens/go/quote_keyword_escape_multi.go
+++ b/test-goldens/go/quote_keyword_escape_multi.go
@@ -1,0 +1,1 @@
+package_ = return_

--- a/test-goldens/go/quote_no_escape.go
+++ b/test-goldens/go/quote_no_escape.go
@@ -1,0 +1,1 @@
+func myHandler()

--- a/test-goldens/haskell/quote_do_notation.hs
+++ b/test-goldens/haskell/quote_do_notation.hs
@@ -1,0 +1,5 @@
+main :: IO()
+main = do =
+  putStrLn "Enter name:"
+  name <-getLine
+  putStrLn("Hello, "++ name)

--- a/test-goldens/haskell/quote_guards.hs
+++ b/test-goldens/haskell/quote_guards.hs
@@ -1,0 +1,5 @@
+classify :: Int -> String
+classify n
+| n < 0 = "negative"
+| n == 0 = "zero"
+| otherwise = "positive"

--- a/test-goldens/haskell/quote_list_comprehension.hs
+++ b/test-goldens/haskell/quote_list_comprehension.hs
@@ -1,0 +1,2 @@
+evens :: [Int] ->[Int]
+evens xs = [x | x <-xs, even x]

--- a/test-goldens/haskell/quote_typeclass_instance.hs
+++ b/test-goldens/haskell/quote_typeclass_instance.hs
@@ -1,0 +1,2 @@
+instance Show Point where
+  show(Point x y) = "("++ show x++ ", "++ show y++ ")"

--- a/test-goldens/java/quote_annotation.java
+++ b/test-goldens/java/quote_annotation.java
@@ -1,0 +1,4 @@
+@Override
+public String toString() {
+    return "MyClass";
+}

--- a/test-goldens/java/quote_generic_method.java
+++ b/test-goldens/java/quote_generic_method.java
@@ -1,0 +1,3 @@
+public < T > T fromJson(String json, Class<T> clazz) {
+    return gson.fromJson(json, clazz);
+}

--- a/test-goldens/java/quote_stream.java
+++ b/test-goldens/java/quote_stream.java
@@ -1,0 +1,4 @@
+List<String> names = users.stream()
+.filter(u -> u.isActive())
+.map(u -> u.getName())
+.collect(Collectors.toList());

--- a/test-goldens/java/quote_try_resources.java
+++ b/test-goldens/java/quote_try_resources.java
@@ -1,0 +1,4 @@
+try (BufferedReader reader = new BufferedReader(new FileReader(path))) {
+    String line = reader.readLine();
+    System.out.println(line);
+}

--- a/test-goldens/javascript/quote_arrow_function.js
+++ b/test-goldens/javascript/quote_arrow_function.js
@@ -1,0 +1,2 @@
+const add = (a, b) => a + b;
+const greet = (name) =>{return 'Hello, ' + name;};

--- a/test-goldens/javascript/quote_async_await.js
+++ b/test-goldens/javascript/quote_async_await.js
@@ -1,0 +1,5 @@
+async function fetchData(url) {
+  const response = await fetch(url);
+  const data = await response.json();
+  return data;
+}

--- a/test-goldens/javascript/quote_destructuring.js
+++ b/test-goldens/javascript/quote_destructuring.js
@@ -1,0 +1,5 @@
+const {
+  name, age
+}
+= user;
+const[first,...rest] = items;

--- a/test-goldens/javascript/quote_spread.js
+++ b/test-goldens/javascript/quote_spread.js
@@ -1,0 +1,2 @@
+const merged = {...defaults,...overrides};
+const combined = [...arr1,...arr2];

--- a/test-goldens/javascript/quote_ternary_nullish.js
+++ b/test-goldens/javascript/quote_ternary_nullish.js
@@ -1,0 +1,2 @@
+const value = x != null ? x : defaultValue;
+const name = user?.name ?? 'anonymous';

--- a/test-goldens/kotlin/quote_extension_fun.kt
+++ b/test-goldens/kotlin/quote_extension_fun.kt
@@ -1,0 +1,3 @@
+fun String.addExclamation(): String {
+    return this + "!"
+}

--- a/test-goldens/kotlin/quote_lambda_receiver.kt
+++ b/test-goldens/kotlin/quote_lambda_receiver.kt
@@ -1,0 +1,1 @@
+val config = Config().apply{host = "localhost"; port = 8080;}

--- a/test-goldens/kotlin/quote_sealed_class.kt
+++ b/test-goldens/kotlin/quote_sealed_class.kt
@@ -1,0 +1,4 @@
+sealed class Result<out T> {
+    data class Success<T>(val value: T): Result<T>()
+    data class Error(val message: String): Result<Nothing>()
+}

--- a/test-goldens/kotlin/quote_when.kt
+++ b/test-goldens/kotlin/quote_when.kt
@@ -1,0 +1,1 @@
+val result = when (x){0 -> "zero" 1 -> "one" else -> "many"}

--- a/test-goldens/lua/quote_for_loop.lua
+++ b/test-goldens/lua/quote_for_loop.lua
@@ -1,0 +1,6 @@
+for i = 1, 10 do
+  print(i)
+end
+for k, v in pairs(t) do
+  print(k, v)
+end

--- a/test-goldens/lua/quote_method_call.lua
+++ b/test-goldens/lua/quote_method_call.lua
@@ -1,0 +1,3 @@
+local obj = {}
+obj: init("config")
+local result = obj: getValue()

--- a/test-goldens/lua/quote_multiline_table.lua
+++ b/test-goldens/lua/quote_multiline_table.lua
@@ -1,0 +1,1 @@
+local config = {host = "localhost", port = 8080, debug = true,}

--- a/test-goldens/lua/quote_vararg.lua
+++ b/test-goldens/lua/quote_vararg.lua
@@ -1,0 +1,4 @@
+local function printf(fmt,...)
+  local args = {...}
+  print(string.format(fmt,...))
+end

--- a/test-goldens/ocaml/quote_let_in.ml
+++ b/test-goldens/ocaml/quote_let_in.ml
@@ -1,0 +1,4 @@
+let compute x =
+let squared = x * x in
+let doubled = squared * 2 in
+doubled + 1

--- a/test-goldens/ocaml/quote_pattern_match.ml
+++ b/test-goldens/ocaml/quote_pattern_match.ml
@@ -1,0 +1,3 @@
+let describe x = match x with =
+  | Some(v) -> Printf.printf "value: %d" v
+  | None -> print_endline "none"

--- a/test-goldens/ocaml/quote_pipe.ml
+++ b/test-goldens/ocaml/quote_pipe.ml
@@ -1,0 +1,4 @@
+let result = input
+|> List.map f
+|> List.filter g
+|> List.fold_left(+) 0

--- a/test-goldens/ocaml/quote_record_update.ml
+++ b/test-goldens/ocaml/quote_record_update.ml
@@ -1,0 +1,1 @@
+let updated = {user with name = "Bob"; age = 30}

--- a/test-goldens/python/quote_async.py
+++ b/test-goldens/python/quote_async.py
@@ -1,0 +1,4 @@
+async def fetch_data(url: str) -> bytes::
+    async with aiohttp.ClientSession() as session::
+        response = await session.get(url)
+        return await response.read()

--- a/test-goldens/python/quote_comprehension.py
+++ b/test-goldens/python/quote_comprehension.py
@@ -1,0 +1,2 @@
+squares = [x * x for x in range(10)]
+evens = [x for x in items if x % 2 == 0]

--- a/test-goldens/python/quote_decorator.py
+++ b/test-goldens/python/quote_decorator.py
@@ -1,0 +1,3 @@
+@app.route("/users")
+def get_users()::
+    return jsonify(users)

--- a/test-goldens/python/quote_type_hints.py
+++ b/test-goldens/python/quote_type_hints.py
@@ -1,0 +1,3 @@
+def process(items: list[str], count: int = 10) -> dict[str, int]::
+    result: dict[str, int] = {}
+    return result

--- a/test-goldens/python/quote_with.py
+++ b/test-goldens/python/quote_with.py
@@ -1,0 +1,2 @@
+with open('file.txt', 'r') as f::
+    content = f.read()

--- a/test-goldens/rust/quote_closure.rs
+++ b/test-goldens/rust/quote_closure.rs
@@ -1,0 +1,2 @@
+let add = | a: i32, b: i32 | -> i32{a + b};
+let result: Vec<i32> = items.iter().map(| x | x * 2).collect();

--- a/test-goldens/rust/quote_impl_block.rs
+++ b/test-goldens/rust/quote_impl_block.rs
@@ -1,0 +1,5 @@
+impl < T: Display > fmt::Display for Wrapper<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "({})", self.0)
+    }
+}

--- a/test-goldens/rust/quote_lifetime.rs
+++ b/test-goldens/rust/quote_lifetime.rs
@@ -1,0 +1,7 @@
+fn longest < 'a >(x: &'a str, y: &'a str) -> &'a str {
+    if x.len() > y.len() {
+        x
+    } else {
+        y
+    }
+}

--- a/test-goldens/rust/quote_pattern_match.rs
+++ b/test-goldens/rust/quote_pattern_match.rs
@@ -1,0 +1,6 @@
+match value {
+    Some(x) if x > 0 => println!("positive: {}", x),
+    Some(0) => println!("zero"),
+    None => println!("nothing"),
+    _ => unreachable!(),
+}

--- a/test-goldens/rust/quote_trait_bound.rs
+++ b/test-goldens/rust/quote_trait_bound.rs
@@ -1,0 +1,3 @@
+fn process < T: Clone + Send + 'static >(item: T) -> T {
+    item.clone()
+}

--- a/test-goldens/scala/quote_case_class.scala
+++ b/test-goldens/scala/quote_case_class.scala
@@ -1,0 +1,2 @@
+case class Person(name: String, age: Int)
+case class Address(street: String, city: String, zip: String)

--- a/test-goldens/scala/quote_for_comprehension.scala
+++ b/test-goldens/scala/quote_for_comprehension.scala
@@ -1,0 +1,5 @@
+val result = for {
+  x <-fetchX()
+  y <-fetchY(x)
+}
+yield (x, y)

--- a/test-goldens/scala/quote_implicit.scala
+++ b/test-goldens/scala/quote_implicit.scala
@@ -1,0 +1,1 @@
+def execute(query: String)(implicit ctx: ExecutionContext): Future[Result] = {Future(runQuery(query));}

--- a/test-goldens/scala/quote_trait_mixin.scala
+++ b/test-goldens/scala/quote_trait_mixin.scala
@@ -1,0 +1,6 @@
+trait Serializable {
+  def serialize(): String
+}
+class User(val name: String) extends Entity with Serializable {
+  def serialize(): String = name
+}

--- a/test-goldens/swift/quote_closure.swift
+++ b/test-goldens/swift/quote_closure.swift
@@ -1,0 +1,2 @@
+let transform: (Int) -> Int = {(x: Int) -> Int in return x * 2}
+let sorted = items.sorted(by: {a, b in a.name < b.name})

--- a/test-goldens/swift/quote_enum_associated.swift
+++ b/test-goldens/swift/quote_enum_associated.swift
@@ -1,0 +1,4 @@
+enum Result<T> {
+    case success(T)
+    case failure(Error)
+}

--- a/test-goldens/swift/quote_guard_let.swift
+++ b/test-goldens/swift/quote_guard_let.swift
@@ -1,0 +1,6 @@
+func process(value: Int ?) {
+    guard let unwrapped = value else {
+        return
+    }
+    print(unwrapped)
+}

--- a/test-goldens/swift/quote_protocol_extension.swift
+++ b/test-goldens/swift/quote_protocol_extension.swift
@@ -1,0 +1,8 @@
+protocol Drawable {
+    func draw()
+}
+extension Drawable {
+    func draw() {
+        print("default draw")
+    }
+}

--- a/test-goldens/typescript/quote_async_await.ts
+++ b/test-goldens/typescript/quote_async_await.ts
@@ -1,0 +1,4 @@
+async function fetchData(url: string): Promise<Response> {
+  const response = await fetch(url);
+  return response.json();
+}

--- a/test-goldens/typescript/quote_destructuring.ts
+++ b/test-goldens/typescript/quote_destructuring.ts
@@ -1,0 +1,11 @@
+const {
+  name, age
+}
+= person;
+const[first,...rest] = items;
+const {
+  data: {
+    users
+  }
+}
+= response;

--- a/test-goldens/typescript/quote_generic_function.ts
+++ b/test-goldens/typescript/quote_generic_function.ts
@@ -1,0 +1,4 @@
+function identity < T >(arg: T): T {
+  return arg;
+}
+const result = identity < string >('hello');

--- a/test-goldens/typescript/quote_mapped_type.ts
+++ b/test-goldens/typescript/quote_mapped_type.ts
@@ -1,0 +1,1 @@
+type Readonly<T> = {readonly[K in keyof T]: T[K];};

--- a/test-goldens/typescript/quote_union_intersection.ts
+++ b/test-goldens/typescript/quote_union_intersection.ts
@@ -1,0 +1,5 @@
+type StringOrNumber = string | number;
+type Combined = TypeA & TypeB;
+function process(value: string | number | null): void {
+  console.log(value);
+}

--- a/test-goldens/zsh/quote_array_operations.zsh
+++ b/test-goldens/zsh/quote_array_operations.zsh
@@ -1,0 +1,4 @@
+typeset - a ITEMS
+ITEMS = (one two three)
+echo ${ITEMS[@]}
+echo ${#ITEMS[@]}

--- a/test-goldens/zsh/quote_function.zsh
+++ b/test-goldens/zsh/quote_function.zsh
@@ -1,0 +1,4 @@
+function greet() {
+    local name =$1
+    echo "Hello, \$name\!"
+}

--- a/test-goldens/zsh/quote_imports.zsh
+++ b/test-goldens/zsh/quote_imports.zsh
@@ -1,0 +1,5 @@
+source "./lib/config.zsh"
+source "./lib/log.zsh"
+
+get_config--reload
+log_info "config loaded"

--- a/test-goldens/zsh/quote_percent_escape.zsh
+++ b/test-goldens/zsh/quote_percent_escape.zsh
@@ -1,0 +1,2 @@
+PROMPT ="%%F{green}%%n@%%m%%f"
+echo $PROMPT

--- a/test-goldens/zsh/quote_variable_expansion.zsh
+++ b/test-goldens/zsh/quote_variable_expansion.zsh
@@ -1,0 +1,3 @@
+DEFAULT =${NAME:-guest}
+LENGTH =${#ITEMS[@]}
+echo $DEFAULT $LENGTH

--- a/tests/bash/main.rs
+++ b/tests/bash/main.rs
@@ -7,3 +7,5 @@ mod builder_functions;
 mod builder_imports;
 mod quote_basic;
 mod quote_control_flow;
+mod quote_edge_cases;
+mod quote_imports;

--- a/tests/bash/quote_edge_cases.rs
+++ b/tests/bash/quote_edge_cases.rs
@@ -1,0 +1,59 @@
+use sigil_stitch::code_block::CodeBlock;
+use sigil_stitch::prelude::*;
+use sigil_stitch::spec::file_spec::FileSpec;
+
+use super::golden;
+
+fn render(block: &CodeBlock) -> String {
+    FileSpec::builder("test.bash")
+        .add_code(block.clone())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap()
+}
+
+#[test]
+fn test_array_syntax() {
+    let block = sigil_quote!(Bash {
+        declare -a ITEMS;
+        ITEMS=(one two three);
+        echo $L("${ITEMS[@]}");
+        echo $L("${#ITEMS[@]}");
+    })
+    .unwrap();
+    golden::assert_golden("bash/quote_array.bash", &render(&block));
+}
+
+#[test]
+fn test_parameter_expansion() {
+    let block = sigil_quote!(Bash {
+        DEFAULT=$L("${NAME:-guest}");
+        UPPER=$L("${NAME^^}");
+        SUBSTR=$L("${NAME:0:3}");
+    })
+    .unwrap();
+    golden::assert_golden("bash/quote_parameter_expansion.bash", &render(&block));
+}
+
+#[test]
+fn test_here_string() {
+    let block = sigil_quote!(Bash {
+        read -r line <<< $S("hello world");
+        echo $L("$line");
+    })
+    .unwrap();
+    golden::assert_golden("bash/quote_here_string.bash", &render(&block));
+}
+
+#[test]
+fn test_function_with_local() {
+    let block = sigil_quote!(Bash {
+        function greet() {
+            local name=$L("$1");
+            echo $S("Hello, ${name}!");
+        }
+    })
+    .unwrap();
+    golden::assert_golden("bash/quote_function_local.bash", &render(&block));
+}

--- a/tests/bash/quote_imports.rs
+++ b/tests/bash/quote_imports.rs
@@ -1,0 +1,27 @@
+use sigil_stitch::code_block::CodeBlock;
+use sigil_stitch::prelude::*;
+use sigil_stitch::spec::file_spec::FileSpec;
+use sigil_stitch::type_name::TypeName;
+
+use super::golden;
+
+fn render(block: &CodeBlock) -> String {
+    FileSpec::builder("test.bash")
+        .add_code(block.clone())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap()
+}
+
+#[test]
+fn test_imports() {
+    let log_fn = TypeName::importable("./lib/log.sh", "log_info");
+    let config_fn = TypeName::importable("./lib/config.sh", "load_config");
+    let block = sigil_quote!(Bash {
+        $T(config_fn);
+        $T(log_fn) $S("started");
+    })
+    .unwrap();
+    golden::assert_golden("bash/quote_imports.bash", &render(&block));
+}

--- a/tests/c/main.rs
+++ b/tests/c/main.rs
@@ -8,4 +8,5 @@ mod builder_imports;
 mod builder_types;
 mod quote_basic;
 mod quote_control_flow;
+mod quote_edge_cases;
 mod quote_imports;

--- a/tests/c/quote_edge_cases.rs
+++ b/tests/c/quote_edge_cases.rs
@@ -1,0 +1,68 @@
+use sigil_stitch::code_block::CodeBlock;
+use sigil_stitch::lang::c_lang::CLang;
+use sigil_stitch::prelude::*;
+use sigil_stitch::spec::file_spec::FileSpec;
+
+use super::golden;
+
+fn render(block: &CodeBlock) -> String {
+    FileSpec::builder_with("test.c", CLang::new())
+        .add_code(block.clone())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap()
+}
+
+#[test]
+fn test_pointer_declaration() {
+    let block = sigil_quote!(CLang {
+        int* ptr = malloc(sizeof(int));
+        const char* msg = "hello";
+        void* data = NULL;
+    })
+    .unwrap();
+    golden::assert_golden("c/quote_pointer_decl.c", &render(&block));
+}
+
+#[test]
+fn test_struct_access() {
+    let block = sigil_quote!(CLang {
+        node->next = NULL;
+        node->data = value;
+        result.x = node->point.x;
+    })
+    .unwrap();
+    golden::assert_golden("c/quote_struct_access.c", &render(&block));
+}
+
+#[test]
+fn test_preprocessor_define() {
+    let block = sigil_quote!(CLang {
+        #define MAX_SIZE 1024
+        #define MIN(a, b) ((a) < (b) ? (a) : (b))
+    })
+    .unwrap();
+    golden::assert_golden("c/quote_preprocessor.c", &render(&block));
+}
+
+#[test]
+fn test_cast_and_sizeof() {
+    let block = sigil_quote!(CLang {
+        size_t size = sizeof(struct Node);
+        int* arr = (int*)malloc(size * sizeof(int));
+    })
+    .unwrap();
+    golden::assert_golden("c/quote_cast_sizeof.c", &render(&block));
+}
+
+#[test]
+fn test_for_loop_with_pointer() {
+    let block = sigil_quote!(CLang {
+        for (int i = 0; i < n; i++) {
+            arr[i] = i * 2;
+        }
+    })
+    .unwrap();
+    golden::assert_golden("c/quote_for_loop.c", &render(&block));
+}

--- a/tests/cpp/quote_edge_cases.rs
+++ b/tests/cpp/quote_edge_cases.rs
@@ -26,3 +26,47 @@ fn test_includes() {
     .unwrap();
     golden::assert_golden("cpp/macro_includes.cpp", &render(&block));
 }
+
+#[test]
+fn test_lambda() {
+    let block = sigil_quote!(CppLang {
+        auto fn = [&](int x) {
+            return x * 2;
+        };
+        auto result = fn(21);
+    })
+    .unwrap();
+    golden::assert_golden("cpp/quote_lambda.cpp", &render(&block));
+}
+
+#[test]
+fn test_template_angle_brackets() {
+    let block = sigil_quote!(CppLang {
+        std::vector<std::pair<int, std::string>> items;
+        std::map<std::string, std::vector<int>> index;
+    })
+    .unwrap();
+    golden::assert_golden("cpp/quote_template_angle.cpp", &render(&block));
+}
+
+#[test]
+fn test_range_for() {
+    let block = sigil_quote!(CppLang {
+        for (const auto& item : items) {
+            std::cout << item << std::endl;
+        }
+    })
+    .unwrap();
+    golden::assert_golden("cpp/quote_range_for.cpp", &render(&block));
+}
+
+#[test]
+fn test_smart_pointers() {
+    let block = sigil_quote!(CppLang {
+        auto ptr = std::make_unique<Config>();
+        auto shared = std::make_shared<Node>(42);
+        std::weak_ptr<Node> weak = shared;
+    })
+    .unwrap();
+    golden::assert_golden("cpp/quote_smart_pointers.cpp", &render(&block));
+}

--- a/tests/csharp/quote_edge_cases.rs
+++ b/tests/csharp/quote_edge_cases.rs
@@ -23,3 +23,52 @@ fn test_null_conditional() {
     .unwrap();
     golden::assert_golden("csharp/quote_null_conditional.cs", &render(&block));
 }
+
+#[test]
+fn test_async_await() {
+    let block = sigil_quote!(CSharp {
+        async Task<string> FetchDataAsync(string url) {
+            using var client = new HttpClient();
+            var response = await client.GetAsync(url);
+            return await response.Content.ReadAsStringAsync();
+        }
+    })
+    .unwrap();
+    golden::assert_golden("csharp/quote_async_await.cs", &render(&block));
+}
+
+#[test]
+fn test_linq_query() {
+    let block = sigil_quote!(CSharp {
+        var results = items
+            .Where(x => x.IsActive)
+            .Select(x => x.Name)
+            .ToList();
+    })
+    .unwrap();
+    golden::assert_golden("csharp/quote_linq.cs", &render(&block));
+}
+
+#[test]
+fn test_pattern_matching() {
+    let block = sigil_quote!(CSharp {
+        var result = shape switch {
+            Circle(c) => c.Radius * c.Radius * Math.PI,
+            Rectangle(r) => r.Width * r.Height,
+            _ => 0,
+        };
+    })
+    .unwrap();
+    golden::assert_golden("csharp/quote_pattern_matching.cs", &render(&block));
+}
+
+#[test]
+fn test_nullable_type() {
+    let block = sigil_quote!(CSharp {
+        string? name = null;
+        int? count = GetCount();
+        var value = name ?? $S("default");
+    })
+    .unwrap();
+    golden::assert_golden("csharp/quote_nullable.cs", &render(&block));
+}

--- a/tests/dart/quote_edge_cases.rs
+++ b/tests/dart/quote_edge_cases.rs
@@ -24,3 +24,37 @@ fn test_cascade() {
     .unwrap();
     golden::assert_golden("dart/quote_cascade.dart", &render(&block));
 }
+
+#[test]
+fn test_named_params() {
+    let block = sigil_quote!(DartLang {
+        void configure({required String host, int port = 8080}) {
+            print(host);
+        }
+    })
+    .unwrap();
+    golden::assert_golden("dart/quote_named_params.dart", &render(&block));
+}
+
+#[test]
+fn test_null_aware() {
+    let block = sigil_quote!(DartLang {
+        String name = user?.name ?? $S("anonymous");
+        list ??= [];
+        final length = items?.length ?? 0;
+    })
+    .unwrap();
+    golden::assert_golden("dart/quote_null_aware.dart", &render(&block));
+}
+
+#[test]
+fn test_async_await() {
+    let block = sigil_quote!(DartLang {
+        Future<String> fetchData(String url) async {
+            final response = await http.get(Uri.parse(url));
+            return response.body;
+        }
+    })
+    .unwrap();
+    golden::assert_golden("dart/quote_async_await.dart", &render(&block));
+}

--- a/tests/go/quote_edge_cases.rs
+++ b/tests/go/quote_edge_cases.rs
@@ -43,6 +43,7 @@ fn test_name_escape_in_macro() {
         output.contains("var type_ string"),
         "Expected 'var type_ string', got: {output}"
     );
+    golden::assert_golden("go/quote_keyword_escape.go", &output);
 }
 
 #[test]
@@ -57,6 +58,7 @@ fn test_name_escape_multiple_keywords_in_macro() {
     let output = render(&block);
     assert!(output.contains("package_"), "Expected 'package_': {output}");
     assert!(output.contains("return_"), "Expected 'return_': {output}");
+    golden::assert_golden("go/quote_keyword_escape_multi.go", &output);
 }
 
 #[test]
@@ -72,4 +74,48 @@ fn test_name_no_escape_in_macro() {
         output.contains("func myHandler()"),
         "Expected 'func myHandler()', got: {output}"
     );
+    golden::assert_golden("go/quote_no_escape.go", &output);
+}
+
+#[test]
+fn test_goroutine() {
+    let block = sigil_quote!(GoLang {
+        go func() {
+            fmt.Println($S("hello from goroutine"));
+        }();
+    })
+    .unwrap();
+    golden::assert_golden("go/quote_goroutine.go", &render(&block));
+}
+
+#[test]
+fn test_channel() {
+    let block = sigil_quote!(GoLang {
+        ch := make(chan int, 10);
+        ch <- 42;
+        val := <-ch;
+    })
+    .unwrap();
+    golden::assert_golden("go/quote_channel.go", &render(&block));
+}
+
+#[test]
+fn test_interface() {
+    let block = sigil_quote!(GoLang {
+        type Reader interface {
+            Read(p []byte) (int, error);
+        }
+    })
+    .unwrap();
+    golden::assert_golden("go/quote_interface.go", &render(&block));
+}
+
+#[test]
+fn test_defer() {
+    let block = sigil_quote!(GoLang {
+        f, err := os.Open(path);
+        defer f.Close();
+    })
+    .unwrap();
+    golden::assert_golden("go/quote_defer.go", &render(&block));
 }

--- a/tests/haskell/quote_edge_cases.rs
+++ b/tests/haskell/quote_edge_cases.rs
@@ -34,3 +34,51 @@ fn test_type_annotation() {
     .unwrap();
     golden::assert_golden("haskell/quote_type_annotation.hs", &render(&block));
 }
+
+#[test]
+fn test_do_notation() {
+    let block = sigil_quote!(Haskell {
+        main :: IO ();
+        main = do {
+            putStrLn $S("Enter name:");
+            name <- getLine;
+            putStrLn ($S("Hello, ") ++ name);
+        }
+    })
+    .unwrap();
+    golden::assert_golden("haskell/quote_do_notation.hs", &render(&block));
+}
+
+#[test]
+fn test_guards() {
+    let block = sigil_quote!(Haskell {
+        classify :: Int -> String;
+        classify n
+            | n < 0 = $S("negative")
+            | n == 0 = $S("zero")
+            | otherwise = $S("positive");
+    })
+    .unwrap();
+    golden::assert_golden("haskell/quote_guards.hs", &render(&block));
+}
+
+#[test]
+fn test_list_comprehension() {
+    let block = sigil_quote!(Haskell {
+        evens :: [Int] -> [Int];
+        evens xs = [x | x <- xs, even x];
+    })
+    .unwrap();
+    golden::assert_golden("haskell/quote_list_comprehension.hs", &render(&block));
+}
+
+#[test]
+fn test_typeclass_instance() {
+    let block = sigil_quote!(Haskell {
+        instance Show Point {
+            show (Point x y) = $S("(") ++ show x ++ $S(", ") ++ show y ++ $S(")");
+        }
+    })
+    .unwrap();
+    golden::assert_golden("haskell/quote_typeclass_instance.hs", &render(&block));
+}

--- a/tests/java/quote_edge_cases.rs
+++ b/tests/java/quote_edge_cases.rs
@@ -23,3 +23,50 @@ fn test_ternary() {
     .unwrap();
     golden::assert_golden("java/quote_ternary.java", &render(&block));
 }
+
+#[test]
+fn test_generic_method() {
+    let block = sigil_quote!(JavaLang {
+        public <T> T fromJson(String json, Class<T> clazz) {
+            return gson.fromJson(json, clazz);
+        }
+    })
+    .unwrap();
+    golden::assert_golden("java/quote_generic_method.java", &render(&block));
+}
+
+#[test]
+fn test_annotation() {
+    let block = sigil_quote!(JavaLang {
+        @Override
+        public String toString() {
+            return $S("MyClass");
+        }
+    })
+    .unwrap();
+    golden::assert_golden("java/quote_annotation.java", &render(&block));
+}
+
+#[test]
+fn test_stream_api() {
+    let block = sigil_quote!(JavaLang {
+        List<String> names = users.stream()
+            .filter(u -> u.isActive())
+            .map(u -> u.getName())
+            .collect(Collectors.toList());
+    })
+    .unwrap();
+    golden::assert_golden("java/quote_stream.java", &render(&block));
+}
+
+#[test]
+fn test_try_with_resources() {
+    let block = sigil_quote!(JavaLang {
+        try (BufferedReader reader = new BufferedReader(new FileReader(path))) {
+            String line = reader.readLine();
+            System.out.println(line);
+        }
+    })
+    .unwrap();
+    golden::assert_golden("java/quote_try_resources.java", &render(&block));
+}

--- a/tests/javascript/main.rs
+++ b/tests/javascript/main.rs
@@ -8,4 +8,5 @@ mod builder_imports;
 mod builder_types;
 mod quote_basic;
 mod quote_control_flow;
+mod quote_edge_cases;
 mod quote_imports;

--- a/tests/javascript/quote_edge_cases.rs
+++ b/tests/javascript/quote_edge_cases.rs
@@ -1,0 +1,70 @@
+use sigil_stitch::code_block::CodeBlock;
+use sigil_stitch::lang::javascript::JavaScript;
+use sigil_stitch::prelude::*;
+use sigil_stitch::spec::file_spec::FileSpec;
+
+use super::golden;
+
+fn render(block: &CodeBlock) -> String {
+    FileSpec::builder_with("test.js", JavaScript::new())
+        .add_code(block.clone())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap()
+}
+
+#[test]
+fn test_arrow_function() {
+    let block = sigil_quote!(JavaScript {
+        const add = (a, b) => a + b;
+        const greet = (name) => {
+            return $S("Hello, ") + name;
+        };
+    })
+    .unwrap();
+    golden::assert_golden("javascript/quote_arrow_function.js", &render(&block));
+}
+
+#[test]
+fn test_destructuring() {
+    let block = sigil_quote!(JavaScript {
+        const { name, age } = user;
+        const [first, ...rest] = items;
+    })
+    .unwrap();
+    golden::assert_golden("javascript/quote_destructuring.js", &render(&block));
+}
+
+#[test]
+fn test_async_await() {
+    let block = sigil_quote!(JavaScript {
+        async function fetchData(url) {
+            const response = await fetch(url);
+            const data = await response.json();
+            return data;
+        }
+    })
+    .unwrap();
+    golden::assert_golden("javascript/quote_async_await.js", &render(&block));
+}
+
+#[test]
+fn test_spread_operator() {
+    let block = sigil_quote!(JavaScript {
+        const merged = { ...defaults, ...overrides };
+        const combined = [...arr1, ...arr2];
+    })
+    .unwrap();
+    golden::assert_golden("javascript/quote_spread.js", &render(&block));
+}
+
+#[test]
+fn test_ternary_and_nullish() {
+    let block = sigil_quote!(JavaScript {
+        const value = x != null ? x : defaultValue;
+        const name = user?.name ?? $S("anonymous");
+    })
+    .unwrap();
+    golden::assert_golden("javascript/quote_ternary_nullish.js", &render(&block));
+}

--- a/tests/kotlin/quote_edge_cases.rs
+++ b/tests/kotlin/quote_edge_cases.rs
@@ -33,3 +33,51 @@ fn test_elvis() {
     .unwrap();
     golden::assert_golden("kotlin/quote_elvis.kt", &render(&block));
 }
+
+#[test]
+fn test_when_expression() {
+    let block = sigil_quote!(Kotlin {
+        val result = when (x) {
+            0 -> $S("zero")
+            1 -> $S("one")
+            else -> $S("many")
+        };
+    })
+    .unwrap();
+    golden::assert_golden("kotlin/quote_when.kt", &render(&block));
+}
+
+#[test]
+fn test_lambda_with_receiver() {
+    let block = sigil_quote!(Kotlin {
+        val config = Config().apply {
+            host = $S("localhost");
+            port = 8080;
+        };
+    })
+    .unwrap();
+    golden::assert_golden("kotlin/quote_lambda_receiver.kt", &render(&block));
+}
+
+#[test]
+fn test_sealed_class() {
+    let block = sigil_quote!(Kotlin {
+        sealed class Result<out T> {
+            data class Success<T>(val value: T) : Result<T>();
+            data class Error(val message: String) : Result<Nothing>();
+        }
+    })
+    .unwrap();
+    golden::assert_golden("kotlin/quote_sealed_class.kt", &render(&block));
+}
+
+#[test]
+fn test_extension_function() {
+    let block = sigil_quote!(Kotlin {
+        fun String.addExclamation(): String {
+            return this + $S("!");
+        }
+    })
+    .unwrap();
+    golden::assert_golden("kotlin/quote_extension_fun.kt", &render(&block));
+}

--- a/tests/lua/quote_edge_cases.rs
+++ b/tests/lua/quote_edge_cases.rs
@@ -35,3 +35,53 @@ fn test_local_function() {
     .unwrap();
     golden::assert_golden("lua/quote_local_function.lua", &render(&block));
 }
+
+#[test]
+fn test_method_call() {
+    let block = sigil_quote!(Lua {
+        local obj = {}
+        obj:init("config")
+        local result = obj:getValue()
+    })
+    .unwrap();
+    golden::assert_golden("lua/quote_method_call.lua", &render(&block));
+}
+
+#[test]
+fn test_vararg() {
+    let block = sigil_quote!(Lua {
+        local function printf(fmt, ...) {
+            local args = {...}
+            print(string.format(fmt, ...))
+        }
+    })
+    .unwrap();
+    golden::assert_golden("lua/quote_vararg.lua", &render(&block));
+}
+
+#[test]
+fn test_multiline_table() {
+    let block = sigil_quote!(Lua {
+        local config = {
+            host = "localhost",
+            port = 8080,
+            debug = true,
+        }
+    })
+    .unwrap();
+    golden::assert_golden("lua/quote_multiline_table.lua", &render(&block));
+}
+
+#[test]
+fn test_for_loop() {
+    let block = sigil_quote!(Lua {
+        for i = 1, 10 do {
+            print(i)
+        }
+        for k, v in pairs(t) do {
+            print(k, v)
+        }
+    })
+    .unwrap();
+    golden::assert_golden("lua/quote_for_loop.lua", &render(&block));
+}

--- a/tests/ocaml/quote_edge_cases.rs
+++ b/tests/ocaml/quote_edge_cases.rs
@@ -25,3 +25,48 @@ fn test_open_struct() {
     .unwrap();
     golden::assert_golden("ocaml/macro_open_struct.ml", &render(&block));
 }
+
+#[test]
+fn test_pipe_operator() {
+    let block = sigil_quote!(OCaml {
+        let result = input
+            |> List.map f
+            |> List.filter g
+            |> List.fold_left (+) 0
+    })
+    .unwrap();
+    golden::assert_golden("ocaml/quote_pipe.ml", &render(&block));
+}
+
+#[test]
+fn test_pattern_match() {
+    let block = sigil_quote!(OCaml {
+        let describe x = match x with {
+            | Some(v) -> Printf.printf $S("value: %d") v
+            | None -> print_endline $S("none")
+        }
+    })
+    .unwrap();
+    golden::assert_golden("ocaml/quote_pattern_match.ml", &render(&block));
+}
+
+#[test]
+fn test_let_in() {
+    let block = sigil_quote!(OCaml {
+        let compute x =
+            let squared = x * x in
+            let doubled = squared * 2 in
+            doubled + 1
+    })
+    .unwrap();
+    golden::assert_golden("ocaml/quote_let_in.ml", &render(&block));
+}
+
+#[test]
+fn test_record_update() {
+    let block = sigil_quote!(OCaml {
+        let updated = { user with name = $S("Bob"); age = 30 }
+    })
+    .unwrap();
+    golden::assert_golden("ocaml/quote_record_update.ml", &render(&block));
+}

--- a/tests/python/main.rs
+++ b/tests/python/main.rs
@@ -8,4 +8,5 @@ mod builder_imports;
 mod builder_types;
 mod quote_basic;
 mod quote_control_flow;
+mod quote_edge_cases;
 mod quote_imports;

--- a/tests/python/quote_edge_cases.rs
+++ b/tests/python/quote_edge_cases.rs
@@ -1,0 +1,73 @@
+use sigil_stitch::code_block::CodeBlock;
+use sigil_stitch::prelude::*;
+use sigil_stitch::spec::file_spec::FileSpec;
+
+use super::golden;
+
+fn render(block: &CodeBlock) -> String {
+    FileSpec::builder("test.py")
+        .add_code(block.clone())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap()
+}
+
+#[test]
+fn test_decorator() {
+    let block = sigil_quote!(Python {
+        @app.route("/users")
+        def get_users(): {
+            return jsonify(users)
+        }
+    })
+    .unwrap();
+    golden::assert_golden("python/quote_decorator.py", &render(&block));
+}
+
+#[test]
+fn test_type_hints() {
+    let block = sigil_quote!(Python {
+        def process(items: list[str], count: int = 10) -> dict[str, int]: {
+            result: dict[str, int] = {}
+            return result
+        }
+    })
+    .unwrap();
+    golden::assert_golden("python/quote_type_hints.py", &render(&block));
+}
+
+#[test]
+fn test_comprehension() {
+    let block = sigil_quote!(Python {
+        squares = [x * x for x in range(10)]
+        evens = [x for x in items if x % 2 == 0]
+    })
+    .unwrap();
+    golden::assert_golden("python/quote_comprehension.py", &render(&block));
+}
+
+#[test]
+fn test_async_def() {
+    let block = sigil_quote!(Python {
+        async def fetch_data(url: str) -> bytes: {
+            async with aiohttp.ClientSession() as session: {
+                response = await session.get(url)
+                return await response.read()
+            }
+        }
+    })
+    .unwrap();
+    golden::assert_golden("python/quote_async.py", &render(&block));
+}
+
+#[test]
+fn test_with_statement() {
+    let block = sigil_quote!(Python {
+        with open($S("file.txt"), $S("r")) as f: {
+            content = f.read()
+        }
+    })
+    .unwrap();
+    golden::assert_golden("python/quote_with.py", &render(&block));
+}

--- a/tests/rust/quote_edge_cases.rs
+++ b/tests/rust/quote_edge_cases.rs
@@ -23,3 +23,66 @@ fn test_path_separator() {
     .unwrap();
     golden::assert_golden("rust/macro_path_separator.rs", &render(&block));
 }
+
+#[test]
+fn test_lifetime() {
+    let block = sigil_quote!(RustLang {
+        fn longest<'a>(x: &'a str, y: &'a str) -> &'a str {
+            if x.len() > y.len() {
+                x
+            } else {
+                y
+            }
+        }
+    })
+    .unwrap();
+    golden::assert_golden("rust/quote_lifetime.rs", &render(&block));
+}
+
+#[test]
+fn test_trait_bound() {
+    let block = sigil_quote!(RustLang {
+        fn process<T: Clone + Send + 'static>(item: T) -> T {
+            item.clone()
+        }
+    })
+    .unwrap();
+    golden::assert_golden("rust/quote_trait_bound.rs", &render(&block));
+}
+
+#[test]
+fn test_pattern_matching() {
+    let block = sigil_quote!(RustLang {
+        match value {
+            Some(x) if x > 0 => println!($S("positive: {}"), x),
+            Some(0) => println!($S("zero")),
+            None => println!($S("nothing")),
+            _ => unreachable!(),
+        }
+    })
+    .unwrap();
+    golden::assert_golden("rust/quote_pattern_match.rs", &render(&block));
+}
+
+#[test]
+fn test_closure() {
+    let block = sigil_quote!(RustLang {
+        let add = |a: i32, b: i32| -> i32 { a + b };
+        let result: Vec<i32> = items.iter().map(|x| x * 2).collect();
+    })
+    .unwrap();
+    golden::assert_golden("rust/quote_closure.rs", &render(&block));
+}
+
+#[test]
+fn test_impl_block() {
+    let block = sigil_quote!(RustLang {
+        impl<T: Display> fmt::Display for Wrapper<T> {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                write!(f, $S("({})"), self.0)
+            }
+        }
+    })
+    .unwrap();
+    golden::assert_golden("rust/quote_impl_block.rs", &render(&block));
+}

--- a/tests/scala/quote_edge_cases.rs
+++ b/tests/scala/quote_edge_cases.rs
@@ -25,3 +25,50 @@ fn test_pattern_match() {
     .unwrap();
     golden::assert_golden("scala/quote_pattern_match.scala", &render(&block));
 }
+
+#[test]
+fn test_implicit_param() {
+    let block = sigil_quote!(Scala {
+        def execute(query: String)(implicit ctx: ExecutionContext): Future[Result] = {
+            Future(runQuery(query));
+        }
+    })
+    .unwrap();
+    golden::assert_golden("scala/quote_implicit.scala", &render(&block));
+}
+
+#[test]
+fn test_for_comprehension() {
+    let block = sigil_quote!(Scala {
+        val result = for {
+            x <- fetchX();
+            y <- fetchY(x);
+        } yield (x, y);
+    })
+    .unwrap();
+    golden::assert_golden("scala/quote_for_comprehension.scala", &render(&block));
+}
+
+#[test]
+fn test_case_class() {
+    let block = sigil_quote!(Scala {
+        case class Person(name: String, age: Int);
+        case class Address(street: String, city: String, zip: String);
+    })
+    .unwrap();
+    golden::assert_golden("scala/quote_case_class.scala", &render(&block));
+}
+
+#[test]
+fn test_trait_mixin() {
+    let block = sigil_quote!(Scala {
+        trait Serializable {
+            def serialize(): String;
+        }
+        class User(val name: String) extends Entity with Serializable {
+            def serialize(): String = name;
+        }
+    })
+    .unwrap();
+    golden::assert_golden("scala/quote_trait_mixin.scala", &render(&block));
+}

--- a/tests/swift/quote_edge_cases.rs
+++ b/tests/swift/quote_edge_cases.rs
@@ -23,3 +23,57 @@ fn test_optional_chaining() {
     .unwrap();
     golden::assert_golden("swift/quote_optional_chain.swift", &render(&block));
 }
+
+#[test]
+fn test_guard_let() {
+    let block = sigil_quote!(Swift {
+        func process(value: Int?) {
+            guard let unwrapped = value else {
+                return;
+            }
+            print(unwrapped);
+        }
+    })
+    .unwrap();
+    golden::assert_golden("swift/quote_guard_let.swift", &render(&block));
+}
+
+#[test]
+fn test_closure() {
+    let block = sigil_quote!(Swift {
+        let transform: (Int) -> Int = { (x: Int) -> Int in
+            return x * 2
+        };
+        let sorted = items.sorted(by: { a, b in a.name < b.name });
+    })
+    .unwrap();
+    golden::assert_golden("swift/quote_closure.swift", &render(&block));
+}
+
+#[test]
+fn test_protocol_extension() {
+    let block = sigil_quote!(Swift {
+        protocol Drawable {
+            func draw();
+        }
+        extension Drawable {
+            func draw() {
+                print($S("default draw"));
+            }
+        }
+    })
+    .unwrap();
+    golden::assert_golden("swift/quote_protocol_extension.swift", &render(&block));
+}
+
+#[test]
+fn test_enum_with_associated_values() {
+    let block = sigil_quote!(Swift {
+        enum Result<T> {
+            case success(T)
+            case failure(Error)
+        }
+    })
+    .unwrap();
+    golden::assert_golden("swift/quote_enum_associated.swift", &render(&block));
+}

--- a/tests/typescript/quote_edge_cases.rs
+++ b/tests/typescript/quote_edge_cases.rs
@@ -22,3 +22,62 @@ fn test_object_literal() {
     .unwrap();
     golden::assert_golden("typescript/macro_object_literal.ts", &render(&block));
 }
+
+#[test]
+fn test_generic_function() {
+    let block = sigil_quote!(TypeScript {
+        function identity<T>(arg: T): T {
+            return arg;
+        }
+        const result = identity<string>($S("hello"));
+    })
+    .unwrap();
+    golden::assert_golden("typescript/quote_generic_function.ts", &render(&block));
+}
+
+#[test]
+fn test_async_await() {
+    let block = sigil_quote!(TypeScript {
+        async function fetchData(url: string): Promise<Response> {
+            const response = await fetch(url);
+            return response.json();
+        }
+    })
+    .unwrap();
+    golden::assert_golden("typescript/quote_async_await.ts", &render(&block));
+}
+
+#[test]
+fn test_union_and_intersection() {
+    let block = sigil_quote!(TypeScript {
+        type StringOrNumber = string | number;
+        type Combined = TypeA & TypeB;
+        function process(value: string | number | null): void {
+            console.log(value);
+        }
+    })
+    .unwrap();
+    golden::assert_golden("typescript/quote_union_intersection.ts", &render(&block));
+}
+
+#[test]
+fn test_destructuring() {
+    let block = sigil_quote!(TypeScript {
+        const { name, age } = person;
+        const [first, ...rest] = items;
+        const { data: { users } } = response;
+    })
+    .unwrap();
+    golden::assert_golden("typescript/quote_destructuring.ts", &render(&block));
+}
+
+#[test]
+fn test_mapped_type() {
+    let block = sigil_quote!(TypeScript {
+        type Readonly<T> = {
+            readonly [K in keyof T]: T[K];
+        };
+    })
+    .unwrap();
+    golden::assert_golden("typescript/quote_mapped_type.ts", &render(&block));
+}

--- a/tests/zsh/main.rs
+++ b/tests/zsh/main.rs
@@ -7,3 +7,5 @@ mod builder_functions;
 mod builder_imports;
 mod quote_basic;
 mod quote_control_flow;
+mod quote_edge_cases;
+mod quote_imports;

--- a/tests/zsh/quote_edge_cases.rs
+++ b/tests/zsh/quote_edge_cases.rs
@@ -1,0 +1,59 @@
+use sigil_stitch::code_block::CodeBlock;
+use sigil_stitch::prelude::*;
+use sigil_stitch::spec::file_spec::FileSpec;
+
+use super::golden;
+
+fn render(block: &CodeBlock) -> String {
+    FileSpec::builder("test.zsh")
+        .add_code(block.clone())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap()
+}
+
+#[test]
+fn test_percent_escape_in_quote() {
+    let block = sigil_quote!(Zsh {
+        PROMPT=$S("%F{green}%n@%m%f");
+        echo $L("$PROMPT");
+    })
+    .unwrap();
+    golden::assert_golden("zsh/quote_percent_escape.zsh", &render(&block));
+}
+
+#[test]
+fn test_variable_expansion() {
+    let block = sigil_quote!(Zsh {
+        DEFAULT=$L("${NAME:-guest}");
+        LENGTH=$L("${#ITEMS[@]}");
+        echo $L("$DEFAULT") $L("$LENGTH");
+    })
+    .unwrap();
+    golden::assert_golden("zsh/quote_variable_expansion.zsh", &render(&block));
+}
+
+#[test]
+fn test_array_operations() {
+    let block = sigil_quote!(Zsh {
+        typeset -a ITEMS;
+        ITEMS=(one two three);
+        echo $L("${ITEMS[@]}");
+        echo $L("${#ITEMS[@]}");
+    })
+    .unwrap();
+    golden::assert_golden("zsh/quote_array_operations.zsh", &render(&block));
+}
+
+#[test]
+fn test_function_definition() {
+    let block = sigil_quote!(Zsh {
+        function greet() {
+            local name=$L("$1");
+            echo $S("Hello, $name!");
+        }
+    })
+    .unwrap();
+    golden::assert_golden("zsh/quote_function.zsh", &render(&block));
+}

--- a/tests/zsh/quote_imports.rs
+++ b/tests/zsh/quote_imports.rs
@@ -1,0 +1,27 @@
+use sigil_stitch::code_block::CodeBlock;
+use sigil_stitch::prelude::*;
+use sigil_stitch::spec::file_spec::FileSpec;
+use sigil_stitch::type_name::TypeName;
+
+use super::golden;
+
+fn render(block: &CodeBlock) -> String {
+    FileSpec::builder("test.zsh")
+        .add_code(block.clone())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap()
+}
+
+#[test]
+fn test_imports() {
+    let log_fn = TypeName::importable("./lib/log.zsh", "log_info");
+    let config_fn = TypeName::importable("./lib/config.zsh", "get_config");
+    let block = sigil_quote!(Zsh {
+        $T(config_fn) --reload;
+        $T(log_fn) $S("config loaded");
+    })
+    .unwrap();
+    golden::assert_golden("zsh/quote_imports.zsh", &render(&block));
+}


### PR DESCRIPTION
## Summary

- Adds golden tests covering language-specific edge cases for all 18 supported languages (one commit per language)
- Converts existing `assert!`-only tests to also use `golden::assert_golden()` (Go, Rust)
- Pins current rendering output as golden files, exposing several known bugs for future fixing

## Bugs discovered (issues filed)

- #72 — Extra spaces in generic type parameters `< T >`
- #73 — Brace blocks collapse to single line in some contexts
- #74 — Operator spacing issues (`<-`, `++`, `...`)
- #75 — Haskell do-notation spurious `=`
- #76 — Object destructuring breaks incorrectly
- #77 — Go goroutine invocation + slice syntax
- #78 — Swift optional type spurious space
- #79 — Method chaining loses indentation

## Stats

- 106 files changed, 1297 insertions
- 18 commits (one per language)
- All tests pass, clippy clean, fmt clean

## Test plan

- [x] `cargo test --all` — 473+ tests pass
- [x] `cargo clippy --all-targets` — no warnings
- [x] `cargo fmt --check` — clean