### PR TITLE
feat: add @{expr} interpolation support to $L strings

### DIFF
--- a/macros/src/codegen.rs
+++ b/macros/src/codegen.rs
@@ -139,10 +139,30 @@ fn build_args_tuple(args: &[TypedArg]) -> TokenStream {
             .map(|arg| {
                 let expr = &arg.expr;
                 match arg.kind {
-                    InterpolationKind::Type
-                    | InterpolationKind::Literal
-                    | InterpolationKind::Code => {
+                    InterpolationKind::Type | InterpolationKind::Code => {
                         quote! { #expr }
+                    }
+                    InterpolationKind::Literal => {
+                        match extract_at_interpolation(expr) {
+                            Some(VerbatimResult::Interpolated {
+                                format_string,
+                                expressions,
+                            }) => {
+                                let fmt_lit = Literal::string(&format_string);
+                                let exprs: Vec<TokenStream> = expressions
+                                    .iter()
+                                    .map(|e| e.parse::<TokenStream>().unwrap())
+                                    .collect();
+                                quote! { ::std::format!(#fmt_lit, #(#exprs),*) }
+                            }
+                            Some(VerbatimResult::Literal(s)) => {
+                                let lit = Literal::string(&s);
+                                quote! { ::std::string::String::from(#lit) }
+                            }
+                            _ => {
+                                quote! { #expr }
+                            }
+                        }
                     }
                     InterpolationKind::Name => {
                         quote! { ::sigil_stitch::code_block::NameArg((#expr).to_string()) }
@@ -151,7 +171,7 @@ fn build_args_tuple(args: &[TypedArg]) -> TokenStream {
                         quote! { ::sigil_stitch::code_block::StringLitArg((#expr).to_string()) }
                     }
                     InterpolationKind::VerbatimStr => {
-                        match extract_verbatim_interpolation(expr) {
+                        match extract_at_interpolation(expr) {
                             Some(VerbatimResult::Interpolated {
                                 format_string,
                                 expressions,
@@ -223,11 +243,11 @@ fn generate_meta_if(branches: &[MetaBranch]) -> TokenStream {
     result
 }
 
-/// Try to extract a string literal from a token stream and parse `@{expr}` interpolations.
+/// Try to extract a string literal from a token stream and parse `@{expr}` interpolation.
 ///
-/// Returns `None` if the expression is not a single string literal (e.g. a variable or
-/// function call), in which case the expression is used as-is.
-fn extract_verbatim_interpolation(expr: &TokenStream) -> Option<VerbatimResult> {
+/// Used by both `$V` (verbatim) and `$L` (literal). Returns `None` if the expression
+/// is not a single string literal, in which case the expression is used as-is.
+fn extract_at_interpolation(expr: &TokenStream) -> Option<VerbatimResult> {
     let tokens: Vec<TokenTree> = expr.clone().into_iter().collect();
     if tokens.len() != 1 {
         return None;

--- a/tests/macro/c_each.rs
+++ b/tests/macro/c_each.rs
@@ -459,3 +459,71 @@ fn test_c_each_inside_plain_function() {
     assert!(output.contains("function bar()"), "got:\n{output}");
     assert!(output.contains("x = 1"), "got:\n{output}");
 }
+
+// ── @{expr} in $L and $V ─────────────────────────────────
+
+#[test]
+fn test_literal_at_interpolation_typescript() {
+    let disc = "foo.bar";
+    let block = sigil_quote!(TypeScript {
+        switch ($L("@{disc}")) {
+            $L("case 1:") {
+                break;
+            }
+        }
+    })
+    .unwrap();
+    let output = render_ts(&block);
+    assert!(output.contains("switch (foo.bar)"), "got:\n{output}");
+}
+
+#[test]
+fn test_literal_at_interpolation_multiple() {
+    let prefix = "data";
+    let suffix = "type";
+    let block = sigil_quote!(TypeScript {
+        const name = $L("@{prefix}_@{suffix}");
+    })
+    .unwrap();
+    let output = render_ts(&block);
+    assert!(output.contains("const name = data_type;"), "got:\n{output}");
+}
+
+#[test]
+fn test_literal_at_escape() {
+    let block = sigil_quote!(TypeScript {
+        const user = $L("admin@@local");
+    })
+    .unwrap();
+    let output = render_ts(&block);
+    assert!(
+        output.contains("const user = admin@local;"),
+        "got:\n{output}"
+    );
+}
+
+#[test]
+fn test_verbatim_at_typescript_no_backticks() {
+    // $V wraps in backticks for TS — but @{expr} resolve first
+    let name = "Alice";
+    let block = sigil_quote!(TypeScript {
+        const greeting = $V("Hello, @{name}");
+    })
+    .unwrap();
+    let output = render_ts(&block);
+    assert!(
+        output.contains("const greeting = `Hello, Alice`;"),
+        "got:\n{output}"
+    );
+}
+
+#[test]
+fn test_literal_no_at_unchanged() {
+    // No @ present — behaves like normal $L
+    let block = sigil_quote!(TypeScript {
+        const x = $L("42");
+    })
+    .unwrap();
+    let output = render_ts(&block);
+    assert!(output.contains("const x = 42;"), "got:\n{output}");
+}


### PR DESCRIPTION
## Summary

`$L` (literal) now supports `@{expr}` compile-time interpolation inside string literals, using the same scanning logic as `$V`. 

## Motivation

`$V` wraps output in language-specific delimiters (backticks for TS/JS, `f"..."` for Python, etc.), making `@{expr}` unusable in contexts that need plain text: type expressions, switch headers, return statements, etc.

```rust
// Before: $V wraps in backticks → broken for type expressions
$V("@{wire_body}")  // → `A | B | C`  (backtick-wrapped, invalid)

// After: $L with @{expr} → plain text, no wrapping
$L("@{wire_body}")  // → A | B | C     (plain, valid)
```

## Changes

- `$L` arm in codegen now calls `extract_at_interpolation` to parse `@{expr}` patterns
- Renamed `extract_verbatim_interpolation` → `extract_at_interpolation` (shared by both `$V` and `$L`)
- 5 new tests

## Test results

```
test result: ok. 1721 passed; 0 failed
```