### PR TITLE
feat: language-aware rewrite pass for Go IIFE and Haskell $ operator

### DIFF
--- a/src/code_block.rs
+++ b/src/code_block.rs
@@ -147,6 +147,11 @@ impl CodeBlock {
         CodeBlockBuilder::new()
     }
 
+    /// Access the node tree for rewriting. Used by language rewrite passes.
+    pub fn nodes_mut(&mut self) -> &mut Vec<CodeNode> {
+        &mut self.nodes
+    }
+
     /// Create a CodeBlock from a single format string and arguments.
     pub fn of(format: &str, args: impl IntoArgs) -> Result<Self, crate::error::SigilStitchError> {
         let mut builder = CodeBlockBuilder::new();

--- a/src/code_renderer.rs
+++ b/src/code_renderer.rs
@@ -39,7 +39,9 @@ impl<'a> CodeRenderer<'a> {
 
     /// Render a CodeBlock to string.
     pub fn render(&mut self, block: &CodeBlock) -> Result<String, SigilStitchError> {
-        self.render_nodes(&block.nodes)?;
+        let mut nodes = block.nodes.clone();
+        self.lang.rewrite_nodes(&mut nodes);
+        self.render_nodes(&nodes)?;
         Ok(std::mem::take(&mut self.output))
     }
 

--- a/src/lang/go_lang.rs
+++ b/src/lang/go_lang.rs
@@ -1,5 +1,6 @@
 //! Go language implementation.
 
+use crate::code_node::CodeNode;
 use crate::import::{ImportEntry, ImportGroup};
 use crate::lang::CodeLang;
 use crate::lang::config::{
@@ -104,6 +105,71 @@ fn package_name(module: &str) -> &str {
 fn is_stdlib(module: &str) -> bool {
     let first_segment = module.split('/').next().unwrap_or(module);
     !first_segment.contains('.')
+}
+
+impl GoLang {
+    /// Rewrite IIFE continuation: fuse `}` + `()` onto the same line.
+    ///
+    /// The pattern `go func() { ... }();` produces nodes:
+    ///   BlockClose("go func()"), StatementBegin, Literal("(...)"), StatementEnd, Newline
+    ///
+    /// We fuse these into:
+    ///   Literal("}"), Literal("(...)"), Newline
+    fn rewrite_iife(nodes: &mut Vec<CodeNode>) {
+        let mut i = 0;
+        while i < nodes.len() {
+            let is_func_block_close =
+                matches!(&nodes[i], CodeNode::BlockClose(cond) if cond.contains("func"));
+            if !is_func_block_close {
+                i += 1;
+                continue;
+            }
+
+            // Check if next nodes are: StatementBegin, Literal(...), StatementEnd, Newline
+            // The call arguments might span multiple literal nodes.
+            let remaining = nodes.len() - i - 1;
+            if remaining >= 3 && matches!(&nodes[i + 1], CodeNode::StatementBegin) {
+                // Find StatementEnd
+                let end_idx = nodes[(i + 2)..]
+                    .iter()
+                    .position(|n| matches!(n, CodeNode::StatementEnd))
+                    .map(|pos| pos + i + 2);
+
+                if let Some(stmt_end) = end_idx {
+                    // Collect the call literal nodes between StatementBegin and StatementEnd
+                    let call_nodes: Vec<CodeNode> = nodes[(i + 2)..stmt_end].to_vec();
+
+                    // Check that this looks like a call (starts with "(")
+                    let looks_like_call = call_nodes
+                        .iter()
+                        .any(|n| matches!(n, CodeNode::Literal(s) if s.starts_with('(')));
+
+                    if looks_like_call {
+                        // Determine how many nodes to remove after BlockClose
+                        // Remove: StatementBegin, ...call_nodes..., StatementEnd
+                        // Optionally also remove the following Newline (BlockClose already emitted one)
+                        let mut remove_end = stmt_end + 1; // exclusive
+                        if remove_end < nodes.len()
+                            && matches!(&nodes[remove_end], CodeNode::Newline)
+                        {
+                            remove_end += 1;
+                        }
+
+                        // Replace BlockClose with Literal("}") + call_nodes + Newline
+                        let mut replacement = Vec::with_capacity(2 + call_nodes.len());
+                        replacement.push(CodeNode::Literal("}".to_string()));
+                        replacement.extend(call_nodes);
+                        replacement.push(CodeNode::Newline);
+
+                        nodes.splice(i..remove_end, replacement);
+                        continue;
+                    }
+                }
+            }
+
+            i += 1;
+        }
+    }
 }
 
 impl CodeLang for GoLang {
@@ -341,6 +407,10 @@ impl CodeLang for GoLang {
             variant_separator: "",
             ..Default::default()
         }
+    }
+
+    fn rewrite_nodes(&self, nodes: &mut Vec<CodeNode>) {
+        crate::lang::rewrite::walk_nodes_mut(nodes, &Self::rewrite_iife);
     }
 }
 

--- a/src/lang/haskell.rs
+++ b/src/lang/haskell.rs
@@ -1,5 +1,6 @@
 //! Haskell language implementation.
 
+use crate::code_node::CodeNode;
 use crate::import::{ImportEntry, ImportGroup};
 use crate::lang::CodeLang;
 use crate::spec::modifiers::{DeclarationContext, TypeKind, Visibility};
@@ -78,6 +79,40 @@ impl Haskell {
     pub fn with_extension(mut self, s: &str) -> Self {
         self.extension = s.to_string();
         self
+    }
+
+    /// Fix `$` operator spacing: `$word` → `$ word`.
+    ///
+    /// The `$$` escape in `sigil_quote!` emits a literal `$` with space suppression
+    /// (designed for `$1` in shell). In Haskell, `$` is an infix operator needing
+    /// a space after it. This pass inserts the missing space when `$` is directly
+    /// followed by a word character.
+    #[allow(clippy::ptr_arg)]
+    fn rewrite_dollar_spacing(nodes: &mut Vec<CodeNode>) {
+        for node in nodes.iter_mut() {
+            let text = match node {
+                CodeNode::Literal(s) => s,
+                CodeNode::InlineLiteral(s) => s,
+                _ => continue,
+            };
+            if !text.contains('$') {
+                continue;
+            }
+            let mut result = String::with_capacity(text.len() + 4);
+            let chars: Vec<char> = text.chars().collect();
+            for (i, &ch) in chars.iter().enumerate() {
+                result.push(ch);
+                if ch == '$' && i + 1 < chars.len() {
+                    let after = chars[i + 1];
+                    if after.is_alphanumeric() || after == '_' || after == '(' {
+                        result.push(' ');
+                    }
+                }
+            }
+            if result != *text {
+                *text = result;
+            }
+        }
     }
 }
 
@@ -375,6 +410,10 @@ impl CodeLang for Haskell {
             variant_separator: "",
             ..Default::default()
         }
+    }
+
+    fn rewrite_nodes(&self, nodes: &mut Vec<CodeNode>) {
+        crate::lang::rewrite::walk_nodes_mut(nodes, &Self::rewrite_dollar_spacing);
     }
 }
 

--- a/src/lang/mod.rs
+++ b/src/lang/mod.rs
@@ -37,6 +37,9 @@ pub mod typescript;
 /// Zsh shell language support.
 pub mod zsh;
 
+/// Helpers for implementing language-specific node rewrite passes.
+pub mod rewrite;
+
 use crate::import::ImportGroup;
 
 /// Trait defining language-specific behavior for code generation.
@@ -396,6 +399,13 @@ pub trait CodeLang: std::fmt::Debug + 'static {
     fn enum_and_annotation(&self) -> config::EnumAndAnnotationConfig<'_> {
         config::EnumAndAnnotationConfig::default()
     }
