### PR TITLE
Migrate $L to $N for identifiers, add keyword-escape tests for all 18 languages

### DIFF
--- a/examples/macro_features.rs
+++ b/examples/macro_features.rs
@@ -45,11 +45,36 @@ fn type_reference() {
 /// `$N(expr)` — identifier name with keyword escaping.
 fn name_identifier() {
     println!("--- $N: Name Identifier ---\n");
+
+    // Reserved word escaping: "type" → "type_" in TypeScript
     let field_name = "type";
     let block = sigil_quote!(TypeScript {
         const $N(field_name) = getValue();
     })
     .unwrap();
+    println!("Keyword escaping ({field_name}):");
+    println!("{}", render_ts(&block));
+
+    // Dynamic name construction: build getter names from field names
+    let field = "userName";
+    let getter = format!(
+        "get{}",
+        field.chars().next().unwrap().to_uppercase().to_string() + &field[1..]
+    );
+    let block = sigil_quote!(TypeScript {
+        $N(getter)(): string;
+    })
+    .unwrap();
+    println!("Dynamic name ({getter}):");
+    println!("{}", render_ts(&block));
+
+    // Member access: this.$N(name) for dynamic property access
+    let prop = "email";
+    let block = sigil_quote!(TypeScript {
+        this.$N(prop) = value;
+    })
+    .unwrap();
+    println!("Member access (this.{prop}):");
     println!("{}", render_ts(&block));
 }
 

--- a/examples/meta_programming.rs
+++ b/examples/meta_programming.rs
@@ -76,7 +76,7 @@ fn meta_for_loop() {
     let fields = vec!["name", "email", "age"];
     let block = sigil_quote!(TypeScript {
         $for(field in &fields) {
-            this.$L(*field) = data.$L(*field);
+            this.$N(*field) = data.$N(*field);
         }
     })
     .unwrap();
@@ -121,7 +121,7 @@ fn splice_each() {
         .iter()
         .map(|f| {
             sigil_quote!(TypeScript {
-                this.$L(*f) = config.$L(*f);
+                this.$N(*f) = config.$N(*f);
             })
             .unwrap()
         })
@@ -149,7 +149,7 @@ fn nested_meta() {
     let block = sigil_quote!(TypeScript {
         $for((name, ty, required) in &fields) {
             $if(*required) {
-                $L(*name): $L(*ty);
+                $N(*name): $L(*ty);
             } $else {
                 $L(format!("{}?: {}", name, ty));
             }
@@ -217,7 +217,7 @@ fn schema_driven_codegen() {
     for field in &schema {
         if !field.optional {
             let body = sigil_quote!(TypeScript {
-                return this.$L(field.name);
+                return this.$N(field.name);
             })
             .unwrap();
             let getter = FunSpec::builder(&format!("get{}", capitalize(field.name)))

--- a/tests/bash/quote_edge_cases.rs
+++ b/tests/bash/quote_edge_cases.rs
@@ -57,3 +57,31 @@ fn test_function_with_local() {
     .unwrap();
     golden::assert_golden("bash/quote_function_local.bash", &render(&block));
 }
+
+#[test]
+fn test_name_keyword_escape_in_macro() {
+    let name = "declare";
+    let block = sigil_quote!(Bash {
+        $$name=$N(name)
+        echo $$name
+    })
+    .unwrap();
+
+    let output = render(&block);
+    assert!(output.contains("declare_"), "got: {output}");
+}
+
+#[test]
+fn test_flags_and_shell_vars() {
+    let image = "myapp";
+    let block = sigil_quote!(Bash {
+        docker pull -q --platform linux/amd64 $L("${REGISTRY}")/$N(image):$L("${TAG}")
+    })
+    .unwrap();
+
+    let output = render(&block);
+    // Known limitation: `-q` and `linux/amd64` get spaces around `-` and `/`
+    // because the tokenizer treats them as operators.
+    // TODO(#93): shell-aware tokenizer mode for `-flags` and `/paths`
+    assert!(output.contains("myapp"), "got: {output}");
+}

--- a/tests/c/quote_edge_cases.rs
+++ b/tests/c/quote_edge_cases.rs
@@ -66,3 +66,15 @@ fn test_for_loop_with_pointer() {
     .unwrap();
     golden::assert_golden("c/quote_for_loop.c", &render(&block));
 }
+
+#[test]
+fn test_name_keyword_escape_in_macro() {
+    let name = "auto";
+    let block = sigil_quote!(CLang {
+        $N(name) = 1;
+    })
+    .unwrap();
+
+    let output = render(&block);
+    assert!(output.contains("auto_ = 1;"), "got: {output}");
+}

--- a/tests/cpp/quote_edge_cases.rs
+++ b/tests/cpp/quote_edge_cases.rs
@@ -70,3 +70,15 @@ fn test_smart_pointers() {
     .unwrap();
     golden::assert_golden("cpp/quote_smart_pointers.cpp", &render(&block));
 }
+
+#[test]
+fn test_name_keyword_escape_in_macro() {
+    let name = "class";
+    let block = sigil_quote!(CppLang {
+        $N(name) = 1;
+    })
+    .unwrap();
+
+    let output = render(&block);
+    assert!(output.contains("class_ = 1;"), "got: {output}");
+}

--- a/tests/csharp/quote_edge_cases.rs
+++ b/tests/csharp/quote_edge_cases.rs
@@ -72,3 +72,15 @@ fn test_nullable_type() {
     .unwrap();
     golden::assert_golden("csharp/quote_nullable.cs", &render(&block));
 }
+
+#[test]
+fn test_name_keyword_escape_in_macro() {
+    let name = "class";
+    let block = sigil_quote!(CSharp {
+        $N(name) = 1;
+    })
+    .unwrap();
+
+    let output = render(&block);
+    assert!(output.contains("@class = 1;"), "got: {output}");
+}

--- a/tests/dart/quote_edge_cases.rs
+++ b/tests/dart/quote_edge_cases.rs
@@ -58,3 +58,15 @@ fn test_async_await() {
     .unwrap();
     golden::assert_golden("dart/quote_async_await.dart", &render(&block));
 }
+
+#[test]
+fn test_name_keyword_escape_in_macro() {
+    let name = "class";
+    let block = sigil_quote!(Dart {
+        $N(name) = 1;
+    })
+    .unwrap();
+
+    let output = render(&block);
+    assert!(output.contains("class_ = 1;"), "got: {output}");
+}

--- a/tests/haskell/quote_edge_cases.rs
+++ b/tests/haskell/quote_edge_cases.rs
@@ -91,3 +91,15 @@ fn test_dollar_operator() {
     .unwrap();
     golden::assert_golden("haskell/quote_dollar_operator.hs", &render(&block));
 }
+
+#[test]
+fn test_name_keyword_escape_in_macro() {
+    let name = "data";
+    let block = sigil_quote!(Haskell {
+        $N(name) = 1
+    })
+    .unwrap();
+
+    let output = render(&block);
+    assert!(output.contains("data' = 1"), "got: {output}");
+}

--- a/tests/java/quote_edge_cases.rs
+++ b/tests/java/quote_edge_cases.rs
@@ -70,3 +70,15 @@ fn test_try_with_resources() {
     .unwrap();
     golden::assert_golden("java/quote_try_resources.java", &render(&block));
 }
+
+#[test]
+fn test_name_keyword_escape_in_macro() {
+    let name = "class";
+    let block = sigil_quote!(JavaLang {
+        $N(name) = 1;
+    })
+    .unwrap();
+
+    let output = render(&block);
+    assert!(output.contains("class_ = 1;"), "got: {output}");
+}

--- a/tests/javascript/quote_edge_cases.rs
+++ b/tests/javascript/quote_edge_cases.rs
@@ -68,3 +68,15 @@ fn test_ternary_and_nullish() {
     .unwrap();
     golden::assert_golden("javascript/quote_ternary_nullish.js", &render(&block));
 }
+
+#[test]
+fn test_name_keyword_escape_in_macro() {
+    let name = "class";
+    let block = sigil_quote!(JavaScript {
+        const $N(name) = 1;
+    })
+    .unwrap();
+
+    let output = render(&block);
+    assert!(output.contains("const class_ = 1;"), "got: {output}");
+}

--- a/tests/kotlin/quote_edge_cases.rs
+++ b/tests/kotlin/quote_edge_cases.rs
@@ -81,3 +81,15 @@ fn test_extension_function() {
     .unwrap();
     golden::assert_golden("kotlin/quote_extension_fun.kt", &render(&block));
 }
+
+#[test]
+fn test_name_keyword_escape_in_macro() {
+    let name = "class";
+    let block = sigil_quote!(Kotlin {
+        val $N(name) = 1
+    })
+    .unwrap();
+
+    let output = render(&block);
+    assert!(output.contains("val `class` = 1"), "got: {output}");
+}

--- a/tests/lua/quote_edge_cases.rs
+++ b/tests/lua/quote_edge_cases.rs
@@ -85,3 +85,15 @@ fn test_for_loop() {
     .unwrap();
     golden::assert_golden("lua/quote_for_loop.lua", &render(&block));
 }
+
+#[test]
+fn test_name_keyword_escape_in_macro() {
+    let name = "local";
+    let block = sigil_quote!(Lua {
+        $N(name) = 1
+    })
+    .unwrap();
+
+    let output = render(&block);
+    assert!(output.contains("local_ = 1"), "got: {output}");
+}

--- a/tests/macro/c_each.rs
+++ b/tests/macro/c_each.rs
@@ -348,7 +348,7 @@ fn test_c_each_no_trailing_blank_line_in_fun_spec_body() {
         .iter()
         .map(|f| {
             sigil_quote!(JavaLang {
-                this.$L(*f) = $L(*f);
+                this.$N(*f) = $N(*f);
             })
             .unwrap()
         })

--- a/tests/macro/interpolation.rs
+++ b/tests/macro/interpolation.rs
@@ -83,7 +83,7 @@ fn test_multiple_interpolations_in_one_statement() {
     let t1 = TypeName::primitive("string");
     let t2 = TypeName::primitive("number");
     let block = sigil_quote!(TypeScript {
-        const x: $T(t1) = $L("getVal") as $T(t2);
+        const x: $T(t1) = $N("getVal") as $T(t2);
     })
     .unwrap();
 
@@ -121,4 +121,61 @@ fn test_consecutive_specifiers_no_space() {
         "consecutive $L should have no space between them, got: {output}"
     );
     golden::assert_golden("macro/quote_consecutive_specifiers.txt", &output);
+}
+
+#[test]
+fn test_name_dynamic_getter() {
+    let fields = vec!["name", "age"];
+
+    let block = sigil_quote!(TypeScript {
+        $for(field in &fields) {
+            $let(getter = format!("get{}", field
+                .chars()
+                .next()
+                .map(|c| c.to_uppercase().to_string())
+                .unwrap_or_default()
+                + &field[1..]));
+            $N(getter)(): string;
+        }
+    })
+    .unwrap();
+
+    let output = render_ts(&block);
+    assert!(output.contains("getName(): string;"), "got: {output}");
+    assert!(output.contains("getAge(): string;"), "got: {output}");
+}
+
+#[test]
+fn test_name_keyword_escape_in_sigil_quote() {
+    let reserved = "type";
+    let safe = "myVar";
+
+    let block = sigil_quote!(TypeScript {
+        const $N(reserved) = 1;
+        const $N(safe) = 2;
+    })
+    .unwrap();
+
+    let output = render_ts(&block);
+    assert!(
+        output.contains("const type_ = 1;"),
+        "reserved word should be escaped, got: {output}"
+    );
+    assert!(
+        output.contains("const myVar = 2;"),
+        "non-reserved should pass through, got: {output}"
+    );
+}
+
+#[test]
+fn test_name_member_access() {
+    let field_name = "email";
+
+    let block = sigil_quote!(TypeScript {
+        this.$N(field_name) = value;
+    })
+    .unwrap();
+
+    let output = render_ts(&block);
+    assert!(output.contains("this.email = value;"), "got: {output}");
 }

--- a/tests/macro/meta_for.rs
+++ b/tests/macro/meta_for.rs
@@ -9,7 +9,7 @@ fn test_meta_for_simple() {
 
     let block = sigil_quote!(TypeScript {
         $for(field in &fields) {
-            console.log($L(*field));
+            console.log($N(*field));
         }
     })
     .unwrap();
@@ -114,9 +114,9 @@ fn test_meta_if_nested_in_meta_for() {
     let block = sigil_quote!(TypeScript {
         $for((field, required) in &fields) {
             $if(*required) {
-                this.$N(*field) = validate($L(*field));
+                this.$N(*field) = validate($N(*field));
             } $else {
-                this.$N(*field) = $L(*field);
+                this.$N(*field) = $N(*field);
             }
         }
     })
@@ -181,7 +181,7 @@ fn test_meta_for_enum_variants() {
 
     let block = sigil_quote!(TypeScript {
         $for((name, value) in &variants) {
-            $L(*name) = $L(*value),
+            $N(*name) = $L(*value),
         }
     })
     .unwrap();
@@ -198,7 +198,7 @@ fn test_meta_for_golden() {
 
     let block = sigil_quote!(TypeScript {
         $for(field in &fields) {
-            console.log($L(*field));
+            console.log($N(*field));
         }
     })
     .unwrap();

--- a/tests/ocaml/quote_edge_cases.rs
+++ b/tests/ocaml/quote_edge_cases.rs
@@ -70,3 +70,15 @@ fn test_record_update() {
     .unwrap();
     golden::assert_golden("ocaml/quote_record_update.ml", &render(&block));
 }
+
+#[test]
+fn test_name_keyword_escape_in_macro() {
+    let name = "let";
+    let block = sigil_quote!(OCaml {
+        $N(name) = 1
+    })
+    .unwrap();
+
+    let output = render(&block);
+    assert!(output.contains("let_ = 1"), "got: {output}");
+}

--- a/tests/python/quote_edge_cases.rs
+++ b/tests/python/quote_edge_cases.rs
@@ -71,3 +71,15 @@ fn test_with_statement() {
     .unwrap();
     golden::assert_golden("python/quote_with.py", &render(&block));
 }
+
+#[test]
+fn test_name_keyword_escape_in_macro() {
+    let name = "class";
+    let block = sigil_quote!(Python {
+        $N(name) = 1
+    })
+    .unwrap();
+
+    let output = render(&block);
+    assert!(output.contains("class_ = 1"), "got: {output}");
+}

--- a/tests/rust/quote_edge_cases.rs
+++ b/tests/rust/quote_edge_cases.rs
@@ -86,3 +86,15 @@ fn test_impl_block() {
     .unwrap();
     golden::assert_golden("rust/quote_impl_block.rs", &render(&block));
 }
+
+#[test]
+fn test_name_keyword_escape_in_macro() {
+    let name = "type";
+    let block = sigil_quote!(RustLang {
+        let $N(name) = 1;
+    })
+    .unwrap();
+
+    let output = render(&block);
+    assert!(output.contains("let r#type = 1;"), "got: {output}");
+}

--- a/tests/scala/quote_edge_cases.rs
+++ b/tests/scala/quote_edge_cases.rs
@@ -72,3 +72,15 @@ fn test_trait_mixin() {
     .unwrap();
     golden::assert_golden("scala/quote_trait_mixin.scala", &render(&block));
 }
+
+#[test]
+fn test_name_keyword_escape_in_macro() {
+    let name = "class";
+    let block = sigil_quote!(Scala {
+        val $N(name) = 1
+    })
+    .unwrap();
+
+    let output = render(&block);
+    assert!(output.contains("val `class` = 1"), "got: {output}");
+}

--- a/tests/swift/quote_edge_cases.rs
+++ b/tests/swift/quote_edge_cases.rs
@@ -77,3 +77,15 @@ fn test_enum_with_associated_values() {
     .unwrap();
     golden::assert_golden("swift/quote_enum_associated.swift", &render(&block));
 }
+
+#[test]
+fn test_name_keyword_escape_in_macro() {
+    let name = "class";
+    let block = sigil_quote!(Swift {
+        let $N(name) = 1
+    })
+    .unwrap();
+
+    let output = render(&block);
+    assert!(output.contains("let `class` = 1"), "got: {output}");
+}

--- a/tests/typescript/quote_edge_cases.rs
+++ b/tests/typescript/quote_edge_cases.rs
@@ -81,3 +81,15 @@ fn test_mapped_type() {
     .unwrap();
     golden::assert_golden("typescript/quote_mapped_type.ts", &render(&block));
 }
+
+#[test]
+fn test_name_keyword_escape_in_macro() {
+    let name = "class";
+    let block = sigil_quote!(TypeScript {
+        const $N(name) = 1;
+    })
+    .unwrap();
+
+    let output = render(&block);
+    assert!(output.contains("const class_ = 1;"), "got: {output}");
+}

--- a/tests/zsh/quote_edge_cases.rs
+++ b/tests/zsh/quote_edge_cases.rs
@@ -57,3 +57,31 @@ fn test_function_definition() {
     .unwrap();
     golden::assert_golden("zsh/quote_function.zsh", &render(&block));
 }
+
+#[test]
+fn test_name_keyword_escape_in_macro() {
+    let name = "autoload";
+    let block = sigil_quote!(Zsh {
+        $$name=$N(name)
+        echo $$name
+    })
+    .unwrap();
+
+    let output = render(&block);
+    assert!(output.contains("autoload_"), "got: {output}");
+}
+
+#[test]
+fn test_flags_and_shell_vars() {
+    let image = "myapp";
+    let block = sigil_quote!(Zsh {
+        docker pull -q --platform linux/amd64 $L("${REGISTRY}")/$N(image):$L("${TAG}")
+    })
+    .unwrap();
+
+    let output = render(&block);
+    // Known limitation: `-q` and `linux/amd64` get spaces around `-` and `/`
+    // because the tokenizer treats them as operators.
+    // TODO(#93): shell-aware tokenizer mode for `-flags` and `/paths`
+    assert!(output.contains("myapp"), "got: {output}");
+}


### PR DESCRIPTION
## Summary

- Migrate 14 `$L` → `$N` in tests and examples where identifiers were interpolated without reserved-word escaping
- Add 3 new `$N` tests: dynamic getter names, keyword escaping, member access
- Expand `macro_features` example to demonstrate dynamic names, keyword escaping, and member access patterns
- Add `test_name_keyword_escape_in_macro` to all 18 language `quote_edge_cases`, covering every escape style (`kw_`, `` `kw` ``, `r#kw`, `@kw`, `kw'`)
- Add `test_flags_and_shell_vars` for bash/zsh documenting #93 tokenizer limitation

## Test plan

- [x] `cargo test --all` — all pass
- [x] `cargo fmt --check` — clean
- [x] `cargo run --example macro_features` — shows keyword escaping, dynamic names, member access
- [x] `cargo run --example meta_programming` — output unchanged after migration