### PR TITLE
refactor: split CodeLang into RendererLang supertrait

### DIFF
--- a/src/code_renderer.rs
+++ b/src/code_renderer.rs
@@ -4,7 +4,7 @@ use crate::code_block::CodeBlock;
 use crate::code_node::CodeNode;
 use crate::error::SigilStitchError;
 use crate::import::ImportGroup;
-use crate::lang::CodeLang;
+use crate::lang::RendererLang;
 
 /// Pass 2 of the three-pass rendering model.
 ///
@@ -14,7 +14,7 @@ use crate::lang::CodeLang;
 /// - `%W` soft break support via `pretty` crate
 /// - Proper indentation via `%>` / `%<`
 pub struct CodeRenderer<'a> {
-    lang: &'a dyn CodeLang,
+    lang: &'a dyn RendererLang,
     imports: &'a ImportGroup,
     width: usize,
     output: String,
@@ -25,7 +25,7 @@ pub struct CodeRenderer<'a> {
 
 impl<'a> CodeRenderer<'a> {
     /// Create a new renderer with the given language, imports, and target width.
-    pub fn new(lang: &'a dyn CodeLang, imports: &'a ImportGroup, width: usize) -> Self {
+    pub fn new(lang: &'a dyn RendererLang, imports: &'a ImportGroup, width: usize) -> Self {
         Self {
             lang,
             imports,
@@ -66,17 +66,17 @@ impl<'a> CodeRenderer<'a> {
         tn.to_doc_with_lang(&resolve, self.lang)
     }
 
-    fn resolve_block_open<'b>(lang: &'b dyn CodeLang, cond: &str) -> &'b str {
+    fn resolve_block_open<'b>(lang: &'b dyn RendererLang, cond: &str) -> &'b str {
         lang.block_open_for(cond)
             .unwrap_or(lang.block_syntax().block_open)
     }
 
-    fn resolve_block_close<'b>(lang: &'b dyn CodeLang, cond: &str) -> &'b str {
+    fn resolve_block_close<'b>(lang: &'b dyn RendererLang, cond: &str) -> &'b str {
         lang.block_close_for(cond)
             .unwrap_or(lang.block_syntax().block_close)
     }
 