+
+    // ── Node rewriting — language-specific structural transforms ───
+
+    /// Rewrite the node tree before rendering. Called automatically by the
+    /// renderer. Default is no-op. Languages override this to handle constructs
+    /// that require language-specific structural knowledge (e.g. Go IIFE `}()`).
+    fn rewrite_nodes(&self, _nodes: &mut Vec<crate::code_node::CodeNode>) {}
 }
 
 /// Derive a PascalCase namespace alias from a module path.

--- a/src/lang/rewrite.rs
+++ b/src/lang/rewrite.rs
@@ -1,0 +1,16 @@
+use crate::code_node::CodeNode;
+
+/// Recursively apply a rewrite function to all node vectors in the tree.
+///
+/// Visits the given `nodes` first, then recurses into any `Nested(CodeBlock)`
+/// or `Sequence(Vec<CodeNode>)` children.
+pub fn walk_nodes_mut(nodes: &mut Vec<CodeNode>, f: &dyn Fn(&mut Vec<CodeNode>)) {
+    f(nodes);
+    for node in nodes.iter_mut() {
+        match node {
+            CodeNode::Nested(block) => walk_nodes_mut(block.nodes_mut(), f),
+            CodeNode::Sequence(children) => walk_nodes_mut(children, f),
+            _ => {}
+        }
+    }
+}

--- a/test-goldens/go/quote_goroutine.go
+++ b/test-goldens/go/quote_goroutine.go
@@ -1,4 +1,3 @@
 go func() {
 	fmt.Println("hello from goroutine")
-}
-()
+}()

--- a/test-goldens/haskell/quote_dollar_operator.hs
+++ b/test-goldens/haskell/quote_dollar_operator.hs
@@ -1,0 +1,1 @@
+main = putStrLn $ show 42

--- a/tests/haskell/quote_edge_cases.rs
+++ b/tests/haskell/quote_edge_cases.rs
@@ -82,3 +82,12 @@ fn test_typeclass_instance() {
     .unwrap();
     golden::assert_golden("haskell/quote_typeclass_instance.hs", &render(&block));
 }
+
+#[test]
+fn test_dollar_operator() {
+    let block = sigil_quote!(Haskell {
+        main = putStrLn $$ show 42;
+    })
+    .unwrap();
+    golden::assert_golden("haskell/quote_dollar_operator.hs", &render(&block));
+}


### PR DESCRIPTION
## Summary

- Add `rewrite_nodes(&mut Vec<CodeNode>)` method to `CodeLang` trait (default no-op), called automatically by `CodeRenderer::render()` before rendering
- Add `walk_nodes_mut` recursive helper in `src/lang/rewrite.rs` for applying transforms to all nested node vectors
- **Go**: fuse IIFE continuation `}()` onto same line — previously `go func() { ... }` and `()` rendered on separate lines
- **Haskell**: insert space after `$` operator — the `$$` escape suppresses trailing space (designed for shell `$1`), but Haskell needs `putStrLn $ show x`

## Test plan

- [x] Go goroutine golden updated: `}()` on same line
- [x] New Haskell `$$` operator test + golden: `putStrLn $ show 42`
- [x] Full test suite passes (0 failures across all languages)
- [x] No regressions in any other language's goldens (rewrite default is no-op)
- [x] clippy clean, cargo fmt clean