### PR TITLE
docs: add MacroLang tokenizer design documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,10 +23,11 @@ sigil-stitch/
 │   ├── lang/               # CodeLang trait + 6 config struct accessors + language implementations
 │   │   ├── mod.rs          # CodeLang trait (33 methods)
 │   │   ├── config.rs       # Config structs (BlockSyntaxConfig, FunctionSyntaxConfig, etc.)
+│   │   ├── rewrite.rs      # Runtime node rewrite walker
 │   │   ├── typescript.rs   # One file per language: typescript, javascript,
 │   │   └── ...             # rust_lang, go_lang, python, java_lang, kotlin,
 │   │                       # swift, dart, scala, haskell, ocaml, c_lang,
-│   │                       # cpp_lang, bash, zsh
+│   │                       # cpp_lang, bash, zsh, lua, csharp
 │   └── spec/               # Structural builders (emit CodeBlocks)
 │       ├── type_spec.rs    # Class, struct, interface, trait, enum, type alias, newtype
 │       ├── fun_spec.rs     # Functions and methods
@@ -35,9 +36,11 @@ sigil-stitch/
 │       ├── project_spec.rs # Multi-file generation
 │       └── ...             # ParameterSpec, PropertySpec, AnnotationSpec, etc.
 ├── macros/                 # sigil_quote! proc macro crate
-├── tests/                  # Integration tests (one file per language)
-│   ├── golden/             # Golden test output files
+│   └── src/parse/          # Tokenizer: format.rs (annotations), statements.rs, types.rs (MacroLang)
+├── tests/                  # Integration tests (one directory per language)
+│   ├── <lang>/             # main.rs + quote_*.rs + builder_*.rs submodules
 │   └── golden.rs           # Golden test assertion helper
+├── test-goldens/           # Golden test output files (one directory per language)
 └── docs/                   # mdbook documentation
 ```
 
@@ -85,20 +88,21 @@ CI runs `cargo fmt --check`, `cargo clippy -D warnings`, `cargo test`, `cargo do
 
 **Unit tests** live alongside source code in `#[cfg(test)]` modules.
 
-**Integration tests** are in `tests/`, organized by language:
-- `tests/<lang>_tests.rs` — CodeBlock-level rendering
-- `tests/phase2_<lang>_tests.rs` — spec-layer rendering (TypeSpec, FunSpec, FileSpec)
+**Integration tests** are in `tests/`, organized by language directory:
+- `tests/<lang>/main.rs` — test harness entry point with submodules
+- `tests/<lang>/quote_*.rs` — `sigil_quote!` macro tests
+- `tests/<lang>/builder_*.rs` — builder API tests
 
-**Golden tests** compare rendered output against files in `tests/golden/<lang>/`. The workflow:
+**Golden tests** compare rendered output against files in `test-goldens/<lang>/`. The workflow:
 
-1. Tests call `golden::assert_golden("lang", "test_name", "ext", &output)`
+1. Tests call `golden::assert_golden("lang/test_name.ext", &output)`
 2. On normal runs, the assertion compares output against the golden file and fails on mismatch
 3. `BLESS=1 cargo test` (or `just bless`) writes actual output to the golden files
-4. Review the diffs in `tests/golden/` manually, then commit
+4. Review the diffs in `test-goldens/` manually, then commit
 
 When your change affects rendered output:
 1. Run `just bless` to update golden files
-2. `git diff tests/golden/` to review what changed
+2. `git diff test-goldens/` to review what changed
 3. Commit the updated golden files together with your code change
 
 **Adding a language:** See [Adding a Language](docs/src/adding_a_language.md) for the full walkthrough — implement `CodeLang`, add tests, run `just bless`, review golden files.
@@ -120,6 +124,7 @@ The [sigil-stitch book](docs/src/SUMMARY.md) covers the internals:
 
 - [Architecture](docs/src/architecture.md) — four layers, three-pass pipeline, import resolution
 - [Type Presentation](docs/src/type_presentation.md) — data-driven cross-language type rendering
+- [Language-Aware Tokenizer](docs/src/macrolang.md) — `MacroLang` enum, annotation heuristics, runtime rewrite passes
 - [Adding a Language](docs/src/adding_a_language.md) — implementing the CodeLang trait step by step
 
 Build the book locally:

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -33,4 +33,5 @@
 
 - [Architecture](architecture.md)
 - [Type Presentation](type_presentation.md)
+- [Language-Aware Tokenizer (MacroLang)](macrolang.md)
 - [Adding a Language](adding_a_language.md)