-    fn resolve_comment(lang: &dyn CodeLang, text: &str) -> String {
+    fn resolve_comment(lang: &dyn RendererLang, text: &str) -> String {
         let prefix = lang.line_comment_prefix();
         let suffix = lang.line_comment_suffix();
         format!("{prefix} {text}{suffix}")

--- a/src/lang/bash.rs
+++ b/src/lang/bash.rs
@@ -1,11 +1,11 @@
 //! Bash shell language implementation.
 
 use crate::import::ImportGroup;
-use crate::lang::CodeLang;
 use crate::lang::config::{
     BlockSyntaxConfig, EnumAndAnnotationConfig, FunctionSyntaxConfig, GenericSyntaxConfig,
     TypeDeclSyntaxConfig, TypePresentationConfig,
 };
+use crate::lang::{CodeLang, RendererLang};
 use crate::spec::modifiers::{DeclarationContext, TypeKind, Visibility};
 
 /// Bash shell language implementation.
@@ -91,35 +91,13 @@ const BASH_RESERVED: &[&str] = &[
     "select", "shift", "source", "then", "time", "trap", "typeset", "unset", "until", "while",
 ];
 
-impl CodeLang for Bash {
+impl RendererLang for Bash {
     fn file_extension(&self) -> &str {
         &self.extension
     }
 
     fn reserved_words(&self) -> &[&str] {
         BASH_RESERVED
-    }
-
-    fn render_imports(&self, imports: &ImportGroup) -> String {
-        if imports.entries().is_empty() {
-            return String::new();
-        }
-
-        // Deduplicate to unique source paths.
-        let mut paths: Vec<&str> = Vec::new();
-        let mut seen = std::collections::HashSet::new();
-        for entry in imports.entries() {
-            if seen.insert(entry.module.as_str()) {
-                paths.push(&entry.module);
-            }
-        }
-        paths.sort();
-
-        paths
-            .iter()
-            .map(|p| format!("source \"{p}\""))
-            .collect::<Vec<_>>()
-            .join("\n")
     }
 
     fn render_string_literal(&self, s: &str) -> String {
@@ -134,43 +112,8 @@ impl CodeLang for Bash {
         format!("\"{escaped}\"")
     }
 
-    fn render_doc_comment(&self, lines: &[&str]) -> String {
-        // Bash has no doc comment convention; use # comment blocks.
-        lines
-            .iter()
-            .map(|line| {
-                if line.is_empty() {
-                    "#".to_string()
-                } else {
-                    format!("# {line}")
-                }
-            })
-            .collect::<Vec<_>>()
-            .join("\n")
-    }
-
     fn line_comment_prefix(&self) -> &str {
         "#"
-    }
-
-    // --- Spec support ---
-    // Shell has no visibility, generics, inheritance, or interfaces.
-    // Return empty/no-op for all structural methods.
-
-    fn render_visibility(&self, _vis: Visibility, _ctx: DeclarationContext) -> &str {
-        ""
-    }
-
-    fn function_keyword(&self, _ctx: DeclarationContext) -> &str {
-        "function"
-    }
-
-    fn type_keyword(&self, _kind: TypeKind) -> &str {
-        ""
-    }
-
-    fn methods_inside_type_body(&self, _kind: TypeKind) -> bool {
-        true
     }
 
     // --- Config struct accessors ---
@@ -237,6 +180,65 @@ impl CodeLang for Bash {
         } else {
             None
         }
+    }
+}
+
+impl CodeLang for Bash {
+    fn render_imports(&self, imports: &ImportGroup) -> String {
+        if imports.entries().is_empty() {
+            return String::new();
+        }
+
+        // Deduplicate to unique source paths.
+        let mut paths: Vec<&str> = Vec::new();
+        let mut seen = std::collections::HashSet::new();
+        for entry in imports.entries() {
+            if seen.insert(entry.module.as_str()) {
+                paths.push(&entry.module);
+            }
+        }
+        paths.sort();
+
+        paths
+            .iter()
+            .map(|p| format!("source \"{p}\""))
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    fn render_doc_comment(&self, lines: &[&str]) -> String {
+        // Bash has no doc comment convention; use # comment blocks.
+        lines
+            .iter()
+            .map(|line| {
+                if line.is_empty() {
+                    "#".to_string()
+                } else {
+                    format!("# {line}")
+                }
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    // --- Spec support ---
+    // Shell has no visibility, generics, inheritance, or interfaces.
+    // Return empty/no-op for all structural methods.
+
+    fn render_visibility(&self, _vis: Visibility, _ctx: DeclarationContext) -> &str {
+        ""
+    }
+
+    fn function_keyword(&self, _ctx: DeclarationContext) -> &str {
+        "function"
+    }
+
+    fn type_keyword(&self, _kind: TypeKind) -> &str {
+        ""
+    }
+
+    fn methods_inside_type_body(&self, _kind: TypeKind) -> bool {
+        true
     }
 
     fn function_syntax(&self) -> FunctionSyntaxConfig<'_> {

--- a/src/lang/c_lang.rs
+++ b/src/lang/c_lang.rs
@@ -1,7 +1,7 @@
 //! C language implementation.
 
 use crate::import::{ImportEntry, ImportGroup};
-use crate::lang::CodeLang;
+use crate::lang::{CodeLang, RendererLang};
 use crate::spec::modifiers::{DeclarationContext, TypeKind, Visibility};
 
 /// C language implementation.
@@ -134,7 +134,7 @@ fn strip_local_prefix(module: &str) -> &str {
     module.strip_prefix("./").unwrap_or(module)
 }
 
-impl CodeLang for CLang {
+impl RendererLang for CLang {
     fn file_extension(&self) -> &str {
         &self.extension
     }
@@ -143,6 +143,59 @@ impl CodeLang for CLang {
         C_RESERVED
     }
 
+    fn render_string_literal(&self, s: &str) -> String {
+        format!(
+            "\"{}\"",
+            s.replace('\\', "\\\\")
+                .replace('"', "\\\"")
+                .replace('\n', "\\n")
+                .replace('\t', "\\t")
+                .replace('\r', "\\r")
+                .replace('\0', "\\0")
+        )
+    }
+
+    fn line_comment_prefix(&self) -> &str {
+        "//"
+    }
+
+    fn type_presentation(&self) -> crate::lang::config::TypePresentationConfig<'_> {
+        crate::lang::config::TypePresentationConfig {
+            pointer: crate::type_name::TypePresentation::Postfix { suffix: "*" },
+            reference: crate::type_name::TypePresentation::Surround {
+                prefix: "const ",
+                suffix: "*",
+            },
+            reference_mut: crate::type_name::TypePresentation::Postfix { suffix: "*" },
+            function: crate::type_name::FunctionPresentation {
+                arrow: "",
+                return_first: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    }
+
+    fn generic_syntax(&self) -> crate::lang::config::GenericSyntaxConfig<'_> {
+        crate::lang::config::GenericSyntaxConfig {
+            constraint_keyword: "",
+            constraint_separator: "",
+            context_bound_keyword: "",
+            ..Default::default()
+        }
+    }
+
+    fn block_syntax(&self) -> crate::lang::config::BlockSyntaxConfig<'_> {
+        crate::lang::config::BlockSyntaxConfig {
+            indent_unit: &self.indent,
+            field_terminator: ";",
+            type_close_terminator: ";",
+            ..Default::default()
+        }
+    }
+}
+
+impl CodeLang for CLang {
     fn render_imports(&self, imports: &ImportGroup) -> String {
         if imports.entries().is_empty() {
             return String::new();
@@ -188,18 +241,6 @@ impl CodeLang for CLang {
         lines.join("\n")
     }
 
-    fn render_string_literal(&self, s: &str) -> String {
-        format!(
-            "\"{}\"",
-            s.replace('\\', "\\\\")
-                .replace('"', "\\\"")
-                .replace('\n', "\\n")
-                .replace('\t', "\\t")
-                .replace('\r', "\\r")
-                .replace('\0', "\\0")
-        )
-    }
-
     fn render_doc_comment(&self, lines: &[&str]) -> String {
         if lines.len() == 1 {
             format!("/* {} */", lines[0])
@@ -217,10 +258,6 @@ impl CodeLang for CLang {
             result.push_str("\n */");
             result
         }
-    }
-
-    fn line_comment_prefix(&self) -> &str {
-        "//"
     }
 
     fn render_visibility(&self, _vis: Visibility, _ctx: DeclarationContext) -> &str {
@@ -253,41 +290,6 @@ impl CodeLang for CLang {
 
     fn optional_field_style(&self) -> crate::lang::config::OptionalFieldStyle {
         crate::lang::config::OptionalFieldStyle::TypePrefix("*")
-    }
-
-    fn type_presentation(&self) -> crate::lang::config::TypePresentationConfig<'_> {
-        crate::lang::config::TypePresentationConfig {
-            pointer: crate::type_name::TypePresentation::Postfix { suffix: "*" },
-            reference: crate::type_name::TypePresentation::Surround {
-                prefix: "const ",
-                suffix: "*",
-            },
-            reference_mut: crate::type_name::TypePresentation::Postfix { suffix: "*" },
-            function: crate::type_name::FunctionPresentation {
-                arrow: "",
-                return_first: true,
-                ..Default::default()
-            },
-            ..Default::default()
-        }
-    }
-
-    fn generic_syntax(&self) -> crate::lang::config::GenericSyntaxConfig<'_> {
-        crate::lang::config::GenericSyntaxConfig {
-            constraint_keyword: "",
-            constraint_separator: "",
-            context_bound_keyword: "",
-            ..Default::default()
-        }
-    }
-
-    fn block_syntax(&self) -> crate::lang::config::BlockSyntaxConfig<'_> {
-        crate::lang::config::BlockSyntaxConfig {
-            indent_unit: &self.indent,
-            field_terminator: ";",
-            type_close_terminator: ";",
-            ..Default::default()
-        }
     }
 
     fn function_syntax(&self) -> crate::lang::config::FunctionSyntaxConfig<'_> {

--- a/src/lang/cpp_lang.rs
+++ b/src/lang/cpp_lang.rs
@@ -1,7 +1,7 @@
 //! C++ language implementation.
 
 use crate::import::{ImportEntry, ImportGroup};
-use crate::lang::CodeLang;
+use crate::lang::{CodeLang, RendererLang};
 use crate::spec::modifiers::{DeclarationContext, TypeKind, Visibility};
 
 /// C++ language implementation.
@@ -163,58 +163,13 @@ fn strip_local_prefix(module: &str) -> &str {
     module.strip_prefix("./").unwrap_or(module)
 }
 
-impl CodeLang for CppLang {
+impl RendererLang for CppLang {
     fn file_extension(&self) -> &str {
         &self.extension
     }
 
     fn reserved_words(&self) -> &[&str] {
         CPP_RESERVED
-    }
-
-    fn render_imports(&self, imports: &ImportGroup) -> String {
-        if imports.entries().is_empty() {
-            return String::new();
-        }
-
-        // Deduplicate to header-level: C++ includes entire headers, not symbols.
-        let mut seen = std::collections::BTreeSet::new();
-        let mut system_headers: Vec<&ImportEntry> = Vec::new();
-        let mut local_headers: Vec<&ImportEntry> = Vec::new();
-
-        for entry in imports.entries() {
-            if seen.contains(&entry.module) {
-                continue;
-            }
-            seen.insert(&entry.module);
-            if is_system_header(&entry.module) {
-                system_headers.push(entry);
-            } else {
-                local_headers.push(entry);
-            }
-        }
-
-        system_headers.sort_by_key(|e| &e.module);
-        local_headers.sort_by_key(|e| &e.module);
-
-        let mut lines: Vec<String> = Vec::new();
-
-        for entry in &system_headers {
-            lines.push(format!("#include <{}>", entry.module));
-        }
-
-        if !system_headers.is_empty() && !local_headers.is_empty() {
-            lines.push(String::new());
-        }
-
-        for entry in &local_headers {
-            lines.push(format!(
-                "#include \"{}\"",
-                strip_local_prefix(&entry.module)
-            ));
-        }
-
-        lines.join("\n")
     }
 
     fn render_string_literal(&self, s: &str) -> String {
@@ -229,62 +184,8 @@ impl CodeLang for CppLang {
         )
     }
 
-    fn render_doc_comment(&self, lines: &[&str]) -> String {
-        // Doxygen-style /// comments.
-        let mut result = String::new();
-        for (i, line) in lines.iter().enumerate() {
-            if i > 0 {
-                result.push('\n');
-            }
-            if line.is_empty() {
-                result.push_str("///");
-            } else {
-                result.push_str("/// ");
-                result.push_str(line);
-            }
-        }
-        result
-    }
-
     fn line_comment_prefix(&self) -> &str {
         "//"
-    }
-
-    fn render_visibility(&self, _vis: Visibility, _ctx: DeclarationContext) -> &str {
-        // C++ uses section-header access specifiers, not per-member keywords.
-        // Users add `public:` / `private:` / `protected:` via extra_member.
-        ""
-    }
-
-    fn function_keyword(&self, _ctx: DeclarationContext) -> &str {
-        // C++ has no function keyword.
-        ""
-    }
-
-    fn type_keyword(&self, kind: TypeKind) -> &str {
-        match kind {
-            TypeKind::Class => "class",
-            TypeKind::Struct => "struct",
-            TypeKind::Enum => "enum class",
-            TypeKind::Interface | TypeKind::Trait => "class",
-            TypeKind::TypeAlias => "using",
-            TypeKind::Newtype => "struct",
-        }
-    }
-
-    fn methods_inside_type_body(&self, kind: TypeKind) -> bool {
-        match kind {
-            TypeKind::Class | TypeKind::Interface | TypeKind::Trait => true,
-            TypeKind::Struct | TypeKind::Enum | TypeKind::TypeAlias | TypeKind::Newtype => false,
-        }
-    }
-
-    fn optional_field_style(&self) -> crate::lang::config::OptionalFieldStyle {
-        // Note: callers must `#include <optional>` to use `std::optional<T>`.
-        crate::lang::config::OptionalFieldStyle::TypeWrap {
-            open: "std::optional<",
-            close: ">",
-        }
     }
 
     fn type_presentation(&self) -> crate::lang::config::TypePresentationConfig<'_> {
@@ -339,6 +240,111 @@ impl CodeLang for CppLang {
         }
     }
 
+    fn rewrite_nodes(&self, nodes: &mut Vec<crate::code_node::CodeNode>) {
+        crate::lang::rewrite::walk_nodes_mut(nodes, &Self::rewrite_lambda_semicolon);
+    }
+}
+
+impl CodeLang for CppLang {
+    fn render_imports(&self, imports: &ImportGroup) -> String {
+        if imports.entries().is_empty() {
+            return String::new();
+        }
+
+        // Deduplicate to header-level: C++ includes entire headers, not symbols.
+        let mut seen = std::collections::BTreeSet::new();
+        let mut system_headers: Vec<&ImportEntry> = Vec::new();
+        let mut local_headers: Vec<&ImportEntry> = Vec::new();
+
+        for entry in imports.entries() {
+            if seen.contains(&entry.module) {
+                continue;
+            }
+            seen.insert(&entry.module);
+            if is_system_header(&entry.module) {
+                system_headers.push(entry);
+            } else {
+                local_headers.push(entry);
+            }
+        }
+
+        system_headers.sort_by_key(|e| &e.module);
+        local_headers.sort_by_key(|e| &e.module);
+
+        let mut lines: Vec<String> = Vec::new();
+
+        for entry in &system_headers {
+            lines.push(format!("#include <{}>", entry.module));
+        }
+
+        if !system_headers.is_empty() && !local_headers.is_empty() {
+            lines.push(String::new());
+        }
+
+        for entry in &local_headers {
+            lines.push(format!(
+                "#include \"{}\"",
+                strip_local_prefix(&entry.module)
+            ));
+        }
+
+        lines.join("\n")
+    }
+
+    fn render_doc_comment(&self, lines: &[&str]) -> String {
+        // Doxygen-style /// comments.
+        let mut result = String::new();
+        for (i, line) in lines.iter().enumerate() {
+            if i > 0 {
+                result.push('\n');
+            }
+            if line.is_empty() {
+                result.push_str("///");
+            } else {
+                result.push_str("/// ");
+                result.push_str(line);
+            }
+        }
+        result
+    }
+
+    fn render_visibility(&self, _vis: Visibility, _ctx: DeclarationContext) -> &str {
+        // C++ uses section-header access specifiers, not per-member keywords.
+        // Users add `public:` / `private:` / `protected:` via extra_member.
+        ""
+    }
+
+    fn function_keyword(&self, _ctx: DeclarationContext) -> &str {
+        // C++ has no function keyword.
+        ""
+    }
+
+    fn type_keyword(&self, kind: TypeKind) -> &str {
+        match kind {
+            TypeKind::Class => "class",
+            TypeKind::Struct => "struct",
+            TypeKind::Enum => "enum class",
+            TypeKind::Interface | TypeKind::Trait => "class",
+            TypeKind::TypeAlias => "using",
+            TypeKind::Newtype => "struct",
+        }
+    }
+
+    fn methods_inside_type_body(&self, kind: TypeKind) -> bool {
+        match kind {
+            TypeKind::Class | TypeKind::Interface | TypeKind::Trait => true,
+            TypeKind::Struct | TypeKind::Enum | TypeKind::TypeAlias | TypeKind::Newtype => false,
+        }
+    }
+
+    fn optional_field_style(&self) -> crate::lang::config::OptionalFieldStyle {
+        // Note: callers must `#include <optional>` to use `std::optional<T>`.
+        crate::lang::config::OptionalFieldStyle::TypeWrap {
+            open: "std::optional<",
+            close: ">",
+        }
+    }
+
     fn function_syntax(&self) -> crate::lang::config::FunctionSyntaxConfig<'_> {
         crate::lang::config::FunctionSyntaxConfig {
             return_type_separator: " ",
@@ -363,10 +369,6 @@ impl CodeLang for CppLang {
             annotation_suffix: "]]",
             ..Default::default()
         }
-    }
-
-    fn rewrite_nodes(&self, nodes: &mut Vec<crate::code_node::CodeNode>) {
-        crate::lang::rewrite::walk_nodes_mut(nodes, &Self::rewrite_lambda_semicolon);
     }
 }
 

--- a/src/lang/csharp.rs
+++ b/src/lang/csharp.rs
@@ -1,5 +1,5 @@
 use crate::import::ImportGroup;
-use crate::lang::CodeLang;
+use crate::lang::{CodeLang, RendererLang};
 use crate::spec::modifiers::{DeclarationContext, TypeKind, Visibility};
 
 /// C# language implementation.
@@ -116,7 +116,7 @@ fn import_group_order(module: &str) -> u8 {
     }
 }
 
-impl CodeLang for CSharp {
+impl RendererLang for CSharp {
     fn file_extension(&self) -> &str {
         &self.extension
     }
@@ -133,6 +133,57 @@ impl CodeLang for CSharp {
         }
     }
 
+    fn render_string_literal(&self, s: &str) -> String {
+        format!(
+            "\"{}\"",
+            s.replace('\\', "\\\\")
+                .replace('"', "\\\"")
+                .replace('\n', "\\n")
+                .replace('\t', "\\t")
+                .replace('\r', "\\r")
+                .replace('\0', "\\0")
+        )
+    }
+
+    fn line_comment_prefix(&self) -> &str {
+        "//"
+    }
+
+    fn type_presentation(&self) -> crate::lang::config::TypePresentationConfig<'_> {
+        crate::lang::config::TypePresentationConfig {
+            array: crate::type_name::TypePresentation::GenericWrap { name: "List" },
+            readonly_array: Some(crate::type_name::TypePresentation::GenericWrap {
+                name: "IReadOnlyList",
+            }),
+            optional: crate::type_name::TypePresentation::Postfix { suffix: "?" },
+            associated_type: crate::type_name::AssociatedTypeStyle::DotAccess,
+            ..Default::default()
+        }
+    }
+
+    fn generic_syntax(&self) -> crate::lang::config::GenericSyntaxConfig<'_> {
+        crate::lang::config::GenericSyntaxConfig {
+            constraint_keyword: " : ",
+            constraint_separator: ", ",
+            context_bound_keyword: " : ",
+            ..Default::default()
+        }
+    }
+
+    fn module_separator(&self) -> Option<&str> {
+        Some(".")
+    }
+
+    fn block_syntax(&self) -> crate::lang::config::BlockSyntaxConfig<'_> {
+        crate::lang::config::BlockSyntaxConfig {
+            indent_unit: &self.indent,
+            field_terminator: ";",
+            ..Default::default()
+        }
+    }
+}
+
+impl CodeLang for CSharp {
     fn render_imports(&self, imports: &ImportGroup) -> String {
         if imports.entries().is_empty() {
             return String::new();
@@ -182,18 +233,6 @@ impl CodeLang for CSharp {
         lines.join("\n")
     }
 
-    fn render_string_literal(&self, s: &str) -> String {
-        format!(
-            "\"{}\"",
-            s.replace('\\', "\\\\")
-                .replace('"', "\\\"")
-                .replace('\n', "\\n")
-                .replace('\t', "\\t")
-                .replace('\r', "\\r")
-                .replace('\0', "\\0")
-        )
-    }
-
     fn render_doc_comment(&self, lines: &[&str]) -> String {
         let mut result = String::new();
         for (i, line) in lines.iter().enumerate() {
@@ -208,10 +247,6 @@ impl CodeLang for CSharp {
             }
         }
         result
-    }
-
-    fn line_comment_prefix(&self) -> &str {
-        "//"
     }
 
     fn render_visibility(&self, vis: Visibility, ctx: DeclarationContext) -> &str {
@@ -248,39 +283,6 @@ impl CodeLang for CSharp {
 
     fn optional_field_style(&self) -> crate::lang::config::OptionalFieldStyle {
         crate::lang::config::OptionalFieldStyle::TypeSuffix("?")
-    }
-
-    fn type_presentation(&self) -> crate::lang::config::TypePresentationConfig<'_> {
-        crate::lang::config::TypePresentationConfig {
-            array: crate::type_name::TypePresentation::GenericWrap { name: "List" },
-            readonly_array: Some(crate::type_name::TypePresentation::GenericWrap {
-                name: "IReadOnlyList",
-            }),
-            optional: crate::type_name::TypePresentation::Postfix { suffix: "?" },
-            associated_type: crate::type_name::AssociatedTypeStyle::DotAccess,
-            ..Default::default()
-        }
-    }
-
-    fn generic_syntax(&self) -> crate::lang::config::GenericSyntaxConfig<'_> {
-        crate::lang::config::GenericSyntaxConfig {
-            constraint_keyword: " : ",
-            constraint_separator: ", ",
-            context_bound_keyword: " : ",
-            ..Default::default()
-        }
-    }
-
-    fn module_separator(&self) -> Option<&str> {
-        Some(".")
-    }
-
-    fn block_syntax(&self) -> crate::lang::config::BlockSyntaxConfig<'_> {
-        crate::lang::config::BlockSyntaxConfig {
-            indent_unit: &self.indent,
-            field_terminator: ";",
-            ..Default::default()
-        }
     }
 
     fn function_syntax(&self) -> crate::lang::config::FunctionSyntaxConfig<'_> {

--- a/src/lang/dart.rs
+++ b/src/lang/dart.rs
@@ -1,7 +1,7 @@
 //! Dart language implementation.
 
 use crate::import::ImportGroup;
-use crate::lang::CodeLang;
+use crate::lang::{CodeLang, RendererLang};
 use crate::spec::modifiers::{DeclarationContext, TypeKind, Visibility};
 
 /// Dart language implementation.
@@ -112,7 +112,7 @@ fn import_group_order(module: &str) -> u8 {
     }
 }
 
-impl CodeLang for DartLang {
+impl RendererLang for DartLang {
     fn file_extension(&self) -> &str {
         &self.extension
     }
@@ -121,6 +121,67 @@ impl CodeLang for DartLang {
         DART_RESERVED
     }
 
+    fn render_string_literal(&self, s: &str) -> String {
+        // Dart prefers single quotes by convention.
+        format!(
+            "'{}'",
+            s.replace('\\', "\\\\")
+                .replace('\'', "\\'")
+                .replace('\n', "\\n")
+                .replace('\t', "\\t")
+                .replace('\r', "\\r")
+                .replace('\0', "\\0")
+                .replace('$', "\\$")
+        )
+    }
+
+    fn line_comment_prefix(&self) -> &str {
+        "//"
+    }
+
+    fn type_presentation(&self) -> crate::lang::config::TypePresentationConfig<'_> {
+        crate::lang::config::TypePresentationConfig {
+            array: crate::type_name::TypePresentation::GenericWrap { name: "List" },
+            readonly_array: Some(crate::type_name::TypePresentation::GenericWrap { name: "List" }),
+            optional: crate::type_name::TypePresentation::Postfix { suffix: "?" },
+            function: crate::type_name::FunctionPresentation {
+                keyword: " Function",
+                params_open: "(",
+                params_sep: ", ",
+                params_close: ")",
+                arrow: "",
+                return_first: true,
+                curried: false,
+                wrapper_open: "",
+                wrapper_close: "",
+            },
+            ..Default::default()
+        }
+    }
+
+    fn generic_syntax(&self) -> crate::lang::config::GenericSyntaxConfig<'_> {
+        crate::lang::config::GenericSyntaxConfig {
+            constraint_keyword: " extends ",
+            constraint_separator: ", ",
+            context_bound_keyword: " extends ",
+            ..Default::default()
+        }
+    }
+
+    fn module_separator(&self) -> Option<&str> {
+        Some(".")
+    }
+
+    fn block_syntax(&self) -> crate::lang::config::BlockSyntaxConfig<'_> {
+        crate::lang::config::BlockSyntaxConfig {
+            indent_unit: &self.indent,
+            field_terminator: ";",
+            ..Default::default()
+        }
+    }
+}
+
+impl CodeLang for DartLang {
     fn render_imports(&self, imports: &ImportGroup) -> String {
         if imports.entries().is_empty() {
             return String::new();
@@ -165,20 +226,6 @@ impl CodeLang for DartLang {
         lines.join("\n")
     }
 
-    fn render_string_literal(&self, s: &str) -> String {
-        // Dart prefers single quotes by convention.
-        format!(
-            "'{}'",
-            s.replace('\\', "\\\\")
-                .replace('\'', "\\'")
-                .replace('\n', "\\n")
-                .replace('\t', "\\t")
-                .replace('\r', "\\r")
-                .replace('\0', "\\0")
-                .replace('$', "\\$")
-        )
-    }
-
     fn render_doc_comment(&self, lines: &[&str]) -> String {
         // Dartdoc uses /// line-prefix style.
         let mut result = String::new();
@@ -194,10 +241,6 @@ impl CodeLang for DartLang {
             }
         }
         result
-    }
-
-    fn line_comment_prefix(&self) -> &str {
-        "//"
     }
 
     fn render_visibility(&self, _vis: Visibility, _ctx: DeclarationContext) -> &str {
@@ -226,47 +269,6 @@ impl CodeLang for DartLang {
 
     fn optional_field_style(&self) -> crate::lang::config::OptionalFieldStyle {
         crate::lang::config::OptionalFieldStyle::TypeSuffix("?")
-    }
-
-    fn type_presentation(&self) -> crate::lang::config::TypePresentationConfig<'_> {
-        crate::lang::config::TypePresentationConfig {
-            array: crate::type_name::TypePresentation::GenericWrap { name: "List" },
-            readonly_array: Some(crate::type_name::TypePresentation::GenericWrap { name: "List" }),
-            optional: crate::type_name::TypePresentation::Postfix { suffix: "?" },
-            function: crate::type_name::FunctionPresentation {
-                keyword: " Function",
-                params_open: "(",
-                params_sep: ", ",
-                params_close: ")",
-                arrow: "",
-                return_first: true,
-                curried: false,
-                wrapper_open: "",
-                wrapper_close: "",
-            },
-            ..Default::default()
-        }
-    }
-
-    fn generic_syntax(&self) -> crate::lang::config::GenericSyntaxConfig<'_> {
-        crate::lang::config::GenericSyntaxConfig {
-            constraint_keyword: " extends ",
-            constraint_separator: ", ",
-            context_bound_keyword: " extends ",
-            ..Default::default()
-        }
-    }
-
-    fn module_separator(&self) -> Option<&str> {
-        Some(".")
-    }
-
-    fn block_syntax(&self) -> crate::lang::config::BlockSyntaxConfig<'_> {
-        crate::lang::config::BlockSyntaxConfig {
-            indent_unit: &self.indent,
-            field_terminator: ";",
-            ..Default::default()
-        }
     }
 
     fn function_syntax(&self) -> crate::lang::config::FunctionSyntaxConfig<'_> {

--- a/src/lang/go_lang.rs
+++ b/src/lang/go_lang.rs
@@ -2,11 +2,11 @@
 
 use crate::code_node::CodeNode;
 use crate::import::{ImportEntry, ImportGroup};
-use crate::lang::CodeLang;
 use crate::lang::config::{
     BlockSyntaxConfig, EnumAndAnnotationConfig, FunctionSyntaxConfig, GenericSyntaxConfig,
     TypeDeclSyntaxConfig, TypePresentationConfig,
 };
+use crate::lang::{CodeLang, RendererLang};
 use crate::spec::modifiers::{DeclarationContext, TypeKind, Visibility};
 use crate::type_name::{FunctionPresentation, TypePresentation, WildcardPresentation};
 
@@ -194,7 +194,7 @@ impl GoLang {
     }
 }
 
-impl CodeLang for GoLang {
+impl RendererLang for GoLang {
     fn file_extension(&self) -> &str {
         &self.extension
     }
@@ -203,6 +203,91 @@ impl CodeLang for GoLang {
         GO_RESERVED
     }
 
+    fn render_string_literal(&self, s: &str) -> String {
+        format!(
+            "\"{}\"",
+            s.replace('\\', "\\\\")
+                .replace('"', "\\\"")
+                .replace('\n', "\\n")
+                .replace('\t', "\\t")
+        )
+    }
+
+    fn line_comment_prefix(&self) -> &str {
+        "//"
+    }
+
+    fn qualify_import_name(&self, module: &str, resolved_name: &str) -> String {
+        let pkg = package_name(module);
+        format!("{pkg}.{resolved_name}")
+    }
+
+    fn module_separator(&self) -> Option<&str> {
+        Some(".")
+    }
+
+    // --- Config struct accessors ---
+
+    fn type_presentation(&self) -> TypePresentationConfig<'_> {
+        TypePresentationConfig {
+            array: TypePresentation::Prefix { prefix: "[]" },
+            readonly_array: Some(TypePresentation::Prefix { prefix: "[]" }),
+            optional: TypePresentation::Prefix { prefix: "*" },
+            map: TypePresentation::Delimited {
+                open: "map[",
+                sep: "]",
+                close: "",
+            },
+            pointer: TypePresentation::Prefix { prefix: "*" },
+            slice: TypePresentation::Prefix { prefix: "[]" },
+            reference_mut: TypePresentation::Prefix { prefix: "*" },
+            function: FunctionPresentation {
+                keyword: "func",
+                params_open: "(",
+                params_sep: ", ",
+                params_close: ")",
+                arrow: " ",
+                return_first: false,
+                curried: false,
+                wrapper_open: "",
+                wrapper_close: "",
+            },
+            wildcard: WildcardPresentation {
+                unbounded: "any",
+                upper_keyword: "any ",
+                lower_keyword: "any ",
+            },
+            ..Default::default()
+        }
+    }
+
+    fn generic_syntax(&self) -> GenericSyntaxConfig<'_> {
+        GenericSyntaxConfig {
+            open: "[",
+            close: "]",
+            constraint_keyword: " ",
+            constraint_separator: " ",
+            context_bound_keyword: " ",
+            ..Default::default()
+        }
+    }
+
+    fn block_syntax(&self) -> BlockSyntaxConfig<'_> {
+        BlockSyntaxConfig {
+            indent_unit: &self.indent,
+            uses_semicolons: false,
+            field_terminator: "",
+            ..Default::default()
+        }
+    }
+
+    fn rewrite_nodes(&self, nodes: &mut Vec<CodeNode>) {
+        crate::lang::rewrite::walk_nodes_mut(nodes, &Self::rewrite_iife);
+        crate::lang::rewrite::walk_nodes_mut(nodes, &Self::rewrite_receive_op);
+    }
+}
+
+impl CodeLang for GoLang {
     fn render_imports(&self, imports: &ImportGroup) -> String {
         if imports.entries().is_empty() {
             return String::new();
@@ -271,16 +356,6 @@ impl CodeLang for GoLang {
         }
     }
 
-    fn render_string_literal(&self, s: &str) -> String {
-        format!(
-            "\"{}\"",
-            s.replace('\\', "\\\\")
-                .replace('"', "\\\"")
-                .replace('\n', "\\n")
-                .replace('\t', "\\t")
-        )
-    }
-
     fn render_doc_comment(&self, lines: &[&str]) -> String {
         lines
             .iter()
@@ -293,10 +368,6 @@ impl CodeLang for GoLang {
             })
             .collect::<Vec<_>>()
             .join("\n")
-    }
-
-    fn line_comment_prefix(&self) -> &str {
-        "//"
     }
 
     fn render_visibility(&self, _vis: Visibility, _ctx: DeclarationContext) -> &str {
@@ -334,11 +405,6 @@ impl CodeLang for GoLang {
         format!("type {name} {inner}")
     }
 
-    fn qualify_import_name(&self, module: &str, resolved_name: &str) -> String {
-        let pkg = package_name(module);
-        format!("{pkg}.{resolved_name}")
-    }
-
     fn type_kind_suffix(&self, kind: TypeKind) -> &str {
         match kind {
             TypeKind::Struct | TypeKind::Class => "struct",
@@ -349,65 +415,6 @@ impl CodeLang for GoLang {
 
     fn optional_field_style(&self) -> crate::lang::config::OptionalFieldStyle {
         crate::lang::config::OptionalFieldStyle::TypePrefix("*")
-    }
-
-    fn module_separator(&self) -> Option<&str> {
-        Some(".")
-    }
-
-    // --- Config struct accessors ---
-
-    fn type_presentation(&self) -> TypePresentationConfig<'_> {
-        TypePresentationConfig {
-            array: TypePresentation::Prefix { prefix: "[]" },
-            readonly_array: Some(TypePresentation::Prefix { prefix: "[]" }),
-            optional: TypePresentation::Prefix { prefix: "*" },
-            map: TypePresentation::Delimited {
-                open: "map[",
-                sep: "]",
-                close: "",
-            },
-            pointer: TypePresentation::Prefix { prefix: "*" },
-            slice: TypePresentation::Prefix { prefix: "[]" },
-            reference_mut: TypePresentation::Prefix { prefix: "*" },
-            function: FunctionPresentation {
-                keyword: "func",
-                params_open: "(",
-                params_sep: ", ",
-                params_close: ")",
-                arrow: " ",
-                return_first: false,
-                curried: false,
-                wrapper_open: "",
-                wrapper_close: "",
-            },
-            wildcard: WildcardPresentation {
-                unbounded: "any",
-                upper_keyword: "any ",
-                lower_keyword: "any ",
-            },
-            ..Default::default()
-        }
-    }
-
-    fn generic_syntax(&self) -> GenericSyntaxConfig<'_> {
-        GenericSyntaxConfig {
-            open: "[",
-            close: "]",
-            constraint_keyword: " ",
-            constraint_separator: " ",
-            context_bound_keyword: " ",
-            ..Default::default()
-        }
-    }
-
-    fn block_syntax(&self) -> BlockSyntaxConfig<'_> {
-        BlockSyntaxConfig {
-            indent_unit: &self.indent,
-            uses_semicolons: false,
-            field_terminator: "",
-            ..Default::default()
-        }
     }
 
     fn function_syntax(&self) -> FunctionSyntaxConfig<'_> {
@@ -429,11 +436,6 @@ impl CodeLang for GoLang {
             variant_separator: "",
             ..Default::default()
         }
-    }
-
-    fn rewrite_nodes(&self, nodes: &mut Vec<CodeNode>) {
-        crate::lang::rewrite::walk_nodes_mut(nodes, &Self::rewrite_iife);
-        crate::lang::rewrite::walk_nodes_mut(nodes, &Self::rewrite_receive_op);
     }
 }
 

--- a/src/lang/haskell.rs
+++ b/src/lang/haskell.rs
@@ -2,7 +2,7 @@
 
 use crate::code_node::CodeNode;
 use crate::import::{ImportEntry, ImportGroup};
-use crate::lang::CodeLang;
+use crate::lang::{CodeLang, RendererLang};
 use crate::spec::modifiers::{DeclarationContext, TypeKind, Visibility};
 
 /// Haskell language implementation.
@@ -143,7 +143,7 @@ fn import_group_order(module: &str) -> u8 {
     }
 }
 
-impl CodeLang for Haskell {
+impl RendererLang for Haskell {
     fn file_extension(&self) -> &str {
         &self.extension
     }
@@ -160,6 +160,94 @@ impl CodeLang for Haskell {
         }
     }
 
+    fn render_string_literal(&self, s: &str) -> String {
+        format!(
+            "\"{}\"",
+            s.replace('\\', "\\\\")
+                .replace('"', "\\\"")
+                .replace('\n', "\\n")
+                .replace('\t', "\\t")
+        )
+    }
+
+    fn line_comment_prefix(&self) -> &str {
+        "--"
+    }
+
+    fn type_presentation(&self) -> crate::lang::config::TypePresentationConfig<'_> {
+        crate::lang::config::TypePresentationConfig {
+            array: crate::type_name::TypePresentation::Delimited {
+                open: "[",
+                sep: "",
+                close: "]",
+            },
+            readonly_array: Some(crate::type_name::TypePresentation::Delimited {
+                open: "[",
+                sep: "",
+                close: "]",
+            }),
+            optional: crate::type_name::TypePresentation::GenericWrap { name: "Maybe" },
+            function: crate::type_name::FunctionPresentation {
+                params_open: "",
+                params_sep: " -> ",
+                params_close: "",
+                arrow: " -> ",
+                curried: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    }
+
+    fn generic_syntax(&self) -> crate::lang::config::GenericSyntaxConfig<'_> {
+        crate::lang::config::GenericSyntaxConfig {
+            open: "",
+            close: "",
+            application_style: crate::type_name::GenericApplicationStyle::PrefixJuxtaposition,
+            constraint_keyword: "",
+            constraint_separator: "",
+            context_bound_keyword: "",
+        }
+    }
+
+    fn module_separator(&self) -> Option<&str> {
+        Some(".")
+    }
+
+    fn block_syntax(&self) -> crate::lang::config::BlockSyntaxConfig<'_> {
+        crate::lang::config::BlockSyntaxConfig {
+            block_open: " =",
+            block_close: "",
+            indent_unit: &self.indent,
+            uses_semicolons: false,
+            field_terminator: ",",
+            ..Default::default()
+        }
+    }
+
+    fn block_open_for(&self, condition: &str) -> Option<&str> {
+        let t = condition.trim();
+        if t.starts_with("class ") || t.starts_with("instance ") {
+            Some(" where")
+        } else if t == "do" || t.ends_with(" do") {
+            Some("")
+        } else if t.starts_with("if ") || t.starts_with("else if ") {
+            Some(" then")
+        } else if t == "else" {
+            Some("")
+        } else if t.starts_with("case ") {
+            Some(" of")
+        } else {
+            None
+        }
+    }
+
+    fn rewrite_nodes(&self, nodes: &mut Vec<CodeNode>) {
+        crate::lang::rewrite::walk_nodes_mut(nodes, &Self::rewrite_dollar_spacing);
+    }
+}
+
+impl CodeLang for Haskell {
     fn render_imports(&self, imports: &ImportGroup) -> String {
         if imports.entries().is_empty() {
             return String::new();
@@ -213,16 +301,6 @@ impl CodeLang for Haskell {
         lines.join("\n")
     }
 
-    fn render_string_literal(&self, s: &str) -> String {
-        format!(
-            "\"{}\"",
-            s.replace('\\', "\\\\")
-                .replace('"', "\\\"")
-                .replace('\n', "\\n")
-                .replace('\t', "\\t")
-        )
-    }
-
     fn render_doc_comment(&self, lines: &[&str]) -> String {
         let mut result = Vec::new();
         for (i, line) in lines.iter().enumerate() {
@@ -239,10 +317,6 @@ impl CodeLang for Haskell {
             }
         }
         result.join("\n")
-    }
-
-    fn line_comment_prefix(&self) -> &str {
-        "--"
     }
 
     fn render_visibility(&self, _vis: Visibility, _ctx: DeclarationContext) -> &str {
@@ -326,74 +400,6 @@ impl CodeLang for Haskell {
         format!("  deriving ({})", impl_types.join(", "))
     }
 
-    fn type_presentation(&self) -> crate::lang::config::TypePresentationConfig<'_> {
-        crate::lang::config::TypePresentationConfig {
-            array: crate::type_name::TypePresentation::Delimited {
-                open: "[",
-                sep: "",
-                close: "]",
-            },
-            readonly_array: Some(crate::type_name::TypePresentation::Delimited {
-                open: "[",
-                sep: "",
-                close: "]",
-            }),
-            optional: crate::type_name::TypePresentation::GenericWrap { name: "Maybe" },
-            function: crate::type_name::FunctionPresentation {
-                params_open: "",
-                params_sep: " -> ",
-                params_close: "",
-                arrow: " -> ",
-                curried: true,
-                ..Default::default()
-            },
-            ..Default::default()
-        }
-    }
-
-    fn generic_syntax(&self) -> crate::lang::config::GenericSyntaxConfig<'_> {
-        crate::lang::config::GenericSyntaxConfig {
-            open: "",
-            close: "",
-            application_style: crate::type_name::GenericApplicationStyle::PrefixJuxtaposition,
-            constraint_keyword: "",
-            constraint_separator: "",
-            context_bound_keyword: "",
-        }
-    }
-
-    fn module_separator(&self) -> Option<&str> {
-        Some(".")
-    }
-
-    fn block_syntax(&self) -> crate::lang::config::BlockSyntaxConfig<'_> {
-        crate::lang::config::BlockSyntaxConfig {
-            block_open: " =",
-            block_close: "",
-            indent_unit: &self.indent,
-            uses_semicolons: false,
-            field_terminator: ",",
-            ..Default::default()
-        }
-    }
-
-    fn block_open_for(&self, condition: &str) -> Option<&str> {
-        let t = condition.trim();
-        if t.starts_with("class ") || t.starts_with("instance ") {
-            Some(" where")
-        } else if t == "do" || t.ends_with(" do") {
-            Some("")
-        } else if t.starts_with("if ") || t.starts_with("else if ") {
-            Some(" then")
-        } else if t == "else" {
-            Some("")
-        } else if t.starts_with("case ") {
-            Some(" of")
-        } else {
-            None
-        }
-    }
-
     fn function_syntax(&self) -> crate::lang::config::FunctionSyntaxConfig<'_> {
         crate::lang::config::FunctionSyntaxConfig {
             return_type_separator: " -> ",
@@ -416,10 +422,6 @@ impl CodeLang for Haskell {
             variant_separator: "",
             ..Default::default()
         }
-    }
-
-    fn rewrite_nodes(&self, nodes: &mut Vec<CodeNode>) {
-        crate::lang::rewrite::walk_nodes_mut(nodes, &Self::rewrite_dollar_spacing);
     }
 }
 

--- a/src/lang/java_lang.rs
+++ b/src/lang/java_lang.rs
@@ -1,7 +1,7 @@
 //! Java language implementation.
 
 use crate::import::ImportGroup;
-use crate::lang::CodeLang;
+use crate::lang::{CodeLang, RendererLang};
 use crate::spec::modifiers::{DeclarationContext, TypeKind, Visibility};
 
 /// Java language implementation.
@@ -100,7 +100,7 @@ fn import_group_order(module: &str) -> u8 {
     }
 }
 
-impl CodeLang for JavaLang {
+impl RendererLang for JavaLang {
     fn file_extension(&self) -> &str {
         &self.extension
     }
@@ -109,6 +109,55 @@ impl CodeLang for JavaLang {
         JAVA_RESERVED
     }
 
+    fn render_string_literal(&self, s: &str) -> String {
+        format!(
+            "\"{}\"",
+            s.replace('\\', "\\\\")
+                .replace('"', "\\\"")
+                .replace('\n', "\\n")
+                .replace('\t', "\\t")
+                .replace('\r', "\\r")
+                .replace('\0', "\\0")
+        )
+    }
+
+    fn line_comment_prefix(&self) -> &str {
+        "//"
+    }
+
+    fn type_presentation(&self) -> crate::lang::config::TypePresentationConfig<'_> {
+        crate::lang::config::TypePresentationConfig {
+            array: crate::type_name::TypePresentation::GenericWrap { name: "List" },
+            readonly_array: Some(crate::type_name::TypePresentation::GenericWrap { name: "List" }),
+            optional: crate::type_name::TypePresentation::GenericWrap { name: "Optional" },
+            associated_type: crate::type_name::AssociatedTypeStyle::DotAccess,
+            ..Default::default()
+        }
+    }
+
+    fn generic_syntax(&self) -> crate::lang::config::GenericSyntaxConfig<'_> {
+        crate::lang::config::GenericSyntaxConfig {
+            constraint_keyword: " extends ",
+            constraint_separator: " & ",
+            context_bound_keyword: " extends ",
+            ..Default::default()
+        }
+    }
+
+    fn module_separator(&self) -> Option<&str> {
+        Some(".")
+    }
+
+    fn block_syntax(&self) -> crate::lang::config::BlockSyntaxConfig<'_> {
+        crate::lang::config::BlockSyntaxConfig {
+            indent_unit: &self.indent,
+            field_terminator: ";",
+            ..Default::default()
+        }
+    }
+}
+
+impl CodeLang for JavaLang {
     fn render_imports(&self, imports: &ImportGroup) -> String {
         if imports.entries().is_empty() {
             return String::new();
@@ -165,18 +214,6 @@ impl CodeLang for JavaLang {
         lines.join("\n")
     }
 
-    fn render_string_literal(&self, s: &str) -> String {
-        format!(
-            "\"{}\"",
-            s.replace('\\', "\\\\")
-                .replace('"', "\\\"")
-                .replace('\n', "\\n")
-                .replace('\t', "\\t")
-                .replace('\r', "\\r")
-                .replace('\0', "\\0")
-        )
-    }
-
     fn render_doc_comment(&self, lines: &[&str]) -> String {
         // Javadoc /** ... */ style.
         let mut result = String::from("/**");
@@ -192,10 +229,6 @@ impl CodeLang for JavaLang {
         result.push('\n');
         result.push_str(" */");
         result
-    }
-
-    fn line_comment_prefix(&self) -> &str {
-        "//"
     }
 
     fn render_visibility(&self, vis: Visibility, ctx: DeclarationContext) -> &str {
@@ -240,37 +273,6 @@ impl CodeLang for JavaLang {
         crate::lang::config::OptionalFieldStyle::TypeWrap {
             open: "Optional<",
             close: ">",
-        }
-    }
-
-    fn type_presentation(&self) -> crate::lang::config::TypePresentationConfig<'_> {
-        crate::lang::config::TypePresentationConfig {
-            array: crate::type_name::TypePresentation::GenericWrap { name: "List" },
-            readonly_array: Some(crate::type_name::TypePresentation::GenericWrap { name: "List" }),
-            optional: crate::type_name::TypePresentation::GenericWrap { name: "Optional" },
-            associated_type: crate::type_name::AssociatedTypeStyle::DotAccess,
-            ..Default::default()
-        }
-    }
-
-    fn generic_syntax(&self) -> crate::lang::config::GenericSyntaxConfig<'_> {
-        crate::lang::config::GenericSyntaxConfig {
-            constraint_keyword: " extends ",
-            constraint_separator: " & ",
-            context_bound_keyword: " extends ",
-            ..Default::default()
-        }
-    }
-
-    fn module_separator(&self) -> Option<&str> {
-        Some(".")
-    }
-
-    fn block_syntax(&self) -> crate::lang::config::BlockSyntaxConfig<'_> {
-        crate::lang::config::BlockSyntaxConfig {
-            indent_unit: &self.indent,
-            field_terminator: ";",
-            ..Default::default()
         }
     }
 

--- a/src/lang/javascript.rs
+++ b/src/lang/javascript.rs
@@ -1,11 +1,11 @@
 //! JavaScript language implementation.
 
 use crate::import::{ImportEntry, ImportGroup};
-use crate::lang::CodeLang;
 use crate::lang::config::{
     BlockSyntaxConfig, EnumAndAnnotationConfig, FunctionSyntaxConfig, GenericSyntaxConfig,
     QuoteStyle, TypeDeclSyntaxConfig, TypePresentationConfig,
 };
+use crate::lang::{CodeLang, RendererLang};
 use crate::spec::modifiers::{DeclarationContext, TypeKind, Visibility};
 use crate::type_name::TypePresentation;
 
@@ -127,7 +127,7 @@ const JS_RESERVED: &[&str] = &[
     "async", "await",
 ];
 
-impl CodeLang for JavaScript {
+impl RendererLang for JavaScript {
     fn file_extension(&self) -> &str {
         &self.extension
     }
@@ -136,6 +136,54 @@ impl CodeLang for JavaScript {
         JS_RESERVED
     }
 
+    fn render_string_literal(&self, s: &str) -> String {
+        match self.quote_style {
+            QuoteStyle::Single => {
+                format!("'{}'", s.replace('\\', "\\\\").replace('\'', "\\'"))
+            }
+            QuoteStyle::Double => {
+                format!("\"{}\"", s.replace('\\', "\\\\").replace('"', "\\\""))
+            }
+        }
+    }
+
+    fn line_comment_prefix(&self) -> &str {
+        "//"
+    }
+
+    // --- Config struct accessors ---
+
+    fn type_presentation(&self) -> TypePresentationConfig<'_> {
+        TypePresentationConfig {
+            tuple: TypePresentation::Delimited {
+                open: "[",
+                sep: ", ",
+                close: "]",
+            },
+            ..Default::default()
+        }
+    }
+
+    fn generic_syntax(&self) -> GenericSyntaxConfig<'_> {
+        GenericSyntaxConfig {
+            constraint_keyword: "",
+            constraint_separator: "",
+            context_bound_keyword: "",
+            ..Default::default()
+        }
+    }
+
+    fn block_syntax(&self) -> BlockSyntaxConfig<'_> {
+        BlockSyntaxConfig {
+            indent_unit: &self.indent,
+            uses_semicolons: self.semicolons,
+            field_terminator: ";",
+            ..Default::default()
+        }
+    }
+}
+
+impl CodeLang for JavaScript {
     fn render_imports(&self, imports: &ImportGroup) -> String {
         let mut lines = Vec::new();
         let quote = self.quote_style.char();
@@ -187,17 +235,6 @@ impl CodeLang for JavaScript {
         lines.join("\n")
     }
 
-    fn render_string_literal(&self, s: &str) -> String {
-        match self.quote_style {
-            QuoteStyle::Single => {
-                format!("'{}'", s.replace('\\', "\\\\").replace('\'', "\\'"))
-            }
-            QuoteStyle::Double => {
-                format!("\"{}\"", s.replace('\\', "\\\\").replace('"', "\\\""))
-            }
-        }
-    }
-
     fn render_doc_comment(&self, lines: &[&str]) -> String {
         if lines.is_empty() {
             return String::new();
@@ -212,10 +249,6 @@ impl CodeLang for JavaScript {
         }
         out.push_str(" */");
         out
-    }
-
-    fn line_comment_prefix(&self) -> &str {
-        "//"
     }
 
     fn render_visibility(&self, vis: Visibility, ctx: DeclarationContext) -> &str {
@@ -248,37 +281,6 @@ impl CodeLang for JavaScript {
 
     fn methods_inside_type_body(&self, _kind: TypeKind) -> bool {
         true
-    }
-
-    // --- Config struct accessors ---
-
-    fn type_presentation(&self) -> TypePresentationConfig<'_> {
-        TypePresentationConfig {
-            tuple: TypePresentation::Delimited {
-                open: "[",
-                sep: ", ",
-                close: "]",
-            },
-            ..Default::default()
-        }
-    }
-
-    fn generic_syntax(&self) -> GenericSyntaxConfig<'_> {
-        GenericSyntaxConfig {
-            constraint_keyword: "",
-            constraint_separator: "",
-            context_bound_keyword: "",
-            ..Default::default()
-        }
-    }
-
-    fn block_syntax(&self) -> BlockSyntaxConfig<'_> {
-        BlockSyntaxConfig {
-            indent_unit: &self.indent,
-            uses_semicolons: self.semicolons,
-            field_terminator: ";",
-            ..Default::default()
-        }
     }
 
     fn function_syntax(&self) -> FunctionSyntaxConfig<'_> {

--- a/src/lang/kotlin.rs
+++ b/src/lang/kotlin.rs
@@ -1,7 +1,7 @@
 //! Kotlin language implementation.
 
 use crate::import::ImportGroup;
-use crate::lang::CodeLang;
+use crate::lang::{CodeLang, RendererLang};
 use crate::spec::modifiers::{DeclarationContext, TypeKind, Visibility};
 
 /// Kotlin language implementation.
@@ -139,7 +139,7 @@ fn import_group_order(module: &str) -> u8 {
     }
 }
 
-impl CodeLang for Kotlin {
+impl RendererLang for Kotlin {
     fn file_extension(&self) -> &str {
         &self.extension
     }
@@ -156,6 +156,73 @@ impl CodeLang for Kotlin {
         }
     }
 
+    fn render_string_literal(&self, s: &str) -> String {
+        format!(
+            "\"{}\"",
+            s.replace('\\', "\\\\")
+                .replace('"', "\\\"")
+                .replace('\n', "\\n")
+                .replace('\t', "\\t")
+                .replace('\r', "\\r")
+                .replace('\0', "\\0")
+                .replace('$', "\\$")
+        )
+    }
+
+    fn line_comment_prefix(&self) -> &str {
+        "//"
+    }
+
+    fn type_presentation(&self) -> crate::lang::config::TypePresentationConfig<'_> {
+        crate::lang::config::TypePresentationConfig {
+            array: crate::type_name::TypePresentation::GenericWrap { name: "List" },
+            readonly_array: Some(crate::type_name::TypePresentation::GenericWrap { name: "List" }),
+            optional: crate::type_name::TypePresentation::Postfix { suffix: "?" },
+            function: crate::type_name::FunctionPresentation {
+                keyword: "",
+                params_open: "(",
+                params_sep: ", ",
+                params_close: ")",
+                arrow: " -> ",
+                return_first: false,
+                curried: false,
+                wrapper_open: "",
+                wrapper_close: "",
+            },
+            associated_type: crate::type_name::AssociatedTypeStyle::DotAccess,
+            wildcard: crate::type_name::WildcardPresentation {
+                unbounded: "*",
+                upper_keyword: "out ",
+                lower_keyword: "in ",
+            },
+            ..Default::default()
+        }
+    }
+
+    fn generic_syntax(&self) -> crate::lang::config::GenericSyntaxConfig<'_> {
+        crate::lang::config::GenericSyntaxConfig {
+            constraint_keyword: " : ",
+            constraint_separator: ", ",
+            context_bound_keyword: " : ",
+            ..Default::default()
+        }
+    }
+
+    fn module_separator(&self) -> Option<&str> {
+        Some(".")
+    }
+
+    fn block_syntax(&self) -> crate::lang::config::BlockSyntaxConfig<'_> {
+        crate::lang::config::BlockSyntaxConfig {
+            indent_unit: &self.indent,
+            uses_semicolons: false,
+            field_terminator: "",
+            ..Default::default()
+        }
+    }
+}
+
+impl CodeLang for Kotlin {
     fn render_imports(&self, imports: &ImportGroup) -> String {
         if imports.entries().is_empty() {
             return String::new();
@@ -224,19 +291,6 @@ impl CodeLang for Kotlin {
         lines.join("\n")
     }
 
-    fn render_string_literal(&self, s: &str) -> String {
-        format!(
-            "\"{}\"",
-            s.replace('\\', "\\\\")
-                .replace('"', "\\\"")
-                .replace('\n', "\\n")
-                .replace('\t', "\\t")
-                .replace('\r', "\\r")
-                .replace('\0', "\\0")
-                .replace('$', "\\$")
-        )
-    }
-
     fn render_doc_comment(&self, lines: &[&str]) -> String {
         // KDoc uses /** ... */ style (same as Javadoc).
         let mut result = String::from("/**");
@@ -252,10 +306,6 @@ impl CodeLang for Kotlin {
         result.push('\n');
         result.push_str(" */");
         result
-    }
-
-    fn line_comment_prefix(&self) -> &str {
-        "//"
     }
 
     fn render_visibility(&self, vis: Visibility, ctx: DeclarationContext) -> &str {
@@ -310,54 +360,6 @@ impl CodeLang for Kotlin {
 
     fn optional_field_style(&self) -> crate::lang::config::OptionalFieldStyle {
         crate::lang::config::OptionalFieldStyle::TypeSuffix("?")
-    }
-
-    fn type_presentation(&self) -> crate::lang::config::TypePresentationConfig<'_> {
-        crate::lang::config::TypePresentationConfig {
-            array: crate::type_name::TypePresentation::GenericWrap { name: "List" },
-            readonly_array: Some(crate::type_name::TypePresentation::GenericWrap { name: "List" }),
-            optional: crate::type_name::TypePresentation::Postfix { suffix: "?" },
-            function: crate::type_name::FunctionPresentation {
-                keyword: "",
-                params_open: "(",
-                params_sep: ", ",
-                params_close: ")",
-                arrow: " -> ",
-                return_first: false,
-                curried: false,
-                wrapper_open: "",
-                wrapper_close: "",
-            },
-            associated_type: crate::type_name::AssociatedTypeStyle::DotAccess,
-            wildcard: crate::type_name::WildcardPresentation {
-                unbounded: "*",
-                upper_keyword: "out ",
-                lower_keyword: "in ",
-            },
-            ..Default::default()
-        }
-    }
-
-    fn generic_syntax(&self) -> crate::lang::config::GenericSyntaxConfig<'_> {
-        crate::lang::config::GenericSyntaxConfig {
-            constraint_keyword: " : ",
-            constraint_separator: ", ",
-            context_bound_keyword: " : ",
-            ..Default::default()
-        }
-    }
-
-    fn module_separator(&self) -> Option<&str> {
-        Some(".")
-    }
-
-    fn block_syntax(&self) -> crate::lang::config::BlockSyntaxConfig<'_> {
-        crate::lang::config::BlockSyntaxConfig {
-            indent_unit: &self.indent,
-            uses_semicolons: false,
-            field_terminator: "",
-            ..Default::default()
-        }
     }
 
     fn function_syntax(&self) -> crate::lang::config::FunctionSyntaxConfig<'_> {

--- a/src/lang/lua.rs
+++ b/src/lang/lua.rs
@@ -10,11 +10,11 @@
 //! - 2-space indent by convention
 
 use crate::import::ImportGroup;
-use crate::lang::CodeLang;
 use crate::lang::config::{
     BlockSyntaxConfig, EnumAndAnnotationConfig, FunctionSyntaxConfig, GenericSyntaxConfig,
     TypeDeclSyntaxConfig, TypePresentationConfig,
 };
+use crate::lang::{CodeLang, RendererLang};
 use crate::spec::modifiers::{DeclarationContext, TypeKind, Visibility};
 
 /// Lua language implementation.
@@ -80,7 +80,7 @@ const LUA_RESERVED: &[&str] = &[
     "local", "nil", "not", "or", "repeat", "return", "then", "true", "until", "while",
 ];
 
-impl CodeLang for Lua {
+impl RendererLang for Lua {
     fn file_extension(&self) -> &str {
         &self.extension
     }
@@ -103,23 +103,6 @@ impl CodeLang for Lua {
         LUA_RESERVED
     }
 
-    fn render_visibility(&self, _vis: Visibility, _ctx: DeclarationContext) -> &str {
-        ""
-    }
-
-    fn function_keyword(&self, _ctx: DeclarationContext) -> &str {
-        "function"
-    }
-
-    fn type_keyword(&self, _kind: TypeKind) -> &str {
-        // Lua has no class/struct/enum keywords — tables and metatables fill
-        // that role. TypeSpec should not be used with Lua; use CodeBlock
-        // directly for table constructors and function definitions instead.
-        // If TypeSpec IS used, this returns "" so the name emits as a bare
-        // identifier block (valid Lua, treated as a scope by the interpreter).
-        ""
-    }
-
     fn module_separator(&self) -> Option<&str> {
         Some(".")
     }
@@ -132,32 +115,6 @@ impl CodeLang for Lua {
         } else {
             name.to_string()
         }
-    }
-
-    fn render_imports(&self, imports: &ImportGroup) -> String {
-        let mut lines = Vec::new();
-        for entry in imports.entries() {
-            let module = entry.module.replace('.', "/");
-            if entry.name.is_empty() || entry.is_side_effect {
-                lines.push(format!("require(\"{}\");", module));
-            } else {
-                let name = entry.resolved_name();
-                lines.push(format!("local {} = require(\"{}\");", name, module));
-            }
-        }
-        lines.join("\n")
-    }
-
-    fn render_doc_comment(&self, lines: &[&str]) -> String {
-        let mut out = String::new();
-        for line in lines {
-            if line.is_empty() {
-                out.push_str("---\n");
-            } else {
-                out.push_str(&format!("--- {}\n", line));
-            }
-        }
-        out
     }
 
     // ── Config accessors ──
@@ -187,6 +144,70 @@ impl CodeLang for Lua {
         }
     }
 
+    fn generic_syntax(&self) -> GenericSyntaxConfig<'_> {
+        GenericSyntaxConfig {
+            open: "",
+            close: "",
+            ..Default::default()
+        }
+    }
+
+    fn type_presentation(&self) -> TypePresentationConfig<'_> {
+        TypePresentationConfig {
+            optional_absent_literal: "nil",
+            ..Default::default()
+        }
+    }
+
+    fn rewrite_nodes(&self, nodes: &mut Vec<crate::code_node::CodeNode>) {
+        crate::lang::rewrite::walk_nodes_mut(nodes, &Self::rewrite_method_colon);
+    }
+}
+
+impl CodeLang for Lua {
+    fn render_visibility(&self, _vis: Visibility, _ctx: DeclarationContext) -> &str {
+        ""
+    }
+
+    fn function_keyword(&self, _ctx: DeclarationContext) -> &str {
+        "function"
+    }
+
+    fn type_keyword(&self, _kind: TypeKind) -> &str {
+        // Lua has no class/struct/enum keywords — tables and metatables fill
+        // that role. TypeSpec should not be used with Lua; use CodeBlock
+        // directly for table constructors and function definitions instead.
+        // If TypeSpec IS used, this returns "" so the name emits as a bare
+        // identifier block (valid Lua, treated as a scope by the interpreter).
+        ""
+    }
+
+    fn render_imports(&self, imports: &ImportGroup) -> String {
+        let mut lines = Vec::new();
+        for entry in imports.entries() {
+            let module = entry.module.replace('.', "/");
+            if entry.name.is_empty() || entry.is_side_effect {
+                lines.push(format!("require(\"{}\");", module));
+            } else {
+                let name = entry.resolved_name();
+                lines.push(format!("local {} = require(\"{}\");", name, module));
+            }
+        }
+        lines.join("\n")
+    }
+
+    fn render_doc_comment(&self, lines: &[&str]) -> String {
+        let mut out = String::new();
+        for line in lines {
+            if line.is_empty() {
+                out.push_str("---\n");
+            } else {
+                out.push_str(&format!("--- {}\n", line));
+            }
+        }
+        out
+    }
+
     fn fun_block_open(&self) -> &str {
         "" // Function bodies start on the next line
     }
@@ -212,30 +233,11 @@ impl CodeLang for Lua {
         }
     }
 
