### PR TITLE
docs: add @{expr} in $L to mdbook, add language tests, bump to 0.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.6.3
+
+### Added
+
+- `@{expr}` compile-time interpolation inside `$L` string literals. Like
+  `$V`, `$L("@{expr}")` resolves Rust expressions at macro expansion time,
+  but emits the result as-is with no wrapping quotes or template delimiters.
+  Suitable for type expressions, switch headers, return statements, and other
+  contexts where language-specific `$V` wrapping is unwanted.
+
 ## 0.6.2
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,7 +100,7 @@ dependencies = [
 
 [[package]]
 name = "sigil-stitch"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "pretty",
  "serde",
@@ -111,7 +111,7 @@ dependencies = [
 
 [[package]]
 name = "sigil-stitch-macros"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["macros"]
 resolver = "3"
 
 [workspace.package]
-version = "0.6.2"
+version = "0.6.3"
 edition = "2024"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"
@@ -35,7 +35,7 @@ exclude = [
 [dependencies]
 pretty = "0.12"
 snafu = "0.9"
-sigil-stitch-macros = { path = "macros", version = "0.6.2" }
+sigil-stitch-macros = { path = "macros", version = "0.6.3" }
 serde = { version = "1", features = ["derive"] }
 
 [dev-dependencies]

--- a/docs/src/format_specifiers.md
+++ b/docs/src/format_specifiers.md
@@ -171,9 +171,9 @@ For Bash/Zsh, `%V` is pure passthrough — the string is emitted as-is with no w
 
 For languages without string interpolation (C, C++, Go, Rust, Java, Haskell, OCaml, Lua), `%V` falls back to `%S` behavior (full escaping).
 
-### `@{expr}` interpolation in `$V`
+### `@{expr}` interpolation in `$V` and `$L`
 
-When using `$V` with a string literal in `sigil_quote!`, you can embed Rust expressions with `@{expr}`. These are evaluated at compile time and spliced into the verbatim output:
+When using `$V` or `$L` with a string literal in `sigil_quote!`, you can embed Rust expressions with `@{expr}`. These are evaluated at compile time and spliced into the output:
 
 ```rust
 # extern crate sigil_stitch;
@@ -185,6 +185,25 @@ let block = sigil_quote!(Bash {
     docker push $V("@{registry}/myapp:@{tag}")
 }).unwrap();
 // Output: docker push ghcr.io/myapp:latest
+# }
+```
+
+Use `$V` when you want the result wrapped in the target language's string delimiter (backticks for JS/TS, `f"..."` for Python, etc.). Use `$L` when you need plain unwrapped output — type expressions, switch headers, return statements, and other non-string-literal contexts:
+
+```rust
+# extern crate sigil_stitch;
+# use sigil_stitch::prelude::*;
+# fn main() {
+let disc = "foo.bar";
+let block = sigil_quote!(TypeScript {
+    switch ($L("@{disc}")) {
+        $L("case 1:") {
+            break;
+        }
+    }
+}).unwrap();
+// Output: switch (foo.bar) {
+// (No backticks — $L emits plain text, $V would wrap in `...`)
 # }
 ```
 
@@ -217,9 +236,11 @@ let block = sigil_quote!(Bash {
 # }
 ```
 
-If `$V` receives a non-literal expression (e.g. `$V(my_var)` or `$V(format!(...))`), `@{...}` processing is skipped and the expression is used as-is.
+If the expression is not a string literal (e.g. `$V(my_var)` or `$L(format!(...))`), `@{...}` processing is skipped and the expression is used as-is.
 
 ## `%L` -- Literal
+
+Emits a raw value with no transformation. This is the default for bare `&str` and `String` arguments, so no wrapper is needed. Also accepts `CodeBlock` for embedding nested blocks. Supports `@{expr}` interpolation inside string literals (see above).
 
 Emits a raw value with no transformation. This is the default for bare `&str` and `String` arguments, so no wrapper is needed. Also accepts `CodeBlock` for embedding nested blocks.
 

--- a/docs/src/sigil_quote.md
+++ b/docs/src/sigil_quote.md
@@ -142,7 +142,7 @@ let block = sigil_quote!(Bash {
 
 #### `@{expr}` interpolation
 
-Embed Rust expressions inside `$V` string literals with `@{expr}`. These are resolved at compile time while the rest passes through for the target language's runtime:
+Embed Rust expressions inside `$V` or `$L` string literals with `@{expr}`. These are resolved at compile time while the rest passes through for the target language's runtime:
 
 ```rust
 # extern crate sigil_stitch;
@@ -157,7 +157,9 @@ let block = sigil_quote!(Bash {
 # }
 ```
 
-Use `@@` to emit a literal `@`. Bare `@` not followed by `{` passes through unchanged. Works with all languages that support `$V`.
+Use `$V` when the output should be wrapped in the target language's string delimiter; use `$L` when you need plain unwrapped text (e.g., type expressions, switch headers).
+
+Use `@@` to emit a literal `@`. Bare `@` not followed by `{` passes through unchanged. Works with all languages.
 
 ### Literals (`$L`)
 

--- a/tests/kotlin/quote_verbatim_string.rs
+++ b/tests/kotlin/quote_verbatim_string.rs
@@ -74,3 +74,23 @@ fn verbatim_at_mixed_with_kotlin_interpolation() {
         "got:\n{output}"
     );
 }
+
+// ── $L with @{expr} (plain text, no quotes) ──────────────
+
+#[test]
+fn literal_at_interpolation_kotlin() {
+    let pkg = "com.example.auth";
+    let block = sigil_quote!(Kotlin {
+        val user = $L("@{pkg}.User()");
+    })
+    .unwrap();
+    let output = render(&block);
+    assert!(
+        output.contains("val user = com.example.auth.User()"),
+        "got:\n{output}"
+    );
+    assert!(
+        !output.contains("\"com.example.auth.User()\""),
+        "$L should NOT wrap in quotes, got:\n{output}"
+    );
+}

--- a/tests/python/quote_verbatim_string.rs
+++ b/tests/python/quote_verbatim_string.rs
@@ -74,3 +74,20 @@ fn verbatim_at_expr_method_call() {
     let output = render(&block);
     assert!(output.contains("f\"total=3\""), "got:\n{output}");
 }
+
+// ── $L with @{expr} (plain text, no wrapping) ────────────
+
+#[test]
+fn literal_at_interpolation_python() {
+    let cls = "UserService";
+    let block = sigil_quote!(Python {
+        obj = $L("@{cls}()");
+    })
+    .unwrap();
+    let output = render(&block);
+    assert!(output.contains("obj = UserService()"), "got:\n{output}");
+    assert!(
+        !output.contains("f\""),
+        "$L should NOT produce f-string, got:\n{output}"
+    );
+}

--- a/tests/typescript/quote_verbatim_string.rs
+++ b/tests/typescript/quote_verbatim_string.rs
@@ -88,3 +88,42 @@ fn verbatim_at_expr_method_call() {
     let output = render(&block);
     assert!(output.contains("`total: 3 items`"), "got:\n{output}");
 }
+
+// ── $L with @{expr} (plain text, no backticks) ────────────
+
+#[test]
+fn literal_at_interpolation_plain_text() {
+    let disc = "foo.bar";
+    let block = sigil_quote!(TypeScript {
+        switch ($L("@{disc}")) {
+            $L("case 1:") {
+                break;
+            }
+        }
+    })
+    .unwrap();
+    let output = render(&block);
+    assert!(output.contains("switch (foo.bar)"), "got:\n{output}");
+    assert!(
+        !output.contains("`foo.bar`"),
+        "$L should NOT wrap in backticks, got:\n{output}"
+    );
+}
+
+#[test]
+fn literal_at_vs_verbatim_at_typescript() {
+    let name = "Alice";
+    let block = sigil_quote!(TypeScript {
+        const a = $V("Hello, @{name}");
+        const b = $L("@{name}");
+    })
+    .unwrap();
+    let output = render(&block);
+    // $V wraps in backticks
+    assert!(
+        output.contains("const a = `Hello, Alice`;"),
+        "got:\n{output}"
+    );
+    // $L does NOT wrap
+    assert!(output.contains("const b = Alice;"), "got:\n{output}");
+}


### PR DESCRIPTION
## Summary

Follow-up to PR #121: adds mdbook documentation, language-specific tests, and the 0.6.3 version bump.

## Changes

- **Docs**: Update `format_specifiers.md` and `sigil_quote.md` to document `$L` `@{expr}` support
- **Tests**: Add `$L` @{expr} tests for TypeScript (plain vs backtick comparison), Kotlin, Python
- **Version**: Bump to 0.6.3