### PR TITLE
fix: language-aware statement rewriting for Haskell guards and OCaml blocks

### DIFF
--- a/macros/src/parse/mod.rs
+++ b/macros/src/parse/mod.rs
@@ -5,6 +5,7 @@
 
 mod format;
 mod statements;
+mod stmt_rewrite;
 mod types;
 mod util;
 
@@ -22,6 +23,7 @@ fn parse_macro_lang(ts: &TokenStream) -> MacroLang {
             "Zsh" => MacroLang::Zsh,
             "GoLang" => MacroLang::GoLang,
             "Haskell" => MacroLang::Haskell,
+            "OCaml" => MacroLang::OCaml,
             _ => MacroLang::Unaware,
         }
     } else {
@@ -102,5 +104,5 @@ pub(super) fn parse_body(
         pos = next_pos;
     }
 
-    Ok(statements)
+    Ok(stmt_rewrite::rewrite_statements(statements, lang))
 }

--- a/macros/src/parse/stmt_rewrite.rs
+++ b/macros/src/parse/stmt_rewrite.rs
@@ -1,0 +1,83 @@
+use super::types::{MacroLang, Statement};
+
+/// Post-parse rewrite pass that injects Indent/Dedent around language-specific
+/// structural patterns (guards, let-body continuations).
+pub(super) fn rewrite_statements(stmts: Vec<Statement>, lang: MacroLang) -> Vec<Statement> {
+    match lang {
+        MacroLang::Haskell => rewrite_haskell(stmts),
+        MacroLang::OCaml => rewrite_ocaml(stmts),
+        _ => stmts,
+    }
+}
+
+fn is_guard_format(format: &str) -> bool {
+    format.starts_with("| ") || format == "|"
+}
+
+fn is_guard(stmt: &Statement) -> bool {
+    match stmt {
+        Statement::Line { format, .. } | Statement::Statement { format, .. } => {
+            is_guard_format(format)
+        }
+        _ => false,
+    }
+}
+
+/// Haskell: indent guard lines (`| cond = expr`) under the preceding function header.
+fn rewrite_haskell(stmts: Vec<Statement>) -> Vec<Statement> {
+    let mut out = Vec::with_capacity(stmts.len() + 4);
+    let mut iter = stmts.into_iter().peekable();
+
+    while let Some(stmt) = iter.next() {
+        if !is_guard(&stmt) {
+            out.push(stmt);
+            if iter.peek().is_some_and(is_guard) {
+                out.push(Statement::Indent);
+                while iter.peek().is_some_and(is_guard) {
+                    out.push(iter.next().unwrap());
+                }
+                out.push(Statement::Dedent);
+            }
+        } else {
+            // Guard at start of sequence (no header) — still indent
+            out.push(Statement::Indent);
+            out.push(stmt);
+            while iter.peek().is_some_and(is_guard) {
+                out.push(iter.next().unwrap());
+            }
+            out.push(Statement::Dedent);
+        }
+    }
+
+    out
+}
+
+fn is_let_opener(stmt: &Statement) -> bool {
+    match stmt {
+        Statement::Line { format, .. } => format.ends_with(" ="),
+        _ => false,
+    }
+}
+
+fn is_content_stmt(stmt: &Statement) -> bool {
+    matches!(stmt, Statement::Line { .. } | Statement::Statement { .. })
+}
+
+/// OCaml: indent continuation lines under a `let ... =` opener.
+fn rewrite_ocaml(stmts: Vec<Statement>) -> Vec<Statement> {
+    let mut out = Vec::with_capacity(stmts.len() + 4);
+    let mut iter = stmts.into_iter().peekable();
+
+    while let Some(stmt) = iter.next() {
+        out.push(stmt);
+        if is_let_opener(out.last().unwrap()) && iter.peek().is_some_and(is_content_stmt) {
+            out.push(Statement::Indent);
+            while iter.peek().is_some_and(is_content_stmt) {
+                out.push(iter.next().unwrap());
+            }
+            out.push(Statement::Dedent);
+        }
+    }
+
+    out
+}

--- a/macros/src/parse/types.rs
+++ b/macros/src/parse/types.rs
@@ -11,6 +11,7 @@ pub(crate) enum MacroLang {
     Zsh,
     GoLang,
     Haskell,
+    OCaml,
 }
 
 impl MacroLang {

--- a/src/lang/ocaml.rs
+++ b/src/lang/ocaml.rs
@@ -96,7 +96,6 @@ impl OCaml {
         cb.begin_control_flow(&format!("module {name}"), ());
         cb.add_code(body);
         cb.end_control_flow();
-        cb.add("end", ());
         cb.build()
     }
 
@@ -109,7 +108,6 @@ impl OCaml {
         cb.begin_control_flow(&format!("module type {name}"), ());
         cb.add_code(body);
         cb.end_control_flow();
-        cb.add("end", ());
         cb.build()
     }
 }
