### PR TITLE
feat: property params, enum validation, and C# where clauses

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -122,4 +122,13 @@ pub enum SigilStitchError {
         /// The filename of the FileSpec.
         filename: String,
     },
+
+    /// Invalid enum declaration.
+    #[snafu(display("invalid enum {type_name:?}: {reason}"))]
+    InvalidEnum {
+        /// The type name.
+        type_name: String,
+        /// The reason the declaration is invalid.
+        reason: String,
+    },
 }

--- a/src/lang/csharp.rs
+++ b/src/lang/csharp.rs
@@ -288,6 +288,7 @@ impl CodeLang for CSharp {
             return_type_separator: " ",
             async_keyword: "async ",
             suppress_async_in_interface: true,
+            where_clause_style: crate::spec::fun_spec::WhereClauseStyle::SeparateWhere,
             ..Default::default()
         }
     }

--- a/src/spec/enum_variant_spec.rs
+++ b/src/spec/enum_variant_spec.rs
@@ -92,6 +92,11 @@ impl EnumVariantSpec {
         })
     }
 
+    /// Whether this variant has an explicit value.
+    pub fn has_value(&self) -> bool {
+        self.value.is_some()
+    }
+
     /// Create a variant builder for more complex variants.
     pub fn builder(name: &str) -> EnumVariantSpecBuilder {
         EnumVariantSpecBuilder {

--- a/src/spec/fun_spec.rs
+++ b/src/spec/fun_spec.rs
@@ -25,6 +25,14 @@ pub enum WhereClauseStyle {
     Inline,
     /// Rust-style `where` block after the signature.
     WhereBlock,
+    /// C#-style per-constraint `where` clauses after the signature.
+    ///
+    /// Each constraint gets its own `where` keyword on an indented line:
+    /// ```text
+    ///     where T : IComparable
+    ///     where U : ISerializable
+    /// ```
+    SeparateWhere,
 }
 
 /// How function parameter lists are formatted.
@@ -571,11 +579,18 @@ impl FunSpec {
     }
 
     fn emit_where_and_open(&self, sig: &mut String, sig_args: &mut Vec<Arg>, lang: &dyn CodeLang) {
-        let has_where = !self.where_constraints.is_empty()
-            && lang.function_syntax().where_clause_style == WhereClauseStyle::WhereBlock;
+        let style = lang.function_syntax().where_clause_style;
+        let has_where = !self.where_constraints.is_empty() && style != WhereClauseStyle::Inline;
         if has_where {
-            emit_where_block(sig, sig_args, &self.where_constraints, lang);
-            // After a where clause, put the block-open brace on its own line.
+            match style {
+                WhereClauseStyle::WhereBlock => {
+                    emit_where_block(sig, sig_args, &self.where_constraints, lang);
+                }
+                WhereClauseStyle::SeparateWhere => {
+                    emit_separate_where_block(sig, sig_args, &self.where_constraints, lang);
+                }
+                WhereClauseStyle::Inline => unreachable!(),
+            }
             sig.push_str("\n{");
         } else {
             sig.push_str(lang.fun_block_open());
@@ -694,6 +709,36 @@ pub(crate) fn emit_where_block(
             args.push(Arg::TypeName(bound.clone()));
         }
         fmt.push(',');
+    }
+}
+
+/// Append C#-style per-constraint where clauses to a format string.
+///
+/// Renders:
+/// ```text
+/// \n    where T : IComparable\n    where U : ISerializable
+/// ```
+pub(crate) fn emit_separate_where_block(
+    fmt: &mut String,
+    args: &mut Vec<Arg>,
+    constraints: &[WhereConstraint],
+    lang: &dyn CodeLang,
+) {
+    let generic = lang.generic_syntax();
+    let indent = lang.block_syntax().indent_unit;
+    for wc in constraints {
+        fmt.push('\n');
+        fmt.push_str(indent);
+        fmt.push_str("where %T");
+        args.push(Arg::TypeName(wc.subject.clone()));
+        fmt.push_str(generic.constraint_keyword);
+        for (j, bound) in wc.bounds.iter().enumerate() {
+            if j > 0 {
+                fmt.push_str(generic.constraint_separator);
+            }
+            fmt.push_str("%T");
+            args.push(Arg::TypeName(bound.clone()));
+        }
     }
 }
 

--- a/src/spec/parameter_spec.rs
+++ b/src/spec/parameter_spec.rs
@@ -32,6 +32,8 @@ pub struct ParameterSpec {
     pub(crate) param_type: TypeName,
     pub(crate) default_value: Option<crate::code_block::CodeBlock>,
     pub(crate) is_variadic: bool,
+    pub(crate) is_property: bool,
+    pub(crate) is_mutable_property: bool,
 }
 
 impl ParameterSpec {
@@ -42,6 +44,8 @@ impl ParameterSpec {
             param_type,
             default_value: None,
             is_variadic: false,
+            is_property: false,
+            is_mutable_property: false,
         }
     }
 
@@ -81,11 +85,27 @@ impl ParameterSpec {
                 args.push(Arg::TypeName(self.param_type.clone()));
                 fmt.push(' ');
             }
+            if self.is_property {
+                fmt.push_str(lang.enum_and_annotation().readonly_keyword);
+            } else if self.is_mutable_property {
+                let mk = lang.enum_and_annotation().mutable_field_keyword;
+                if !mk.is_empty() {
+                    fmt.push_str(mk);
+                }
+            }
             fmt.push_str(&lang.escape_reserved(&self.name));
         } else {
             // TS/Rust/Go/Python-style: name sep type
             if self.is_variadic {
                 fmt.push_str("...");
+            }
+            if self.is_property {
+                fmt.push_str(lang.enum_and_annotation().readonly_keyword);
+            } else if self.is_mutable_property {
+                let mk = lang.enum_and_annotation().mutable_field_keyword;
+                if !mk.is_empty() {
+                    fmt.push_str(mk);
+                }
             }
             fmt.push_str(&lang.escape_reserved(&self.name));
 
@@ -114,6 +134,8 @@ pub struct ParameterSpecBuilder {
     param_type: TypeName,
     default_value: Option<crate::code_block::CodeBlock>,
     is_variadic: bool,
+    is_property: bool,
+    is_mutable_property: bool,
 }
 
 impl ParameterSpecBuilder {
@@ -126,6 +148,24 @@ impl ParameterSpecBuilder {
     /// Mark this parameter as variadic.
     pub fn variadic(mut self) -> Self {
         self.is_variadic = true;
+        self
+    }
+
+    /// Mark this parameter as a readonly property declaration.
+    ///
+    /// When emitting, prepends the language's readonly keyword (e.g., `val` in Kotlin).
+    /// Used for primary constructor parameters that declare properties.
+    pub fn is_property(mut self) -> Self {
+        self.is_property = true;
+        self
+    }
+
+    /// Mark this parameter as a mutable property declaration.
+    ///
+    /// When emitting, prepends the language's mutable field keyword (e.g., `var` in Kotlin).
+    /// Used for primary constructor parameters that declare mutable properties.
+    pub fn is_mutable_property(mut self) -> Self {
+        self.is_mutable_property = true;
         self
     }
 
@@ -146,6 +186,8 @@ impl ParameterSpecBuilder {
             param_type: self.param_type,
             default_value: self.default_value,
             is_variadic: self.is_variadic,
+            is_property: self.is_property,
+            is_mutable_property: self.is_mutable_property,
         })
     }
 }
@@ -206,5 +248,37 @@ mod tests {
                 .to_string()
                 .contains("'name' must not be empty")
         );
+    }
+
+    #[test]
+    fn test_property_param_kotlin() {
+        let kt = crate::lang::kotlin::Kotlin::new();
+        let param = ParameterSpec::builder("name", TypeName::primitive("String"))
+            .is_property()
+            .build()
+            .unwrap();
+        let mut cb = CodeBlock::builder();
+        param.emit_into(&mut cb, &kt);
+        let block = cb.build().unwrap();
+        let imports = crate::import::ImportGroup::new();
+        let mut renderer = crate::code_renderer::CodeRenderer::new(&kt, &imports, 80);
+        let output = renderer.render(&block).unwrap();
+        assert_eq!(output, "val name: String");
+    }
+
+    #[test]
+    fn test_mutable_property_param_kotlin() {
+        let kt = crate::lang::kotlin::Kotlin::new();
+        let param = ParameterSpec::builder("name", TypeName::primitive("String"))
+            .is_mutable_property()
+            .build()
+            .unwrap();
+        let mut cb = CodeBlock::builder();
+        param.emit_into(&mut cb, &kt);
+        let block = cb.build().unwrap();
+        let imports = crate::import::ImportGroup::new();
+        let mut renderer = crate::code_renderer::CodeRenderer::new(&kt, &imports, 80);
+        let output = renderer.render(&block).unwrap();
+        assert_eq!(output, "var name: String");
     }
 }

