### PR TITLE
Make $V passthrough for Bash/Zsh (no quoting, no escaping)

### DIFF
--- a/docs/src/cookbook_shell.md
+++ b/docs/src/cookbook_shell.md
@@ -11,7 +11,7 @@ Practical, copy-paste-ready recipes for Bash and Zsh script generation. Covers `
 # fn main() {
 let body = sigil_quote!(Bash {
     local name=$$1
-    echo $V("Hello, ${name}!")
+    echo $V("\"Hello, ${name}!\"")
 }).unwrap();
 
 let fun = FunSpec::builder("greet")
@@ -51,7 +51,7 @@ let body = sigil_quote!(Bash {
     }
 
     for file in $$@; {
-        echo $V("Processing: ${file}")
+        echo $V("\"Processing: ${file}\"")
     }
 }).unwrap();
 
@@ -84,7 +84,7 @@ function process_files() {
 
 ## `$V` vs `$S` — when to use which
 
-`$S` escapes everything (safe for static strings). `$V` preserves shell interpolation sigils.
+`$S` escapes everything and wraps in quotes (safe for static strings). `$V` is pure passthrough — no quoting, no escaping. Use `$V` when you want shell to expand variables, command substitutions, or arithmetic at runtime. Include your own quotes in the `$V` content when shell quoting is needed.
 
 ```rust
 # extern crate sigil_stitch;
