### PR TITLE
fix: span-aware group spacing for Go slice syntax

### DIFF
--- a/macros/src/parse/format.rs
+++ b/macros/src/parse/format.rs
@@ -31,6 +31,9 @@ pub(super) enum TokenAnnotation {
     ArrowOp,
     /// First `:` of `::` used as operator (not path separator) — space before it.
     DoubleColonOp,
+    /// Group open (paren/bracket) that is span-adjacent to preceding token —
+    /// suppress space (function call, array index).
+    CallOpen,
 }
 
 /// What kind of token was just emitted (for spacing decisions).
@@ -405,11 +408,29 @@ fn annotate_tokens(tokens: &[TokenTree]) -> Vec<TokenAnnotation> {
                     _ => {}
                 }
             }
-            TokenTree::Group(_) => {
-                // Groups are handled recursively in the main pass —
-                // they get their own annotation vector.
-                // Don't clear generic_stack: generics can contain groups
-                // (e.g., `Vec<(A, B)>`).
+            TokenTree::Group(g)
+                if i > 0
+                    && matches!(g.delimiter(), Delimiter::Parenthesis | Delimiter::Bracket) =>
+            {
+                // Mark groups that are span-adjacent to the preceding ident/literal/>
+                // as CallOpen (function call / array index). Non-adjacent groups
+                // or groups after operators/keywords get default spacing.
+                let prev_is_callable = match &tokens[i - 1] {
+                    TokenTree::Ident(id) => {
+                        let s = id.to_string();
+                        !CONTROL_FLOW_KEYWORDS.contains(&s.as_str())
+                            && !DECLARATION_KEYWORDS.contains(&s.as_str())
+                    }
+                    TokenTree::Literal(_) | TokenTree::Group(_) => true,
+                    TokenTree::Punct(p) => p.as_char() == '>',
+                };
+                if prev_is_callable {
+                    let prev_end = tokens[i - 1].span().end();
+                    let group_start = g.span().start();
+                    if prev_end.line == group_start.line && prev_end.column == group_start.column {
+                        annotations[i] = TokenAnnotation::CallOpen;
+                    }
+                }
             }
             _ => {}
         }
@@ -781,7 +802,22 @@ fn tokens_to_format_inner(
 
                 state.colon_ctx = saved_ctx;
                 format.push_str(close);
-                state.prev = PrevTokenKind::Literal;
+
+                // After a bracket group, check if the next token is span-adjacent.
+                // If so, suppress space (e.g., `[]byte` in Go — the ident is directly
+                // after `]`). Also handles `)(` when non-adjacent getting a space.
+                let group_end = g.span().end();
+                let next_adjacent = if pos + 1 < tokens.len() {
+                    let next_start = tokens[pos + 1].span().start();
+                    group_end.line == next_start.line && group_end.column == next_start.column
+                } else {
+                    false
+                };
+                if next_adjacent {
+                    state.prev = PrevTokenKind::GroupOpen;
+                } else {
+                    state.prev = PrevTokenKind::Literal;
+                }
             }
         }
         pos += 1;
@@ -901,17 +937,16 @@ pub(super) fn maybe_space(
         return;
     }
 
-    // No space before `(` when preceded by ident/type-ident (function call),
-    // specifier, literal, or `>` (generic close then call, e.g. `size_of::<u32>()`).
+    // No space before `(` or `[` when span-adjacent to preceding token
+    // (function call, array index). Non-adjacent groups get default spacing.
+    if annotation == TokenAnnotation::CallOpen {
+        return;
+    }
+
+    // No space before a group when preceded by a specifier ($T, $N, etc.)
+    // — handles `$T(x){}` struct literals and `$T(x)()` calls.
     if let PrevTokenKind::GroupOpen = current
-        && matches!(
-            prev,
-            PrevTokenKind::Ident
-                | PrevTokenKind::TypeIdent
-                | PrevTokenKind::Specifier
-                | PrevTokenKind::Literal
-                | PrevTokenKind::Punct('>', _)
-        )
+        && prev == PrevTokenKind::Specifier
     {
         return;
     }

--- a/test-goldens/c/quote_cast_sizeof.c
+++ b/test-goldens/c/quote_cast_sizeof.c
@@ -1,2 +1,2 @@
 size_t size = sizeof(struct Node);
-int* arr = (int*) malloc(size * sizeof(int));
+int* arr = (int*)malloc(size * sizeof(int));

