### PR TITLE
feat: migrate Go <- and Haskell $$ to MacroLang-aware tokenizer

### DIFF
--- a/macros/src/parse/format.rs
+++ b/macros/src/parse/format.rs
@@ -308,6 +308,18 @@ fn annotate_tokens(tokens: &[TokenTree], lang: MacroLang) -> Vec<TokenAnnotation
                             && prev_p.spacing() == Spacing::Joint
                             && annotations[i - 1] != TokenAnnotation::GenericOpen
                         {
+                            // Go: `<-ch` is prefix receive — suppress space after
+                            // if span-adjacent to next token. `ch <- 42` (send) has
+                            // whitespace after `-`, so it keeps the space.
+                            if lang == MacroLang::GoLang && i + 1 < tokens.len() {
+                                let dash_end = p.span().end();
+                                let next_start = tokens[i + 1].span().start();
+                                if dash_end.line == next_start.line
+                                    && dash_end.column == next_start.column
+                                {
+                                    annotations[i] = TokenAnnotation::PrefixOp;
+                                }
+                            }
                             i += 1;
                             continue;
                         }
@@ -726,7 +738,13 @@ fn tokens_to_format_inner(
                     );
                 }
                 format.push('$');
-                state.prev = PrevTokenKind::DollarLiteral;
+                // Haskell: `$` is an infix operator that needs space after it.
+                // Other languages (shell): `$` glues to the next token (`$VAR`).
+                state.prev = if lang == MacroLang::Haskell {
+                    PrevTokenKind::Punct('$', Spacing::Alone)
+                } else {
+                    PrevTokenKind::DollarLiteral
+                };
                 state.prev_specifier_end = None;
                 pos += 1;
                 continue;

--- a/macros/src/parse/mod.rs
+++ b/macros/src/parse/mod.rs
@@ -21,6 +21,7 @@ fn parse_macro_lang(ts: &TokenStream) -> MacroLang {
             "Bash" => MacroLang::Bash,
             "Zsh" => MacroLang::Zsh,
             "GoLang" => MacroLang::GoLang,
+            "Haskell" => MacroLang::Haskell,
             _ => MacroLang::Unaware,
         }
     } else {

--- a/macros/src/parse/types.rs
+++ b/macros/src/parse/types.rs
@@ -10,6 +10,7 @@ pub(crate) enum MacroLang {
     Bash,
     Zsh,
     GoLang,
+    Haskell,
 }
 
 impl MacroLang {

--- a/tests/go/quote_edge_cases.rs
+++ b/tests/go/quote_edge_cases.rs
@@ -119,3 +119,39 @@ fn test_defer() {
     .unwrap();
     golden::assert_golden("go/quote_defer.go", &render(&block));
 }
+
+// ── Channel receive: tokenizer-level <- fix ─────────────
+
+#[test]
+fn test_channel_receive_tight() {
+    let block = sigil_quote!(GoLang { val := <-ch; }).unwrap();
+    let output = render(&block);
+    assert!(
+        output.contains("<-ch"),
+        "receive should be tight, got: {output}"
+    );
+    assert!(
+        !output.contains("<- ch"),
+        "no space after <- in receive, got: {output}"
+    );
+}
+
+#[test]
+fn test_channel_send_has_space() {
+    let block = sigil_quote!(GoLang { ch <- 42; }).unwrap();
+    let output = render(&block);
+    assert!(
+        output.contains("<- 42") || output.contains("ch <- 42"),
+        "send should keep space, got: {output}"
+    );
+}
+
+#[test]
+fn test_channel_receive_standalone() {
+    let block = sigil_quote!(GoLang { <-done; }).unwrap();
+    let output = render(&block);
+    assert!(
+        output.contains("<-done"),
+        "standalone receive should be tight, got: {output}"
+    );
+}

--- a/tests/haskell/quote_edge_cases.rs
+++ b/tests/haskell/quote_edge_cases.rs
@@ -103,3 +103,48 @@ fn test_name_keyword_escape_in_macro() {
     let output = render(&block);
     assert!(output.contains("data' = 1"), "got: {output}");
 }
+
+// ── Dollar operator: tokenizer-level spacing fix ────────
+
+#[test]
+fn test_dollar_op_has_space_after() {
+    let block = sigil_quote!(Haskell {
+        main = putStrLn $$ show 42;
+    })
+    .unwrap();
+    let output = render(&block);
+    assert!(
+        output.contains("$ show"),
+        "dollar should have space after, got: {output}"
+    );
+    assert!(
+        !output.contains("$show"),
+        "dollar must not glue to next word, got: {output}"
+    );
+}
+
+#[test]
+fn test_dollar_op_in_expression() {
+    let block = sigil_quote!(Haskell {
+        result = f $$ g $$ h x;
+    })
+    .unwrap();
+    let output = render(&block);
+    assert!(
+        output.contains("f $ g $ h"),
+        "chained dollar ops need spaces, got: {output}"
+    );
+}
+
+#[test]
+fn test_bind_arrow_has_spaces() {
+    let block = sigil_quote!(Haskell {
+        x <- getLine;
+    })
+    .unwrap();
+    let output = render(&block);
+    assert!(
+        output.contains("x <- getLine"),
+        "bind arrow needs spaces on both sides, got: {output}"
+    );
+}


### PR DESCRIPTION
## Summary

- Adds `MacroLang::Haskell` variant so the tokenizer can apply Haskell-specific spacing
- Go `<-ch` (channel receive) is now handled at compile time via `PrefixOp` annotation when `-` is span-adjacent to the next token; `ch <- 42` (send) preserves space since `-` is not adjacent
- Haskell `$$` now produces `$ word` directly (sets `Punct('$', Alone)` instead of `DollarLiteral`), eliminating the need for the runtime `rewrite_dollar_spacing` pass on `sigil_quote!` output
- Runtime rewrite passes remain intact for builder API compatibility

## Test plan

- [x] `cargo test --all` — all pass (1450+ tests)
- [x] `cargo clippy --all` — no warnings
- [x] `cargo fmt --all -- --check` — clean
- [x] Go receive: `<-ch` tight, `<-done` tight
- [x] Go send: `ch <- 42` keeps space
- [x] Haskell: `putStrLn $ show 42` has space after `$`
- [x] Haskell: `f $ g $ h x` chained dollar ops
- [x] Haskell: `x <- getLine` bind arrow unchanged
- [x] Shell `$$HOME` → `$HOME` still tight (regression)
- [x] All existing golden tests pass unchanged