### PR TITLE
fix: span-aware dash-flag and slash-path spacing (#93)

### DIFF
--- a/macros/src/parse/format.rs
+++ b/macros/src/parse/format.rs
@@ -38,6 +38,10 @@ pub(super) enum TokenAnnotation {
     AssignAdjacent,
     /// `:` span-adjacent to both neighbors (Lua method call `obj:method()`).
     MethodCallColon,
+    /// `-` span-adjacent to following ident/literal (shell flag like `-q`, `-f`).
+    DashFlag,
+    /// `/` span-adjacent to both neighbors (path separator like `linux/amd64`).
+    SlashSep,
 }
 
 /// What kind of token was just emitted (for spacing decisions).
@@ -301,6 +305,24 @@ fn annotate_tokens(tokens: &[TokenTree]) -> Vec<TokenAnnotation> {
                             continue;
                         }
 
+                        // DashFlag: standalone `-` span-adjacent to following ident/literal
+                        // (shell flag like `-q`, `-f`, `-avz`).
+                        if ch == '-'
+                            && p.spacing() == Spacing::Alone
+                            && i + 1 < tokens.len()
+                            && matches!(&tokens[i + 1], TokenTree::Ident(_) | TokenTree::Literal(_))
+                        {
+                            let dash_end = p.span().end();
+                            let next_start = tokens[i + 1].span().start();
+                            if dash_end.line == next_start.line
+                                && dash_end.column == next_start.column
+                            {
+                                annotations[i] = TokenAnnotation::DashFlag;
+                                i += 1;
+                                continue;
+                            }
+                        }
+
                         // PostfixStar: `*` span-adjacent to preceding ident (pointer type like `Config*`).
                         if ch == '*' && i > 0 && matches!(&tokens[i - 1], TokenTree::Ident(_)) {
                             let prev_end = tokens[i - 1].span().end();
@@ -358,6 +380,20 @@ fn annotate_tokens(tokens: &[TokenTree]) -> Vec<TokenAnnotation> {
                         };
                         if is_prefix {
                             annotations[i] = TokenAnnotation::PrefixOp;
+                        }
+                    }
+                    '/' if p.spacing() == Spacing::Alone && i > 0 && i + 1 < tokens.len() => {
+                        // SlashSep: `/` span-adjacent to both neighbors (path like `linux/amd64`).
+                        let prev_end = tokens[i - 1].span().end();
+                        let slash_start = p.span().start();
+                        let slash_end = p.span().end();
+                        let next_start = tokens[i + 1].span().start();
+                        if prev_end.line == slash_start.line
+                            && prev_end.column == slash_start.column
+                            && slash_end.line == next_start.line
+                            && slash_end.column == next_start.column
+                        {
+                            annotations[i] = TokenAnnotation::SlashSep;
                         }
                     }
                     '?' => {
@@ -838,7 +874,9 @@ fn tokens_to_format_inner(
                     TokenAnnotation::PrefixOp => PrevTokenKind::PrefixOp(ch),
                     TokenAnnotation::ArrowOp
                     | TokenAnnotation::AssignAdjacent
-                    | TokenAnnotation::MethodCallColon => PrevTokenKind::PathSep,
+                    | TokenAnnotation::MethodCallColon
+                    | TokenAnnotation::SlashSep => PrevTokenKind::PathSep,
+                    TokenAnnotation::DashFlag => PrevTokenKind::PrefixOp(ch),
                     _ => new_kind,
                 };
             }
@@ -974,7 +1012,8 @@ pub(super) fn maybe_space(
         | TokenAnnotation::PostfixQuestion
         | TokenAnnotation::ArrowOp
         | TokenAnnotation::AssignAdjacent
-        | TokenAnnotation::MethodCallColon => return,
+        | TokenAnnotation::MethodCallColon
+        | TokenAnnotation::SlashSep => return,
         TokenAnnotation::GenericOpen if prev != PrevTokenKind::Keyword => return,
         _ => {}
     }

--- a/test-goldens/bash/macro_control_flow.bash
+++ b/test-goldens/bash/macro_control_flow.bash
@@ -1,4 +1,4 @@
-if [$x - gt 0]; then
+if [$x -gt 0]; then
     echo "positive"
 else
     echo "negative"

--- a/test-goldens/zsh/macro_control_flow.zsh
+++ b/test-goldens/zsh/macro_control_flow.zsh
@@ -1,4 +1,4 @@
-if [$x - gt 0] {
+if [$x -gt 0] {
     echo "positive"
 } else {
     echo "negative"

--- a/tests/bash/quote_edge_cases.rs
+++ b/tests/bash/quote_edge_cases.rs
@@ -80,8 +80,10 @@ fn test_flags_and_shell_vars() {
     .unwrap();
 
     let output = render(&block);
-    // Known limitation: `-q` and `linux/amd64` get spaces around `-` and `/`
-    // because the tokenizer treats them as operators.
-    // TODO(#93): shell-aware tokenizer mode for `-flags` and `/paths`
+    assert!(output.contains("-q"), "flag should be tight, got: {output}");
+    assert!(
+        output.contains("linux/amd64"),
+        "path should be tight, got: {output}"
+    );
     assert!(output.contains("myapp"), "got: {output}");
 }

--- a/tests/macro/spacing.rs
+++ b/tests/macro/spacing.rs
@@ -718,3 +718,62 @@ fn test_binary_star_still_spaced() {
         "binary * should keep spaces. got: {output}"
     );
 }
+
+// ── Dash flag spacing (#93) ──────────────────────────────
+
+#[test]
+fn test_dash_flag_no_space() {
+    let block = sigil_quote!(TypeScript {
+        console.log(-q, -f, -avz);
+    })
+    .unwrap();
+
+    let output = render_ts(&block);
+    assert!(output.contains("-q"), "got: {output}");
+    assert!(output.contains("-f"), "got: {output}");
+    assert!(output.contains("-avz"), "got: {output}");
+}
+
+#[test]
+fn test_dash_binary_with_space() {
+    let block = sigil_quote!(TypeScript {
+        const x = a - b;
+    })
+    .unwrap();
+
+    let output = render_ts(&block);
+    assert!(
+        output.contains("a - b"),
+        "binary minus should keep spaces, got: {output}"
+    );
+}
+
+// ── Slash path spacing (#93) ─────────────────────────────
+
+#[test]
+fn test_slash_path_no_space() {
+    let block = sigil_quote!(TypeScript {
+        const path = linux/amd64;
+    })
+    .unwrap();
+
+    let output = render_ts(&block);
+    assert!(
+        output.contains("linux/amd64"),
+        "path separator should be tight, got: {output}"
+    );
+}
+
+#[test]
+fn test_slash_division_with_space() {
+    let block = sigil_quote!(TypeScript {
+        const x = a / b;
+    })
+    .unwrap();
+
+    let output = render_ts(&block);
+    assert!(
+        output.contains("a / b"),
+        "division should keep spaces, got: {output}"
+    );
+}

--- a/tests/zsh/quote_edge_cases.rs
+++ b/tests/zsh/quote_edge_cases.rs
@@ -80,8 +80,10 @@ fn test_flags_and_shell_vars() {
     .unwrap();
 
     let output = render(&block);
-    // Known limitation: `-q` and `linux/amd64` get spaces around `-` and `/`
-    // because the tokenizer treats them as operators.
-    // TODO(#93): shell-aware tokenizer mode for `-flags` and `/paths`
+    assert!(output.contains("-q"), "flag should be tight, got: {output}");
+    assert!(
+        output.contains("linux/amd64"),
+        "path should be tight, got: {output}"
+    );
     assert!(output.contains("myapp"), "got: {output}");
 }


### PR DESCRIPTION
## Summary

- Add `DashFlag` annotation for `-` span-adjacent to following ident/literal (e.g. `-q`, `-f`, `-avz`)
- Add `SlashSep` annotation for `/` span-adjacent to both neighbors (e.g. `linux/amd64`)
- `DashFlag` suppresses space **after** dash only (`PrefixOp`), preserving space before (so `declare -a` stays correct)
- `SlashSep` suppresses space both before and after (`PathSep`)
- Update bash/zsh golden files: `-gt` now correctly renders tight
- Add 4 dedicated spacing tests + replace TODO comments with real assertions

Closes #93

## Test plan

- [x] `cargo test --all` passes (all 300+ tests)
- [x] `cargo run --example macro_features` clean
- [x] `cargo run --example meta_programming` clean
- [x] Verified `-q` renders tight, `a - b` keeps spaces
- [x] Verified `linux/amd64` renders tight, `a / b` keeps spaces
- [x] Verified `declare -a`, `read -r` not regressed