@@ -305,7 +303,7 @@ impl CodeLang for OCaml {
             Some(" = sig")
         } else if t.starts_with("module ") {
             Some(" = struct")
-        } else if t.starts_with("match ") || t.starts_with("try ") {
+        } else if t.starts_with("match ") || t.starts_with("try ") || t.ends_with(" with") {
             Some("")
         } else if t.starts_with("if ") || t.starts_with("else if ") {
             Some(" then")
@@ -320,7 +318,9 @@ impl CodeLang for OCaml {
 
     fn block_close_for(&self, condition: &str) -> Option<&str> {
         let t = condition.trim();
-        if t.starts_with("for ") || t.starts_with("while ") {
+        if t.starts_with("module type ") || t.starts_with("module ") {
+            Some("end")
+        } else if t.starts_with("for ") || t.starts_with("while ") {
             Some("done")
         } else {
             None

--- a/test-goldens/haskell/quote_guards.hs
+++ b/test-goldens/haskell/quote_guards.hs
@@ -1,5 +1,5 @@
 classify :: Int -> String
 classify n
-| n < 0 = "negative"
-| n == 0 = "zero"
-| otherwise = "positive"
+  | n < 0 = "negative"
+  | n == 0 = "zero"
+  | otherwise = "positive"

--- a/test-goldens/haskell/quote_guards_multi.hs
+++ b/test-goldens/haskell/quote_guards_multi.hs
@@ -1,0 +1,4 @@
+abs :: Int -> Int
+abs n
+  | n < 0 = negate n
+  | otherwise = n

--- a/test-goldens/ocaml/macro_open_struct.ml
+++ b/test-goldens/ocaml/macro_open_struct.ml
@@ -1,3 +1,4 @@
 module Foo = struct
   let x = 42
   let name = "Alice"
+end

--- a/test-goldens/ocaml/quote_let_body.ml
+++ b/test-goldens/ocaml/quote_let_body.ml
@@ -1,0 +1,2 @@
+let add x y =
+  x + y

--- a/test-goldens/ocaml/quote_let_in.ml
+++ b/test-goldens/ocaml/quote_let_in.ml
@@ -1,4 +1,4 @@
 let compute x =
-let squared = x * x in
-let doubled = squared * 2 in
-doubled + 1
+  let squared = x * x in
+  let doubled = squared * 2 in
+  doubled + 1

--- a/test-goldens/ocaml/quote_pattern_match.ml
+++ b/test-goldens/ocaml/quote_pattern_match.ml
@@ -1,3 +1,3 @@
-let describe x = match x with =
+let describe x = match x with
   | Some(v) -> Printf.printf "value: %d" v
   | None -> print_endline "none"

--- a/tests/haskell/quote_edge_cases.rs
+++ b/tests/haskell/quote_edge_cases.rs
@@ -148,3 +148,28 @@ fn test_bind_arrow_has_spaces() {
         "bind arrow needs spaces on both sides, got: {output}"
     );
 }
+
+#[test]
+fn test_guards_multi_equation() {
+    let block = sigil_quote!(Haskell {
+        abs :: Int -> Int;
+        abs n
+            | n < 0 = negate n
+            | otherwise = n;
+    })
+    .unwrap();
+    golden::assert_golden("haskell/quote_guards_multi.hs", &render(&block));
+}
+
+#[test]
+fn test_list_comprehension_no_indent() {
+    let block = sigil_quote!(Haskell {
+        evens xs = [x | x <- xs, even x];
+    })
+    .unwrap();
+    let output = render(&block);
+    assert!(
+        !output.contains("  ["),
+        "list comprehension pipe on same line should not indent, got: {output}"
+    );
+}

--- a/tests/ocaml/quote_edge_cases.rs
+++ b/tests/ocaml/quote_edge_cases.rs
@@ -82,3 +82,28 @@ fn test_name_keyword_escape_in_macro() {
     let output = render(&block);
     assert!(output.contains("let_ = 1"), "got: {output}");
 }
+
+#[test]
+fn test_module_struct_has_end() {
+    let block = sigil_quote!(OCaml {
+        module Bar {
+            let x = 1;
+        }
+    })
+    .unwrap();
+    let output = render(&block);
+    assert!(
+        output.contains("end"),
+        "module struct should have end terminator, got: {output}"
+    );
+}
+
+#[test]
+fn test_simple_let_body_indent() {
+    let block = sigil_quote!(OCaml {
+        let add x y =
+            x + y
+    })
+    .unwrap();
+    golden::assert_golden("ocaml/quote_let_body.ml", &render(&block));
+}


### PR DESCRIPTION
## Summary

- Add post-parse `stmt_rewrite` pass that injects `Indent`/`Dedent` around structural patterns in `sigil_quote!`
- Haskell: indent guard lines (`| cond = expr`) under function header
- OCaml: indent continuation lines under `let ... =` opener, emit `end` for module blocks, fix spurious `=` on pattern match

Closes #89, closes #90

## Test plan

- [x] `cargo test --workspace` passes (all 1400+ tests)
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] Golden diffs reviewed: `haskell/quote_guards.hs`, `ocaml/quote_let_in.ml`, `ocaml/macro_open_struct.ml`, `ocaml/quote_pattern_match.ml`
- [x] Edge cases: list comprehension `[x | x <- xs]` not affected, `||` not affected, non-Haskell/OCaml languages unchanged