-    fn generic_syntax(&self) -> GenericSyntaxConfig<'_> {
-        GenericSyntaxConfig {
-            open: "",
-            close: "",
-            ..Default::default()
-        }
-    }
-
     fn enum_and_annotation(&self) -> EnumAndAnnotationConfig<'_> {
         EnumAndAnnotationConfig {
             readonly_keyword: "",
             ..Default::default()
         }
-    }
-
-    fn type_presentation(&self) -> TypePresentationConfig<'_> {
-        TypePresentationConfig {
-            optional_absent_literal: "nil",
-            ..Default::default()
-        }
-    }
-
-    fn rewrite_nodes(&self, nodes: &mut Vec<crate::code_node::CodeNode>) {
-        crate::lang::rewrite::walk_nodes_mut(nodes, &Self::rewrite_method_colon);
     }
 }
 

--- a/src/lang/mod.rs
+++ b/src/lang/mod.rs
@@ -42,64 +42,13 @@ pub mod rewrite;
 
 use crate::import::ImportGroup;
 
-/// Trait defining language-specific behavior for code generation.
+/// Narrow trait containing only the methods needed by `CodeRenderer` and
+/// `TypeName` rendering. Implement this for basic `CodeBlock` rendering
+/// without needing the full spec-layer surface.
 ///