--- a/docs/src/adding_a_language.md
+++ b/docs/src/adding_a_language.md
@@ -13,6 +13,10 @@ Adding a language takes four steps:
 3. Write integration tests in `tests/`
 4. Run `just bless` to generate golden files
 
+If your language has tokenizer conflicts in `sigil_quote!` that the universal heuristics
+can't handle (e.g., shell flags, Go channel operators), you may also need to add a
+`MacroLang` variant. See [Language-Aware Tokenizer](macrolang.md) for details.
+
 ## The CodeLang Trait
 
 The trait methods fall into natural groups.
@@ -274,29 +278,39 @@ pub mod your_lang;
 
 ### 3. Write tests
 
-Create two test files following the existing pattern:
+Create a test directory `tests/your_lang/` with a `main.rs` entry point and submodules:
 
-**`tests/your_lang_tests.rs`** -- basic CodeBlock rendering:
+**`tests/your_lang/main.rs`**:
 ```rust,ignore
 mod golden;
 
+mod quote_basic;
+mod builder_basic;
+```
+
+**`tests/your_lang/quote_basic.rs`** -- `sigil_quote!` macro tests:
+```rust,ignore
+use sigil_stitch::prelude::*;
+
+fn render(block: &CodeBlock) -> String {
+    FileSpec::builder("test.yl")
+        .add_code(block.clone())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap()
+}
 
 #[test]
 fn test_basic_statement() {
-    let mut cb = CodeBlock::builder();
-    cb.add_statement("const x = 1", ());
-    let block = cb.build().unwrap();
-
-    let lang = YourLang::new();
-    let imports = sigil_stitch::import::ImportGroup::new();
-    let mut renderer = sigil_stitch::code_renderer::CodeRenderer::new(&lang, &imports, 80);
-    let output = renderer.render(&block).unwrap();
-
-    golden::assert_golden("your_lang", "basic_statement", "yl", &output);
+    let block = sigil_quote!(YourLang {
+        const x = 1;
+    });
+    golden::assert_golden("your_lang/basic_statement.yl", &render(&block));
 }
 ```
 
-**`tests/phase2_your_lang_tests.rs`** -- spec-layer rendering (TypeSpec, FunSpec, FileSpec).
+**`tests/your_lang/builder_basic.rs`** -- builder API tests (CodeBlock, TypeSpec, FunSpec, FileSpec).
 
 ### 4. Generate golden files
 