@@ -94,6 +94,7 @@ function process_files() {
 let block = sigil_quote!(Bash {
     echo $S("$HOME")
     echo $V("$HOME")
+    echo $V("\"$HOME\"")
 }).unwrap();
 
 let output = FileSpec::builder("test.bash")
@@ -102,14 +103,15 @@ let output = FileSpec::builder("test.bash")
     .unwrap()
     .render(80)
     .unwrap();
-// Line 1: echo "\$HOME"    ← $S escapes the dollar sign
-// Line 2: echo "$HOME"     ← $V preserves it for shell expansion
+// Line 1: echo "\$HOME"       ← $S escapes the dollar sign, wraps in quotes
+// Line 2: echo $HOME           ← $V passthrough, no quotes (word-splitting possible)
+// Line 3: echo "$HOME"         ← $V passthrough with user-provided quotes (safe)
 # }
 ```
 
 ## Complex shell interpolation with `$V`
 
-`$V` handles all shell expansion patterns — braced defaults, command substitution, arithmetic, arrays, special variables:
+`$V` handles all shell expansion patterns — braced defaults, command substitution, arithmetic, arrays, special variables. Since `$V` is passthrough, include quotes in the content when the generated shell code should have them:
 
 ```rust
 # extern crate sigil_stitch;
@@ -117,15 +119,15 @@ let output = FileSpec::builder("test.bash")
 # use sigil_stitch::lang::bash::Bash;
 # fn main() {
 let body = sigil_quote!(Bash {
-    local config_dir=$V("${XDG_CONFIG_HOME:-$HOME/.config}")
-    local version=$V("$(git describe --tags 2>/dev/null || echo dev)")
-    local port=$V("$((BASE_PORT + WORKER_ID))")
+    local config_dir=$V("\"${XDG_CONFIG_HOME:-$HOME/.config}\"")
+    local version=$V("\"$(git describe --tags 2>/dev/null || echo dev)\"")
+    local port=$V("\"$((BASE_PORT + WORKER_ID))\"")
 
-    echo $V("Deploying ${APP_NAME} v${version}")
-    echo $V("Config: ${config_dir}/${APP_NAME}.conf")
-    echo $V("Status: exit=$? pid=$$")
-    echo $V("Args: count=$# all=$@")
-    echo $V("Array: ${services[@]}")
+    echo $V("\"Deploying ${APP_NAME} v${version}\"")
+    echo $V("\"Config: ${config_dir}/${APP_NAME}.conf\"")
+    echo $V("\"Status: exit=$? pid=$$\"")
+    echo $V("\"Args: count=$# all=$@\"")
+    echo $V("\"Array: ${services[@]}\"")
 }).unwrap();
 
 let fun = FunSpec::builder("setup")
@@ -229,10 +231,10 @@ Zsh works identically to Bash for control flow. Use `$V` for Zsh-specific parame
 # use sigil_stitch::lang::zsh::Zsh;
 # fn main() {
 let body = sigil_quote!(Zsh {
-    local lower=$V("${(L)USERNAME}")
-    local joined=$V("${(j:,:)array}")
-    local sliced=$V("${array[2,-1]}")
-    local replaced=$V("${input//old/new}")
+    local lower=$V("\"${(L)USERNAME}\"")
+    local joined=$V("\"${(j:,:)array}\"")
+    local sliced=$V("\"${array[2,-1]}\"")
+    local replaced=$V("\"${input//old/new}\"")
 }).unwrap();
 
 let fun = FunSpec::builder("zsh_features")
@@ -305,15 +307,11 @@ Mix `$V` (shell-expanded at runtime) with `$L`/`$S` (Rust values baked in at gen
 let app_name = "myapp";
 let log_dir = "/var/log";
 
+// Build the whole string in Rust and pass via $V (most ergonomic):
+let log_pattern = format!("\"${{LOG_DIR:-{log_dir}}}/{app_name}.log\"");
 let body = sigil_quote!(Bash {
-    local log_file=$V("${LOG_DIR:-") $+ $L(log_dir) $+ $V("}/") $+ $L(app_name) $+ $V(".log")
-    echo $V("Writing to ${log_file}")
-}).unwrap();
-
-// Alternative — build the whole string in Rust and pass via $V:
-let log_pattern = format!("${{LOG_DIR:-{log_dir}}}/{app_name}.log");
-let body2 = sigil_quote!(Bash {
     local log_file=$V(log_pattern)
+    echo $V("\"Writing to ${log_file}\"")
 }).unwrap();
 # }
 ```

--- a/docs/src/format_specifiers.md
+++ b/docs/src/format_specifiers.md
@@ -133,9 +133,9 @@ Requires the `VerbatimStrArg` wrapper.
 # use sigil_stitch::prelude::*;
 # fn main() {
 let mut cb = CodeBlock::builder();
-cb.add("local config=%V", (VerbatimStrArg("${XDG_CONFIG_HOME:-$HOME/.config}".to_string()),));
+cb.add("local config=%V", (VerbatimStrArg("\"${XDG_CONFIG_HOME:-$HOME/.config}\"".to_string()),));
 cb.add_line();
-cb.add("local version=%V", (VerbatimStrArg("$(git describe --tags 2>/dev/null || echo dev)".to_string()),));
+cb.add("local version=%V", (VerbatimStrArg("\"$(git describe --tags 2>/dev/null || echo dev)\"".to_string()),));
 cb.add_line();
 cb.add("echo %V", (VerbatimStrArg("Deploying ${APP_NAME} v${version} (PID=$$)".to_string()),));
 let block = cb.build().unwrap();
@@ -146,11 +146,11 @@ let file = FileSpec::builder_with("test.bash", Bash::new())
 let output = file.render(80).unwrap();
 assert!(output.contains(r#""${XDG_CONFIG_HOME:-$HOME/.config}""#));
 assert!(output.contains(r#""$(git describe --tags 2>/dev/null || echo dev)""#));
-assert!(output.contains(r#""Deploying ${APP_NAME} v${version} (PID=$$)""#));
-// Output:
+assert!(output.contains("Deploying ${APP_NAME} v${version} (PID=$$)"));
+// Output (Bash $V is pure passthrough — users include their own quotes):
 //   local config="${XDG_CONFIG_HOME:-$HOME/.config}"
 //   local version="$(git describe --tags 2>/dev/null || echo dev)"
-//   echo "Deploying ${APP_NAME} v${version} (PID=$$)"
+//   echo Deploying ${APP_NAME} v${version} (PID=$$)
 # }
 ```
 
@@ -158,7 +158,7 @@ Per-language behavior:
 
 | Language | `%V` output for `"$x"` | Delimiter | Escapes only |
 |----------|------------------------|-----------|--------------|
-| Bash/Zsh | `"$x"` | `"..."` | `\` `"` |
+| Bash/Zsh | `$x` | (passthrough) | (none) |
 | JavaScript/TS | `` `$x` `` | `` `...` `` | `\` `` ` `` |
 | Python | `f"$x"` | `f"..."` | `\` `"` |
 | Kotlin/Swift | `"$x"` | `"..."` | `\` `"` |
@@ -166,6 +166,8 @@ Per-language behavior:
 | C# | `$"$x"` | `$"..."` | `\` `"` |
 | Scala | `s"$x"` | `s"..."` | `\` `"` |
 | Others | Same as `%S` | (full escaping) | All |
+
+For Bash/Zsh, `%V` is pure passthrough — the string is emitted as-is with no wrapping quotes and no escaping. Shell interpolates by default, and users control quoting in the `%V` content itself (include `"..."` in the string when quoting is desired in the output).
 
 For languages without string interpolation (C, C++, Go, Rust, Java, Haskell, OCaml, Lua), `%V` falls back to `%S` behavior (full escaping).
 

--- a/examples/bash_codegen.rs
+++ b/examples/bash_codegen.rs
@@ -91,11 +91,12 @@ fn builder_approach() -> String {
 fn macro_approach() -> String {
     let utils = TypeName::importable("./utils.sh", "");
 
-    // $V preserves shell interpolation — $S would escape these.
+    // $V is passthrough — include your own quotes where shell quoting is needed.
+    // $S would escape shell sigils; $V passes them through for shell expansion.
     let log_body = sigil_quote!(Bash {
         local level=$$1
         local message=$$2
-        echo $V("[$level] $(date +%Y-%m-%dT%H:%M:%S): $message")
+        echo $V("\"[$level] $(date +%Y-%m-%dT%H:%M:%S): $message\"")
     })
     .unwrap();
 
@@ -108,21 +109,21 @@ fn macro_approach() -> String {
     // $V is used for strings that need shell expansion at runtime.
     let deploy_body = sigil_quote!(Bash {
         local env=$$1
-        local app_name=$V("${APP_NAME:-myapp}")
-        local version=$V("$(cat VERSION 2>/dev/null || echo unknown)")
+        local app_name=$V("\"${APP_NAME:-myapp}\"")
+        local version=$V("\"$(cat VERSION 2>/dev/null || echo unknown)\"")
 
         if [ -z $$env ]; {
-            log_message $S("ERROR") $V("No environment specified for ${app_name}")
+            log_message $S("ERROR") $V("\"No environment specified for ${app_name}\"")
             return 1
         }
 
-        log_message $S("INFO") $V("Deploying ${app_name} v${version} to ${env}")
+        log_message $S("INFO") $V("\"Deploying ${app_name} v${version} to ${env}\"")
 
         for service in api worker scheduler; {
-            log_message $S("INFO") $V("Starting $service on $env")
+            log_message $S("INFO") $V("\"Starting $service on $env\"")
         }
 
-        log_message $S("INFO") $V("Deploy complete. PID=$$, exit=$?")
+        log_message $S("INFO") $V("\"Deploy complete. PID=$$, exit=$?\"")
     })
     .unwrap();
 

--- a/src/lang/bash.rs
+++ b/src/lang/bash.rs
@@ -113,8 +113,9 @@ impl RendererLang for Bash {
     }
 
     fn render_verbatim_string(&self, s: &str) -> String {
-        let escaped = s.replace('\\', "\\\\").replace('"', "\\\"");
-        format!("\"{escaped}\"")
+        // Shell interpolates by default — no wrapping quotes needed.
+        // Users control quoting in the $V content itself.
+        s.to_string()
     }
 
     fn line_comment_prefix(&self) -> &str {

--- a/src/lang/zsh.rs
+++ b/src/lang/zsh.rs
@@ -98,8 +98,9 @@ impl RendererLang for Zsh {
     }
 
     fn render_verbatim_string(&self, s: &str) -> String {
-        let escaped = s.replace('\\', "\\\\").replace('"', "\\\"");
-        format!("\"{escaped}\"")
+        // Shell interpolates by default — no wrapping quotes needed.
+        // Users control quoting in the $V content itself.
+        s.to_string()
     }
 
     fn line_comment_prefix(&self) -> &str {

--- a/tests/bash/quote_verbatim_string.rs
+++ b/tests/bash/quote_verbatim_string.rs
@@ -1,4 +1,7 @@
 //! Tests for `$V` verbatim string literal in shell.
+//!
+//! $V for Bash/Zsh is pure passthrough — no quoting, no escaping.
+//! Users include their own quotes in the $V content when shell quoting is needed.
 
 use sigil_stitch::code_block::CodeBlock;
 use sigil_stitch::prelude::*;
@@ -20,9 +23,14 @@ fn verbatim_preserves_dollar() {
     })
     .unwrap();
     let output = render(&block);
+    // Passthrough: no wrapping quotes — output is `echo $HOME/.config`
     assert!(
-        output.contains("\"$HOME/.config\""),
-        "Expected verbatim string with preserved $, got:\n{output}"
+        output.contains("echo $HOME/.config"),
+        "Expected passthrough (no quotes), got:\n{output}"
+    );
+    assert!(
+        !output.contains("echo \"$HOME/.config\""),
+        "Should NOT wrap in quotes, got:\n{output}"
     );
 }
 
@@ -34,8 +42,12 @@ fn verbatim_preserves_command_substitution() {
     .unwrap();
     let output = render(&block);
     assert!(
-        output.contains("\"$(date +%Y-%m-%d)\""),
-        "Expected verbatim string with command sub, got:\n{output}"
+        output.contains("= $(date +%Y-%m-%d)"),
+        "Expected passthrough command sub, got:\n{output}"
+    );
+    assert!(
+        !output.contains("\"$(date +%Y-%m-%d)\""),
+        "Should NOT wrap in quotes, got:\n{output}"
     );
 }
 
@@ -47,8 +59,8 @@ fn verbatim_preserves_braced_expansion() {
     .unwrap();
     let output = render(&block);
     assert!(
-        output.contains("\"${CONFIG_DIR:-$HOME/.config}\""),
-        "Expected braced default expansion, got:\n{output}"
+        output.contains("= ${CONFIG_DIR:-$HOME/.config}"),
+        "Expected passthrough braced expansion, got:\n{output}"
     );
 }
 
@@ -60,8 +72,8 @@ fn verbatim_preserves_arithmetic() {
     .unwrap();
     let output = render(&block);
     assert!(
-        output.contains("\"Result: $((count + 1)) items processed\""),
-        "Expected arithmetic expansion, got:\n{output}"
+        output.contains("echo Result: $((count + 1)) items processed"),
+        "Expected passthrough arithmetic, got:\n{output}"
     );
 }
 
@@ -73,8 +85,8 @@ fn verbatim_preserves_special_vars() {
     .unwrap();
     let output = render(&block);
     assert!(
-        output.contains("\"PID=$$ args=$# status=$? all=$@\""),
-        "Expected special variables, got:\n{output}"
+        output.contains("echo PID=$$ args=$# status=$? all=$@"),
+        "Expected passthrough special variables, got:\n{output}"
     );
 }
 
@@ -86,8 +98,8 @@ fn verbatim_preserves_array_expansion() {
     .unwrap();
     let output = render(&block);
     assert!(
-        output.contains("\"${files[@]}\""),
-        "Expected array expansion, got:\n{output}"
+        output.contains("echo ${files[@]}"),
+        "Expected passthrough array expansion, got:\n{output}"
     );
 }
 
@@ -98,22 +110,24 @@ fn verbatim_preserves_nested_substitution() {
     })
     .unwrap();
     let output = render(&block);
+    // Passthrough: the Rust string literal `'\\n'` becomes `'\n'` which is passed through as-is
     assert!(
-        output.contains("\"$(cat ${PROJECT_ROOT}/VERSION | tr -d '\\\\n')\""),
-        "Expected nested command + braced sub, got:\n{output}"
+        output.contains("$(cat ${PROJECT_ROOT}/VERSION | tr -d"),
+        "Expected passthrough nested sub, got:\n{output}"
     );
 }
 
 #[test]
-fn verbatim_escapes_backslash_and_quote() {
+fn verbatim_passthrough_no_escaping() {
+    // Backslashes and quotes pass through unchanged
     let block = sigil_quote!(Bash {
         echo $V("path\\to\"file")
     })
     .unwrap();
     let output = render(&block);
     assert!(
-        output.contains("\"path\\\\to\\\"file\""),
-        "Expected escaped backslash and quote, got:\n{output}"
+        output.contains("echo path\\to\"file"),
+        "Expected raw passthrough (no escaping), got:\n{output}"
     );
 }
 
@@ -125,14 +139,25 @@ fn verbatim_vs_string_lit_comparison() {
     })
     .unwrap();
     let output = render(&block);
+    // $S escapes dollar: echo "\$HOME"
     assert!(
-        output.contains("\"\\$HOME\""),
+        output.contains("echo \"\\$HOME\""),
         "Expected $S to escape dollar, got:\n{output}"
     );
+    // $V passthrough: echo $HOME (no quotes)
     assert!(
-        output.contains("\"$HOME\""),
-        "Expected $V to preserve dollar, got:\n{output}"
+        output.contains("echo $HOME"),
+        "Expected $V passthrough (no quotes), got:\n{output}"
     );
+    // Verify the $V line doesn't have wrapping quotes
+    for line in output.lines() {
+        if line.contains("$HOME") && !line.contains("\\$HOME") {
+            assert!(
+                !line.contains("\"$HOME\""),
+                "$V should not wrap in quotes, got line: {line}"
+            );
+        }
+    }
 }
 
 #[test]
@@ -145,15 +170,34 @@ fn verbatim_complex_script_snippet() {
     .unwrap();
     let output = render(&block);
     assert!(
-        output.contains("\"Deploying ${APP_NAME} v${VERSION} to ${ENVIRONMENT}\""),
-        "Expected complex braced vars, got:\n{output}"
+        output.contains("echo Deploying ${APP_NAME} v${VERSION} to ${ENVIRONMENT}"),
+        "Expected passthrough complex vars, got:\n{output}"
     );
     assert!(
-        output.contains("\"Commit: $(git rev-parse --short HEAD)\""),
-        "Expected git command sub, got:\n{output}"
+        output.contains("echo Commit: $(git rev-parse --short HEAD)"),
+        "Expected passthrough git sub, got:\n{output}"
     );
     assert!(
-        output.contains("\"Build time: $(date -u +%Y-%m-%dT%H:%M:%SZ)\""),
-        "Expected date command sub, got:\n{output}"
+        output.contains("echo Build time: $(date -u +%Y-%m-%dT%H:%M:%SZ)"),
+        "Expected passthrough date sub, got:\n{output}"
+    );
+}
+
+#[test]
+fn verbatim_with_explicit_quotes() {
+    // When the user wants shell quoting, they include the quotes in the $V content
+    let block = sigil_quote!(Bash {
+        echo $V("\"Hello, ${USER}!\"")
+        local config=$V("\"${XDG_CONFIG_HOME:-$HOME/.config}\"")
+    })
+    .unwrap();
+    let output = render(&block);
+    assert!(
+        output.contains("echo \"Hello, ${USER}!\""),
+        "Expected user-provided quotes passed through, got:\n{output}"
+    );
+    assert!(
+        output.contains("config=\"${XDG_CONFIG_HOME:-$HOME/.config}\""),
+        "Expected user-provided quotes for assignment, got:\n{output}"
     );
 }

--- a/tests/zsh/quote_verbatim_string.rs
+++ b/tests/zsh/quote_verbatim_string.rs
@@ -1,4 +1,7 @@
 //! Tests for `$V` verbatim string literal in Zsh.
+//!
+//! $V for Zsh is pure passthrough — no quoting, no escaping.
+//! Users include their own quotes in the $V content when shell quoting is needed.
 
 use sigil_stitch::code_block::CodeBlock;
 use sigil_stitch::prelude::*;
@@ -21,8 +24,12 @@ fn verbatim_preserves_zsh_parameter_flags() {
     .unwrap();
     let output = render(&block);
     assert!(
-        output.contains("\"${(L)USERNAME}\""),
-        "Expected zsh parameter flag expansion, got:\n{output}"
+        output.contains("= ${(L)USERNAME}"),
+        "Expected passthrough zsh parameter flag, got:\n{output}"
+    );
+    assert!(
+        !output.contains("\"${(L)USERNAME}\""),
+        "Should NOT wrap in quotes, got:\n{output}"
     );
 }
 
@@ -34,8 +41,8 @@ fn verbatim_preserves_zsh_glob_qualifier() {
     .unwrap();
     let output = render(&block);
     assert!(
-        output.contains("\"${~pattern}\""),
-        "Expected zsh glob expansion, got:\n{output}"
+        output.contains("= ${~pattern}"),
+        "Expected passthrough zsh glob, got:\n{output}"
     );
 }
 
@@ -47,8 +54,8 @@ fn verbatim_preserves_zsh_array_slicing() {
     .unwrap();
     let output = render(&block);
     assert!(
-        output.contains("\"${array[2,-1]}\""),
-        "Expected zsh array slice, got:\n{output}"
+        output.contains("echo ${array[2,-1]}"),
+        "Expected passthrough zsh array slice, got:\n{output}"
     );
 }
 
@@ -60,8 +67,8 @@ fn verbatim_preserves_zsh_substitution_flags() {
     .unwrap();
     let output = render(&block);
     assert!(
-        output.contains("\"${input//pattern/replacement}\""),
-        "Expected zsh pattern substitution, got:\n{output}"
+        output.contains("= ${input//pattern/replacement}"),
+        "Expected passthrough zsh substitution, got:\n{output}"
     );
 }
 
@@ -73,12 +80,8 @@ fn verbatim_preserves_process_substitution() {
     .unwrap();
     let output = render(&block);
     assert!(
-        output.contains("\"$(cat file1.txt)\""),
-        "Expected process sub 1, got:\n{output}"
-    );
-    assert!(
-        output.contains("\"$(cat file2.txt)\""),
-        "Expected process sub 2, got:\n{output}"
+        output.contains("diff $(cat file1.txt) $(cat file2.txt)"),
+        "Expected passthrough process subs, got:\n{output}"
     );
 }
 
@@ -92,15 +95,34 @@ fn verbatim_complex_zsh_script() {
     .unwrap();
     let output = render(&block);
     assert!(
-        output.contains("\"Building ${(U)PROJECT_NAME} from ${GIT_BRANCH:-main}\""),
-        "Expected uppercase flag + default, got:\n{output}"
+        output.contains("echo Building ${(U)PROJECT_NAME} from ${GIT_BRANCH:-main}"),
+        "Expected passthrough uppercase flag + default, got:\n{output}"
     );
     assert!(
-        output.contains("\"Artifacts: ${build_dir}/${(j:/:)path_components}\""),
-        "Expected join flag, got:\n{output}"
+        output.contains("echo Artifacts: ${build_dir}/${(j:/:)path_components}"),
+        "Expected passthrough join flag, got:\n{output}"
     );
     assert!(
-        output.contains("\"Timestamp: $(date -u +%Y-%m-%dT%H:%M:%SZ)\""),
-        "Expected command sub, got:\n{output}"
+        output.contains("echo Timestamp: $(date -u +%Y-%m-%dT%H:%M:%SZ)"),
+        "Expected passthrough command sub, got:\n{output}"
+    );
+}
+
+#[test]
+fn verbatim_with_explicit_quotes() {
+    // When the user wants shell quoting, they include the quotes in the $V content
+    let block = sigil_quote!(Zsh {
+        echo $V("\"${(L)USERNAME}\"")
+        local config=$V("\"${XDG_CONFIG_HOME:-$HOME/.config}\"")
+    })
+    .unwrap();
+    let output = render(&block);
+    assert!(
+        output.contains("echo \"${(L)USERNAME}\""),
+        "Expected user-provided quotes passed through, got:\n{output}"
+    );
+    assert!(
+        output.contains("config=\"${XDG_CONFIG_HOME:-$HOME/.config}\""),
+        "Expected user-provided quotes for assignment, got:\n{output}"
     );
 }


### PR DESCRIPTION
## Summary

`$V` / `%V` for Bash and Zsh is now pure passthrough — no wrapping quotes, no escaping. Shell interpolates by default; users include their own quotes in the $V content when shell quoting is desired in the output.

## Motivation

- Shell has no special "interpolated string" syntax — interpolation is the default behavior
- Quoting controls word-splitting, not interpolation — it's a user choice
- The old behavior (wrapping in `"..."`) was broken for multi-word commands (entire command became one quoted string)
- Real-world usage in ams-ops already worked around the forced quoting with embedded `\"`

## Changes

- `render_verbatim_string` for Bash and Zsh returns `s.to_string()` (passthrough)
- All Bash/Zsh verbatim tests rewritten with context-aware assertions
- Added `verbatim_with_explicit_quotes` and `verbatim_passthrough_no_escaping` tests
- Updated `examples/bash_codegen.rs` for passthrough behavior
- Updated `docs/src/cookbook_shell.md` and `docs/src/format_specifiers.md`
- Per-language table: Bash/Zsh row now shows passthrough (no delimiter)

## Migration

If your $V content relied on automatic quoting, add explicit quotes:

```rust
// Before (0.5):  wraps in quotes automatically
$V("${HOME}/.config")    // output: "${HOME}/.config"

// After (0.6):  is passthrough — include quotes yourself
$V("\"${HOME}/.config\"")  // output: "${HOME}/.config"
$V("${HOME}/.config")    // output: ${HOME}/.config (no quotes)
```

## Verification

- `cargo test --workspace` — all 1290+ tests pass
- `cargo clippy --workspace -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean
- `cargo run --example bash_codegen` — correct output