-/// Concrete language structs (e.g. `TypeScript`, `Rust`, `Python`) implement
-/// this trait so the same CodeBlock and TypeName structures can generate
-/// output for any supported language via `&dyn CodeLang`.
-///
-/// # Required — must implement
-///
-/// Only three methods have no default and must be provided by every language:
-///
-/// - [`file_extension`](CodeLang::file_extension) — e.g. `"ts"`, `"go"`, `"rs"`
-/// - [`render_string_literal`](CodeLang::render_string_literal) — quoting and escaping
-/// - [`line_comment_prefix`](CodeLang::line_comment_prefix) — e.g. `"//"`, `"#"`
-///
-/// # Recommended — have defaults but most real languages will customize
-///
-/// These methods have safe defaults (empty string, empty list, etc.) so a
-/// minimal language compiles immediately, but most production languages
-/// should override them:
-///
-/// - [`reserved_words`](CodeLang::reserved_words) — default `&[]`
-/// - [`render_imports`](CodeLang::render_imports) — default `""`
-/// - [`render_doc_comment`](CodeLang::render_doc_comment) — default uses `line_comment_prefix()`
-/// - [`render_visibility`](CodeLang::render_visibility) — default `""`
-/// - [`function_keyword`](CodeLang::function_keyword) — default `""`
-/// - [`type_keyword`](CodeLang::type_keyword) — default `""`
-/// - [`methods_inside_type_body`](CodeLang::methods_inside_type_body) — default `true`
-/// - [`escape_reserved`](CodeLang::escape_reserved) — default appends `_`
-/// - [`module_separator`](CodeLang::module_separator) — default `None`
-/// - [`optional_field_style`](CodeLang::optional_field_style) — default `Ignored`
-///
-/// # Config struct accessors — data-driven rendering
-///
-/// Six methods return config structs that drive rendering in `spec/*.rs` and
-/// `type_name.rs`. All have defaults (TS/JS-like). Override the accessors
-/// that differ for your language:
-///
-/// - [`type_presentation`](CodeLang::type_presentation)
-/// - [`generic_syntax`](CodeLang::generic_syntax)
-/// - [`block_syntax`](CodeLang::block_syntax)
-/// - [`function_syntax`](CodeLang::function_syntax)
-/// - [`type_decl_syntax`](CodeLang::type_decl_syntax)
-/// - [`enum_and_annotation`](CodeLang::enum_and_annotation)
-///
-/// # Optional — override only for unusual languages
-///
-/// These have sensible defaults and are only overridden by one or two
-/// languages with exotic syntax (Haskell record syntax, OCaml block
-/// comments, Scala HKTs, etc.):
-///
-/// `line_comment_suffix`, `qualify_import_name`, `type_kind_suffix`,
-/// `render_newtype_line`, `fun_block_open`, `type_header_block_open`,
-/// `doc_comment_inside_body`, `doc_before_annotations`, `property_style`,
-/// `property_getter_keyword`, `render_type_context`, `type_body_prefix`,
-/// `type_body_suffix`, `render_type_close_suffix`, `render_type_param_kind`
-pub trait CodeLang: std::fmt::Debug + 'static {
-    // ── Required — must implement ───────────────────────────────────
-
+/// All 14 methods here are used directly by `code_renderer.rs` or by
+/// `TypeName::to_doc_with_lang` (which is called during rendering).
+pub trait RendererLang: std::fmt::Debug + 'static {
     /// File extension for this language (e.g., "ts", "go", "rs").
     fn file_extension(&self) -> &str;
 