@@ -304,7 +318,7 @@ fn test_basic_statement() {
 just bless
 ```
 
-This runs all tests with `BLESS=1`, which creates `tests/golden/your_lang/*.yl` files from the actual output. Review them manually, then commit.
+This runs all tests with `BLESS=1`, which creates `test-goldens/your_lang/*.yl` files from the actual output. Review them manually, then commit.
 
 ### 5. Override defaults
 

--- a/docs/src/architecture.md
+++ b/docs/src/architecture.md
@@ -20,7 +20,9 @@ The library is organized in four layers, each building on the one below:
 
 ### Layer 1: CodeLang
 
-`src/lang/mod.rs` defines the `CodeLang` trait with 36 methods, including 6 config struct accessors (`type_presentation()`, `generic_syntax()`, `block_syntax()`, `function_syntax()`, `type_decl_syntax()`, `enum_and_annotation()`) that return data structs with sensible defaults. Each supported language implements this trait in its own module (`src/lang/typescript.rs`, etc.). Languages can also implement `rewrite_nodes()` to transform the CodeNode tree after macro expansion for language-specific fixups (e.g., `=` assignment spacing in Bash, `do`/`end` block rewrites in Lua).
+`src/lang/mod.rs` defines the `CodeLang` trait with 36 methods, including 6 config struct accessors (`type_presentation()`, `generic_syntax()`, `block_syntax()`, `function_syntax()`, `type_decl_syntax()`, `enum_and_annotation()`) that return data structs with sensible defaults. Each supported language implements this trait in its own module (`src/lang/typescript.rs`, etc.). Languages can also implement `rewrite_nodes()` to transform the CodeNode tree after macro expansion for language-specific fixups (e.g., Go IIFE `}()` fusion, C++ lambda `};` semicolons).
+
+At the macro level, the `MacroLang` enum (`macros/src/parse/types.rs`) provides compile-time language-aware tokenizer annotations. Languages like Bash, Zsh, Go, and Haskell get specialized spacing rules in `sigil_quote!` without runtime overhead. See [Language-Aware Tokenizer](macrolang.md).
 
 Public types are language-agnostic — no generic parameter. The language enters as `&dyn CodeLang` at render time. `FileSpec` stores a `Box<dyn CodeLang>` internally; all other types (`CodeBlock`, `TypeName`, specs) are language-independent.
 

--- a/docs/src/macrolang.md
+++ b/docs/src/macrolang.md
@@ -1,0 +1,124 @@
+# Language-Aware Tokenizer (MacroLang)
+
+`sigil_quote!` uses Rust's proc-macro tokenizer to parse target-language code. Since the
+tokenizer sees Rust tokens, not the target language's tokens, certain patterns are ambiguous:
+shell flags (`-q`) look like negation, paths (`/usr`) look like division, and standalone dots
+(`.`) look like member access. The `MacroLang` system resolves these ambiguities by making the
+tokenizer annotation pass language-aware.
+
+## How It Works
+
+The `sigil_quote!` macro pipeline has three stages:
+
+```text
+sigil_quote!(GoLang { val := <-ch; })
+        │
+        ▼
+┌─ parse_input ─────────────────────────────────────┐
+│  1. Extract language: MacroLang::GoLang           │
+│  2. Parse body tokens                             │
+│  3. annotate_tokens(tokens, lang)                 │
+│     └─ Pre-scan: classify each token              │
+│  4. tokens_to_format(tokens, annotations, lang)   │
+│     └─ Build format string + args                 │
+└───────────────────────────────────────────────────┘
+        │
+        ▼
+  CodeBlockBuilder method calls
+```
+
+The `MacroLang` enum is extracted from the first identifier in the macro invocation
+(`Bash`, `Zsh`, `GoLang`, `Haskell`, etc.) and threaded through the entire parse pipeline.
+Languages not in the enum get `MacroLang::Unaware`, which applies only universal heuristics.
+
+## MacroLang Variants
+
+| Variant | Recognized from | Tokenizer behavior |
+|---------|-----------------|-------------------|
+| `Unaware` | All other languages | Universal heuristics only |
+| `Bash` | `sigil_quote!(Bash { ... })` | Shell-specific (see below) |
+| `Zsh` | `sigil_quote!(Zsh { ... })` | Shell-specific (same as Bash) |
+| `GoLang` | `sigil_quote!(GoLang { ... })` | `<-` prefix receive |
+| `Haskell` | `sigil_quote!(Haskell { ... })` | `$$` dollar operator spacing |
+
+### Shell Languages (Bash, Zsh)
+
+These share a common `is_shell()` check and enable:
+
+- **DashFlag**: `-q`, `-avz` — standalone `-` span-adjacent to the next identifier suppresses
+  space after it, so `declare -a` renders correctly.
+- **DashSep downgrade**: `-- file.txt` — the second `-` of `--` is downgraded from `PrefixOp`
+  to `Normal` when NOT span-adjacent to the next token, preserving the separator space.
+  `--amend` (flag, adjacent) stays tight.
+- **SlashSep leading path**: `/usr/local/bin` — allows `SlashSep` annotation with no left
+  neighbor (relaxes the `i > 0` requirement for shell mode).
+- **DotArg**: `find .`, `cd ..` — standalone `.` or `..` not span-adjacent to the previous
+  token is marked as a shell argument, not member access. Space is preserved on both sides.
+  Guard: if the dot is adjacent to the *next* token (`.gitignore`), it stays as `Normal`.
+
+### Go
+
+- **`<-` prefix receive**: When `-` follows a Joint `<` (not GenericOpen) and is span-adjacent
+  to the next token, it gets `PrefixOp` annotation — suppressing the space to produce `<-ch`.
+  When NOT adjacent (`ch <- 42`), the `-` stays `Normal` and the space is preserved.
+
+### Haskell
+
+- **`$$` dollar operator**: The `$$` escape normally sets `PrevTokenKind::DollarLiteral`, which
+  suppresses space after `$` (designed for shell `$VAR`). For Haskell, it sets
+  `PrevTokenKind::Punct('$', Alone)` instead, allowing the normal spacing rule to insert a
+  space — producing `putStrLn $ show 42`.
+
+## Universal Heuristics (all languages)
+
+These annotations fire regardless of `MacroLang`:
+
+| Annotation | Pattern | Effect |
+|---|---|---|
+| `PathSepComplete` | `::` span-adjacent to left | Suppress space after (path: `std::fmt`) |
+| `DoubleColonOp` | `::` NOT adjacent to left | Space before (Haskell: `fmap :: Type`) |
+| `MethodCallColon` | `:` adjacent to both sides | Suppress space (Lua: `obj:method()`) |
+| `GenericOpen/Close` | `<`/`>` with type context | Suppress space (generics: `Vec<T>`) |
+| `ArrowOp` | `->` adjacent to left | Suppress space (member: `ptr->field`) |
+| `PrefixOp` | `&`, `*`, `-` as prefix | Suppress space after (`&self`, `*ptr`) |
+| `PostfixStar` | `*`/`&` adjacent to ident | Suppress space before (`Config*`) |
+| `PostfixIncDec` | `++`/`--` after ident | Suppress space before (`i++`) |
+| `PostfixQuestion` | `?` adjacent to ident | Suppress space before (`Int?`) |
+| `SafeCallQ` | `?.` | Suppress space before (`x?.y`) |
+| `MacroBang` | `!` after ident | Suppress space before (`println!()`) |
+| `CallOpen` | `(`/`[` adjacent to ident | Suppress space (call: `f(x)`) |
+| `AssignAdjacent` | `=` adjacent to ident | Suppress space (shell: `NAME=val`) |
+| `DashSep` | `-` adjacent to both sides | Hyphenated word (`from-oci-layout`) |
+| `SlashSep` | `/` adjacent to both sides | Path separator (`linux/amd64`) |
+
+## Runtime Rewrite Passes
+
+Some language-specific fixups operate on the rendered `CodeNode` tree rather than the
+source token stream. These handle cases that the tokenizer can't reach — either because
+the pattern is structural (node-level, not token-level) or because it applies to the
+builder API (manually-constructed format strings, not `sigil_quote!`).
+
+| Language | Pass | Purpose | Applies to |
+|---|---|---|---|
+| Go | `rewrite_iife` | Fuse `}()` for immediately-invoked functions | Builder API |
+| Go | `rewrite_receive_op` | `<- ch` → `<-ch` | Builder API only (tokenizer handles `sigil_quote!`) |
+| C++ | `rewrite_lambda_semicolon` | `}` → `};` for lambda block close | Builder API |
+| Lua | `rewrite_method_colon` | `obj: m()` → `obj:m()` | Builder API only (tokenizer handles `sigil_quote!`) |
+| Haskell | `rewrite_dollar_spacing` | `$word` → `$ word` | Builder API only (tokenizer handles `sigil_quote!`) |
+
+For `sigil_quote!` users, the tokenizer-level fixes mean correct output without runtime
+patching. The runtime passes remain as safety nets for the builder API path.
+
+## Adding MacroLang Support for a New Language
+
+If your language has tokenizer conflicts that universal heuristics can't handle:
+
+1. Add a variant to `MacroLang` in `macros/src/parse/types.rs`
+2. Map the language identifier in `parse_macro_lang()` in `macros/src/parse/mod.rs`
+3. Add language-guarded annotation logic in `annotate_tokens()` in `macros/src/parse/format.rs`
+4. If the fix is in spacing after a token, you may also need to adjust `state.prev` assignment
+   in `tokens_to_format_inner()`
+5. Add tests in `tests/<lang>/quote_edge_cases.rs`
+
+Only add a `MacroLang` variant when the universal heuristics produce wrong output for your
+language. Most languages work correctly with `Unaware`.

--- a/docs/src/sigil_quote.md
+++ b/docs/src/sigil_quote.md
@@ -801,6 +801,16 @@ sigil_quote!(RustLang {
 
 ## Known Limitations and Quirks
 
+### Language-Aware Tokenization
+
+`sigil_quote!` recognizes certain language identifiers and applies language-specific spacing
+rules at compile time. For example, shell languages (Bash, Zsh) get correct handling of flags
+(`-q`, `--amend`), paths (`/usr/local/bin`), and standalone dots (`find .`). Go gets tight
+`<-ch` channel receive, and Haskell gets correct `$ operator` spacing.
+
+Languages without dedicated support use universal heuristics that handle most cases correctly.
+See [Language-Aware Tokenizer (MacroLang)](macrolang.md) for the full design.
+
 ### Tokenization
 
 `sigil_quote!` uses Rust's proc_macro2 tokenizer, which means the input is tokenized


### PR DESCRIPTION
## Summary

- New `docs/src/macrolang.md` — comprehensive design doc for the language-aware tokenizer system
- Cross-linked from architecture, sigil_quote, adding_a_language, and CONTRIBUTING docs
- Covers: MacroLang variants, annotation heuristics, runtime rewrite passes, and how to extend

## Test plan

- [x] `cargo test --all` — all pass (docs don't affect code)
- [x] No code changes, documentation only