### PR TITLE
feat: add @{expr} compile-time interpolation in $V strings

### DIFF
--- a/docs/src/cookbook_shell.md
+++ b/docs/src/cookbook_shell.md
@@ -158,6 +158,35 @@ function setup() {
 }
 ```
 
+## `@{expr}` interpolation in `$V`
+
+When you need to mix Rust compile-time values with shell runtime variables, use `@{expr}` inside `$V` strings. The `@{...}` parts are evaluated at compile time; everything else passes through verbatim for shell to interpret at runtime:
+
+```rust
+# extern crate sigil_stitch;
+# use sigil_stitch::prelude::*;
+# use sigil_stitch::lang::bash::Bash;
+# fn main() {
+let registry = "ghcr.io/myorg";
+let app = "api-server";
+let services = ["web", "worker", "scheduler"];
+
+let block = sigil_quote!(Bash {
+    docker push $V("@{registry}/@{app}:${TAG}")
+    echo $V("Deploying @{services.len()} services to ${ENVIRONMENT}")
+    echo $V("Contact: admin@@@{app}.internal")
+}).unwrap();
+# }
+```
+
+```bash
+docker push ghcr.io/myorg/api-server:${TAG}
+echo Deploying 3 services to ${ENVIRONMENT}
+echo Contact: admin@api-server.internal
+```
+
+Use `@@` to emit a literal `@` in the output. Bare `@` not followed by `{` passes through unchanged.
+
 ## Shebang and header
 
 Use `FileSpec::header()` for the shebang and preamble:

--- a/docs/src/format_specifiers.md
+++ b/docs/src/format_specifiers.md
@@ -171,6 +171,54 @@ For Bash/Zsh, `%V` is pure passthrough — the string is emitted as-is with no w
 
 For languages without string interpolation (C, C++, Go, Rust, Java, Haskell, OCaml, Lua), `%V` falls back to `%S` behavior (full escaping).
 
+### `@{expr}` interpolation in `$V`
+
+When using `$V` with a string literal in `sigil_quote!`, you can embed Rust expressions with `@{expr}`. These are evaluated at compile time and spliced into the verbatim output:
+
+```rust
+# extern crate sigil_stitch;
+# use sigil_stitch::prelude::*;
+# fn main() {
+let registry = "ghcr.io";
+let tag = "latest";
+let block = sigil_quote!(Bash {
+    docker push $V("@{registry}/myapp:@{tag}")
+}).unwrap();
+// Output: docker push ghcr.io/myapp:latest
+# }
+```
+
+This is syntactic sugar — the macro transforms the string into a `format!()` call. Shell variables like `$HOME` pass through unchanged while `@{expr}` parts are resolved at Rust compile time.
+
+Escape `@@` to emit a literal `@`:
+
+```rust
+# extern crate sigil_stitch;
+# use sigil_stitch::prelude::*;
+# fn main() {
+let block = sigil_quote!(Bash {
+    echo $V("admin@@localhost")
+}).unwrap();
+// Output: echo admin@localhost
+# }
+```
+
+Arbitrary Rust expressions work inside `@{...}`, including method calls:
+
+```rust
+# extern crate sigil_stitch;
+# use sigil_stitch::prelude::*;
+# fn main() {
+let items = vec!["a", "b", "c"];
+let block = sigil_quote!(Bash {
+    echo $V("count=@{items.len()}")
+}).unwrap();
+// Output: echo count=3
+# }
+```
+
+If `$V` receives a non-literal expression (e.g. `$V(my_var)` or `$V(format!(...))`), `@{...}` processing is skipped and the expression is used as-is.
+
 ## `%L` -- Literal
 
 Emits a raw value with no transformation. This is the default for bare `&str` and `String` arguments, so no wrapper is needed. Also accepts `CodeBlock` for embedding nested blocks.

--- a/docs/src/sigil_quote.md
+++ b/docs/src/sigil_quote.md
@@ -140,6 +140,25 @@ let block = sigil_quote!(Bash {
 # }
 ```
 
+#### `@{expr}` interpolation
+
+Embed Rust expressions inside `$V` string literals with `@{expr}`. These are resolved at compile time while the rest passes through for the target language's runtime:
+
+```rust
+# extern crate sigil_stitch;
+# use sigil_stitch::prelude::*;
+# fn main() {
+let registry = "ghcr.io/myorg";
+let app = "api";
+let block = sigil_quote!(Bash {
+    docker push $V("@{registry}/@{app}:${TAG}")
+}).unwrap();
+// Output: docker push ghcr.io/myorg/api:${TAG}
+# }
+```
+
+Use `@@` to emit a literal `@`. Bare `@` not followed by `{` passes through unchanged. Works with all languages that support `$V`.
+
 ### Literals (`$L`)
 
 ```rust

--- a/macros/src/codegen.rs
+++ b/macros/src/codegen.rs
@@ -2,9 +2,10 @@
 //!
 //! Converts parsed statements into a `TokenStream` of `CodeBlockBuilder` method calls.
 
-use proc_macro2::TokenStream;
+use proc_macro2::{Literal, TokenStream, TokenTree};
 use quote::quote;
 
+use crate::parse::verbatim_interpolation::{VerbatimResult, parse_verbatim_interpolation};
 use crate::parse::{InterpolationKind, MetaBranch, ParsedInput, Statement, TypedArg};
 
 /// Generate the output token stream from a parsed `sigil_quote!` input.
@@ -150,7 +151,34 @@ fn build_args_tuple(args: &[TypedArg]) -> TokenStream {
                         quote! { ::sigil_stitch::code_block::StringLitArg((#expr).to_string()) }
                     }
                     InterpolationKind::VerbatimStr => {
-                        quote! { ::sigil_stitch::code_block::VerbatimStrArg((#expr).to_string()) }
+                        match extract_verbatim_interpolation(expr) {
+                            Some(VerbatimResult::Interpolated {
+                                format_string,
+                                expressions,
+                            }) => {
+                                let fmt_lit = Literal::string(&format_string);
+                                let exprs: Vec<TokenStream> = expressions
+                                    .iter()
+                                    .map(|e| e.parse::<TokenStream>().unwrap())
+                                    .collect();
+                                quote! {
+                                    ::sigil_stitch::code_block::VerbatimStrArg(
+                                        ::std::format!(#fmt_lit, #(#exprs),*)
+                                    )
+                                }
+                            }
+                            Some(VerbatimResult::Literal(s)) => {
+                                let lit = Literal::string(&s);
+                                quote! {
+                                    ::sigil_stitch::code_block::VerbatimStrArg(
+                                        ::std::string::String::from(#lit)
+                                    )
+                                }
+                            }
+                            _ => {
+                                quote! { ::sigil_stitch::code_block::VerbatimStrArg((#expr).to_string()) }
+                            }
+                        }
                     }
                 }
             })
@@ -193,4 +221,67 @@ fn generate_meta_if(branches: &[MetaBranch]) -> TokenStream {
     }
 
     result
+}
+
+/// Try to extract a string literal from a token stream and parse `@{expr}` interpolations.
+///
+/// Returns `None` if the expression is not a single string literal (e.g. a variable or
+/// function call), in which case the expression is used as-is.
+fn extract_verbatim_interpolation(expr: &TokenStream) -> Option<VerbatimResult> {
+    let tokens: Vec<TokenTree> = expr.clone().into_iter().collect();
+    if tokens.len() != 1 {
+        return None;
+    }
+    let lit = match &tokens[0] {
+        TokenTree::Literal(lit) => lit,
+        _ => return None,
+    };
+    let repr = lit.to_string();
+    if !repr.starts_with('"') || !repr.ends_with('"') {
+        return None;
+    }
+    let content = unescape_string_literal(&repr[1..repr.len() - 1])?;
+    parse_verbatim_interpolation(&content).ok()
+}
+
+/// Unescape a Rust string literal body (content between the outer quotes).
+fn unescape_string_literal(s: &str) -> Option<String> {
+    let mut result = String::with_capacity(s.len());
+    let mut chars = s.chars();
+    while let Some(ch) = chars.next() {
+        if ch == '\\' {
+            match chars.next()? {
+                'n' => result.push('\n'),
+                'r' => result.push('\r'),
+                't' => result.push('\t'),
+                '\\' => result.push('\\'),
+                '"' => result.push('"'),
+                '\'' => result.push('\''),
+                '0' => result.push('\0'),
+                'x' => {
+                    let hi = chars.next()?.to_digit(16)?;
+                    let lo = chars.next()?.to_digit(16)?;
+                    result.push(char::from(((hi << 4) | lo) as u8));
+                }
+                'u' => {
+                    if chars.next()? != '{' {
+                        return None;
+                    }
+                    let mut val = 0u32;
+                    loop {
+                        let c = chars.next()?;
+                        if c == '}' {
+                            break;
+                        }
+                        val = val * 16 + c.to_digit(16)?;
+                    }
+                    result.push(char::from_u32(val)?);
+                }
+                _ => return None,
+            }
+        } else {
+            result.push(ch);
+        }
+    }
+    Some(result)
 }

--- a/macros/src/parse/mod.rs
+++ b/macros/src/parse/mod.rs
@@ -10,6 +10,7 @@ mod statements;
 mod stmt_rewrite;
 mod types;
 mod util;
+pub(crate) mod verbatim_interpolation;
 
 pub(crate) use types::*;
 

--- a/macros/src/parse/verbatim_interpolation.rs
+++ b/macros/src/parse/verbatim_interpolation.rs
@@ -1,0 +1,250 @@
+/// Result of scanning a `$V` string literal for `@{expr}` interpolation patterns.
+#[derive(Debug)]
+pub(crate) enum VerbatimResult {
+    /// No `@` characters found — use the original literal as-is.
+    Unchanged,
+    /// Only `@@` escapes found (no `@{}`). Contains the de-escaped string.
+    Literal(String),
+    /// One or more `@{expr}` interpolations found.
+    Interpolated {
+        format_string: String,
+        expressions: Vec<String>,
+    },
+}
+
+/// Scan a string for `@{expr}` patterns and `@@` escapes.
+///
+/// Returns `Unchanged` if no `@` present, `Literal` if only `@@` escapes,
+/// or `Interpolated` with a format string and expression list.
+pub(crate) fn parse_verbatim_interpolation(input: &str) -> Result<VerbatimResult, String> {
+    let mut chars = input.chars().peekable();
+    let mut format_string = String::with_capacity(input.len());
+    let mut expressions: Vec<String> = Vec::new();
+    let mut has_at = false;
+    let mut has_interpolation = false;
+
+    while let Some(ch) = chars.next() {
+        if ch == '@' {
+            match chars.peek() {
+                Some(&'@') => {
+                    has_at = true;
+                    chars.next();
+                    format_string.push('@');
+                }
+                Some(&'{') => {
+                    has_at = true;
+                    chars.next();
+                    has_interpolation = true;
+
+                    let mut expr = String::new();
+                    let mut depth: u32 = 1;
+
+                    loop {
+                        match chars.next() {
+                            None => {
+                                return Err("unclosed `@{` — missing `}`".to_string());
+                            }
+                            Some('{') => {
+                                depth += 1;
+                                expr.push('{');
+                            }
+                            Some('}') => {
+                                depth -= 1;
+                                if depth == 0 {
+                                    break;
+                                }
+                                expr.push('}');
+                            }
+                            Some(c) => expr.push(c),
+                        }
+                    }
+
+                    let trimmed = expr.trim();
+                    if trimmed.is_empty() {
+                        return Err("empty `@{}` — expression required".to_string());
+                    }
+
+                    format_string.push_str("{}");
+                    expressions.push(trimmed.to_string());
+                }
+                _ => {
+                    format_string.push('@');
+                }
+            }
+        } else if ch == '{' {
+            format_string.push_str("{{");
+        } else if ch == '}' {
+            format_string.push_str("}}");
+        } else {
+            format_string.push(ch);
+        }
+    }
+
+    if !has_at {
+        return Ok(VerbatimResult::Unchanged);
+    }
+
+    if !has_interpolation {
+        let literal = format_string.replace("{{", "{").replace("}}", "}");
+        return Ok(VerbatimResult::Literal(literal));
+    }
+
+    Ok(VerbatimResult::Interpolated {
+        format_string,
+        expressions,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_at_returns_unchanged() {
+        assert!(matches!(
+            parse_verbatim_interpolation("hello world").unwrap(),
+            VerbatimResult::Unchanged
+        ));
+    }
+
+    #[test]
+    fn bare_at_passes_through() {
+        let result = parse_verbatim_interpolation("user@host").unwrap();
+        assert!(matches!(result, VerbatimResult::Unchanged));
+    }
+
+    #[test]
+    fn double_at_returns_literal() {
+        let result = parse_verbatim_interpolation("user@@host").unwrap();
+        match result {
+            VerbatimResult::Literal(s) => assert_eq!(s, "user@host"),
+            _ => panic!("expected Literal"),
+        }
+    }
+
+    #[test]
+    fn simple_interpolation() {
+        let result = parse_verbatim_interpolation("Hello @{name}!").unwrap();
+        match result {
+            VerbatimResult::Interpolated {
+                format_string,
+                expressions,
+            } => {
+                assert_eq!(format_string, "Hello {}!");
+                assert_eq!(expressions, vec!["name"]);
+            }
+            _ => panic!("expected Interpolated"),
+        }
+    }
+
+    #[test]
+    fn multiple_interpolations() {
+        let result = parse_verbatim_interpolation("@{registry}/app:@{tag}").unwrap();
+        match result {
+            VerbatimResult::Interpolated {
+                format_string,
+                expressions,
+            } => {
+                assert_eq!(format_string, "{}/app:{}");
+                assert_eq!(expressions, vec!["registry", "tag"]);
+            }
+            _ => panic!("expected Interpolated"),
+        }
+    }
+
+    #[test]
+    fn nested_braces_in_expr() {
+        let result = parse_verbatim_interpolation("count=@{map[\"key\"]}").unwrap();
+        match result {
+            VerbatimResult::Interpolated {
+                format_string,
+                expressions,
+            } => {
+                assert_eq!(format_string, "count={}");
+                assert_eq!(expressions, vec!["map[\"key\"]"]);
+            }
+            _ => panic!("expected Interpolated"),
+        }
+    }
+
+    #[test]
+    fn braces_in_content_escaped() {
+        let result = parse_verbatim_interpolation("json: {\"key\": @{val}}").unwrap();
+        match result {
+            VerbatimResult::Interpolated {
+                format_string,
+                expressions,
+            } => {
+                assert_eq!(format_string, "json: {{\"key\": {}}}");
+                assert_eq!(expressions, vec!["val"]);
+            }
+            _ => panic!("expected Interpolated"),
+        }
+    }
+
+    #[test]
+    fn mixed_escape_and_interpolation() {
+        let result = parse_verbatim_interpolation("@@admin: @{msg}").unwrap();
+        match result {
+            VerbatimResult::Interpolated {
+                format_string,
+                expressions,
+            } => {
+                assert_eq!(format_string, "@admin: {}");
+                assert_eq!(expressions, vec!["msg"]);
+            }
+            _ => panic!("expected Interpolated"),
+        }
+    }
+
+    #[test]
+    fn expr_with_method_call() {
+        let result = parse_verbatim_interpolation("len=@{items.len()}").unwrap();
+        match result {
+            VerbatimResult::Interpolated {
+                format_string,
+                expressions,
+            } => {
+                assert_eq!(format_string, "len={}");
+                assert_eq!(expressions, vec!["items.len()"]);
+            }
+            _ => panic!("expected Interpolated"),
+        }
+    }
+
+    #[test]
+    fn unclosed_at_brace_errors() {
+        let result = parse_verbatim_interpolation("hello @{name");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("unclosed"));
+    }
+
+    #[test]
+    fn empty_at_brace_errors() {
+        let result = parse_verbatim_interpolation("hello @{}");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("empty"));
+    }
+
+    #[test]
+    fn whitespace_only_at_brace_errors() {
+        let result = parse_verbatim_interpolation("hello @{  }");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("empty"));
+    }
+
+    #[test]
+    fn shell_vars_pass_through() {
+        let result = parse_verbatim_interpolation("@{prefix}/$HOME/bin").unwrap();
+        match result {
+            VerbatimResult::Interpolated {
+                format_string,
+                expressions,
+            } => {
+                assert_eq!(format_string, "{}/$HOME/bin");
+                assert_eq!(expressions, vec!["prefix"]);
+            }
+            _ => panic!("expected Interpolated"),
+        }
+    }
+}

--- a/tests/bash/quote_verbatim_string.rs
+++ b/tests/bash/quote_verbatim_string.rs
@@ -201,3 +201,106 @@ fn verbatim_with_explicit_quotes() {
         "Expected user-provided quotes for assignment, got:\n{output}"
     );
 }
+
+// ── @{expr} interpolation ────────────────────────────────
+
+#[test]
+fn verbatim_at_interpolation_simple() {
+    let name = "world";
+    let block = sigil_quote!(Bash {
+        echo $V("Hello @{name}")
+    })
+    .unwrap();
+    let output = render(&block);
+    assert!(output.contains("echo Hello world"), "got:\n{output}");
+}
+
+#[test]
+fn verbatim_at_interpolation_multiple() {
+    let registry = "ghcr.io";
+    let tag = "latest";
+    let block = sigil_quote!(Bash {
+        docker push $V("@{registry}/myapp:@{tag}")
+    })
+    .unwrap();
+    let output = render(&block);
+    assert!(output.contains("ghcr.io/myapp:latest"), "got:\n{output}");
+}
+
+#[test]
+fn verbatim_at_escape() {
+    let block = sigil_quote!(Bash {
+        echo $V("user@@host")
+    })
+    .unwrap();
+    let output = render(&block);
+    assert!(output.contains("echo user@host"), "got:\n{output}");
+}
+
+#[test]
+fn verbatim_at_with_shell_vars() {
+    let prefix = "/opt";
+    let block = sigil_quote!(Bash {
+        echo $V("@{prefix}/$USER/bin")
+    })
+    .unwrap();
+    let output = render(&block);
+    assert!(output.contains("echo /opt/$USER/bin"), "got:\n{output}");
+}
+
+#[test]
+fn verbatim_at_expr_method_call() {
+    let items = ["a", "b"];
+    let block = sigil_quote!(Bash {
+        echo $V("count=@{items.len()}")
+    })
+    .unwrap();
+    let output = render(&block);
+    assert!(output.contains("echo count=2"), "got:\n{output}");
+}
+
+#[test]
+fn verbatim_at_mixed_with_escape_and_shell() {
+    let user = "admin";
+    let block = sigil_quote!(Bash {
+        echo $V("@{user}@@localhost: $HOME")
+    })
+    .unwrap();
+    let output = render(&block);
+    assert!(
+        output.contains("echo admin@localhost: $HOME"),
+        "got:\n{output}"
+    );
+}
+
+#[test]
+fn verbatim_at_no_interpolation_unchanged() {
+    let block = sigil_quote!(Bash {
+        echo $V("$HOME/.config")
+    })
+    .unwrap();
+    let output = render(&block);
+    assert!(output.contains("echo $HOME/.config"), "got:\n{output}");
+}
+
+#[test]
+fn verbatim_at_bare_at_passes_through() {
+    let block = sigil_quote!(Bash {
+        echo $V("user@host.com")
+    })
+    .unwrap();
+    let output = render(&block);
+    assert!(output.contains("echo user@host.com"), "got:\n{output}");
+}
+
+#[test]
+fn verbatim_at_format_expr() {
+    let name = "app";
+    let version = "1.0";
+    let block = sigil_quote!(Bash {
+        echo $V("@{format!(\"{}-{}\", name, version)}")
+    })
+    .unwrap();
+    let output = render(&block);
+    assert!(output.contains("echo app-1.0"), "got:\n{output}");
+}

--- a/tests/csharp/main.rs
+++ b/tests/csharp/main.rs
@@ -9,3 +9,4 @@ mod quote_basic;
 mod quote_control_flow;
 mod quote_edge_cases;
 mod quote_imports;
+mod quote_verbatim_string;

--- a/tests/csharp/quote_verbatim_string.rs
+++ b/tests/csharp/quote_verbatim_string.rs
@@ -1,0 +1,62 @@
+//! Tests for `$V` verbatim string literal in C#.
+
+use sigil_stitch::code_block::CodeBlock;
+use sigil_stitch::prelude::*;
+use sigil_stitch::spec::file_spec::FileSpec;
+
+fn render(block: &CodeBlock) -> String {
+    FileSpec::builder("test.cs")
+        .add_code(block.clone())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap()
+}
+
+#[test]
+fn verbatim_uses_interpolated_string() {
+    let block = sigil_quote!(CSharp {
+        var msg = $V("Hello, {name}!")
+    })
+    .unwrap();
+    let output = render(&block);
+    assert!(
+        output.contains("$\"Hello, {name}!\""),
+        "Expected C# interpolated string, got:\n{output}"
+    );
+}
+
+// ── @{expr} interpolation ────────────────────────────────
+
+#[test]
+fn verbatim_at_interpolation_simple() {
+    let greeting = "Hi";
+    let block = sigil_quote!(CSharp {
+        var msg = $V("@{greeting}, {name}!")
+    })
+    .unwrap();
+    let output = render(&block);
+    assert!(output.contains("$\"Hi, {name}!\""), "got:\n{output}");
+}
+
+#[test]
+fn verbatim_at_interpolation_multiple() {
+    let ns = "MyApp";
+    let module = "Auth";
+    let block = sigil_quote!(CSharp {
+        var pkg = $V("@{ns}.@{module}")
+    })
+    .unwrap();
+    let output = render(&block);
+    assert!(output.contains("$\"MyApp.Auth\""), "got:\n{output}");
+}
+
+#[test]
+fn verbatim_at_escape() {
+    let block = sigil_quote!(CSharp {
+        var email = $V("user@@host.com")
+    })
+    .unwrap();
+    let output = render(&block);
+    assert!(output.contains("$\"user@host.com\""), "got:\n{output}");
+}

--- a/tests/dart/main.rs
+++ b/tests/dart/main.rs
@@ -10,3 +10,4 @@ mod quote_basic;
 mod quote_control_flow;
 mod quote_edge_cases;
 mod quote_imports;
+mod quote_verbatim_string;

--- a/tests/dart/quote_verbatim_string.rs
+++ b/tests/dart/quote_verbatim_string.rs
@@ -1,0 +1,62 @@
+//! Tests for `$V` verbatim string literal in Dart.
+
+use sigil_stitch::code_block::CodeBlock;
+use sigil_stitch::prelude::*;
+use sigil_stitch::spec::file_spec::FileSpec;
+
+fn render(block: &CodeBlock) -> String {
+    FileSpec::builder("test.dart")
+        .add_code(block.clone())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap()
+}
+
+#[test]
+fn verbatim_preserves_dollar_interpolation() {
+    let block = sigil_quote!(Dart {
+        var msg = $V("Hello, ${name}!")
+    })
+    .unwrap();
+    let output = render(&block);
+    assert!(
+        output.contains("'Hello, ${name}!'"),
+        "Expected Dart interpolation preserved, got:\n{output}"
+    );
+}
+
+// ── @{expr} interpolation ────────────────────────────────
+
+#[test]
+fn verbatim_at_interpolation_simple() {
+    let greeting = "Hi";
+    let block = sigil_quote!(Dart {
+        var msg = $V("@{greeting}, ${name}!")
+    })
+    .unwrap();
+    let output = render(&block);
+    assert!(output.contains("'Hi, ${name}!'"), "got:\n{output}");
+}
+
+#[test]
+fn verbatim_at_interpolation_multiple() {
+    let base = "com.example";
+    let module = "auth";
+    let block = sigil_quote!(Dart {
+        var pkg = $V("@{base}.@{module}")
+    })
+    .unwrap();
+    let output = render(&block);
+    assert!(output.contains("'com.example.auth'"), "got:\n{output}");
+}
+
+#[test]
+fn verbatim_at_escape() {
+    let block = sigil_quote!(Dart {
+        var email = $V("user@@host.com")
+    })
+    .unwrap();
+    let output = render(&block);
+    assert!(output.contains("'user@host.com'"), "got:\n{output}");
+}

--- a/tests/go/main.rs
+++ b/tests/go/main.rs
@@ -10,3 +10,4 @@ mod quote_basic;
 mod quote_control_flow;
 mod quote_edge_cases;
 mod quote_imports;
+mod quote_verbatim_string;

--- a/tests/go/quote_verbatim_string.rs
+++ b/tests/go/quote_verbatim_string.rs
@@ -1,0 +1,52 @@
+//! Tests for `$V` verbatim string literal in Go.
+//!
+//! Go has no string interpolation, so $V falls back to $S behavior (full escaping).
+//! @{expr} still works at the macro level — it's compile-time interpolation.
+
+use sigil_stitch::code_block::CodeBlock;
+use sigil_stitch::prelude::*;
+use sigil_stitch::spec::file_spec::FileSpec;
+
+fn render(block: &CodeBlock) -> String {
+    FileSpec::builder("test.go")
+        .add_code(block.clone())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap()
+}
+
+// ── @{expr} interpolation ────────────────────────────────
+
+#[test]
+fn verbatim_at_interpolation_simple() {
+    let name = "world";
+    let block = sigil_quote!(GoLang {
+        msg := $V("hello @{name}")
+    })
+    .unwrap();
+    let output = render(&block);
+    assert!(output.contains("\"hello world\""), "got:\n{output}");
+}
+
+#[test]
+fn verbatim_at_interpolation_multiple() {
+    let host = "localhost";
+    let port = "8080";
+    let block = sigil_quote!(GoLang {
+        addr := $V("@{host}:@{port}")
+    })
+    .unwrap();
+    let output = render(&block);
+    assert!(output.contains("\"localhost:8080\""), "got:\n{output}");
+}
+
+#[test]
+fn verbatim_at_escape() {
+    let block = sigil_quote!(GoLang {
+        email := $V("user@@host.com")
+    })
+    .unwrap();
+    let output = render(&block);
+    assert!(output.contains("\"user@host.com\""), "got:\n{output}");
+}

--- a/tests/java/main.rs
+++ b/tests/java/main.rs
@@ -10,3 +10,4 @@ mod quote_basic;
 mod quote_control_flow;
 mod quote_edge_cases;
 mod quote_imports;
+mod quote_verbatim_string;

--- a/tests/java/quote_verbatim_string.rs
+++ b/tests/java/quote_verbatim_string.rs
@@ -1,0 +1,52 @@
+//! Tests for `$V` verbatim string literal in Java.
+//!
+//! Java has no string interpolation, so $V falls back to $S behavior (full escaping).
+//! @{expr} still works at the macro level — it's compile-time interpolation.
+
+use sigil_stitch::code_block::CodeBlock;
+use sigil_stitch::prelude::*;
+use sigil_stitch::spec::file_spec::FileSpec;
+
+fn render(block: &CodeBlock) -> String {
+    FileSpec::builder("test.java")
+        .add_code(block.clone())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap()
+}
+
+// ── @{expr} interpolation ────────────────────────────────
+
+#[test]
+fn verbatim_at_interpolation_simple() {
+    let name = "world";
+    let block = sigil_quote!(Java {
+        String msg = $V("hello @{name}")
+    })
+    .unwrap();
+    let output = render(&block);
+    assert!(output.contains("\"hello world\""), "got:\n{output}");
+}
+
+#[test]
+fn verbatim_at_interpolation_multiple() {
+    let pkg = "com.example";
+    let cls = "Main";
+    let block = sigil_quote!(Java {
+        String fqn = $V("@{pkg}.@{cls}")
+    })
+    .unwrap();
+    let output = render(&block);
+    assert!(output.contains("\"com.example.Main\""), "got:\n{output}");
+}
+
+#[test]
+fn verbatim_at_escape() {
+    let block = sigil_quote!(Java {
+        String email = $V("user@@host.com")
+    })
+    .unwrap();
+    let output = render(&block);
+    assert!(output.contains("\"user@host.com\""), "got:\n{output}");
+}

--- a/tests/javascript/main.rs
+++ b/tests/javascript/main.rs
@@ -10,3 +10,4 @@ mod quote_basic;
 mod quote_control_flow;
 mod quote_edge_cases;
 mod quote_imports;
+mod quote_verbatim_string;

--- a/tests/javascript/quote_verbatim_string.rs
+++ b/tests/javascript/quote_verbatim_string.rs
@@ -1,11 +1,11 @@
-//! Tests for `$V` verbatim string literal in TypeScript.
+//! Tests for `$V` verbatim string literal in JavaScript.
 
 use sigil_stitch::code_block::CodeBlock;
 use sigil_stitch::prelude::*;
 use sigil_stitch::spec::file_spec::FileSpec;
 
 fn render(block: &CodeBlock) -> String {
-    FileSpec::builder("test.ts")
+    FileSpec::builder("test.js")
         .add_code(block.clone())
         .build()
         .unwrap()
@@ -15,28 +15,14 @@ fn render(block: &CodeBlock) -> String {
 
 #[test]
 fn verbatim_uses_template_literal() {
-    let block = sigil_quote!(TypeScript {
+    let block = sigil_quote!(JavaScript {
         const msg = $V("Hello, ${name}!")
     })
     .unwrap();
     let output = render(&block);
     assert!(
         output.contains("`Hello, ${name}!`"),
-        "Expected template literal with interpolation, got:\n{output}"
-    );
-}
-
-#[test]
-fn verbatim_escapes_backtick() {
-    let block = sigil_quote!(TypeScript {
-        const msg = $V("use \\` for templates")
-    })
-    .unwrap();
-    let output = render(&block);
-    // Input: "use \` for templates" → escapes \ to \\ and ` to \`
-    assert!(
-        output.contains("`use \\\\\\` for templates`"),
-        "Expected escaped backtick in template literal, got:\n{output}"
+        "Expected template literal, got:\n{output}"
     );
 }
 
