### PR TITLE
fix: sigil_quote spacing for generics, operators, and postfix markers

### DIFF
--- a/macros/src/parse/format.rs
+++ b/macros/src/parse/format.rs
@@ -25,6 +25,8 @@ pub(super) enum TokenAnnotation {
     PostfixIncDec,
     /// `*` used as postfix pointer marker (e.g. `Config*`) — suppress space before.
     PostfixStar,
+    /// `?` used as postfix type marker (e.g. `Int?`, `String?`) — suppress space before.
+    PostfixQuestion,
     /// `-` starting `->` when adjacent to preceding token (member access, not type arrow).
     ArrowOp,
     /// First `:` of `::` used as operator (not path separator) — space before it.
@@ -211,7 +213,23 @@ fn annotate_tokens(tokens: &[TokenTree]) -> Vec<TokenAnnotation> {
                             }
                         };
                         if is_postfix {
-                            annotations[i] = TokenAnnotation::PostfixIncDec;
+                            // Look-ahead: if the token after `++`/`--` is an operand
+                            // (ident, literal, group, or `$` interpolation), this is a
+                            // binary operator (e.g. Haskell `++`), not postfix inc/dec.
+                            let after_second = i + 2;
+                            let followed_by_operand = if after_second < tokens.len() {
+                                match &tokens[after_second] {
+                                    TokenTree::Ident(_)
+                                    | TokenTree::Literal(_)
+                                    | TokenTree::Group(_) => true,
+                                    TokenTree::Punct(p2) => p2.as_char() == '$',
+                                }
+                            } else {
+                                false
+                            };
+                            if !followed_by_operand {
+                                annotations[i] = TokenAnnotation::PostfixIncDec;
+                            }
                         }
                     }
                     '&' | '*' | '-' => {
@@ -233,6 +251,20 @@ fn annotate_tokens(tokens: &[TokenTree]) -> Vec<TokenAnnotation> {
                                 i += 2;
                                 continue;
                             }
+                        }
+
+                        // `<-` compound operator: when `-` follows Joint `<` that
+                        // isn't GenericOpen, the pair forms a binary operator (Haskell
+                        // bind, Go channel). Don't mark as PrefixOp.
+                        if ch == '-'
+                            && i > 0
+                            && let TokenTree::Punct(prev_p) = &tokens[i - 1]
+                            && prev_p.as_char() == '<'
+                            && prev_p.spacing() == Spacing::Joint
+                            && annotations[i - 1] != TokenAnnotation::GenericOpen
+                        {
+                            i += 1;
+                            continue;
                         }
 
                         // PostfixStar: `*` span-adjacent to preceding ident (pointer type like `Config*`).