@@ -109,17 +58,91 @@ pub trait CodeLang: std::fmt::Debug + 'static {
     /// Single-line comment prefix (e.g., "//", "#").
     fn line_comment_prefix(&self) -> &str;
 
-    // ── Recommended — have defaults but most languages customize ───
+    /// Suffix appended after a single-line comment.
+    ///
+    /// Default: `""` (no suffix — most languages use line comments like `//`).
+    /// OCaml overrides to `" *)"` to close `(* comment *)` block comments.
+    fn line_comment_suffix(&self) -> &str {
+        ""
+    }
 
     /// Reserved words that need escaping.
-    ///
-    /// Default: `&[]` (no reserved words).
     fn reserved_words(&self) -> &[&str] {
         &[]
     }
 
+    /// Escape a name if it collides with a reserved word.
+    /// Default: append underscore.
+    fn escape_reserved(&self, name: &str) -> String {
+        if self.reserved_words().contains(&name) {
+            format!("{name}_")
+        } else {
+            name.to_string()
+        }
+    }
+
+    /// Block delimiters, indentation, and statement termination.
+    fn block_syntax(&self) -> config::BlockSyntaxConfig<'_> {
+        config::BlockSyntaxConfig::default()
+    }
+
+    /// Map a control-flow condition to its block-opening delimiter.
+    ///
+    /// Called at render time with the condition text from `begin_control_flow`.
+    /// Return `Some("...")` to override the default `block_syntax().block_open`.
+    fn block_open_for(&self, _condition: &str) -> Option<&str> {
+        None
+    }
+
+    /// Map a control-flow condition to its block-closing delimiter.
+    ///
+    /// Called at render time with the condition text from `begin_control_flow`.
+    /// Return `Some("...")` to override the default `block_syntax().block_close`.
+    fn block_close_for(&self, _condition: &str) -> Option<&str> {
+        None
+    }
+
+    /// Rewrite the node tree before rendering. Called automatically by the
+    /// renderer. Default is no-op.
+    fn rewrite_nodes(&self, _nodes: &mut Vec<crate::code_node::CodeNode>) {}
+
+    /// Qualify an import name for rendering in code.
+    ///
+    /// Default: return the resolved name as-is.
+    /// Go overrides this to prefix the package name (e.g., `"http.Server"`).
+    fn qualify_import_name(&self, _module: &str, resolved_name: &str) -> String {
+        resolved_name.to_string()
+    }
+
+    /// The separator between module path and type name for qualified inline
+    /// references (e.g., `"::"` for Rust/C++, `"."` for Go/Python/Java).
+    fn module_separator(&self) -> Option<&str> {
+        None
+    }
+
+    /// How each compound `TypeName` variant renders.
+    fn type_presentation(&self) -> config::TypePresentationConfig<'_> {
+        config::TypePresentationConfig::default()
+    }
+
+    /// Generic type parameter delimiters and constraints.
+    fn generic_syntax(&self) -> config::GenericSyntaxConfig<'_> {
+        config::GenericSyntaxConfig::default()
+    }
+}
+
+/// Full language trait for spec-level code generation.
+///
+/// Extends [`RendererLang`] with the additional methods needed by the spec
+/// layer (`FunSpec`, `TypeSpec`, `FieldSpec`, etc.) and `FileSpec` (imports).
+///
+/// Implement this when you need full `FileSpec`-level generation including
+/// functions, types, fields, and imports. For basic `CodeBlock` rendering,
+/// only [`RendererLang`] is required.
+pub trait CodeLang: RendererLang {
+    // ── Spec-layer methods — used by FunSpec, TypeSpec, FieldSpec, etc. ───
+
     /// Render an import group to a string.
-    /// `imports` is deduplicated and grouped by module.
     ///
     /// Default: `""` (no import system).
     fn render_imports(&self, _imports: &ImportGroup) -> String {
@@ -179,50 +202,10 @@ pub trait CodeLang: std::fmt::Debug + 'static {
         true
     }
 
-    /// Suffix appended after a single-line comment.
-    ///
-    /// Default: `""` (no suffix — most languages use line comments like `//`).
-    /// OCaml overrides to `" *)"` to close `(* comment *)` block comments.
-    fn line_comment_suffix(&self) -> &str {
-        ""
-    }
-
-    /// Escape a name if it collides with a reserved word.
-    /// Default: append underscore.
-    fn escape_reserved(&self, name: &str) -> String {
-        if self.reserved_words().contains(&name) {
-            format!("{name}_")
-        } else {
-            name.to_string()
-        }
-    }
-
     /// Escape a field/property name. Languages where property names never
     /// conflict with reserved words (e.g. TypeScript) can return the name as-is.
     fn escape_field_name(&self, name: &str) -> String {
         self.escape_reserved(name)
-    }
-
-    // ── Optional — override only for unusual languages ────────────
-
-    /// Qualify an import name for rendering in code.
-    ///
-    /// Default: return the resolved name as-is (TS/Rust import individual symbols).
-    /// Go overrides this to prefix the package name (e.g., `"http.Server"`).
-    fn qualify_import_name(&self, _module: &str, resolved_name: &str) -> String {
-        resolved_name.to_string()
-    }
-
-    /// The separator between module path and type name for qualified inline
-    /// references (e.g., `"::"` for Rust/C++, `"."` for Go/Python/Java).
-    ///
-    /// Return `Some(sep)` if [`crate::type_name::TypeName::qualified()`] should render
-    /// `module{sep}name` inline. Return `None` if the language has no concept
-    /// of module-qualified inline type references (e.g., TypeScript, Bash),
-    /// in which case [`crate::type_name::TypeName::qualified()`] silently falls back to
-    /// unqualified rendering.
-    fn module_separator(&self) -> Option<&str> {
-        None
     }
 
     /// Optional kind suffix after the type name (e.g., Go's `type Foo struct`).
@@ -242,7 +225,6 @@ pub trait CodeLang: std::fmt::Debug + 'static {
     /// Opening block delimiter for function bodies specifically.
     ///
     /// Default: `" {"`.
-    /// Scala overrides to `" = {"` since Scala function definitions use `=`.
     fn fun_block_open(&self) -> &str {
         " {"
     }
@@ -250,7 +232,6 @@ pub trait CodeLang: std::fmt::Debug + 'static {
     /// Opening block delimiter for type headers, parameterized by type kind.
     ///
     /// Default: `" {"`.
-    /// Haskell overrides: Trait -> `" where"`, others -> `" ="`.
     fn type_header_block_open(&self, _kind: crate::spec::modifiers::TypeKind) -> &str {
         " {"
     }
@@ -265,17 +246,12 @@ pub trait CodeLang: std::fmt::Debug + 'static {
 
     /// Whether doc comments should be emitted before annotations/attributes.
     ///
-    /// Default: `true`. Most languages (Rust, Go, TypeScript) put doc comments
-    /// above annotations. Java overrides to `false` (`@Override` before Javadoc).
+    /// Default: `true`.
     fn doc_before_annotations(&self) -> bool {
         true
     }
 
     /// How this language expresses that a field is optional (key may be absent).
-    ///
-    /// Consulted by `FieldSpec::emit()` when `is_optional` is set. Languages
-    /// that can't express optional fields return `OptionalFieldStyle::Ignored`
-    /// and the field is rendered as if it were required.
     ///
     /// Default: `OptionalFieldStyle::Ignored`.
     fn optional_field_style(&self) -> crate::lang::config::OptionalFieldStyle {
@@ -284,24 +260,19 @@ pub trait CodeLang: std::fmt::Debug + 'static {
 
     /// How `PropertySpec` renders: accessor methods or inline field body.
     ///
-    /// Default: `Accessor` — emits `get name()` / `set name(v)` methods (TS/JS).
-    /// Swift and Kotlin override to `Field` — emits a field with inline `get`/`set` blocks.
+    /// Default: `Accessor`.
     fn property_style(&self) -> crate::spec::modifiers::PropertyStyle {
         crate::spec::modifiers::PropertyStyle::Accessor
     }
 
     /// The keyword for a property getter in field-style rendering.
     ///
-    /// Default: `"get"` (Swift: `get { ... }`).
-    /// Kotlin overrides to `"get()"`.
+    /// Default: `"get"`.
     fn property_getter_keyword(&self) -> &str {
         "get"
     }
 
     /// Render a type context / constraint prefix for split function signatures.
-    ///
-    /// Called in the `Split` path of `FunSpec::emit()` when building the type
-    /// signature line. Used for Haskell's `(Show a, Eq a) => ...` prefix.
     ///
     /// Default: `""` (no context).
     fn render_type_context(&self, _type_params: &[crate::spec::fun_spec::TypeParamSpec]) -> String {
@@ -310,21 +281,20 @@ pub trait CodeLang: std::fmt::Debug + 'static {
 
     /// Content emitted after `block_open` but before the first field in a type body.
     ///
-    /// Default: `""`. Haskell overrides to `"Person {"` for record syntax.
+    /// Default: `""`.
     fn type_body_prefix(&self, _name: &str, _kind: crate::spec::modifiers::TypeKind) -> String {
         String::new()
     }
 
     /// Content emitted after the last field but before `block_close` in a type body.
     ///
-    /// Default: `""`. Haskell overrides to `"}"` for record syntax.
+    /// Default: `""`.
     fn type_body_suffix(&self, _name: &str, _kind: crate::spec::modifiers::TypeKind) -> String {
         String::new()
     }
 
     /// Suffix rendered after the type's closing delimiter (e.g., Haskell `deriving`).
     ///
-    /// `impl_types` contains rendered type names from `TypeSpecBuilder::implements()`.
     /// Default: `""`.
     fn render_type_close_suffix(
         &self,
@@ -336,54 +306,12 @@ pub trait CodeLang: std::fmt::Debug + 'static {
 
     /// Render a type parameter's kind annotation (for higher-kinded types).
     ///
-    /// Default: empty string (no kind annotation).
+    /// Default: empty string.
     fn render_type_param_kind(&self, _kind: &crate::spec::fun_spec::TypeParamKind) -> String {
         String::new()
     }
 
-    // ── Config struct accessors — data-driven rendering ───────────
-
-    /// How each compound `TypeName` variant renders.
-    fn type_presentation(&self) -> config::TypePresentationConfig<'_> {
-        config::TypePresentationConfig::default()
-    }
-
-    /// Generic type parameter delimiters and constraints.
-    fn generic_syntax(&self) -> config::GenericSyntaxConfig<'_> {
-        config::GenericSyntaxConfig::default()
-    }
-
-    /// Block delimiters, indentation, and statement termination.
-    fn block_syntax(&self) -> config::BlockSyntaxConfig<'_> {
-        config::BlockSyntaxConfig::default()
-    }
-
-    /// Map a control-flow condition to its block-opening delimiter.
-    ///
-    /// Called at render time with the condition text from `begin_control_flow`.
-    /// Return `Some("...")` to override the default `block_syntax().block_open`.
-    ///
-    /// # Examples
-    ///
-    /// Bash maps `"if [ -f ... ];"` → `Some("; then")` and
-    /// `"for f in *.txt;"` → `Some("; do")`.
-    /// Haskell maps `"class Functor f"` → `Some(" where")`.
-    fn block_open_for(&self, _condition: &str) -> Option<&str> {
-        None
-    }
-
-    /// Map a control-flow condition to its block-closing delimiter.
-    ///
-    /// Called at render time with the condition text from `begin_control_flow`.
-    /// Return `Some("...")` to override the default `block_syntax().block_close`.
-    ///
-    /// # Examples
-    ///
-    /// Bash maps `"if ..."` → `Some("fi")`, `"for ..."` → `Some("done")`,
-    /// `"case ..."` → `Some("esac")`.
-    fn block_close_for(&self, _condition: &str) -> Option<&str> {
-        None
-    }
+    // ── Config struct accessors (spec-only) ───────────────────────────
 
     /// Function signature syntax.
     fn function_syntax(&self) -> config::FunctionSyntaxConfig<'_> {
@@ -399,13 +327,6 @@ pub trait CodeLang: std::fmt::Debug + 'static {
     fn enum_and_annotation(&self) -> config::EnumAndAnnotationConfig<'_> {
         config::EnumAndAnnotationConfig::default()
     }
-
-    // ── Node rewriting — language-specific structural transforms ───
-
-    /// Rewrite the node tree before rendering. Called automatically by the
-    /// renderer. Default is no-op. Languages override this to handle constructs
-    /// that require language-specific structural knowledge (e.g. Go IIFE `}()`).
-    fn rewrite_nodes(&self, _nodes: &mut Vec<crate::code_node::CodeNode>) {}
 }
 
 /// Derive a PascalCase namespace alias from a module path.

--- a/src/lang/ocaml.rs
+++ b/src/lang/ocaml.rs
@@ -1,11 +1,11 @@
 //! OCaml language implementation.
 
 use crate::import::ImportGroup;
-use crate::lang::CodeLang;
 use crate::lang::config::{
     BlockSyntaxConfig, EnumAndAnnotationConfig, FunctionSyntaxConfig, GenericSyntaxConfig,
     TypeDeclSyntaxConfig, TypePresentationConfig,
 };