@@ -45,7 +31,7 @@ fn verbatim_escapes_backtick() {
 #[test]
 fn verbatim_at_interpolation_simple() {
     let greeting = "Hello";
-    let block = sigil_quote!(TypeScript {
+    let block = sigil_quote!(JavaScript {
         const msg = $V("@{greeting}, ${name}!")
     })
     .unwrap();
@@ -55,10 +41,10 @@ fn verbatim_at_interpolation_simple() {
 
 #[test]
 fn verbatim_at_interpolation_multiple() {
-    let base_url = "https://api.example.com";
-    let version = "v2";
-    let block = sigil_quote!(TypeScript {
-        const url = $V("@{base_url}/@{version}/${endpoint}")
+    let base = "https://api.example.com";
+    let ver = "v2";
+    let block = sigil_quote!(JavaScript {
+        const url = $V("@{base}/@{ver}/${endpoint}")
     })
     .unwrap();
     let output = render(&block);
@@ -70,7 +56,7 @@ fn verbatim_at_interpolation_multiple() {
 
 #[test]
 fn verbatim_at_escape() {
-    let block = sigil_quote!(TypeScript {
+    let block = sigil_quote!(JavaScript {
         const email = $V("user@@example.com")
     })
     .unwrap();
@@ -80,11 +66,11 @@ fn verbatim_at_escape() {
 
 #[test]
 fn verbatim_at_expr_method_call() {
-    let items = ["a", "b", "c"];
-    let block = sigil_quote!(TypeScript {
-        const msg = $V("total: @{items.len()} items")
+    let items = ["a", "b"];
+    let block = sigil_quote!(JavaScript {
+        const msg = $V("count=@{items.len()}")
     })
     .unwrap();
     let output = render(&block);
-    assert!(output.contains("`total: 3 items`"), "got:\n{output}");
+    assert!(output.contains("`count=2`"), "got:\n{output}");
 }

--- a/tests/kotlin/main.rs
+++ b/tests/kotlin/main.rs
@@ -10,3 +10,4 @@ mod quote_basic;
 mod quote_control_flow;
 mod quote_edge_cases;
 mod quote_imports;
+mod quote_verbatim_string;

--- a/tests/kotlin/quote_verbatim_string.rs
+++ b/tests/kotlin/quote_verbatim_string.rs
@@ -1,0 +1,76 @@
+//! Tests for `$V` verbatim string literal in Kotlin.
+
+use sigil_stitch::code_block::CodeBlock;
+use sigil_stitch::prelude::*;
+use sigil_stitch::spec::file_spec::FileSpec;
+
+fn render(block: &CodeBlock) -> String {
+    FileSpec::builder("test.kt")
+        .add_code(block.clone())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap()
+}
+
+#[test]
+fn verbatim_preserves_dollar_interpolation() {
+    let block = sigil_quote!(Kotlin {
+        val msg = $V("Hello, ${name}!")
+    })
+    .unwrap();
+    let output = render(&block);
+    assert!(
+        output.contains("\"Hello, ${name}!\""),
+        "Expected Kotlin string interpolation preserved, got:\n{output}"
+    );
+}
+
+// ── @{expr} interpolation ────────────────────────────────
+
+#[test]
+fn verbatim_at_interpolation_simple() {
+    let greeting = "Hi";
+    let block = sigil_quote!(Kotlin {
+        val msg = $V("@{greeting}, ${name}!")
+    })
+    .unwrap();
+    let output = render(&block);
+    assert!(output.contains("\"Hi, ${name}!\""), "got:\n{output}");
+}
+
+#[test]
+fn verbatim_at_interpolation_multiple() {
+    let base = "com.example";
+    let module = "auth";
+    let block = sigil_quote!(Kotlin {
+        val pkg = $V("@{base}.@{module}")
+    })
+    .unwrap();
+    let output = render(&block);
+    assert!(output.contains("\"com.example.auth\""), "got:\n{output}");
+}
+
+#[test]
+fn verbatim_at_escape() {
+    let block = sigil_quote!(Kotlin {
+        val email = $V("user@@host.com")
+    })
+    .unwrap();
+    let output = render(&block);
+    assert!(output.contains("\"user@host.com\""), "got:\n{output}");
+}
+
+#[test]
+fn verbatim_at_mixed_with_kotlin_interpolation() {
+    let prefix = "api";
+    let block = sigil_quote!(Kotlin {
+        val url = $V("@{prefix}/${version}/${endpoint}")
+    })
+    .unwrap();
+    let output = render(&block);
+    assert!(
+        output.contains("\"api/${version}/${endpoint}\""),
+        "got:\n{output}"
+    );
+}

--- a/tests/python/main.rs
+++ b/tests/python/main.rs
@@ -10,3 +10,4 @@ mod quote_basic;
 mod quote_control_flow;
 mod quote_edge_cases;
 mod quote_imports;
+mod quote_verbatim_string;

--- a/tests/python/quote_verbatim_string.rs
+++ b/tests/python/quote_verbatim_string.rs
@@ -1,0 +1,76 @@
+//! Tests for `$V` verbatim string literal in Python.
+
+use sigil_stitch::code_block::CodeBlock;
+use sigil_stitch::prelude::*;
+use sigil_stitch::spec::file_spec::FileSpec;
+
+fn render(block: &CodeBlock) -> String {
+    FileSpec::builder("test.py")
+        .add_code(block.clone())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap()
+}
+
+#[test]
+fn verbatim_uses_fstring() {
+    let block = sigil_quote!(Python {
+        msg = $V("{name} is {age} years old")
+    })
+    .unwrap();
+    let output = render(&block);
+    assert!(
+        output.contains("f\"{name} is {age} years old\""),
+        "Expected f-string, got:\n{output}"
+    );
+}
+
+// ── @{expr} interpolation ────────────────────────────────
+
+#[test]
+fn verbatim_at_interpolation_simple() {
+    let module = "auth";
+    let block = sigil_quote!(Python {
+        msg = $V("@{module}: {user} logged in")
+    })
+    .unwrap();
+    let output = render(&block);
+    assert!(
+        output.contains("f\"auth: {user} logged in\""),
+        "got:\n{output}"
+    );
+}
+
+#[test]
+fn verbatim_at_interpolation_multiple() {
+    let prefix = "api";
+    let version = "v2";
+    let block = sigil_quote!(Python {
+        url = $V("@{prefix}/@{version}/{endpoint}")
+    })
+    .unwrap();
+    let output = render(&block);
+    assert!(output.contains("f\"api/v2/{endpoint}\""), "got:\n{output}");
+}
+
+#[test]
+fn verbatim_at_escape() {
+    let block = sigil_quote!(Python {
+        email = $V("user@@example.com")
+    })
+    .unwrap();
+    let output = render(&block);
+    assert!(output.contains("f\"user@example.com\""), "got:\n{output}");
+}
+
+#[test]
+fn verbatim_at_expr_method_call() {
+    let items = ["a", "b", "c"];
+    let block = sigil_quote!(Python {
+        msg = $V("total=@{items.len()}")
+    })
+    .unwrap();
+    let output = render(&block);
+    assert!(output.contains("f\"total=3\""), "got:\n{output}");
+}

--- a/tests/scala/main.rs
+++ b/tests/scala/main.rs
@@ -10,3 +10,4 @@ mod quote_basic;
 mod quote_control_flow;
 mod quote_edge_cases;
 mod quote_imports;
+mod quote_verbatim_string;

--- a/tests/scala/quote_verbatim_string.rs
+++ b/tests/scala/quote_verbatim_string.rs
@@ -1,0 +1,62 @@
+//! Tests for `$V` verbatim string literal in Scala.
+
+use sigil_stitch::code_block::CodeBlock;
+use sigil_stitch::prelude::*;
+use sigil_stitch::spec::file_spec::FileSpec;
+
+fn render(block: &CodeBlock) -> String {
+    FileSpec::builder("test.scala")
+        .add_code(block.clone())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap()
+}
+
+#[test]
+fn verbatim_uses_s_string() {
+    let block = sigil_quote!(Scala {
+        val msg = $V("Hello, ${name}!")
+    })
+    .unwrap();
+    let output = render(&block);
+    assert!(
+        output.contains("s\"Hello, ${name}!\""),
+        "Expected s-string interpolation, got:\n{output}"
+    );
+}
+
+// ── @{expr} interpolation ────────────────────────────────
+
+#[test]
+fn verbatim_at_interpolation_simple() {
+    let greeting = "Hi";
+    let block = sigil_quote!(Scala {
+        val msg = $V("@{greeting}, ${name}!")
+    })
+    .unwrap();
+    let output = render(&block);
+    assert!(output.contains("s\"Hi, ${name}!\""), "got:\n{output}");
+}
+
+#[test]
+fn verbatim_at_interpolation_multiple() {
+    let base = "com.example";
+    let module = "auth";
+    let block = sigil_quote!(Scala {
+        val pkg = $V("@{base}.@{module}")
+    })
+    .unwrap();
+    let output = render(&block);
+    assert!(output.contains("s\"com.example.auth\""), "got:\n{output}");
+}
+
+#[test]
+fn verbatim_at_escape() {
+    let block = sigil_quote!(Scala {
+        val email = $V("user@@host.com")
+    })
+    .unwrap();
+    let output = render(&block);
+    assert!(output.contains("s\"user@host.com\""), "got:\n{output}");
+}

--- a/tests/swift/main.rs
+++ b/tests/swift/main.rs
@@ -10,3 +10,4 @@ mod quote_basic;
 mod quote_control_flow;
 mod quote_edge_cases;
 mod quote_imports;
+mod quote_verbatim_string;

--- a/tests/swift/quote_verbatim_string.rs
+++ b/tests/swift/quote_verbatim_string.rs
@@ -1,0 +1,80 @@
+//! Tests for `$V` verbatim string literal in Swift.
+//!
+//! Swift's `render_verbatim_string` escapes `\` and `"` — this means `\(name)`
+//! becomes `\\(name)` in the output (not working Swift interpolation).
+//! Use `$V` in Swift for strings where you want minimal escaping but don't need
+//! the interpolation sigil preserved.
+
+use sigil_stitch::code_block::CodeBlock;
+use sigil_stitch::prelude::*;
+use sigil_stitch::spec::file_spec::FileSpec;
+
+fn render(block: &CodeBlock) -> String {
+    FileSpec::builder("test.swift")
+        .add_code(block.clone())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap()
+}
+
+#[test]
+fn verbatim_escapes_backslash() {
+    let block = sigil_quote!(Swift {
+        let msg = $V("Hello, \\(name)!")
+    })
+    .unwrap();
+    let output = render(&block);
+    // Swift render_verbatim_string escapes \ to \\, so \(name) becomes \\(name)
+    assert!(
+        output.contains("\"Hello, \\\\(name)!\""),
+        "Expected backslash to be escaped, got:\n{output}"
+    );
+}
+
+// ── @{expr} interpolation ────────────────────────────────
+
+#[test]
+fn verbatim_at_interpolation_simple() {
+    let greeting = "Hi";
+    let block = sigil_quote!(Swift {
+        let msg = $V("@{greeting} there")
+    })
+    .unwrap();
+    let output = render(&block);
+    assert!(output.contains("\"Hi there\""), "got:\n{output}");
+}
+
+#[test]
+fn verbatim_at_interpolation_multiple() {
+    let base = "com.example";
+    let module = "auth";
+    let block = sigil_quote!(Swift {
+        let pkg = $V("@{base}.@{module}")
+    })
+    .unwrap();
+    let output = render(&block);
+    assert!(output.contains("\"com.example.auth\""), "got:\n{output}");
+}
+
+#[test]
+fn verbatim_at_escape() {
+    let block = sigil_quote!(Swift {
+        let email = $V("user@@host.com")
+    })
+    .unwrap();
+    let output = render(&block);
+    assert!(output.contains("\"user@host.com\""), "got:\n{output}");
+}
+
+#[test]
+fn verbatim_at_mixed_with_backslash() {
+    let greeting = "Hi";
+    let block = sigil_quote!(Swift {
+        let msg = $V("@{greeting}, \\(name)!")
+    })
+    .unwrap();
+    let output = render(&block);
+    // @{greeting} resolves to "Hi", then \(name) gets backslash-escaped by Swift renderer
+    assert!(output.contains("\"Hi, \\\\(name)!\""), "got:\n{output}");
+}

--- a/tests/zsh/quote_verbatim_string.rs
+++ b/tests/zsh/quote_verbatim_string.rs
@@ -126,3 +126,60 @@ fn verbatim_with_explicit_quotes() {
         "Expected user-provided quotes for assignment, got:\n{output}"
     );
 }
+
+// ── @{expr} interpolation ────────────────────────────────
+
+#[test]
+fn verbatim_at_interpolation_simple() {
+    let name = "world";
+    let block = sigil_quote!(Zsh {
+        echo $V("Hello @{name}")
+    })
+    .unwrap();
+    let output = render(&block);
+    assert!(output.contains("echo Hello world"), "got:\n{output}");
+}
+
+#[test]
+fn verbatim_at_interpolation_multiple() {
+    let registry = "ghcr.io";
+    let tag = "latest";
+    let block = sigil_quote!(Zsh {
+        docker push $V("@{registry}/myapp:@{tag}")
+    })
+    .unwrap();
+    let output = render(&block);
+    assert!(output.contains("ghcr.io/myapp:latest"), "got:\n{output}");
+}
+
+#[test]
+fn verbatim_at_escape() {
+    let block = sigil_quote!(Zsh {
+        echo $V("user@@host")
+    })
+    .unwrap();
+    let output = render(&block);
+    assert!(output.contains("echo user@host"), "got:\n{output}");
+}
+
+#[test]
+fn verbatim_at_with_shell_vars() {
+    let prefix = "/opt";
+    let block = sigil_quote!(Zsh {
+        echo $V("@{prefix}/$USER/bin")
+    })
+    .unwrap();
+    let output = render(&block);
+    assert!(output.contains("echo /opt/$USER/bin"), "got:\n{output}");
+}
+
+#[test]
+fn verbatim_at_with_zsh_flags() {
+    let var = "USERNAME";
+    let block = sigil_quote!(Zsh {
+        echo $V("${(L)@{var}}")
+    })
+    .unwrap();
+    let output = render(&block);
+    assert!(output.contains("echo ${(L)USERNAME}"), "got:\n{output}");
+}


### PR DESCRIPTION
## Summary

Adds `@{expr}` syntax for compile-time Rust expression interpolation inside `$V` string literals. This lets you mix Rust values with target-language runtime interpolation in a single string:

```rust
let registry = "ghcr.io";
let tag = "latest";
sigil_quote!(Bash {
    docker push $V("@{registry}/myapp:@{tag} --target=$ARCH")
})
// Output: docker push ghcr.io/myapp:latest --target=$ARCH
```

## Design

- `@{expr}` — evaluated at compile time, spliced into the verbatim output
- `@@` — emits a literal `@`
- Bare `@` (not followed by `{`) — passes through unchanged
- Non-literal expressions (`$V(my_var)`) — `@{...}` processing is skipped, expression used as-is

The macro transforms `$V("@{x}/path")` into `format!("{}/path", x)` wrapped in `VerbatimStrArg`. This is purely a macro-level feature — works identically across all languages.

## Changes

- **New**: `macros/src/parse/verbatim_interpolation.rs` — scanner with brace-depth tracking, unit tests
- **Modified**: `macros/src/codegen.rs` — detect string literals in `$V`, transform to `format!()` when `@{...}` present
- **Tests**: integration tests for all 12 languages (Bash, Zsh, TypeScript, JavaScript, Python, Kotlin, Swift, Scala, Dart, C#, Java, Go)
- **Docs**: updated `format_specifiers.md`, `cookbook_shell.md`, `sigil_quote.md`

## Testing

- 1701 tests pass, 0 failures
- clippy clean (`-D warnings`)
- `cargo fmt` clean