@@ -288,6 +320,27 @@ fn annotate_tokens(tokens: &[TokenTree]) -> Vec<TokenAnnotation> {
                         {
                             annotations[i] = TokenAnnotation::SafeCallQ;
                         }
+                        // PostfixQuestion: `?` span-adjacent to preceding ident or group-close
+                        // (e.g. `Int?`, `String?`, `(Int)?`)
+                        else if i > 0 {
+                            let prev_end = tokens[i - 1].span().end();
+                            let q_start = p.span().start();
+                            let is_adjacent =
+                                prev_end.line == q_start.line && prev_end.column == q_start.column;
+                            if is_adjacent {
+                                let is_type_context = match &tokens[i - 1] {
+                                    TokenTree::Ident(_) => true,
+                                    TokenTree::Group(g) => matches!(
+                                        g.delimiter(),
+                                        Delimiter::Parenthesis | Delimiter::Bracket
+                                    ),
+                                    _ => false,
+                                };
+                                if is_type_context {
+                                    annotations[i] = TokenAnnotation::PostfixQuestion;
+                                }
+                            }
+                        }
                     }
                     '<' => {
                         // GenericOpen: preceded by uppercase Ident, PathSepComplete,
@@ -305,11 +358,18 @@ fn annotate_tokens(tokens: &[TokenTree]) -> Vec<TokenAnnotation> {
                                     let s = id.to_string();
                                     // Uppercase ident (type name heuristic), OR
                                     // any ident preceded by PathSepComplete
-                                    // (e.g., `std::map<` — lowercase but qualified)
+                                    // (e.g., `std::map<` — lowercase but qualified), OR
+                                    // span-adjacent lowercase ident (`identity<T>`)
                                     s.starts_with(|c: char| c.is_uppercase())
                                         || (i >= 2
                                             && annotations[i - 2]
                                                 == TokenAnnotation::PathSepComplete)
+                                        || {
+                                            let prev_end = id.span().end();
+                                            let lt_start = p.span().start();
+                                            prev_end.line == lt_start.line
+                                                && prev_end.column == lt_start.column
+                                        }
                                 }
                                 TokenTree::Punct(pp) => {
                                     // After PathSepComplete or Joint `:` (turbofish)
@@ -790,6 +850,7 @@ pub(super) fn maybe_space(
         | TokenAnnotation::SafeCallQ
         | TokenAnnotation::PostfixIncDec
         | TokenAnnotation::PostfixStar
+        | TokenAnnotation::PostfixQuestion
         | TokenAnnotation::ArrowOp => return,
         _ => {}
     }

--- a/src/lang/haskell.rs
+++ b/src/lang/haskell.rs
@@ -346,7 +346,7 @@ impl CodeLang for Haskell {
         let t = condition.trim();
         if t.starts_with("class ") || t.starts_with("instance ") {
             Some(" where")
-        } else if t.starts_with("do") {
+        } else if t == "do" || t.ends_with(" do") {
             Some("")
         } else {
             None

--- a/test-goldens/csharp/quote_nullable.cs
+++ b/test-goldens/csharp/quote_nullable.cs
@@ -1,3 +1,3 @@
-string ? name = null;
-int ? count = GetCount();
+string? name = null;
+int? count = GetCount();
 var value = name ?? "default";

--- a/test-goldens/go/quote_channel.go
+++ b/test-goldens/go/quote_channel.go
@@ -1,3 +1,3 @@
 ch := make(chan int, 10)
-ch <-42
-val := <-ch
+ch <- 42
+val := <- ch

--- a/test-goldens/haskell/quote_do_notation.hs
+++ b/test-goldens/haskell/quote_do_notation.hs
@@ -1,5 +1,5 @@
 main :: IO()
-main = do =
+main = do
   putStrLn "Enter name:"
-  name <-getLine
-  putStrLn("Hello, "++ name)
+  name <- getLine
+  putStrLn("Hello, " ++ name)

--- a/test-goldens/haskell/quote_list_comprehension.hs
+++ b/test-goldens/haskell/quote_list_comprehension.hs
@@ -1,2 +1,2 @@
 evens :: [Int] ->[Int]
-evens xs = [x | x <-xs, even x]
+evens xs = [x | x <- xs, even x]

--- a/test-goldens/haskell/quote_typeclass_instance.hs
+++ b/test-goldens/haskell/quote_typeclass_instance.hs
@@ -1,2 +1,2 @@
 instance Show Point where
-  show(Point x y) = "("++ show x++ ", "++ show y++ ")"
+  show(Point x y) = "(" ++ show x ++ ", " ++ show y ++ ")"

--- a/test-goldens/rust/quote_impl_block.rs
+++ b/test-goldens/rust/quote_impl_block.rs
@@ -1,4 +1,4 @@
-impl < T: Display > fmt::Display for Wrapper<T> {
+impl<T: Display> fmt::Display for Wrapper<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "({})", self.0)
     }

--- a/test-goldens/rust/quote_lifetime.rs
+++ b/test-goldens/rust/quote_lifetime.rs
@@ -1,4 +1,4 @@
-fn longest < 'a >(x: &'a str, y: &'a str) -> &'a str {
+fn longest<'a>(x: &'a str, y: &'a str) -> &'a str {
     if x.len() > y.len() {
         x
     } else {

--- a/test-goldens/rust/quote_trait_bound.rs
+++ b/test-goldens/rust/quote_trait_bound.rs
@@ -1,3 +1,3 @@
-fn process < T: Clone + Send + 'static >(item: T) -> T {
+fn process<T: Clone + Send + 'static>(item: T) -> T {
     item.clone()
 }

--- a/test-goldens/scala/quote_for_comprehension.scala
+++ b/test-goldens/scala/quote_for_comprehension.scala
@@ -1,5 +1,5 @@
 val result = for {
-  x <-fetchX()
-  y <-fetchY(x)
+  x <- fetchX()
+  y <- fetchY(x)
 }
 yield (x, y)

--- a/test-goldens/swift/quote_guard_let.swift
+++ b/test-goldens/swift/quote_guard_let.swift
@@ -1,4 +1,4 @@
-func process(value: Int ?) {
+func process(value: Int?) {
     guard let unwrapped = value else {
         return
     }

--- a/test-goldens/typescript/quote_generic_function.ts
+++ b/test-goldens/typescript/quote_generic_function.ts
@@ -1,4 +1,4 @@
-function identity < T >(arg: T): T {
+function identity<T>(arg: T): T {
   return arg;
 }
-const result = identity < string >('hello');
+const result = identity<string>('hello');

--- a/test-goldens/zsh/quote_imports.zsh
+++ b/test-goldens/zsh/quote_imports.zsh
@@ -1,5 +1,5 @@
 source "./lib/config.zsh"
 source "./lib/log.zsh"
 
-get_config--reload
+get_config --reload
 log_info "config loaded"


### PR DESCRIPTION
## Summary

Fixes 4 categories of `sigil_quote!` tokenizer spacing bugs discovered by the golden tests in #80:

- **#72** — Generic type params no longer get extra spaces (`identity<T>` not `identity < T >`)
- **#74** — `<-` operator gets proper trailing space; `++` correctly treated as binary when followed by operand
- **#75** — Haskell `do`-notation no longer emits spurious `=`
- **#78** — Swift/C# postfix `?` no longer gets space before it (`Int?` not `Int ?`)

## Approach

All fixes are in the macro tokenizer's annotation system (`macros/src/parse/format.rs`):

- **Generics**: Use span-adjacency to detect `ident<` even for lowercase idents
- **`<-` operator**: Prevent `-` from being marked `PrefixOp` when it follows Joint `<` that isn't `GenericOpen`
- **`++` binary**: Look ahead after `++`/`--` — if followed by an operand (ident, literal, group, `$`), it's binary, not postfix
- **Postfix `?`**: New `PostfixQuestion` annotation using span-adjacency (same pattern as existing `PostfixStar`)
- **Haskell `do`**: Fix `block_open_for` to match `ends_with(" do")` not just `starts_with("do")`

## Test plan

- [x] `cargo test --all` — all pass
- [x] `cargo clippy --all-targets` — no warnings
- [x] `cargo fmt --check` — clean
- [x] Golden diffs verified: 12 golden files updated, all changes are correct fixes

Closes #72, closes #74, closes #75, closes #78.