--- a/src/spec/type_spec.rs
+++ b/src/spec/type_spec.rs
@@ -7,7 +7,8 @@ use crate::spec::annotation_spec::AnnotationSpec;
 use crate::spec::enum_variant_spec::EnumVariantSpec;
 use crate::spec::field_spec::FieldSpec;
 use crate::spec::fun_spec::{
-    FunSpec, TypeParamSpec, WhereClauseStyle, WhereConstraint, emit_where_block, render_type_params,
+    FunSpec, TypeParamSpec, WhereClauseStyle, WhereConstraint, emit_separate_where_block,
+    emit_where_block, render_type_params,
 };
 use crate::spec::modifiers::{DeclarationContext, Modifiers, TypeKind, Visibility};
 use crate::spec::parameter_spec::ParameterSpec;
@@ -343,11 +344,31 @@ impl TypeSpec {
                 impl_fmt.push_str(gen_syn.close);
             }
             // Where clause on impl block.
-            if !self.where_constraints.is_empty()
-                && lang.function_syntax().where_clause_style == WhereClauseStyle::WhereBlock
-            {
-                emit_where_block(&mut impl_fmt, &mut impl_args, &self.where_constraints, lang);
-                impl_fmt.push_str("\n{");
+            if !self.where_constraints.is_empty() {
+                let style = lang.function_syntax().where_clause_style;
+                match style {
+                    WhereClauseStyle::WhereBlock => {
+                        emit_where_block(
+                            &mut impl_fmt,
+                            &mut impl_args,
+                            &self.where_constraints,
+                            lang,
+                        );
+                        impl_fmt.push_str("\n{");
+                    }
+                    WhereClauseStyle::SeparateWhere => {
+                        emit_separate_where_block(
+                            &mut impl_fmt,
+                            &mut impl_args,
+                            &self.where_constraints,
+                            lang,
+                        );
+                        impl_fmt.push_str("\n{");
+                    }
+                    WhereClauseStyle::Inline => {
+                        impl_fmt.push_str(lang.block_syntax().block_open);
+                    }
+                }
             } else {
                 impl_fmt.push_str(lang.block_syntax().block_open);
             }
@@ -643,12 +664,22 @@ impl TypeSpec {
             }
         }
 
