### PR TITLE
test: add shebang token tests for sigil_quote!

### DIFF
--- a/tests/bash/quote_edge_cases.rs
+++ b/tests/bash/quote_edge_cases.rs
@@ -368,3 +368,49 @@ fn test_dot_standalone_vs_dotfile() {
         "dotfile must stay tight, got: {output}"
     );
 }
+
+// ── Shebang tokens ────────────────────────────────────────
+
+#[test]
+fn test_shebang_bare_tokens() {
+    let block = sigil_quote!(Bash {
+        #!/usr/bin/env bash
+    })
+    .unwrap();
+    let output = render(&block);
+    assert!(
+        output.contains("#!/usr/bin/env bash"),
+        "shebang should render as tight `#!/usr/bin/env bash`, got:\n{output}"
+    );
+}
+
+#[test]
+fn test_shebang_with_set() {
+    let block = sigil_quote!(Bash {
+        #!/usr/bin/env bash
+        set -euo pipefail
+    })
+    .unwrap();
+    let output = render(&block);
+    assert!(
+        output.contains("#!/usr/bin/env bash"),
+        "shebang line, got:\n{output}"
+    );
+    assert!(
+        output.contains("set -euo pipefail"),
+        "set line, got:\n{output}"
+    );
+}
+
+#[test]
+fn test_shebang_bin_bash() {
+    let block = sigil_quote!(Bash {
+        #!/bin/bash
+    })
+    .unwrap();
+    let output = render(&block);
+    assert!(
+        output.contains("#!/bin/bash"),
+        "shebang /bin/bash, got:\n{output}"
+    );
+}

--- a/tests/zsh/quote_edge_cases.rs
+++ b/tests/zsh/quote_edge_cases.rs
@@ -322,3 +322,31 @@ fn test_dot_standalone_vs_dotfile() {
         "dotfile must stay tight, got: {output}"
     );
 }
+
+// ── Shebang tokens ────────────────────────────────────────
+
+#[test]
+fn test_shebang_bare_tokens() {
+    let block = sigil_quote!(Zsh {
+        #!/usr/bin/env zsh
+    })
+    .unwrap();
+    let output = render(&block);
+    assert!(
+        output.contains("#!/usr/bin/env zsh"),
+        "shebang should render as tight `#!/usr/bin/env zsh`, got:\n{output}"
+    );
+}
+
+#[test]
+fn test_shebang_bin_zsh() {
+    let block = sigil_quote!(Zsh {
+        #!/bin/zsh
+    })
+    .unwrap();
+    let output = render(&block);
+    assert!(
+        output.contains("#!/bin/zsh"),
+        "shebang /bin/zsh, got:\n{output}"
+    );
+}


### PR DESCRIPTION
## Summary
- Add shebang rendering tests for both Bash and Zsh in `quote_edge_cases.rs`
- Verifies `#!/usr/bin/env bash`, `#!/bin/bash`, `#!/usr/bin/env zsh`, `#!/bin/zsh` render correctly
- Confirms existing Joint punct + SlashSep tokenizer handles shebangs without code changes

## Test plan
- [x] `cargo test --workspace` — all 1346 tests pass
- [x] Shebang tests cover bare `#!`, with subsequent commands, and `/bin/` variants