--- a/test-goldens/c/quote_function_pointer.c
+++ b/test-goldens/c/quote_function_pointer.c
@@ -1,3 +1,3 @@
-typedef void(*Callback)(int, const char*);
+typedef void (*Callback)(int, const char*);
 Callback cb = NULL;
 cb(42, "hello");

--- a/test-goldens/c/quote_preprocessor.c
+++ b/test-goldens/c/quote_preprocessor.c
@@ -1,2 +1,2 @@
 #define MAX_SIZE 1024
-#define MIN(a, b)((a) < (b) ? (a) : (b))
+#define MIN(a, b) ((a) < (b) ? (a) : (b))

--- a/test-goldens/csharp/macro_foreach.cs
+++ b/test-goldens/csharp/macro_foreach.cs
@@ -1,3 +1,3 @@
-foreach(var item in items) {
+foreach (var item in items) {
     Process(item);
 }

--- a/test-goldens/go/quote_interface.go
+++ b/test-goldens/go/quote_interface.go
@@ -1,3 +1,3 @@
 type Reader interface {
-	Read(p[] byte)(int, error)
+	Read(p []byte) (int, error)
 }

--- a/test-goldens/haskell/quote_do_notation.hs
+++ b/test-goldens/haskell/quote_do_notation.hs
@@ -1,5 +1,5 @@
-main :: IO()
+main :: IO ()
 main = do
   putStrLn "Enter name:"
   name <- getLine
-  putStrLn("Hello, " ++ name)
+  putStrLn ("Hello, " ++ name)

--- a/test-goldens/haskell/quote_imports.hs
+++ b/test-goldens/haskell/quote_imports.hs
@@ -1,4 +1,4 @@
 import Data.Map (Map)
 import Data.Text (Text)
 
-let users = Map.fromList[(Text.pack "alice", 1)]
+let users = Map.fromList [(Text.pack "alice", 1)]

--- a/test-goldens/haskell/quote_list_comprehension.hs
+++ b/test-goldens/haskell/quote_list_comprehension.hs
@@ -1,2 +1,2 @@
-evens :: [Int] ->[Int]
+evens :: [Int] -> [Int]
 evens xs = [x | x <- xs, even x]

--- a/test-goldens/haskell/quote_typeclass_instance.hs
+++ b/test-goldens/haskell/quote_typeclass_instance.hs
@@ -1,2 +1,2 @@
 instance Show Point where
-  show(Point x y) = "(" ++ show x ++ ", " ++ show y ++ ")"
+  show (Point x y) = "(" ++ show x ++ ", " ++ show y ++ ")"

--- a/test-goldens/ocaml/quote_pipe.ml
+++ b/test-goldens/ocaml/quote_pipe.ml
@@ -1,4 +1,4 @@
 let result = input
 |> List.map f
 |> List.filter g
-|> List.fold_left(+) 0
+|> List.fold_left (+) 0

--- a/test-goldens/rust/quote_closure.rs
+++ b/test-goldens/rust/quote_closure.rs
@@ -1,2 +1,2 @@
-let add = | a: i32, b: i32 | -> i32{a + b};
+let add = | a: i32, b: i32 | -> i32 {a + b};
 let result: Vec<i32> = items.iter().map(| x | x * 2).collect();

--- a/test-goldens/typescript/quote_mapped_type.ts
+++ b/test-goldens/typescript/quote_mapped_type.ts
@@ -1,1 +1,1 @@
-type Readonly<T> = {readonly[K in keyof T]: T[K];};
+type Readonly<T> = {readonly [K in keyof T]: T[K];};


### PR DESCRIPTION
## Summary

Closes #77

- Replace heuristic "no space before group when preceded by ident" with span-based `CallOpen` annotation that respects user-written whitespace
- After group close, suppress space before next token only when span-adjacent
- Exclude control-flow and declaration keywords from callable check (preserves `if (x)`, `foreach (...)`)
- Fixes Go slice syntax: `Read(p []byte) (int, error)` (was `Read(p[] byte)(int, error)`)
- Also fixes spacing in C (`typedef void (*Callback)`), Haskell (`putStrLn (...)`), OCaml, Rust, TypeScript

## Test plan

- [x] Go interface golden: `Read(p []byte) (int, error)`
- [x] 12 golden files updated — all now match user-written whitespace
- [x] Full test suite passes (0 failures)
- [x] clippy clean, cargo fmt clean
- [x] No regressions in function call spacing (`f()`, `arr[0]`, `$T(x){}`)