-        // Where clause (Rust-style).
-        if !self.where_constraints.is_empty()
-            && lang.function_syntax().where_clause_style == WhereClauseStyle::WhereBlock
-        {
-            emit_where_block(&mut fmt, &mut args, &self.where_constraints, lang);
-            fmt.push_str("\n{");
+        // Where clause (Rust/C#-style).
+        if !self.where_constraints.is_empty() {
+            let style = lang.function_syntax().where_clause_style;
+            match style {
+                WhereClauseStyle::WhereBlock => {
+                    emit_where_block(&mut fmt, &mut args, &self.where_constraints, lang);
+                    fmt.push_str("\n{");
+                }
+                WhereClauseStyle::SeparateWhere => {
+                    emit_separate_where_block(&mut fmt, &mut args, &self.where_constraints, lang);
+                    fmt.push_str("\n{");
+                }
+                WhereClauseStyle::Inline => {
+                    fmt.push_str(lang.type_header_block_open(self.kind));
+                }
+            }
         } else {
             fmt.push_str(lang.type_header_block_open(self.kind));
         }
@@ -858,6 +889,18 @@ impl TypeSpecBuilder {
                     kind: kind_str,
                     type_name: self.name.clone(),
                     reason: "must not have fields, methods, variants, or properties".to_string(),
+                });
+            }
+        }
+
+        // Validate Enum consistency between primary constructor and variant values.
+        if self.kind == TypeKind::Enum && !self.primary_constructor.is_empty() {
+            let has_valueless_variants = self.variants.iter().any(|v| !v.has_value());
+            if has_valueless_variants {
+                return Err(crate::error::SigilStitchError::InvalidEnum {
+                    type_name: self.name.clone(),
+                    reason: "enum has primary constructor parameters but some variants lack values"
+                        .to_string(),
                 });
             }
         }

