### PR TITLE
chore: release 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,41 @@
 # Changelog
 
+## 0.6.0
+
+### Added
+
+- `$V` / `%V` verbatim string literal — preserves interpolation sigils (`$`, `` ` ``)
+  with minimal escaping, unlike `$S` which escapes everything.
+  - Per-language rendering: Bash/Zsh `"..."`, JS/TS `` `...` ``, Python `f"..."`,
+    Kotlin/Swift `"..."`, Dart `'...'`, C# `$"..."`, Scala `s"..."`.
+  - `VerbatimStrArg` wrapper for the builder API.
+- `MacroLang`-aware tokenizer with per-language annotation rules (Go `<-`,
+  Haskell `$$`, shell dash-flags and slash-paths).
+- Language-aware statement rewriting for Haskell guards and OCaml blocks.
+- Shell cookbook (`cookbook_shell.md`) with comprehensive Bash/Zsh recipes.
+
+### Changed
+
+- `CodeLang` split into `RendererLang` (renderer-only methods) + `CodeLang`
+  (spec-layer). Existing `impl CodeLang` still works; only affects custom trait
+  implementations.
+- Macro crate internals: `format.rs` split into `annotate.rs`, `spacing.rs`,
+  and `format.rs` modules.
+
+### Fixed
+
+- Zsh block delimiters: `begin_control_flow("if ...")` now emits `then`/`fi`
+  and `do`/`done` instead of `{`/`}`.
+- Shell bracket spacing: `[ $x ]` and `[[ $x ]]` render with correct inner
+  spaces in `sigil_quote!`.
+
+### Internal
+
+- Shared `shell_syntax.rs` for Bash/Zsh control-flow logic.
+- `code_renderer.rs` block/comment resolution unified.
+- `fun_spec.rs` body-emission deduplication.
+- Unit tests for annotation and format parsing in macro crate.
+
 ## 0.5.3
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,7 +100,7 @@ dependencies = [
 
 [[package]]
 name = "sigil-stitch"
-version = "0.5.3"
+version = "0.6.0"
 dependencies = [
  "pretty",
  "serde",
@@ -111,7 +111,7 @@ dependencies = [
 
 [[package]]
 name = "sigil-stitch-macros"
-version = "0.5.3"
+version = "0.6.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["macros"]
 resolver = "3"
 
 [workspace.package]
-version = "0.5.3"
+version = "0.6.0"
 edition = "2024"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"
@@ -35,7 +35,7 @@ exclude = [
 [dependencies]
 pretty = "0.12"
 snafu = "0.9"
-sigil-stitch-macros = { path = "macros", version = "0.5.3" }
+sigil-stitch-macros = { path = "macros", version = "0.6.0" }
 serde = { version = "1", features = ["derive"] }
 
 [dev-dependencies]

--- a/docs/src/adding_a_language.md
+++ b/docs/src/adding_a_language.md
@@ -1,6 +1,8 @@
 # Adding a Language
 
-sigil-stitch supports new languages by implementing the `CodeLang` trait. The trait has 36 methods: 10 required (no default) plus 6 config struct accessors and 20 override methods — all with sensible defaults. You only need to override the defaults when your language diverges from the common patterns.
+sigil-stitch supports new languages by implementing two traits: `RendererLang` (renderer-only methods) and `CodeLang` (spec-layer methods). `CodeLang` extends `RendererLang`, so implementing `CodeLang` requires both. If you only need `CodeBlock`-level rendering without specs, `RendererLang` alone is sufficient.
+
+The `RendererLang` trait has 14 methods covering rendering essentials. `CodeLang` adds the spec-layer methods: 4 required plus 6 config struct accessors and override methods — all with sensible defaults. You only need to override the defaults when your language diverges from the common patterns.
 
 This guide walks through the process using a hypothetical language, with references to real implementations you can study.
 
@@ -17,9 +19,9 @@ If your language has tokenizer conflicts in `sigil_quote!` that the universal he
 can't handle (e.g., shell flags, Go channel operators), you may also need to add a
 `MacroLang` variant. See [Language-Aware Tokenizer](macrolang.md) for details.
 
-## The CodeLang Trait
+## The RendererLang Trait
 
-The trait methods fall into natural groups.
+These methods are used by the renderer (`code_renderer.rs`) and type rendering:
 
 ### Core Methods (6 required)
 
@@ -34,7 +36,19 @@ These are enough for CodeBlock-level code generation:
 | `render_doc_comment()` | `/** ... */` | Doc comment block |
 | `line_comment_prefix()` | `"//"` | Single-line comment prefix |
 
+### Override Methods (with defaults)
+
+| Method | Default | Purpose |
+|--------|---------|---------|
+| `render_verbatim_string()` | Delegates to `render_string_literal()` | Minimal escaping for interpolated strings |
+
+Override `render_verbatim_string()` if your language has string interpolation (e.g., Bash `"$x"`, TypeScript `` `${x}` ``, Python `f"{x}"`).
+
 `render_imports()` is the most complex. It receives an `ImportGroup` (deduplicated, with aliases resolved) and must emit the full import header string. Study `src/lang/typescript.rs` for ES module imports or `src/lang/rust_lang.rs` for `use` paths.
+
+## The CodeLang Trait
+
+Extends `RendererLang` with the additional methods needed by the spec layer.
 
 ### Spec Support Methods (4 required)
 

--- a/docs/src/architecture.md
+++ b/docs/src/architecture.md
@@ -18,13 +18,18 @@ The library is organized in four layers, each building on the one below:
 └─────────────────────────────────────┘
 ```
 
-### Layer 1: CodeLang
+### Layer 1: RendererLang + CodeLang
 
-`src/lang/mod.rs` defines the `CodeLang` trait with 36 methods, including 6 config struct accessors (`type_presentation()`, `generic_syntax()`, `block_syntax()`, `function_syntax()`, `type_decl_syntax()`, `enum_and_annotation()`) that return data structs with sensible defaults. Each supported language implements this trait in its own module (`src/lang/typescript.rs`, etc.). Languages can also implement `rewrite_nodes()` to transform the CodeNode tree after macro expansion for language-specific fixups (e.g., Go IIFE `}()` fusion, C++ lambda `};` semicolons).
+`src/lang/mod.rs` defines two traits:
+
+- **`RendererLang`** (14 methods) — the renderer-only surface used by `code_renderer.rs` and `TypeName::to_doc_with_lang`. Covers file extension, string literals, verbatim strings, block syntax, type presentation, generic syntax, imports, and a few rendering helpers. If you only need `CodeBlock`-level rendering (no specs), implementing `RendererLang` is sufficient.
+- **`CodeLang: RendererLang`** — extends `RendererLang` with the additional methods needed by the spec layer (TypeSpec, FunSpec, FieldSpec). Covers visibility, keywords, function syntax, type-decl syntax, enum/annotation config, and structural decisions like `methods_inside_type_body`.
+
+Each supported language implements both traits in its own module (`src/lang/typescript.rs`, etc.). The 6 config struct accessors (`type_presentation()`, `generic_syntax()`, `block_syntax()`, `function_syntax()`, `type_decl_syntax()`, `enum_and_annotation()`) return data structs with sensible defaults. Languages can also implement `rewrite_nodes()` to transform the CodeNode tree after macro expansion for language-specific fixups (e.g., Go IIFE `}()` fusion, C++ lambda `};` semicolons).
 
 At the macro level, the `MacroLang` enum (`macros/src/parse/types.rs`) provides compile-time language-aware tokenizer annotations. Languages like Bash, Zsh, Go, and Haskell get specialized spacing rules in `sigil_quote!` without runtime overhead. See [Language-Aware Tokenizer](macrolang.md).
 
-Public types are language-agnostic — no generic parameter. The language enters as `&dyn CodeLang` at render time. `FileSpec` stores a `Box<dyn CodeLang>` internally; all other types (`CodeBlock`, `TypeName`, specs) are language-independent.
+Public types are language-agnostic — no generic parameter. The language enters as `&dyn RendererLang` (for rendering) or `&dyn CodeLang` (for spec emission) at render time. `FileSpec` stores a `Box<dyn CodeLang>` internally; all other types (`CodeBlock`, `TypeName`, specs) are language-independent.
 
 ### Layer 2: TypeName
 
@@ -115,6 +120,7 @@ Go's `qualify_import_name()` adds another layer: instead of importing `Server` d
 | `TypeRef(tn)` | Resolve import name via ImportGroup, emit |
 | `NameRef(s)` | Emit identifier |
 | `StringLit(s)` | Call `lang.render_string_literal()` |
+| `VerbatimStr(s)` | Call `lang.render_verbatim_string()` |
 | `InlineLiteral(s)` | Emit raw literal |
 | `Nested(block)` | Recursively render the inner CodeBlock |
 | `Comment(s)` | Emit with `lang.line_comment_prefix()` |

--- a/docs/src/format_specifiers.md
+++ b/docs/src/format_specifiers.md
@@ -297,6 +297,7 @@ The critical rule: **bare strings map to `Arg::Literal`** (consumed by `%L`), no
 | `CodeBlock` | `Arg::Code` | `%L` |
 | `NameArg(String)` | `Arg::Name` | `%N` |
 | `StringLitArg(String)` | `Arg::StringLit` | `%S` |
+| `VerbatimStrArg(String)` | `Arg::VerbatimStr` | `%V` |
 | `Vec<Arg>` | passthrough | any |
 
 ### Single Argument
@@ -351,7 +352,7 @@ let block = cb.build().unwrap();
 
 ### Argument Count Validation
 
-The builder checks that the number of argument-consuming specifiers (`%T`, `%N`, `%S`, `%L`) matches the number of arguments provided. A mismatch records a `FormatArgCount` error, surfaced when `build()` is called. The error carries the expected specifier list and the actual argument kinds so you can see exactly which slot is wrong.
+The builder checks that the number of argument-consuming specifiers (`%T`, `%N`, `%S`, `%V`, `%L`) matches the number of arguments provided. A mismatch records a `FormatArgCount` error, surfaced when `build()` is called. The error carries the expected specifier list and the actual argument kinds so you can see exactly which slot is wrong.
 
 ```rust
 # extern crate sigil_stitch;
@@ -369,4 +370,4 @@ let result = cb.build();
 # }
 ```
 
-An unrecognised specifier character (anything after `%` that isn't `T`, `N`, `S`, `L`, `W`, `>`, `<`, `[`, `]`, or `%`) produces `Err(SigilStitchError::InvalidFormatSpecifier { format, specifier })` instead.
+An unrecognised specifier character (anything after `%` that isn't `T`, `N`, `S`, `V`, `L`, `W`, `>`, `<`, `[`, `]`, or `%`) produces `Err(SigilStitchError::InvalidFormatSpecifier { format, specifier })` instead.

--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -12,7 +12,7 @@ Or add it directly to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-sigil-stitch = "0.5"
+sigil-stitch = "0.6"
 ```
 
 sigil-stitch requires Rust edition 2024 and MSRV 1.88.0. Runtime dependencies (`pretty`, `serde` with `derive`, and `snafu`) are pulled in automatically. No feature flags are needed -- all spec types implement `serde::Serialize` and `serde::Deserialize` out of the box.

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -39,7 +39,7 @@ produces a newline with proper indentation. This is the Wadler-Lindig algorithm 
 work, via the `pretty` crate. You pass the target width to `FileSpec::render(width)`,
 and the same code blocks produce different layouts for different widths.
 
-**Multi-language.** The `CodeLang` trait abstracts everything that varies between
+**Multi-language.** The `RendererLang` and `CodeLang` traits abstract everything that varies between
 languages: string delimiters, statement terminators, import syntax, visibility keywords,
 type formatting, annotation style, and more. sigil-stitch ships with implementations
 for TypeScript, JavaScript, Rust, Go, Python, Java, Kotlin, Swift, Dart, Scala,


### PR DESCRIPTION
## Summary

- Bump workspace version 0.5.3 → 0.6.0
- Add CHANGELOG.md entry covering all changes since 0.5.3

## Changes in 0.6.0

**Added:**
- `$V` / `%V` verbatim string literal with per-language rendering
- `MacroLang`-aware tokenizer (Go `<-`, Haskell `$$`, shell flags/paths)
- Language-aware statement rewriting for Haskell guards and OCaml blocks
- Shell cookbook (`cookbook_shell.md`)

**Changed (breaking):**
- `CodeLang` split into `RendererLang` + `CodeLang`
- Macro `format.rs` split into `annotate.rs`, `spacing.rs`, `format.rs`

**Fixed:**
- Zsh block delimiters (`then`/`fi`/`do`/`done`)
- Shell bracket spacing (`[ $x ]`, `[[ $x ]]`)

## Test plan

- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo run --example bash_codegen` works
- [x] `cargo publish -p sigil-stitch-macros --dry-run` succeeds