### PR TITLE
fix: allow $C_each inside method shorthand bodies

### DIFF
--- a/macros/src/parse/statements.rs
+++ b/macros/src/parse/statements.rs
@@ -122,7 +122,15 @@ pub(super) fn parse_one_statement(
                 let has_paren_group = collected.iter().any(
                     |t| matches!(t, TokenTree::Group(g) if g.delimiter() == Delimiter::Parenthesis),
                 );
-                if !last_is_eq || !has_paren_group || !should_be_block(g) {
+                // Another exception: `foo() { $... }` where a paren group precedes
+                // the brace (method shorthand / function declaration) and the body
+                // contains sigil-stitch markers (`$C_each`, `$if`, `$S`, etc.).
+                // Without this, `foo() { $C_each(items); }` is misclassified as a
+                // function call with an object-literal argument.
+                let body_has_meta = has_meta_marker(g);
+                let is_function_body = last_is_eq && has_paren_group && should_be_block(g);
+                let is_method_with_meta = has_paren_group && body_has_meta;
+                if !is_function_body && !is_method_with_meta {
                     // Treat as a literal brace group — not control flow.
                     collected.push(tt.clone());
                     prev_end_line = Some(tt.span().end().line);
@@ -255,6 +263,22 @@ fn looks_like_control_flow_header(tokens: &[TokenTree]) -> bool {
     // Default: assume control flow — backward compatible with brace languages
     // where `{` at statement level always denotes a block.
     true
+}
+
+/// Check if a brace group contains any `$` sigil at the top level,
+/// indicating it's code using sigil-stitch markers (not an object literal).
+/// Used to disambiguate `foo() { $C_each(...) }` (method body) from
+/// `func({ key: value })` (call with object-literal argument).
+fn has_meta_marker(g: &proc_macro2::Group) -> bool {
+    let stream: Vec<TokenTree> = g.stream().into_iter().collect();
+    for tt in &stream {
+        match tt {
+            TokenTree::Punct(p) if p.as_char() == '$' => return true,
+            TokenTree::Group(g) if has_meta_marker(g) => return true,
+            _ => {}
+        }
+    }
+    false
 }
 
 /// Determine if a brace group contains multiple statements (semicolons)

--- a/tests/macro/c_each.rs
+++ b/tests/macro/c_each.rs
@@ -398,3 +398,64 @@ fn test_c_each_golden() {
     let output = render_ts(&block);
     golden::assert_golden("macro/quote_c_each.txt", &output);
 }
+
+// ── $C_each inside function bodies ───────────────────────
+
+#[test]
+fn test_c_each_inside_export_function() {
+    let params = vec![
+        CodeBlock::of("name: string", ()).unwrap(),
+        CodeBlock::of("age: number", ()).unwrap(),
+    ];
+
+    let block = sigil_quote!(TypeScript {
+        export function foo() {
+            $C_each(params);
+        }
+    })
+    .unwrap();
+
+    let output = render_ts(&block);
+    assert!(output.contains("export function foo()"), "got:\n{output}");
+    assert!(output.contains("name: string"), "got:\n{output}");
+    assert!(output.contains("age: number"), "got:\n{output}");
+}
+
+#[test]
+fn test_c_each_inside_method_shorthand() {
+    let params = vec![
+        CodeBlock::of("name: string", ()).unwrap(),
+        CodeBlock::of("age: number", ()).unwrap(),
+    ];
+
+    let block = sigil_quote!(TypeScript {
+        class MyClass {
+            foo() {
+                $C_each(params);
+            }
+        }
+    })
+    .unwrap();
+
+    let output = render_ts(&block);
+    assert!(output.contains("class MyClass"), "got:\n{output}");
+    assert!(output.contains("foo()"), "got:\n{output}");
+    assert!(output.contains("name: string"), "got:\n{output}");
+    assert!(output.contains("age: number"), "got:\n{output}");
+}
+
+#[test]
+fn test_c_each_inside_plain_function() {
+    let params = vec![CodeBlock::of("x = 1", ()).unwrap()];
+
+    let block = sigil_quote!(TypeScript {
+        function bar() {
+            $C_each(params);
+        }
+    })
+    .unwrap();
+
+    let output = render_ts(&block);
+    assert!(output.contains("function bar()"), "got:\n{output}");
+    assert!(output.contains("x = 1"), "got:\n{output}");
+}


### PR DESCRIPTION
## Summary

Fixes `$C_each` failing with `$C_each() must appear at the start of a line` when used inside method shorthand bodies like `foo() { $C_each(params); }`.

## Root cause

`looks_like_control_flow_header` classifies `foo()` (n=2, non-keyword ident before `{`) as a literal brace group — treating the body as an object literal argument rather than a method body. This causes the recursive `parse_body` to never run, so `$C_each` is seen by the format-string processor which rejects it.

## Fix

Added `has_meta_marker()` helper that scans a brace group for `$` sigils. When a paren group precedes the brace AND the body contains sigil-stitch markers, treat it as control flow. This disambiguates `foo() { $C_each(items); }` (method body) from `func({ key: value })` (call with object-literal argument).

## Tests added

- `export function foo() { $C_each(params); }` — already worked, added test
- `function bar() { $C_each(params); }` — already worked, added test
- `class MyClass { foo() { $C_each(params); } }` — previously broken, now fixed

All existing tests pass (0 regressions).