--- a/test-goldens/csharp/generic_class.cs
+++ b/test-goldens/csharp/generic_class.cs
@@ -1,4 +1,6 @@
-public class SortedList<T : IComparable> {
+public class SortedList<T>
+    where T : IComparable
+{
     private List<T> items;
 
     public void Add(T item) {

--- a/test-goldens/csharp/generic_method.cs
+++ b/test-goldens/csharp/generic_method.cs
@@ -1,5 +1,7 @@
 public class Utils {
-    public static T Max<T : IComparable<T>>(T a, T b) {
+    public static T Max<T>(T a, T b)
+        where T : IComparable<T>
+    {
         return a.CompareTo(b) > 0 ? a : b;
     }
 }

--- a/test-goldens/csharp/where_clause_multiple.cs
+++ b/test-goldens/csharp/where_clause_multiple.cs
@@ -1,0 +1,8 @@
+public class Mapper<TIn, TOut>
+    where TIn : IConvertible
+    where TOut : IConvertible, new()
+{
+    public TOut Map(TIn input) {
+        throw new NotImplementedException();
+    }
+}

--- a/tests/csharp/builder_functions.rs
+++ b/tests/csharp/builder_functions.rs
@@ -67,7 +67,7 @@ fn test_async_method() {
 
 #[test]
 fn test_generic_method() {
-    let tp = TypeParamSpec::new("T").with_bound(TypeName::primitive("IComparable<T>"));
+    let tp = TypeParamSpec::new("T");
 
     let body = CodeBlock::of("return a.CompareTo(b) > 0 ? a : b;", ()).unwrap();
 
@@ -78,6 +78,10 @@ fn test_generic_method() {
                 .visibility(Visibility::Public)
                 .is_static()
                 .add_type_param(tp)
+                .add_where_constraint(
+                    TypeName::primitive("T"),
+                    vec![TypeName::primitive("IComparable<T>")],
+                )
                 .returns(TypeName::primitive("T"))
                 .add_param(ParameterSpec::new("a", TypeName::primitive("T")).unwrap())
                 .add_param(ParameterSpec::new("b", TypeName::primitive("T")).unwrap())

--- a/tests/csharp/builder_types.rs
+++ b/tests/csharp/builder_types.rs
@@ -127,11 +127,15 @@ fn test_class_extends_implements() {
 
 #[test]
 fn test_generic_class() {
-    let tp = TypeParamSpec::new("T").with_bound(TypeName::primitive("IComparable"));
+    let tp = TypeParamSpec::new("T");
 
     let ts = TypeSpec::builder("SortedList", TypeKind::Class)
         .visibility(Visibility::Public)
         .add_type_param(tp)
+        .add_where_constraint(
+            TypeName::primitive("T"),
+            vec![TypeName::primitive("IComparable")],
+        )
         .add_field(
             FieldSpec::builder("items", TypeName::primitive("List<T>"))
                 .visibility(Visibility::Private)
@@ -249,4 +253,42 @@ fn test_annotation_bracket_syntax() {
         !output.contains("@Serializable"),
         "should NOT use @-prefix annotation style, got:\n{output}"
     );
+}
+
+#[test]
+fn test_where_clause_multiple() {
+    let ts = TypeSpec::builder("Mapper", TypeKind::Class)
+        .visibility(Visibility::Public)
+        .add_type_param(TypeParamSpec::new("TIn"))
+        .add_type_param(TypeParamSpec::new("TOut"))
+        .add_where_constraint(
+            TypeName::primitive("TIn"),
+            vec![TypeName::primitive("IConvertible")],
+        )
+        .add_where_constraint(
+            TypeName::primitive("TOut"),
+            vec![
+                TypeName::primitive("IConvertible"),
+                TypeName::primitive("new()"),
+            ],
+        )
+        .add_method(
+            FunSpec::builder("Map")
+                .visibility(Visibility::Public)
+                .returns(TypeName::primitive("TOut"))
+                .add_param(ParameterSpec::new("input", TypeName::primitive("TIn")).unwrap())
+                .body(CodeBlock::of("throw new NotImplementedException();", ()).unwrap())
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
+
+    let file = FileSpec::builder_with("Mapper.cs", CSharp::new())
+        .add_type(ts)
+        .build()
+        .unwrap();
+    let output = file.render(80).unwrap();
+
+    golden::assert_golden("csharp/where_clause_multiple.cs", &output);
 }

--- a/tests/kotlin/builder_types.rs
+++ b/tests/kotlin/builder_types.rs
@@ -57,13 +57,22 @@ fn test_data_class() {
         .visibility(Visibility::Public)
         .doc("A user data class.")
         .add_primary_constructor_param(
-            ParameterSpec::new("val name", TypeName::primitive("String")).unwrap(),
+            ParameterSpec::builder("name", TypeName::primitive("String"))
+                .is_property()
+                .build()
+                .unwrap(),
         )
         .add_primary_constructor_param(
-            ParameterSpec::new("val age", TypeName::primitive("Int")).unwrap(),
+            ParameterSpec::builder("age", TypeName::primitive("Int"))
+                .is_property()
+                .build()
+                .unwrap(),
         )
         .add_primary_constructor_param(
-            ParameterSpec::new("val email", TypeName::primitive("String")).unwrap(),
+            ParameterSpec::builder("email", TypeName::primitive("String"))
+                .is_property()
+                .build()
+                .unwrap(),
         )
         .build()
         .unwrap();
@@ -202,7 +211,10 @@ fn test_enum_class() {
 fn test_enum_with_values() {
     let ts = TypeSpec::builder("Status", TypeKind::Enum)
         .add_primary_constructor_param(
-            ParameterSpec::new("val value", TypeName::primitive("String")).unwrap(),
+            ParameterSpec::builder("value", TypeName::primitive("String"))
+                .is_property()
+                .build()
+                .unwrap(),
         )
         .add_variant(
             EnumVariantSpec::builder("ACTIVE")

--- a/tests/type_spec_tests.rs
+++ b/tests/type_spec_tests.rs
@@ -615,3 +615,67 @@ fn test_embedded_import_tracking() {
         "should import io package: {output}"
     );
 }
+
+#[test]
+fn test_enum_constructor_with_valueless_variant_errors() {
+    use sigil_stitch::spec::enum_variant_spec::EnumVariantSpec;
+
+    let result = TypeSpec::builder("Status", TypeKind::Enum)
+        .add_primary_constructor_param(
+            ParameterSpec::builder(
+                "value",
+                sigil_stitch::type_name::TypeName::primitive("String"),
+            )
+            .is_property()
+            .build()
+            .unwrap(),
+        )
+        .add_variant(EnumVariantSpec::new("ACTIVE").unwrap())
+        .build();
+
+    assert!(result.is_err());
+    assert!(
+        result
+            .unwrap_err()
+            .to_string()
+            .contains("some variants lack values"),
+        "should error when enum has constructor but variants lack values"
+    );
+}
+
+#[test]
+fn test_enum_no_values_no_constructor_ok() {
+    use sigil_stitch::spec::enum_variant_spec::EnumVariantSpec;
+
+    let result = TypeSpec::builder("Color", TypeKind::Enum)
+        .add_variant(EnumVariantSpec::new("RED").unwrap())
+        .add_variant(EnumVariantSpec::new("GREEN").unwrap())
+        .build();
+
+    assert!(result.is_ok());
+}
+
+#[test]
+fn test_enum_valued_variants_without_constructor_ok() {
+    use sigil_stitch::spec::enum_variant_spec::EnumVariantSpec;
+
+    let result = TypeSpec::builder("Direction", TypeKind::Enum)
+        .add_variant(
+            EnumVariantSpec::builder("UP")
+                .value(CodeBlock::of("'UP'", ()).unwrap())
+                .build()
+                .unwrap(),
+        )
+        .add_variant(
+            EnumVariantSpec::builder("DOWN")
+                .value(CodeBlock::of("'DOWN'", ()).unwrap())
+                .build()
+                .unwrap(),
+        )
+        .build();
+
+    assert!(
+        result.is_ok(),
+        "assignment-style valued enums should not require a constructor"
+    );
+}


### PR DESCRIPTION
## Summary

Implements three builder improvements filed as issues during batch 4:

- **#86 — Kotlin `val`/`var` on constructor params**: Adds `is_property()` and `is_mutable_property()` to `ParameterSpec`, mirroring `FieldSpec::is_readonly()`. Emits the lang's `readonly_keyword` (`val` in Kotlin) or `mutable_field_keyword` (`var`) before the param name. Replaces the `"val name"` string hack.
- **#87 — Enum constructor validation**: Adds validation in `TypeSpecBuilder::build()` that if an enum has primary constructor params, all variants must have values. Adds `InvalidEnum` error variant and `EnumVariantSpec::has_value()`.
- **#88 — C# `where` clauses**: Adds `WhereClauseStyle::SeparateWhere` for C#-style per-constraint `where` keywords (`where T : IComparable`). Migrates C# generic tests from inline bounds to `add_where_constraint()`.

Closes #86, closes #87, closes #88.

## Test plan

- [x] `cargo test --all` — all pass (no BLESS needed after initial golden update)
- [x] `cargo clippy --all-targets` — clean
- [x] `cargo fmt --check` — clean
- [x] New unit tests for `is_property()`/`is_mutable_property()` with Kotlin lang
- [x] New tests for enum validation (constructor + valueless variant errors, plain enum ok, assignment-style valued enum ok)
- [x] New golden `csharp/where_clause_multiple.cs` for multi-constraint where clauses
- [x] Updated goldens for `csharp/generic_class.cs` and `csharp/generic_method.cs`