### PR TITLE
fix: tokenizer regressions, language configs, and test input semantics

### DIFF
--- a/macros/src/parse/format.rs
+++ b/macros/src/parse/format.rs
@@ -73,6 +73,8 @@ pub(super) enum ColonContext {
     PathSeparator,
     /// `x := 42` — space before `:`.
     WalrusAssign,
+    /// `for (item : collection)` — space before `:`.
+    ForRange,
 }
 
 /// Accumulated state threaded through the format-string builder.
@@ -476,8 +478,15 @@ fn annotate_tokens(tokens: &[TokenTree]) -> Vec<TokenAnnotation> {
                 let prev_is_callable = match &tokens[i - 1] {
                     TokenTree::Ident(id) => {
                         let s = id.to_string();
-                        !CONTROL_FLOW_KEYWORDS.contains(&s.as_str())
-                            && !DECLARATION_KEYWORDS.contains(&s.as_str())
+                        let is_keyword = CONTROL_FLOW_KEYWORDS.contains(&s.as_str())
+                            || DECLARATION_KEYWORDS.contains(&s.as_str());
+                        if !is_keyword {
+                            true
+                        } else if i >= 2 {
+                            matches!(&tokens[i - 2], TokenTree::Punct(p) if p.as_char() == '.')
+                        } else {
+                            false
+                        }
                     }
                     TokenTree::Literal(_) | TokenTree::Group(_) => true,
                     TokenTree::Punct(p) => p.as_char() == '>',
@@ -853,6 +862,12 @@ fn tokens_to_format_inner(
                 let saved_ctx = state.colon_ctx;
                 if g.delimiter() == Delimiter::Brace {
                     state.colon_ctx = ColonContext::MapEntry;
+                } else if g.delimiter() == Delimiter::Parenthesis
+                    && pos > 0
+                    && let TokenTree::Ident(id) = &tokens[pos - 1]
+                    && *id == "for"
+                {
+                    state.colon_ctx = ColonContext::ForRange;
                 }
                 state.prev = PrevTokenKind::GroupOpen;
 
@@ -980,7 +995,7 @@ pub(super) fn maybe_space(
         match ch {
             ',' | ';' | ')' | ']' | '.' => return,
             ':' if annotation != TokenAnnotation::DoubleColonOp => match state.colon_ctx {
-                ColonContext::Ternary | ColonContext::WalrusAssign => {}
+                ColonContext::Ternary | ColonContext::WalrusAssign | ColonContext::ForRange => {}
                 ColonContext::TypeAnnotation
                 | ColonContext::MapEntry
                 | ColonContext::PathSeparator => return,

--- a/src/lang/config.rs
+++ b/src/lang/config.rs
@@ -252,6 +252,10 @@ pub struct FunctionSyntaxConfig<'a> {
     /// (e.g. Dart: `" async"`). Emitted when `is_async` is set, placed
     /// after the closing `)` and before the block-open brace.
     pub async_suffix: &'a str,
+    /// When true, `async_suffix` is emitted between the closing `)` and the
+    /// return type arrow (Swift: `func f() async -> T`). When false (default),
+    /// it is emitted after the return type (Dart: `Future<T> f() async {`).
+    pub async_suffix_before_return: bool,
     /// Keyword for abstract methods (e.g. `"abstract "`, `"virtual "`).
     pub abstract_keyword: &'a str,
     /// Keyword for override methods as an inline modifier (e.g. `"override "`).
@@ -301,6 +305,7 @@ impl Default for FunctionSyntaxConfig<'_> {
             return_type_separator: ": ",
             async_keyword: "async ",
             async_suffix: "",
+            async_suffix_before_return: false,
             abstract_keyword: "abstract ",
             override_keyword: "override ",
             override_annotation: "",

--- a/src/lang/haskell.rs
+++ b/src/lang/haskell.rs
@@ -383,6 +383,12 @@ impl CodeLang for Haskell {
             Some(" where")
         } else if t == "do" || t.ends_with(" do") {
             Some("")
+        } else if t.starts_with("if ") || t.starts_with("else if ") {
+            Some(" then")
+        } else if t == "else" {
+            Some("")
+        } else if t.starts_with("case ") {
+            Some(" of")
         } else {
             None
         }
@@ -679,5 +685,17 @@ mod tests {
     fn test_module_separator() {
         let hs = Haskell::new();
         assert_eq!(hs.module_separator(), Some("."));
+    }
+
+    #[test]
+    fn test_block_open_for_if_else_case() {
+        let hs = Haskell::new();
+        assert_eq!(hs.block_open_for("if x > 0"), Some(" then"));
+        assert_eq!(hs.block_open_for("else if x < 0"), Some(" then"));
+        assert_eq!(hs.block_open_for("else"), Some(""));
+        assert_eq!(hs.block_open_for("case x"), Some(" of"));
+        assert_eq!(hs.block_open_for("class Eq a"), Some(" where"));
+        assert_eq!(hs.block_open_for("do"), Some(""));
+        assert_eq!(hs.block_open_for("let x = 5"), None);
     }
 }

--- a/src/lang/swift.rs
+++ b/src/lang/swift.rs
@@ -339,6 +339,9 @@ impl CodeLang for Swift {
         crate::lang::config::FunctionSyntaxConfig {
             return_type_separator: " -> ",
             abstract_keyword: "",
+            async_keyword: "",
+            async_suffix: " async",
+            async_suffix_before_return: true,
             ..Default::default()
         }
     }
@@ -585,5 +588,13 @@ mod tests {
     fn test_module_separator() {
         let sw = Swift::new();
         assert_eq!(sw.module_separator(), Some("."));
+    }
+
+    #[test]
+    fn test_async_suffix_position() {
+        let sw = Swift::new();
+        let fs = sw.function_syntax();
+        assert_eq!(fs.async_keyword, "");
+        assert_eq!(fs.async_suffix, " async");
     }
 }

--- a/src/spec/fun_spec.rs
+++ b/src/spec/fun_spec.rs
@@ -431,6 +431,14 @@ impl FunSpec {
             sig.push_str(s);
         }
 
+        // Async suffix before return type (Swift: `func f() async -> T`).
+        if self.modifiers.is_async
+            && !suppress_async
+            && lang.function_syntax().async_suffix_before_return
+        {
+            sig.push_str(lang.function_syntax().async_suffix);
+        }
+
         // Return type as suffix (TS/Rust/Go-style: `fn add(...) -> int`).
         // Skip when separator is empty (e.g. Lua) — nothing to separate.
         if !lang.type_decl_syntax().return_type_is_prefix
@@ -459,8 +467,11 @@ impl FunSpec {
             false
         };
 
-        // Async suffix (Dart: `Future<T> foo() async { ... }`).
-        if self.modifiers.is_async && !suppress_async {
+        // Async suffix after return type (Dart: `Future<T> foo() async { ... }`).
+        if self.modifiers.is_async
+            && !suppress_async
+            && !lang.function_syntax().async_suffix_before_return
+        {
             sig.push_str(lang.function_syntax().async_suffix);
         }
 

--- a/test-goldens/c/function_with_includes.c
+++ b/test-goldens/c/function_with_includes.c
@@ -3,7 +3,7 @@
 #include "config.h"
 
 int main(void) {
-    printf("Hello, %s\\n", config.name);
+    printf("Hello, %s\n", cfg.name);
     Config cfg;
 
     return 0;

--- a/test-goldens/c/void_function.c
+++ b/test-goldens/c/void_function.c
@@ -1,5 +1,5 @@
 #include <stdio.h>
 
 void greet(const char* name) {
-    printf("Hello, %s!\\n", name);
+    printf("Hello, %s!\n", name);
 }

--- a/test-goldens/cpp/macro_imports.cpp
+++ b/test-goldens/cpp/macro_imports.cpp
@@ -1,5 +1,5 @@
 #include <string>
 #include <vector>
 
-vector items;
-string name = "Alice";
+std::vector<int> items;
+std::string name = "Alice";

--- a/test-goldens/cpp/quote_range_for.cpp
+++ b/test-goldens/cpp/quote_range_for.cpp
@@ -1,3 +1,3 @@
-for (const auto& item: items) {
+for (const auto& item : items) {
     std::cout << item << std::endl;
 }

--- a/test-goldens/go/macro_indent.go
+++ b/test-goldens/go/macro_indent.go
@@ -1,6 +1,6 @@
-namespace Foo {
-		North = iota
-		East
-		South
-		West
+func printDirections() {
+		fmt.Println("North")
+		fmt.Println("East")
+		fmt.Println("South")
+		fmt.Println("West")
 }

--- a/test-goldens/go/quote_switch_init.go
+++ b/test-goldens/go/quote_switch_init.go
@@ -1,3 +1,4 @@
 switch v := getValue(); v {
+	case "hello":
 	fmt.Println(v)
 }

--- a/test-goldens/haskell/macro_control_flow.hs
+++ b/test-goldens/haskell/macro_control_flow.hs
@@ -1,4 +1,4 @@
-if x > 0 =
+if x > 0 then
   return True
-else =
+else
   return False

--- a/test-goldens/java/full_module.java
+++ b/test-goldens/java/full_module.java
@@ -31,6 +31,6 @@ public class InMemoryUserRepository implements UserRepository {
 
     @Override
     public List<User> findAll() {
-        return new List<>(this.users);
+        return new ArrayList<>(this.users);
     }
 }

--- a/test-goldens/java/generic_params_before_return.java
+++ b/test-goldens/java/generic_params_before_return.java
@@ -1,5 +1,6 @@
 public class Utils {
     public static <T extends Comparable> List<T> sortList(List<T> list) {
-        return Collections.sort(list);
+        Collections.sort(list);
+        return list;
     }
 }

--- a/test-goldens/kotlin/data_class.kt
+++ b/test-goldens/kotlin/data_class.kt
@@ -1,5 +1,5 @@
 /**
  * A user data class.
  */
-data class User(name: String, age: Int, email: String) {
+data class User(val name: String, val age: Int, val email: String) {
 }

--- a/test-goldens/kotlin/enum_with_values.kt
+++ b/test-goldens/kotlin/enum_with_values.kt
@@ -1,8 +1,6 @@
-internal enum class Status {
+internal enum class Status(val value: String) {
     ACTIVE("active"),
     INACTIVE("inactive");
-
-    internal val value: String
 
     internal fun getValue(): String {
         return value

--- a/test-goldens/python/quote_async.py
+++ b/test-goldens/python/quote_async.py
@@ -1,4 +1,4 @@
 async def fetch_data(url: str) -> bytes:
     async with aiohttp.ClientSession() as session:
         response = await session.get(url)
-        return await response.read ()
+        return await response.read()

--- a/test-goldens/python/quote_with.py
+++ b/test-goldens/python/quote_with.py
@@ -1,2 +1,2 @@
 with open('file.txt', 'r') as f:
-    content = f.read ()
+    content = f.read()

--- a/test-goldens/rust/function_with_imports.rs
+++ b/test-goldens/rust/function_with_imports.rs
@@ -5,10 +5,10 @@ use serde::Serialize;
 pub fn create_map() -> HashMap<String, String> {
     let mut map = HashMap::new();
     map.insert("key".to_string(), "value".to_string());
-    map;
+    map
 }
 
 #[derive(Serialize)]
 pub struct Config {
-    pub name: String;
+    pub name: String,
 }

--- a/test-goldens/rust/import_grouping.rs
+++ b/test-goldens/rust/import_grouping.rs
@@ -5,9 +5,11 @@ use serde::{Deserialize, Serialize};
 
 use crate::models::User;
 
-let _h: HashMap<String, String> = Default::default();
-let _b: BTreeMap<String, String> = Default::default();
-let _a: Arc<String> = Arc::new("x".into());
-let _s: Serialize = todo!();
-let _d: Deserialize = todo!();
-let _u: User = todo!();
+fn demo() {
+    let _h: HashMap<String, String> = Default::default();
+    let _b: BTreeMap<String, String> = Default::default();
+    let _a: Arc<String> = Arc::new("x".into());
+    let _s = Serialize::default();
+    let _d = Deserialize::default();
+    let _u: User = todo!();
+}

--- a/test-goldens/rust/macro_imports.rs
+++ b/test-goldens/rust/macro_imports.rs
@@ -1,4 +1,6 @@
 use std::collections::{HashMap, VecDeque};
 
-let map: HashMap = HashMap::new();
-let deque: VecDeque = VecDeque::new();
+fn demo() {
+    let map: HashMap<String, i32> = HashMap::new();
+    let deque: VecDeque<String> = VecDeque::new();
+}

--- a/test-goldens/scala/quote_pattern_match.scala
+++ b/test-goldens/scala/quote_pattern_match.scala
@@ -1,4 +1,4 @@
 val result = x match {
-  case (1) => "one"
-  case (_) => "other"
+  case 1 => "one"
+  case _ => "other"
 }

--- a/test-goldens/swift/async_function.swift
+++ b/test-goldens/swift/async_function.swift
@@ -1,5 +1,5 @@
 import MyModule
 
-async func fetchUser(id: String) -> User {
+func fetchUser(id: String) async -> User {
     return try await api.fetchUser(id: id)
 }

--- a/test-goldens/swift/full_module.swift
+++ b/test-goldens/swift/full_module.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 protocol DataFetcher {
-    async func fetchData(from: URL) -> Data
+    func fetchData(from: URL) async -> Data
 }
 
 /// API response model.
@@ -14,7 +14,7 @@ struct Response {
 class NetworkFetcher: DataFetcher {
     private let session: URLSession
 
-    async func fetchData(from: URL) -> Data {
+    func fetchData(from: URL) async -> Data {
         let (data, _) = try await session.data(from: from)
         return data
     }

--- a/tests/c/builder_functions.rs
+++ b/tests/c/builder_functions.rs
@@ -33,7 +33,7 @@ fn test_void_function() {
     let printf_type = TypeName::importable("stdio.h", "printf");
     let body = CodeBlock::of(
         "%T(%S, name);",
-        (printf_type, StringLitArg("Hello, %s!\\n".to_string())),
+        (printf_type, StringLitArg("Hello, %s!\n".to_string())),
     )
     .unwrap();
     let fun = FunSpec::builder("greet")

--- a/tests/c/builder_imports.rs
+++ b/tests/c/builder_imports.rs
@@ -15,8 +15,8 @@ fn test_function_with_includes() {
     b.add_line();
     b.add("%>", ());
     b.add_statement(
-        "%T(%S, config.name)",
-        (printf_type, StringLitArg("Hello, %s\\n".to_string())),
+        "%T(%S, cfg.name)",
+        (printf_type, StringLitArg("Hello, %s\n".to_string())),
     );
     b.add_statement("%T cfg", (config_type,));
     b.add_line();

--- a/tests/cpp/quote_imports.rs
+++ b/tests/cpp/quote_imports.rs
@@ -17,8 +17,11 @@ fn render(block: &CodeBlock) -> String {
 
 #[test]
 fn test_imports() {
-    let vector = TypeName::importable("vector", "vector");
-    let string = TypeName::importable("string", "string");
+    let vector = TypeName::generic(
+        TypeName::importable("vector", "std::vector"),
+        vec![TypeName::primitive("int")],
+    );
+    let string = TypeName::importable("string", "std::string");
     let block = sigil_quote!(CppLang {
         $T(vector) items;
         $T(string) name = $S("Alice");

--- a/tests/go/quote_control_flow.rs
+++ b/tests/go/quote_control_flow.rs
@@ -53,6 +53,7 @@ fn test_for_init_semicolon() {
 fn test_switch_init_semicolon() {
     let block = sigil_quote!(GoLang {
         switch v := getValue(); v {
+        case "hello":
             fmt.Println(v);
         }
     })

--- a/tests/go/quote_edge_cases.rs
+++ b/tests/go/quote_edge_cases.rs
@@ -17,12 +17,12 @@ fn render(block: &CodeBlock) -> String {
 #[test]
 fn test_indent() {
     let block = sigil_quote!(GoLang {
-        namespace Foo {
+        func printDirections() {
         $>
-        North = iota;
-        East;
-        South;
-        West;
+        fmt.Println("North");
+        fmt.Println("East");
+        fmt.Println("South");
+        fmt.Println("West");
         $<
         }
     })

--- a/tests/java/builder_edge_cases.rs
+++ b/tests/java/builder_edge_cases.rs
@@ -80,6 +80,7 @@ fn test_annotated_method() {
 #[test]
 fn test_full_module() {
     let list = TypeName::importable("java.util", "List");
+    let list_user = TypeName::generic(list, vec![TypeName::primitive("User")]);
     let array_list = TypeName::importable("java.util", "ArrayList");
     let nullable = TypeName::importable("javax.annotation", "Nullable");
 
@@ -96,7 +97,7 @@ fn test_full_module() {
         )
         .add_method(
             FunSpec::builder("findAll")
-                .returns(TypeName::primitive("List<User>"))
+                .returns(list_user.clone())
                 .build()
                 .unwrap(),
         )
@@ -104,20 +105,20 @@ fn test_full_module() {
         .unwrap();
 
     // Implementation class.
-    let ctor_body = CodeBlock::of("this.users = new %T<>();", (array_list,)).unwrap();
+    let ctor_body = CodeBlock::of("this.users = new %T<>();", (array_list.clone(),)).unwrap();
     let find_body = CodeBlock::of(
         "return this.users.stream()\n    .filter(u -> u.getId().equals(id))\n    .findFirst()\n    .orElse(null);",
         (),
     )
     .unwrap();
-    let find_all_body = CodeBlock::of("return new %T<>(this.users);", (list.clone(),)).unwrap();
+    let find_all_body = CodeBlock::of("return new %T<>(this.users);", (array_list,)).unwrap();
 
     let cls_spec = TypeSpec::builder("InMemoryUserRepository", TypeKind::Class)
         .visibility(Visibility::Public)
         .implements(TypeName::primitive("UserRepository"))
         .doc("In-memory implementation of UserRepository.")
         .add_field(
-            FieldSpec::builder("users", TypeName::primitive("List<User>"))
+            FieldSpec::builder("users", list_user.clone())
                 .visibility(Visibility::Private)
                 .is_readonly()
                 .build()
@@ -144,7 +145,7 @@ fn test_full_module() {
         .add_method(
             FunSpec::builder("findAll")
                 .visibility(Visibility::Public)
-                .returns(TypeName::primitive("List<User>"))
+                .returns(list_user)
                 .annotation(CodeBlock::of("@Override", ()).unwrap())
                 .body(find_all_body)
                 .build()

--- a/tests/java/builder_functions.rs
+++ b/tests/java/builder_functions.rs
@@ -35,7 +35,7 @@ fn test_generic_type_params_before_return_type() {
     use sigil_stitch::spec::fun_spec::TypeParamSpec;
 
     let tp = TypeParamSpec::new("T").with_bound(TypeName::primitive("Comparable"));
-    let body = CodeBlock::of("return Collections.sort(list);", ()).unwrap();
+    let body = CodeBlock::of("Collections.sort(list);\nreturn list;", ()).unwrap();
     let fun = FunSpec::builder("sortList")
         .visibility(Visibility::Public)
         .is_static()
@@ -92,7 +92,7 @@ fn test_override_annotation() {
 #[test]
 fn test_generic_params_before_return_golden() {
     let tp = TypeParamSpec::new("T").with_bound(TypeName::primitive("Comparable"));
-    let body = CodeBlock::of("return Collections.sort(list);", ()).unwrap();
+    let body = CodeBlock::of("Collections.sort(list);\nreturn list;", ()).unwrap();
 
     let ts = TypeSpec::builder("Utils", TypeKind::Class)
         .visibility(Visibility::Public)

--- a/tests/kotlin/builder_types.rs
+++ b/tests/kotlin/builder_types.rs
@@ -57,13 +57,13 @@ fn test_data_class() {
         .visibility(Visibility::Public)
         .doc("A user data class.")
         .add_primary_constructor_param(
-            ParameterSpec::new("name", TypeName::primitive("String")).unwrap(),
+            ParameterSpec::new("val name", TypeName::primitive("String")).unwrap(),
         )
         .add_primary_constructor_param(
-            ParameterSpec::new("age", TypeName::primitive("Int")).unwrap(),
+            ParameterSpec::new("val age", TypeName::primitive("Int")).unwrap(),
         )
         .add_primary_constructor_param(
-            ParameterSpec::new("email", TypeName::primitive("String")).unwrap(),
+            ParameterSpec::new("val email", TypeName::primitive("String")).unwrap(),
         )
         .build()
         .unwrap();
@@ -201,6 +201,9 @@ fn test_enum_class() {
 #[test]
 fn test_enum_with_values() {
     let ts = TypeSpec::builder("Status", TypeKind::Enum)
+        .add_primary_constructor_param(
+            ParameterSpec::new("val value", TypeName::primitive("String")).unwrap(),
+        )
         .add_variant(
             EnumVariantSpec::builder("ACTIVE")
                 .value(CodeBlock::of("\"active\"", ()).unwrap())
@@ -210,12 +213,6 @@ fn test_enum_with_values() {
         .add_variant(
             EnumVariantSpec::builder("INACTIVE")
                 .value(CodeBlock::of("\"inactive\"", ()).unwrap())
-                .build()
-                .unwrap(),
-        )
-        .add_field(
-            FieldSpec::builder("value", TypeName::primitive("String"))
-                .is_readonly()
                 .build()
                 .unwrap(),
         )

--- a/tests/macro/non_brace_langs.rs
+++ b/tests/macro/non_brace_langs.rs
@@ -22,7 +22,7 @@ fn test_haskell_control_flow() {
     .unwrap();
 
     let output = render_hs(&block);
-    assert!(output.contains("if x > 0 ="), "got: {output}");
+    assert!(output.contains("if x > 0 then"), "got: {output}");
     assert!(output.contains("return True"), "got: {output}");
 }
 

--- a/tests/rust/builder_imports.rs
+++ b/tests/rust/builder_imports.rs
@@ -16,7 +16,8 @@ fn test_function_with_imports() {
     b.add("%>", ());
     b.add_statement("let mut map = HashMap::new()", ());
     b.add_statement("map.insert(\"key\".to_string(), \"value\".to_string())", ());
-    b.add_statement("map", ());
+    b.add("map", ());
+    b.add_line();
     b.add("%<", ());
     b.add("}", ());
     b.add_line();
@@ -28,7 +29,8 @@ fn test_function_with_imports() {
     b2.add("pub struct Config {", ());
     b2.add_line();
     b2.add("%>", ());
-    b2.add_statement("pub name: String", ());
+    b2.add("pub name: String,", ());
+    b2.add_line();
     b2.add("%<", ());
     b2.add("}", ());
     b2.add_line();
@@ -54,6 +56,9 @@ fn test_import_grouping() {
     let user = TypeName::importable("crate::models", "User");
 
     let mut b = CodeBlock::builder();
+    b.add("fn demo() {", ());
+    b.add_line();
+    b.add("%>", ());
     b.add_statement(
         "let _h: %T<String, String> = Default::default()",
         (hashmap,),
@@ -63,9 +68,12 @@ fn test_import_grouping() {
         (btreemap,),
     );
     b.add_statement("let _a: %T<String> = Arc::new(\"x\".into())", (arc,));
-    b.add_statement("let _s: %T = todo!()", (serialize,));
-    b.add_statement("let _d: %T = todo!()", (deserialize,));
+    b.add_statement("let _s = %T::default()", (serialize,));
+    b.add_statement("let _d = %T::default()", (deserialize,));
     b.add_statement("let _u: %T = todo!()", (user,));
+    b.add("%<", ());
+    b.add("}", ());
+    b.add_line();
     let block = b.build().unwrap();
 
     let file = FileSpec::builder_with("main.rs", RustLang::new())

--- a/tests/rust/quote_imports.rs
+++ b/tests/rust/quote_imports.rs
@@ -17,11 +17,19 @@ fn render(block: &CodeBlock) -> String {
 
 #[test]
 fn test_imports() {
-    let hashmap = TypeName::importable("std::collections", "HashMap");
-    let vec_deque = TypeName::importable("std::collections", "VecDeque");
+    let hashmap = TypeName::generic(
+        TypeName::importable("std::collections", "HashMap"),
+        vec![TypeName::primitive("String"), TypeName::primitive("i32")],
+    );
+    let vec_deque = TypeName::generic(
+        TypeName::importable("std::collections", "VecDeque"),
+        vec![TypeName::primitive("String")],
+    );
     let block = sigil_quote!(RustLang {
-        let map: $T(hashmap.clone()) = $T(hashmap)::new();
-        let deque: $T(vec_deque.clone()) = $T(vec_deque)::new();
+        fn demo() {
+            let map: $T(hashmap) = HashMap::new();
+            let deque: $T(vec_deque) = VecDeque::new();
+        }
     })
     .unwrap();
     golden::assert_golden("rust/macro_imports.rs", &render(&block));

--- a/tests/scala/quote_edge_cases.rs
+++ b/tests/scala/quote_edge_cases.rs
@@ -18,8 +18,8 @@ fn render(block: &CodeBlock) -> String {
 fn test_pattern_match() {
     let block = sigil_quote!(Scala {
         val result = x match {
-            case(1) => "one"
-            case(_) => "other"
+            case 1 => "one"
+            case _ => "other"
         }
     })
     .unwrap();


### PR DESCRIPTION
## Summary

- Fix `.read()` method call regression from batch 3 — `DECLARATION_KEYWORDS` now context-aware (only suppresses `CallOpen` when not after `.`)
- Add `ForRange` colon context for C++ range-for `:` spacing (`item : items`)
- Expand Haskell `block_open_for` with `if`/`else`/`case` handling
- Fix Swift `async` position from prefix to suffix (`func f() async -> T`)
- Fix 12 test inputs producing invalid target-language code across C, Java, Kotlin, Rust, Go, C++, Scala
- File GitHub issues for out-of-scope items: #86, #87, #88, #89, #90

## Test plan

- [x] `cargo test --all` — all pass
- [x] `cargo clippy --all-targets` — no warnings
- [x] `cargo fmt --check` — clean
- [x] Reviewed all 19 updated golden files for correctness