+use crate::lang::{CodeLang, RendererLang};
 use crate::spec::modifiers::{DeclarationContext, TypeKind, Visibility};
 use crate::type_name::{
     AssociatedTypeStyle, FunctionPresentation, GenericApplicationStyle, TypePresentation,
@@ -124,7 +124,7 @@ const OCAML_RESERVED: &[&str] = &[
     "virtual", "when", "while", "with",
 ];
 
-impl CodeLang for OCaml {
+impl RendererLang for OCaml {
     fn file_extension(&self) -> &str {
         &self.extension
     }
@@ -141,29 +141,6 @@ impl CodeLang for OCaml {
         }
     }
 
-    fn render_imports(&self, imports: &ImportGroup) -> String {
-        if imports.entries().is_empty() {
-            return String::new();
-        }
-
-        let mut seen = std::collections::BTreeSet::new();
-        let mut lines: Vec<String> = Vec::new();
-
-        for entry in imports.entries() {
-            if entry.is_side_effect {
-                continue;
-            }
-            let module = &entry.module;
-            if !seen.insert(module.clone()) {
-                continue;
-            }
-            lines.push(format!("open {module}"));
-        }
-
-        lines.sort();
-        lines.join("\n")
-    }
-
     fn render_string_literal(&self, s: &str) -> String {
         format!(
             "\"{}\"",
@@ -175,26 +152,6 @@ impl CodeLang for OCaml {
         )
     }
 
-    fn render_doc_comment(&self, lines: &[&str]) -> String {
-        if lines.len() == 1 {
-            return format!("(** {} *)", lines[0]);
-        }
-        let mut result = String::from("(**");
-        for (i, line) in lines.iter().enumerate() {
-            result.push('\n');
-            if line.is_empty() {
-                if i < lines.len() - 1 {
-                    result.push_str("    ");
-                }
-            } else {
-                result.push_str("    ");
-                result.push_str(line);
-            }
-        }
-        result.push_str(" *)");
-        result
-    }
-
     fn line_comment_prefix(&self) -> &str {
         "(*"
     }
@@ -203,49 +160,9 @@ impl CodeLang for OCaml {
         " *)"
     }
 
-    fn render_visibility(&self, _vis: Visibility, _ctx: DeclarationContext) -> &str {
-        ""
-    }
-
-    fn function_keyword(&self, _ctx: DeclarationContext) -> &str {
-        "let"
-    }
-
-    fn type_keyword(&self, _kind: TypeKind) -> &str {
-        "type"
-    }
-
-    fn methods_inside_type_body(&self, _kind: TypeKind) -> bool {
-        false
-    }
-
-    fn fun_block_open(&self) -> &str {
-        " ="
-    }
-
-    fn type_header_block_open(&self, _kind: TypeKind) -> &str {
-        " ="
-    }
-
-    fn type_body_prefix(&self, _name: &str, kind: crate::spec::modifiers::TypeKind) -> String {
-        match kind {
-            crate::spec::modifiers::TypeKind::Struct => "{".to_string(),
-            _ => String::new(),
-        }
-    }
-
-    fn type_body_suffix(&self, _name: &str, kind: crate::spec::modifiers::TypeKind) -> String {
-        match kind {
-            crate::spec::modifiers::TypeKind::Struct => "}".to_string(),
-            _ => String::new(),
-        }
-    }
-
     fn module_separator(&self) -> Option<&str> {
         Some(".")
     }
-
-    // --- Config struct accessors ---
 
     fn type_presentation(&self) -> TypePresentationConfig<'_> {
         TypePresentationConfig {
@@ -324,6 +241,89 @@ impl CodeLang for OCaml {
             Some("done")
         } else {
             None
+        }
+    }
+}
+
+impl CodeLang for OCaml {
+    fn render_imports(&self, imports: &ImportGroup) -> String {
+        if imports.entries().is_empty() {
+            return String::new();
+        }
+
+        let mut seen = std::collections::BTreeSet::new();
+        let mut lines: Vec<String> = Vec::new();
+
+        for entry in imports.entries() {
+            if entry.is_side_effect {
+                continue;
+            }
+            let module = &entry.module;
+            if !seen.insert(module.clone()) {
+                continue;
+            }
+            lines.push(format!("open {module}"));
+        }
+
+        lines.sort();
+        lines.join("\n")
+    }
+
+    fn render_doc_comment(&self, lines: &[&str]) -> String {
+        if lines.len() == 1 {
+            return format!("(** {} *)", lines[0]);
+        }
+        let mut result = String::from("(**");
+        for (i, line) in lines.iter().enumerate() {
+            result.push('\n');
+            if line.is_empty() {
+                if i < lines.len() - 1 {
+                    result.push_str("    ");
+                }
+            } else {
+                result.push_str("    ");
+                result.push_str(line);
+            }
+        }
+        result.push_str(" *)");
+        result
+    }
+
+    fn render_visibility(&self, _vis: Visibility, _ctx: DeclarationContext) -> &str {
+        ""
+    }
+
+    fn function_keyword(&self, _ctx: DeclarationContext) -> &str {
+        "let"
+    }
+
+    fn type_keyword(&self, _kind: TypeKind) -> &str {
+        "type"
+    }
+
+    fn methods_inside_type_body(&self, _kind: TypeKind) -> bool {
+        false
+    }
+
+    fn fun_block_open(&self) -> &str {
+        " ="
+    }
+
+    fn type_header_block_open(&self, _kind: TypeKind) -> &str {
+        " ="
+    }
+
+    fn type_body_prefix(&self, _name: &str, kind: crate::spec::modifiers::TypeKind) -> String {
+        match kind {
+            crate::spec::modifiers::TypeKind::Struct => "{".to_string(),
+            _ => String::new(),
+        }
+    }
+
+    fn type_body_suffix(&self, _name: &str, kind: crate::spec::modifiers::TypeKind) -> String {
+        match kind {
+            crate::spec::modifiers::TypeKind::Struct => "}".to_string(),
+            _ => String::new(),
         }
     }
 

--- a/src/lang/python.rs
+++ b/src/lang/python.rs
@@ -1,11 +1,11 @@
 //! Python language implementation.
 
 use crate::import::{ImportEntry, ImportGroup};
-use crate::lang::CodeLang;
 use crate::lang::config::{
     BlockSyntaxConfig, EnumAndAnnotationConfig, FunctionSyntaxConfig, GenericSyntaxConfig,
     QuoteStyle, TypeDeclSyntaxConfig, TypePresentationConfig,
 };
+use crate::lang::{CodeLang, RendererLang};
 use crate::spec::modifiers::{DeclarationContext, TypeKind, Visibility};
 use crate::type_name::{AssociatedTypeStyle, FunctionPresentation, TypePresentation};
 
@@ -181,69 +181,13 @@ fn is_stdlib(module: &str) -> bool {
     PYTHON_STDLIB.contains(&top)
 }
 
-impl CodeLang for Python {
+impl RendererLang for Python {
     fn file_extension(&self) -> &str {
         &self.extension
     }
 
     fn reserved_words(&self) -> &[&str] {
         PYTHON_RESERVED
-    }
-
-    fn render_imports(&self, imports: &ImportGroup) -> String {
-        if imports.entries().is_empty() {
-            return String::new();
-        }
-
-        let mut lines: Vec<String> = Vec::new();
-
-        // Handle side-effect and wildcard imports first.
-        for entry in imports.entries() {
-            if entry.is_side_effect {
-                lines.push(format!("import {}", entry.module));
-            } else if entry.is_wildcard {
-                lines.push(format!("from {} import *", entry.module));
-            }
-        }
-
-        // Group named imports by module, merging names from the same module.
-        let mut stdlib: std::collections::BTreeMap<&str, Vec<&ImportEntry>> =
-            std::collections::BTreeMap::new();
-        let mut thirdparty: std::collections::BTreeMap<&str, Vec<&ImportEntry>> =
-            std::collections::BTreeMap::new();
-
-        for entry in imports.entries() {
-            if entry.is_side_effect || entry.is_wildcard {
-                continue;
-            }
-            let target = if is_stdlib(&entry.module) {
-                &mut stdlib
-            } else {
-                &mut thirdparty
-            };
-            target.entry(entry.module.as_str()).or_default().push(entry);
-        }
-
-        if !lines.is_empty() && (!stdlib.is_empty() || !thirdparty.is_empty()) {
-            lines.push(String::new());
-        }
-
-        // Emit stdlib imports.
-        for (module, entries) in &stdlib {
-            lines.push(render_from_import(module, entries));
-        }
-
-        // Blank line between groups.
-        if !stdlib.is_empty() && !thirdparty.is_empty() {
-            lines.push(String::new());
-        }
-
-        // Emit third-party imports.
-        for (module, entries) in &thirdparty {
-            lines.push(render_from_import(module, entries));
-        }
-
-        lines.join("\n")
     }
 
     fn render_string_literal(&self, s: &str) -> String {
@@ -265,59 +209,8 @@ impl CodeLang for Python {
         }
     }
 
-    fn render_doc_comment(&self, lines: &[&str]) -> String {
-        if lines.len() == 1 {
-            format!("\"\"\"{}\"\"\"", lines[0])
-        } else {
-            let mut result = String::from("\"\"\"");
-            for line in lines {
-                result.push('\n');
-                result.push_str(line);
-            }
-            result.push_str("\n\"\"\"");
-            result
-        }
-    }
-
     fn line_comment_prefix(&self) -> &str {
         "#"
-    }
-
-    fn render_visibility(&self, _vis: Visibility, _ctx: DeclarationContext) -> &str {
-        // Python uses naming conventions (_private, __mangled), not keywords.
-        ""
-    }
-
-    fn function_keyword(&self, _ctx: DeclarationContext) -> &str {
-        "def"
-    }
-
-    fn type_keyword(&self, kind: TypeKind) -> &str {
-        match kind {
-            TypeKind::TypeAlias => "type",
-            TypeKind::Newtype => "class",
-            _ => "class",
-        }
-    }
-
-    fn methods_inside_type_body(&self, _kind: TypeKind) -> bool {
-        true
-    }
-
-    fn render_newtype_line(&self, _vis: &str, name: &str, inner: &str) -> String {
-        format!("{name} = NewType(\"{name}\", {inner})")
-    }
-
-    fn doc_comment_inside_body(&self) -> bool {
-        true
-    }
-
-    fn fun_block_open(&self) -> &str {
-        ":"
-    }
-
-    fn type_header_block_open(&self, _kind: crate::spec::modifiers::TypeKind) -> &str {
-        ":"
     }
 
     fn block_open_for(&self, condition: &str) -> Option<&str> {
@@ -326,10 +219,6 @@ impl CodeLang for Python {
         } else {
             None
         }
-    }
-
-    fn optional_field_style(&self) -> crate::lang::config::OptionalFieldStyle {
-        crate::lang::config::OptionalFieldStyle::UnionWithNone(" | ")
     }
 
     fn module_separator(&self) -> Option<&str> {
@@ -386,6 +275,119 @@ impl CodeLang for Python {
             bases_close: ")",
             ..Default::default()
         }
+    }
+}
+
+impl CodeLang for Python {
+    fn render_imports(&self, imports: &ImportGroup) -> String {
+        if imports.entries().is_empty() {
+            return String::new();
+        }
+
+        let mut lines: Vec<String> = Vec::new();
+
+        // Handle side-effect and wildcard imports first.
+        for entry in imports.entries() {
+            if entry.is_side_effect {
+                lines.push(format!("import {}", entry.module));
+            } else if entry.is_wildcard {
+                lines.push(format!("from {} import *", entry.module));
+            }
+        }
+
+        // Group named imports by module, merging names from the same module.
+        let mut stdlib: std::collections::BTreeMap<&str, Vec<&ImportEntry>> =
+            std::collections::BTreeMap::new();
+        let mut thirdparty: std::collections::BTreeMap<&str, Vec<&ImportEntry>> =
+            std::collections::BTreeMap::new();
+
+        for entry in imports.entries() {
+            if entry.is_side_effect || entry.is_wildcard {
+                continue;
+            }
+            let target = if is_stdlib(&entry.module) {
+                &mut stdlib
+            } else {
+                &mut thirdparty
+            };
+            target.entry(entry.module.as_str()).or_default().push(entry);
+        }
+
+        if !lines.is_empty() && (!stdlib.is_empty() || !thirdparty.is_empty()) {
+            lines.push(String::new());
+        }
+
+        // Emit stdlib imports.
+        for (module, entries) in &stdlib {
+            lines.push(render_from_import(module, entries));
+        }
+
+        // Blank line between groups.
+        if !stdlib.is_empty() && !thirdparty.is_empty() {
+            lines.push(String::new());
+        }
+
+        // Emit third-party imports.
+        for (module, entries) in &thirdparty {
+            lines.push(render_from_import(module, entries));
+        }
+
+        lines.join("\n")
+    }
+
+    fn render_doc_comment(&self, lines: &[&str]) -> String {
+        if lines.len() == 1 {
+            format!("\"\"\"{}\"\"\"", lines[0])
+        } else {
+            let mut result = String::from("\"\"\"");
+            for line in lines {
+                result.push('\n');
+                result.push_str(line);
+            }
+            result.push_str("\n\"\"\"");
+            result
+        }
+    }
+
+    fn render_visibility(&self, _vis: Visibility, _ctx: DeclarationContext) -> &str {
+        // Python uses naming conventions (_private, __mangled), not keywords.
+        ""
+    }
+
+    fn function_keyword(&self, _ctx: DeclarationContext) -> &str {
+        "def"
+    }
+
+    fn type_keyword(&self, kind: TypeKind) -> &str {
+        match kind {
+            TypeKind::TypeAlias => "type",
+            TypeKind::Newtype => "class",
+            _ => "class",
+        }
+    }
+
+    fn methods_inside_type_body(&self, _kind: TypeKind) -> bool {
+        true
+    }
+
+    fn render_newtype_line(&self, _vis: &str, name: &str, inner: &str) -> String {
+        format!("{name} = NewType(\"{name}\", {inner})")
+    }
+
+    fn doc_comment_inside_body(&self) -> bool {
+        true
+    }
+
+    fn fun_block_open(&self) -> &str {
+        ":"
+    }
+
+    fn type_header_block_open(&self, _kind: crate::spec::modifiers::TypeKind) -> &str {
+        ":"
+    }
+
+    fn optional_field_style(&self) -> crate::lang::config::OptionalFieldStyle {
+        crate::lang::config::OptionalFieldStyle::UnionWithNone(" | ")
     }
 
     fn function_syntax(&self) -> FunctionSyntaxConfig<'_> {

--- a/src/lang/rust_lang.rs
+++ b/src/lang/rust_lang.rs
@@ -1,9 +1,9 @@
 use crate::import::{ImportEntry, ImportGroup};
-use crate::lang::CodeLang;
 use crate::lang::config::{
     BlockSyntaxConfig, EnumAndAnnotationConfig, FunctionSyntaxConfig, GenericSyntaxConfig,
     TypeDeclSyntaxConfig, TypePresentationConfig,
 };
+use crate::lang::{CodeLang, RendererLang};
 use crate::spec::fun_spec::WhereClauseStyle;
 use crate::spec::modifiers::{DeclarationContext, TypeKind, Visibility};
 use crate::type_name::{FunctionPresentation, TypePresentation, WildcardPresentation};
@@ -56,7 +56,7 @@ const RUST_RESERVED: &[&str] = &[
     "unsized", "virtual", "yield",
 ];
 
-impl CodeLang for RustLang {
+impl RendererLang for RustLang {
     fn file_extension(&self) -> &str {
         &self.extension
     }
@@ -65,6 +65,76 @@ impl CodeLang for RustLang {
         RUST_RESERVED
     }
 
+    fn render_string_literal(&self, s: &str) -> String {
+        format!("\"{}\"", s.replace('\\', "\\\\").replace('"', "\\\""))
+    }
+
+    fn line_comment_prefix(&self) -> &str {
+        "//"
+    }
+
+    fn escape_reserved(&self, name: &str) -> String {
+        if self.reserved_words().contains(&name) {
+            format!("r#{name}")
+        } else {
+            name.to_string()
+        }
+    }
+
+    fn module_separator(&self) -> Option<&str> {
+        Some("::")
+    }
+
+    // --- Config struct accessors ---
+
+    fn type_presentation(&self) -> TypePresentationConfig<'_> {
+        TypePresentationConfig {
+            array: TypePresentation::GenericWrap { name: "Vec" },
+            readonly_array: Some(TypePresentation::GenericWrap { name: "Vec" }),
+            optional: TypePresentation::GenericWrap { name: "Option" },
+            map: TypePresentation::GenericWrap { name: "HashMap" },
+            intersection: TypePresentation::Infix { sep: " + " },
+            pointer: TypePresentation::Prefix { prefix: "*const " },
+            slice: TypePresentation::Delimited {
+                open: "&[",
+                sep: "",
+                close: "]",
+            },
+            reference: TypePresentation::Prefix { prefix: "&" },
+            reference_mut: TypePresentation::Prefix { prefix: "&mut " },
+            function: FunctionPresentation {
+                keyword: "fn",
+                params_open: "(",
+                params_sep: ", ",
+                params_close: ")",
+                arrow: " -> ",
+                return_first: false,
+                curried: false,
+                wrapper_open: "",
+                wrapper_close: "",
+            },
+            wildcard: WildcardPresentation {
+                unbounded: "_",
+                upper_keyword: "impl ",
+                lower_keyword: "impl ",
+            },
+            ..Default::default()
+        }
+    }
+
+    fn generic_syntax(&self) -> GenericSyntaxConfig<'_> {
+        GenericSyntaxConfig::default()
+    }
+
+    fn block_syntax(&self) -> BlockSyntaxConfig<'_> {
+        BlockSyntaxConfig {
+            indent_unit: &self.indent,
+            ..Default::default()
+        }
+    }
+}
+
+impl CodeLang for RustLang {
     fn render_imports(&self, imports: &ImportGroup) -> String {
         if imports.entries().is_empty() {
             return String::new();
@@ -157,10 +227,6 @@ impl CodeLang for RustLang {
         lines.join("\n")
     }
 
-    fn render_string_literal(&self, s: &str) -> String {
-        format!("\"{}\"", s.replace('\\', "\\\\").replace('"', "\\\""))
-    }
-
     fn render_doc_comment(&self, lines: &[&str]) -> String {
         lines
             .iter()
@@ -173,18 +239,6 @@ impl CodeLang for RustLang {
             })
             .collect::<Vec<_>>()
             .join("\n")
-    }
-
-    fn line_comment_prefix(&self) -> &str {
-        "//"
-    }
-
-    fn escape_reserved(&self, name: &str) -> String {
-        if self.reserved_words().contains(&name) {
-            format!("r#{name}")
-        } else {
-            name.to_string()
-        }
     }
 
     fn render_visibility(&self, vis: Visibility, _ctx: DeclarationContext) -> &str {
@@ -227,58 +281,6 @@ impl CodeLang for RustLang {
         crate::lang::config::OptionalFieldStyle::TypeWrap {
             open: "Option<",
             close: ">",
-        }
-    }
-
-    fn module_separator(&self) -> Option<&str> {
-        Some("::")
-    }
-
-    // --- Config struct accessors ---
-
-    fn type_presentation(&self) -> TypePresentationConfig<'_> {
-        TypePresentationConfig {
-            array: TypePresentation::GenericWrap { name: "Vec" },
-            readonly_array: Some(TypePresentation::GenericWrap { name: "Vec" }),
-            optional: TypePresentation::GenericWrap { name: "Option" },
-            map: TypePresentation::GenericWrap { name: "HashMap" },
-            intersection: TypePresentation::Infix { sep: " + " },
-            pointer: TypePresentation::Prefix { prefix: "*const " },
-            slice: TypePresentation::Delimited {
-                open: "&[",
-                sep: "",
-                close: "]",
-            },
-            reference: TypePresentation::Prefix { prefix: "&" },
-            reference_mut: TypePresentation::Prefix { prefix: "&mut " },
-            function: FunctionPresentation {
-                keyword: "fn",
-                params_open: "(",
-                params_sep: ", ",
-                params_close: ")",
-                arrow: " -> ",
-                return_first: false,
-                curried: false,
-                wrapper_open: "",
-                wrapper_close: "",
-            },
-            wildcard: WildcardPresentation {
-                unbounded: "_",
-                upper_keyword: "impl ",
-                lower_keyword: "impl ",
-            },
-            ..Default::default()
-        }
-    }
-
-    fn generic_syntax(&self) -> GenericSyntaxConfig<'_> {
-        GenericSyntaxConfig::default()
-    }
-
-    fn block_syntax(&self) -> BlockSyntaxConfig<'_> {
-        BlockSyntaxConfig {
-            indent_unit: &self.indent,
-            ..Default::default()
         }
     }
 

--- a/src/lang/scala.rs
+++ b/src/lang/scala.rs
@@ -1,7 +1,7 @@
 //! Scala language implementation.
 
 use crate::import::ImportGroup;
-use crate::lang::CodeLang;
+use crate::lang::{CodeLang, RendererLang};
 use crate::spec::modifiers::{DeclarationContext, TypeKind, Visibility};
 
 /// Scala language implementation.
@@ -114,7 +114,7 @@ fn import_group_order(module: &str) -> u8 {
     }
 }
 
-impl CodeLang for Scala {
+impl RendererLang for Scala {
     fn file_extension(&self) -> &str {
         &self.extension
     }
@@ -131,6 +131,64 @@ impl CodeLang for Scala {
         }
     }
 
+    fn render_string_literal(&self, s: &str) -> String {
+        format!(
+            "\"{}\"",
+            s.replace('\\', "\\\\")
+                .replace('"', "\\\"")
+                .replace('\n', "\\n")
+                .replace('\t', "\\t")
+                .replace('\r', "\\r")
+                .replace('\0', "\\0")
+        )
+    }
+
+    fn line_comment_prefix(&self) -> &str {
+        "//"
+    }
+
+    fn type_presentation(&self) -> crate::lang::config::TypePresentationConfig<'_> {
+        crate::lang::config::TypePresentationConfig {
+            array: crate::type_name::TypePresentation::GenericWrap { name: "Array" },
+            readonly_array: Some(crate::type_name::TypePresentation::GenericWrap { name: "List" }),
+            optional: crate::type_name::TypePresentation::GenericWrap { name: "Option" },
+            intersection: crate::type_name::TypePresentation::Infix { sep: " with " },
+            associated_type: crate::type_name::AssociatedTypeStyle::DotAccess,
+            wildcard: crate::type_name::WildcardPresentation {
+                unbounded: "_",
+                upper_keyword: "_ <: ",
+                lower_keyword: "_ >: ",
+            },
+            ..Default::default()
+        }
+    }
+
+    fn generic_syntax(&self) -> crate::lang::config::GenericSyntaxConfig<'_> {
+        crate::lang::config::GenericSyntaxConfig {
+            open: "[",
+            close: "]",
+            constraint_keyword: " <: ",
+            constraint_separator: " with ",
+            context_bound_keyword: " : ",
+            ..Default::default()
+        }
+    }
+
+    fn module_separator(&self) -> Option<&str> {
+        Some(".")
+    }
+
+    fn block_syntax(&self) -> crate::lang::config::BlockSyntaxConfig<'_> {
+        crate::lang::config::BlockSyntaxConfig {
+            indent_unit: &self.indent,
+            uses_semicolons: false,
+            field_terminator: "",
+            ..Default::default()
+        }
+    }
+}
+
+impl CodeLang for Scala {
     fn render_imports(&self, imports: &ImportGroup) -> String {
         if imports.entries().is_empty() {
             return String::new();
@@ -185,18 +243,6 @@ impl CodeLang for Scala {
         lines.join("\n")
     }
 
-    fn render_string_literal(&self, s: &str) -> String {
-        format!(
-            "\"{}\"",
-            s.replace('\\', "\\\\")
-                .replace('"', "\\\"")
-                .replace('\n', "\\n")
-                .replace('\t', "\\t")
-                .replace('\r', "\\r")
-                .replace('\0', "\\0")
-        )
-    }
-
     fn render_doc_comment(&self, lines: &[&str]) -> String {
         let mut result = String::from("/**");
         for line in lines {
@@ -211,10 +257,6 @@ impl CodeLang for Scala {
         result.push('\n');
         result.push_str(" */");
         result
-    }
-
-    fn line_comment_prefix(&self) -> &str {
-        "//"
     }
 
     fn render_visibility(&self, vis: Visibility, _ctx: DeclarationContext) -> &str {
@@ -267,46 +309,6 @@ impl CodeLang for Scala {
 
     fn fun_block_open(&self) -> &str {
         " = {"
-    }
-
-    fn type_presentation(&self) -> crate::lang::config::TypePresentationConfig<'_> {
-        crate::lang::config::TypePresentationConfig {
-            array: crate::type_name::TypePresentation::GenericWrap { name: "Array" },
-            readonly_array: Some(crate::type_name::TypePresentation::GenericWrap { name: "List" }),
-            optional: crate::type_name::TypePresentation::GenericWrap { name: "Option" },
-            intersection: crate::type_name::TypePresentation::Infix { sep: " with " },
-            associated_type: crate::type_name::AssociatedTypeStyle::DotAccess,
-            wildcard: crate::type_name::WildcardPresentation {
-                unbounded: "_",
-                upper_keyword: "_ <: ",
-                lower_keyword: "_ >: ",
-            },
-            ..Default::default()
-        }
-    }
-
-    fn generic_syntax(&self) -> crate::lang::config::GenericSyntaxConfig<'_> {
-        crate::lang::config::GenericSyntaxConfig {
-            open: "[",
-            close: "]",
-            constraint_keyword: " <: ",
-            constraint_separator: " with ",
-            context_bound_keyword: " : ",
-            ..Default::default()
-        }
-    }
-
-    fn module_separator(&self) -> Option<&str> {
-        Some(".")
-    }
-
-    fn block_syntax(&self) -> crate::lang::config::BlockSyntaxConfig<'_> {
-        crate::lang::config::BlockSyntaxConfig {
-            indent_unit: &self.indent,
-            uses_semicolons: false,
-            field_terminator: "",
-            ..Default::default()
-        }
     }
 
     fn function_syntax(&self) -> crate::lang::config::FunctionSyntaxConfig<'_> {

--- a/src/lang/swift.rs
+++ b/src/lang/swift.rs
@@ -1,7 +1,7 @@
 //! Swift language implementation.
 
 use crate::import::ImportGroup;
-use crate::lang::CodeLang;
+use crate::lang::{CodeLang, RendererLang};
 use crate::spec::modifiers::{DeclarationContext, TypeKind, Visibility};
 
 /// Swift language implementation.
@@ -162,7 +162,7 @@ fn is_apple_framework(module: &str) -> bool {
     APPLE_FRAMEWORKS.contains(&module)
 }
 
-impl CodeLang for Swift {
+impl RendererLang for Swift {
     fn file_extension(&self) -> &str {
         &self.extension
     }
@@ -179,48 +179,6 @@ impl CodeLang for Swift {
         }
     }
 
-    fn render_imports(&self, imports: &ImportGroup) -> String {
-        if imports.entries().is_empty() {
-            return String::new();
-        }
-
-        // Swift imports entire modules — deduplicate at the module level.
-        let mut apple_imports: Vec<String> = Vec::new();
-        let mut other_imports: Vec<String> = Vec::new();
-
-        let mut seen = std::collections::BTreeSet::new();
-        for entry in imports.entries() {
-            if !seen.insert(&entry.module) {
-                continue;
-            }
-
-            let line = format!("import {}", entry.module);
-            if is_apple_framework(&entry.module) {
-                apple_imports.push(line);
-            } else {
-                other_imports.push(line);
-            }
-        }
-
-        apple_imports.sort();
-        other_imports.sort();
-
-        let groups: Vec<&Vec<String>> = [&apple_imports, &other_imports]
-            .into_iter()
-            .filter(|g| !g.is_empty())
-            .collect();
-
-        let mut lines = Vec::new();
-        for (i, group) in groups.iter().enumerate() {
-            if i > 0 {
-                lines.push(String::new());
-            }
-            lines.extend(group.iter().cloned());
-        }
-
-        lines.join("\n")
-    }
-
     fn render_string_literal(&self, s: &str) -> String {
         format!(
             "\"{}\"",
@@ -233,62 +191,8 @@ impl CodeLang for Swift {
         )
     }
 
-    fn render_doc_comment(&self, lines: &[&str]) -> String {
-        // Swift Markup: /// prefix per line.
-        let mut result = String::new();
-        for (i, line) in lines.iter().enumerate() {
-            if i > 0 {
-                result.push('\n');
-            }
-            if line.is_empty() {
-                result.push_str("///");
-            } else {
-                result.push_str("/// ");
-                result.push_str(line);
-            }
-        }
-        result
-    }
-
     fn line_comment_prefix(&self) -> &str {
         "//"
-    }
-
-    fn render_visibility(&self, vis: Visibility, _ctx: DeclarationContext) -> &str {
-        match vis {
-            Visibility::Public => "public ",
-            Visibility::Private => "private ",
-            Visibility::Protected => "internal ",
-            Visibility::PublicCrate => "internal ",
-            Visibility::PublicSuper => "fileprivate ",
-            Visibility::Inherited => "",
-        }
-    }
-
-    fn function_keyword(&self, _ctx: DeclarationContext) -> &str {
-        "func"
-    }
-
-    fn type_keyword(&self, kind: TypeKind) -> &str {
-        match kind {
-            TypeKind::Class => "class",
-            TypeKind::Struct => "struct",
-            TypeKind::Interface | TypeKind::Trait => "protocol",
-            TypeKind::Enum => "enum",
-            TypeKind::TypeAlias | TypeKind::Newtype => "typealias",
-        }
-    }
-
-    fn methods_inside_type_body(&self, _kind: TypeKind) -> bool {
-        true
-    }
-
-    fn property_style(&self) -> crate::spec::modifiers::PropertyStyle {
-        crate::spec::modifiers::PropertyStyle::Field
-    }
-
-    fn optional_field_style(&self) -> crate::lang::config::OptionalFieldStyle {
-        crate::lang::config::OptionalFieldStyle::TypeSuffix("?")
     }
 
     fn type_presentation(&self) -> crate::lang::config::TypePresentationConfig<'_> {
@@ -333,6 +237,104 @@ impl CodeLang for Swift {
             field_terminator: "",
             ..Default::default()
         }
+    }
+}
+
+impl CodeLang for Swift {
+    fn render_imports(&self, imports: &ImportGroup) -> String {
+        if imports.entries().is_empty() {
+            return String::new();
+        }
+
+        // Swift imports entire modules — deduplicate at the module level.
+        let mut apple_imports: Vec<String> = Vec::new();
+        let mut other_imports: Vec<String> = Vec::new();
+
+        let mut seen = std::collections::BTreeSet::new();
+        for entry in imports.entries() {
+            if !seen.insert(&entry.module) {
+                continue;
+            }
+
+            let line = format!("import {}", entry.module);
+            if is_apple_framework(&entry.module) {
+                apple_imports.push(line);
+            } else {
+                other_imports.push(line);
+            }
+        }
+
+        apple_imports.sort();
+        other_imports.sort();
+
+        let groups: Vec<&Vec<String>> = [&apple_imports, &other_imports]
+            .into_iter()
+            .filter(|g| !g.is_empty())
+            .collect();
+
+        let mut lines = Vec::new();
+        for (i, group) in groups.iter().enumerate() {
+            if i > 0 {
+                lines.push(String::new());
+            }
+            lines.extend(group.iter().cloned());
+        }
+
+        lines.join("\n")
+    }
+
+    fn render_doc_comment(&self, lines: &[&str]) -> String {
+        // Swift Markup: /// prefix per line.
+        let mut result = String::new();
+        for (i, line) in lines.iter().enumerate() {
+            if i > 0 {
+                result.push('\n');
+            }
+            if line.is_empty() {
+                result.push_str("///");
+            } else {
+                result.push_str("/// ");
+                result.push_str(line);
+            }
+        }
+        result
+    }
+
+    fn render_visibility(&self, vis: Visibility, _ctx: DeclarationContext) -> &str {
+        match vis {
+            Visibility::Public => "public ",
+            Visibility::Private => "private ",
+            Visibility::Protected => "internal ",
+            Visibility::PublicCrate => "internal ",
+            Visibility::PublicSuper => "fileprivate ",
+            Visibility::Inherited => "",
+        }
+    }
+
+    fn function_keyword(&self, _ctx: DeclarationContext) -> &str {
+        "func"
+    }
+
+    fn type_keyword(&self, kind: TypeKind) -> &str {
+        match kind {
+            TypeKind::Class => "class",
+            TypeKind::Struct => "struct",
+            TypeKind::Interface | TypeKind::Trait => "protocol",
+            TypeKind::Enum => "enum",
+            TypeKind::TypeAlias | TypeKind::Newtype => "typealias",
+        }
+    }
+
+    fn methods_inside_type_body(&self, _kind: TypeKind) -> bool {
+        true
+    }
+
+    fn property_style(&self) -> crate::spec::modifiers::PropertyStyle {
+        crate::spec::modifiers::PropertyStyle::Field
+    }
+
+    fn optional_field_style(&self) -> crate::lang::config::OptionalFieldStyle {
+        crate::lang::config::OptionalFieldStyle::TypeSuffix("?")
     }
 
     fn function_syntax(&self) -> crate::lang::config::FunctionSyntaxConfig<'_> {

--- a/src/lang/typescript.rs
+++ b/src/lang/typescript.rs
@@ -1,9 +1,9 @@
 use crate::import::{ImportEntry, ImportGroup};
-use crate::lang::CodeLang;
 use crate::lang::config::{
     BlockSyntaxConfig, EnumAndAnnotationConfig, FunctionSyntaxConfig, GenericSyntaxConfig,
     QuoteStyle, TypeDeclSyntaxConfig, TypePresentationConfig,
 };
+use crate::lang::{CodeLang, RendererLang};
 use crate::spec::modifiers::{DeclarationContext, TypeKind, Visibility};
 use crate::type_name::{
     AssociatedTypeStyle, BoundsPresentation, TypePresentation, WildcardPresentation,
@@ -159,7 +159,7 @@ const TS_RESERVED: &[&str] = &[
     "defer",
 ];
 
-impl CodeLang for TypeScript {
+impl RendererLang for TypeScript {
     fn file_extension(&self) -> &str {
         &self.extension
     }
@@ -168,6 +168,67 @@ impl CodeLang for TypeScript {
         TS_RESERVED
     }
 
+    fn render_string_literal(&self, s: &str) -> String {
+        match self.quote_style {
+            QuoteStyle::Single => {
+                format!("'{}'", s.replace('\\', "\\\\").replace('\'', "\\'"))
+            }
+            QuoteStyle::Double => {
+                format!("\"{}\"", s.replace('\\', "\\\\").replace('"', "\\\""))
+            }
+        }
+    }
+
+    fn line_comment_prefix(&self) -> &str {
+        "//"
+    }
+
+    // --- Config struct accessors ---
+
+    fn type_presentation(&self) -> TypePresentationConfig<'_> {
+        TypePresentationConfig {
+            map: TypePresentation::GenericWrap { name: "Record" },
+            tuple: TypePresentation::Delimited {
+                open: "[",
+                sep: ", ",
+                close: "]",
+            },
+            associated_type: AssociatedTypeStyle::IndexAccess {
+                open: "[\"",
+                close: "\"]",
+            },
+            impl_trait: BoundsPresentation {
+                keyword: "",
+                separator: " & ",
+            },
+            wildcard: WildcardPresentation {
+                unbounded: "unknown",
+                upper_keyword: "unknown ",
+                lower_keyword: "unknown ",
+            },
+            ..Default::default()
+        }
+    }
+
+    fn generic_syntax(&self) -> GenericSyntaxConfig<'_> {
+        GenericSyntaxConfig {
+            constraint_keyword: " extends ",
+            constraint_separator: " & ",
+            ..Default::default()
+        }
+    }
+
+    fn block_syntax(&self) -> BlockSyntaxConfig<'_> {
+        BlockSyntaxConfig {
+            indent_unit: &self.indent,
+            uses_semicolons: self.uses_semicolons,
+            field_terminator: ";",
+            ..Default::default()
+        }
+    }
+}
+
+impl CodeLang for TypeScript {
     fn escape_field_name(&self, name: &str) -> String {
         name.to_string()
     }
@@ -238,17 +299,6 @@ impl CodeLang for TypeScript {
         lines.join("\n")
     }
 
-    fn render_string_literal(&self, s: &str) -> String {
-        match self.quote_style {
-            QuoteStyle::Single => {
-                format!("'{}'", s.replace('\\', "\\\\").replace('\'', "\\'"))
-            }
-            QuoteStyle::Double => {
-                format!("\"{}\"", s.replace('\\', "\\\\").replace('"', "\\\""))
-            }
-        }
-    }
-
     fn render_doc_comment(&self, lines: &[&str]) -> String {
         if lines.is_empty() {
             return String::new();
@@ -263,10 +313,6 @@ impl CodeLang for TypeScript {
         }
         out.push_str(" */");
         out
-    }
-
-    fn line_comment_prefix(&self) -> &str {
-        "//"
     }
 
     fn render_visibility(&self, vis: Visibility, ctx: DeclarationContext) -> &str {
@@ -306,50 +352,6 @@ impl CodeLang for TypeScript {
 
     fn optional_field_style(&self) -> crate::lang::config::OptionalFieldStyle {
         crate::lang::config::OptionalFieldStyle::NameSuffix("?")
-    }
-
-    // --- Config struct accessors ---
-
-    fn type_presentation(&self) -> TypePresentationConfig<'_> {
-        TypePresentationConfig {
-            map: TypePresentation::GenericWrap { name: "Record" },
-            tuple: TypePresentation::Delimited {
-                open: "[",
-                sep: ", ",
-                close: "]",
-            },
-            associated_type: AssociatedTypeStyle::IndexAccess {
-                open: "[\"",
-                close: "\"]",
-            },
-            impl_trait: BoundsPresentation {
-                keyword: "",
-                separator: " & ",
-            },
-            wildcard: WildcardPresentation {
-                unbounded: "unknown",
-                upper_keyword: "unknown ",
-                lower_keyword: "unknown ",
-            },
-            ..Default::default()
-        }
-    }
-
-    fn generic_syntax(&self) -> GenericSyntaxConfig<'_> {
-        GenericSyntaxConfig {
-            constraint_keyword: " extends ",
-            constraint_separator: " & ",
-            ..Default::default()
-        }
-    }
-
-    fn block_syntax(&self) -> BlockSyntaxConfig<'_> {
-        BlockSyntaxConfig {
-            indent_unit: &self.indent,
-            uses_semicolons: self.uses_semicolons,
-            field_terminator: ";",
-            ..Default::default()
-        }
     }
 
     fn function_syntax(&self) -> FunctionSyntaxConfig<'_> {

--- a/src/lang/zsh.rs
+++ b/src/lang/zsh.rs
@@ -1,11 +1,11 @@
 //! Zsh shell language implementation.
 
 use crate::import::ImportGroup;
-use crate::lang::CodeLang;
 use crate::lang::config::{
     BlockSyntaxConfig, EnumAndAnnotationConfig, FunctionSyntaxConfig, GenericSyntaxConfig,
     TypeDeclSyntaxConfig, TypePresentationConfig,
 };
+use crate::lang::{CodeLang, RendererLang};
 use crate::spec::modifiers::{DeclarationContext, TypeKind, Visibility};
 
 /// Zsh shell language implementation.
@@ -74,35 +74,13 @@ const ZSH_RESERVED: &[&str] = &[
     "zle", "zmodload", "zshexit", "zstyle",
 ];
 
-impl CodeLang for Zsh {
+impl RendererLang for Zsh {
     fn file_extension(&self) -> &str {
         &self.extension
     }
 
     fn reserved_words(&self) -> &[&str] {
         ZSH_RESERVED
-    }
-
-    fn render_imports(&self, imports: &ImportGroup) -> String {
-        if imports.entries().is_empty() {
-            return String::new();
-        }
-
-        // Deduplicate to unique source paths.
-        let mut paths: Vec<&str> = Vec::new();
-        let mut seen = std::collections::HashSet::new();
-        for entry in imports.entries() {
-            if seen.insert(entry.module.as_str()) {
-                paths.push(&entry.module);
-            }
-        }
-        paths.sort();
-
-        paths
-            .iter()
-            .map(|p| format!("source \"{p}\""))
-            .collect::<Vec<_>>()
-            .join("\n")
     }
 
     fn render_string_literal(&self, s: &str) -> String {
@@ -119,38 +97,8 @@ impl CodeLang for Zsh {
         format!("\"{escaped}\"")
     }
 
-    fn render_doc_comment(&self, lines: &[&str]) -> String {
-        lines
-            .iter()
-            .map(|line| {
-                if line.is_empty() {
-                    "#".to_string()
-                } else {
-                    format!("# {line}")
-                }
-            })
-            .collect::<Vec<_>>()
-            .join("\n")
-    }
-
     fn line_comment_prefix(&self) -> &str {
         "#"
-    }
-
-    fn render_visibility(&self, _vis: Visibility, _ctx: DeclarationContext) -> &str {
-        ""
-    }
-
-    fn function_keyword(&self, _ctx: DeclarationContext) -> &str {
-        "function"
-    }
-
-    fn type_keyword(&self, _kind: TypeKind) -> &str {
-        ""
-    }
-
-    fn methods_inside_type_body(&self, _kind: TypeKind) -> bool {
-        true
     }
 
     // --- Config struct accessors ---
@@ -174,6 +122,60 @@ impl CodeLang for Zsh {
             field_terminator: "",
             ..Default::default()
         }
+    }
+}
+
+impl CodeLang for Zsh {
+    fn render_imports(&self, imports: &ImportGroup) -> String {
+        if imports.entries().is_empty() {
+            return String::new();
+        }
+
+        // Deduplicate to unique source paths.
+        let mut paths: Vec<&str> = Vec::new();
+        let mut seen = std::collections::HashSet::new();
+        for entry in imports.entries() {
+            if seen.insert(entry.module.as_str()) {
+                paths.push(&entry.module);
+            }
+        }
+        paths.sort();
+
+        paths
+            .iter()
+            .map(|p| format!("source \"{p}\""))
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    fn render_doc_comment(&self, lines: &[&str]) -> String {
+        lines
+            .iter()
+            .map(|line| {
+                if line.is_empty() {
+                    "#".to_string()
+                } else {
+                    format!("# {line}")
+                }
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    fn render_visibility(&self, _vis: Visibility, _ctx: DeclarationContext) -> &str {
+        ""
+    }
+
+    fn function_keyword(&self, _ctx: DeclarationContext) -> &str {
+        "function"
+    }
+
+    fn type_keyword(&self, _kind: TypeKind) -> &str {
+        ""
+    }
+
+    fn methods_inside_type_body(&self, _kind: TypeKind) -> bool {
+        true
     }
 
     fn function_syntax(&self) -> FunctionSyntaxConfig<'_> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,7 +97,7 @@ pub mod prelude {
     pub use crate::code_block::{CodeBlock, CodeBlockBuilder, NameArg, Specifier, StringLitArg};
     pub use crate::code_template::{CodeTemplate, ParamKind};
     pub use crate::error::SigilStitchError;
-    pub use crate::lang::CodeLang;
+    pub use crate::lang::{CodeLang, RendererLang};
     pub use crate::spec::annotation_spec::AnnotationSpec;
     pub use crate::spec::emittable::Emittable;
     pub use crate::spec::enum_variant_spec::EnumVariantSpec;

--- a/src/type_name.rs
+++ b/src/type_name.rs
@@ -1,7 +1,7 @@
 use pretty::BoxDoc;
 
 use crate::import::ImportRef;
-use crate::lang::CodeLang;
+use crate::lang::RendererLang;
 ///
 /// Each variant describes a structural pattern for assembling already-rendered
 /// inner type docs into the output. The rendering engine in `type_name.rs`
@@ -190,7 +190,7 @@ pub enum TypeName {
         alias: Option<String>,
         /// When true, render as `module{sep}name` inline (e.g., `serde_json::Value`)
         /// and skip import generation. The separator comes from
-        /// [`CodeLang::module_separator()`]. Falls back to unqualified rendering
+        /// [`RendererLang::module_separator()`]. Falls back to unqualified rendering
         /// if the language returns `None`.
         #[serde(default)]
         qualified: bool,
@@ -305,7 +305,7 @@ impl TypeName {
 
     /// Create a qualified type name that renders inline as `module{sep}name`.
     ///
-    /// The separator comes from [`CodeLang::module_separator()`] — `"::"` for
+    /// The separator comes from [`RendererLang::module_separator()`] — `"::"` for
     /// Rust/C++, `"."` for Go/Python/Java/etc.  No import statement is generated.
     ///
     /// If the target language returns `None` from `module_separator()`, the
@@ -584,7 +584,7 @@ impl TypeName {
 
     /// Language-aware variant of [`TypeName::to_doc`] that consults the lang for
     /// syntax differences (e.g., generic delimiters `<>` vs `[]`).
-    pub fn to_doc_with_lang<F>(&self, resolve: &F, lang: &dyn CodeLang) -> BoxDoc<'static, ()>
+    pub fn to_doc_with_lang<F>(&self, resolve: &F, lang: &dyn RendererLang) -> BoxDoc<'static, ()>
     where
         F: Fn(&str, &str) -> String,
     {
@@ -610,23 +610,25 @@ mod tests {
             impl $name {
                 fn new() -> Self { Self(<$base>::new()) }
             }
-            impl crate::lang::CodeLang for $name {
+            impl crate::lang::RendererLang for $name {
                 fn file_extension(&self) -> &str { self.0.file_extension() }
                 fn reserved_words(&self) -> &[&str] { self.0.reserved_words() }
-                fn render_imports(&self, imports: &crate::import::ImportGroup) -> String { self.0.render_imports(imports) }
                 fn render_string_literal(&self, s: &str) -> String { self.0.render_string_literal(s) }
-                fn render_doc_comment(&self, lines: &[&str]) -> String { self.0.render_doc_comment(lines) }
                 fn line_comment_prefix(&self) -> &str { self.0.line_comment_prefix() }
+                fn type_presentation(&self) -> crate::lang::config::TypePresentationConfig<'_> { self.0.type_presentation() }
+                fn block_syntax(&self) -> crate::lang::config::BlockSyntaxConfig<'_> { self.0.block_syntax() }
+                $($override)*
+            }
+            impl crate::lang::CodeLang for $name {
+                fn render_imports(&self, imports: &crate::import::ImportGroup) -> String { self.0.render_imports(imports) }
+                fn render_doc_comment(&self, lines: &[&str]) -> String { self.0.render_doc_comment(lines) }
                 fn render_visibility(&self, vis: crate::spec::modifiers::Visibility, ctx: crate::spec::modifiers::DeclarationContext) -> &str { self.0.render_visibility(vis, ctx) }
                 fn function_keyword(&self, ctx: crate::spec::modifiers::DeclarationContext) -> &str { self.0.function_keyword(ctx) }
                 fn type_keyword(&self, kind: crate::spec::modifiers::TypeKind) -> &str { self.0.type_keyword(kind) }
                 fn methods_inside_type_body(&self, kind: crate::spec::modifiers::TypeKind) -> bool { self.0.methods_inside_type_body(kind) }
-                fn type_presentation(&self) -> crate::lang::config::TypePresentationConfig<'_> { self.0.type_presentation() }
-                fn block_syntax(&self) -> crate::lang::config::BlockSyntaxConfig<'_> { self.0.block_syntax() }
                 fn function_syntax(&self) -> crate::lang::config::FunctionSyntaxConfig<'_> { self.0.function_syntax() }
                 fn type_decl_syntax(&self) -> crate::lang::config::TypeDeclSyntaxConfig<'_> { self.0.type_decl_syntax() }
                 fn enum_and_annotation(&self) -> crate::lang::config::EnumAndAnnotationConfig<'_> { self.0.enum_and_annotation() }
-                $($override)*
             }
         };
     }

--- a/src/type_name_render.rs
+++ b/src/type_name_render.rs
@@ -1,6 +1,6 @@
 use pretty::BoxDoc;
 
-use crate::lang::CodeLang;
+use crate::lang::RendererLang;
 use crate::lang::config::GenericSyntaxConfig;
 use crate::type_name::{
     AssociatedTypeStyle, FunctionPresentation, GenericApplicationStyle, TypeName, TypePresentation,
@@ -263,7 +263,11 @@ pub fn render(
     })
 }
 
-pub fn to_doc_with_lang<F>(tn: &TypeName, resolve: &F, lang: &dyn CodeLang) -> BoxDoc<'static, ()>
+pub fn to_doc_with_lang<F>(
+    tn: &TypeName,
+    resolve: &F,
+    lang: &dyn RendererLang,
+) -> BoxDoc<'static, ()>
 where
     F: Fn(&str, &str) -> String,
 {

--- a/tests/ocaml/builder_edge_cases.rs
+++ b/tests/ocaml/builder_edge_cases.rs
@@ -1,5 +1,5 @@
 use sigil_stitch::code_block::CodeBlock;
-use sigil_stitch::lang::CodeLang;
+use sigil_stitch::lang::RendererLang;
 use sigil_stitch::lang::ocaml::OCaml;
 use sigil_stitch::spec::file_spec::FileSpec;
 


### PR DESCRIPTION
## Summary

Closes #102.

- Extract 14 renderer-facing methods into a narrow `RendererLang` trait (used by `CodeRenderer` and `TypeName` rendering)
- `CodeLang` now extends `RendererLang` as a supertrait, retaining 24 spec-facing methods
- `CodeRenderer` accepts `&dyn RendererLang` instead of `&dyn CodeLang`, making its minimal interface explicit
- All 18 language implementations split into separate `impl RendererLang` + `impl CodeLang` blocks
- New languages can start with just `RendererLang` for basic `CodeBlock` rendering without implementing the full spec layer

## Test plan

- [x] `cargo test --workspace` — all 1567 tests pass
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] Supertrait coercion verified: `&dyn CodeLang` coerces to `&dyn RendererLang` at all call sites