### PR TITLE
fix: allow $C_each inside object literals after $N(...) =

### DIFF
--- a/macros/src/parse/brace_classifier.rs
+++ b/macros/src/parse/brace_classifier.rs
@@ -39,19 +39,32 @@ pub(super) fn classify(prefix_tokens: &[TokenTree], group: &proc_macro2::Group) 
     let last_is_eq = prefix_tokens
         .last()
         .is_some_and(|t| matches!(t, TokenTree::Punct(p) if p.as_char() == '='));
-    let has_paren_group = prefix_tokens
-        .iter()
-        .any(|t| matches!(t, TokenTree::Group(g) if g.delimiter() == Delimiter::Parenthesis));
+    let has_paren_group = prefix_tokens.iter().enumerate().any(|(i, t)| {
+        if matches!(t, TokenTree::Group(g) if g.delimiter() == Delimiter::Parenthesis) {
+            // Exclude paren groups that belong to sigil-stitch interpolation
+            // markers ($N(...), $V(...), $C_each(...), etc.). These are NOT
+            // function-signature parens; they only appear as interpolation args.
+            // Pattern: Punct('$'), Ident(_), Group(Paren)
+            !is_interpolation_paren(prefix_tokens, i)
+        } else {
+            false
+        }
+    });
 
     // Exception: `foo() { $... }` where a paren group precedes the brace
     // (method shorthand / function declaration) and the body contains
     // sigil-stitch markers. Without this, `foo() { $C_each(items); }` is
     // misclassified as a function call with an object-literal argument.
     let body_has_meta = has_meta_marker(group);
+    let body_has_stmt_marker = has_statement_marker(group);
     let is_function_body = last_is_eq && has_paren_group && should_be_block(group);
     let is_method_with_meta = has_paren_group && body_has_meta;
+    // `= { $C_each(...) }` — object literal containing statement-level markers.
+    // Use `has_statement_marker` (not `has_meta_marker`) to avoid triggering on
+    // inline specifiers like `$S("x")` inside Lua table constructors.
+    let is_eq_object_with_stmt = last_is_eq && body_has_stmt_marker;
 
-    if is_function_body || is_method_with_meta {
+    if is_function_body || is_method_with_meta || is_eq_object_with_stmt {
         BraceKind::ControlFlow
     } else {
         BraceKind::Literal
@@ -134,6 +147,42 @@ pub(super) fn looks_like_control_flow_header(tokens: &[TokenTree]) -> bool {
     // Default: assume control flow — backward compatible with brace languages
     // where `{` at statement level always denotes a block.
     true
+}
+
+/// Check whether the paren group at `pos` in `tokens` is part of a
+/// sigil-stitch interpolation marker (pattern: `$Ident(...)`).
+fn is_interpolation_paren(tokens: &[TokenTree], pos: usize) -> bool {
+    if pos < 2 {
+        return false;
+    }
+    matches!(&tokens[pos - 2], TokenTree::Punct(p) if p.as_char() == '$')
+        && matches!(&tokens[pos - 1], TokenTree::Ident(_))
+}
+
+/// Check if a brace group contains a statement-level sigil marker
+/// (`$C_each`, `$for`, `$if`, `$let`) that requires a control-flow context.
+/// Unlike `has_meta_marker`, this skips inline specifiers (`$S`, `$V`, `$L`,
+/// `$N`, `$T`, `$join`) which work fine inside literal brace groups.
+fn has_statement_marker(g: &proc_macro2::Group) -> bool {
+    let stream: Vec<TokenTree> = g.stream().into_iter().collect();
+    let mut i = 0;
+    while i < stream.len() {
+        if i + 1 < stream.len()
+            && let TokenTree::Punct(p) = &stream[i]
+            && p.as_char() == '$'
+            && let TokenTree::Ident(id) = &stream[i + 1]
+        {
+            let s = id.to_string();
+            if matches!(
+                s.as_str(),
+                "C_each" | "for" | "if" | "else_if" | "else" | "let"
+            ) {
+                return true;
+            }
+        }
+        i += 1;
+    }
+    false
 }
 
 /// Check if a brace group contains any `$` sigil at the top level,

--- a/tests/macro/c_each.rs
+++ b/tests/macro/c_each.rs
@@ -527,3 +527,26 @@ fn test_literal_no_at_unchanged() {
     let output = render_ts(&block);
     assert!(output.contains("const x = 42;"), "got:\n{output}");
 }
+
+// ── $C_each inside object literal after $N assignment ─────
+
+#[test]
+fn test_c_each_inside_object_literal_with_name_interp() {
+    let entries = vec![
+        CodeBlock::of("name: \"Alice\",", ()).unwrap(),
+        CodeBlock::of("age: 30,", ()).unwrap(),
+    ];
+    let name = "config";
+
+    let block = sigil_quote!(TypeScript {
+        export const $N(name) = {
+            $C_each(entries);
+        }
+    })
+    .unwrap();
+
+    let output = render_ts(&block);
+    assert!(output.contains("export const config = {"), "got:\n{output}");
+    assert!(output.contains("name: \"Alice\""), "got:\n{output}");
+    assert!(output.contains("age: 30"), "got:\n{output}");
+}


### PR DESCRIPTION
## Summary

Fixes `$C_each` failing with `$C_each() must appear at the start of a line` inside object literal assignments that use `$N(...)`:

```rust
sigil_quote!(TypeScript {
    export const $N(name) = {   // ← $N's paren falsely triggered "function body" detection
        $C_each(entries);       // ← parser saw this inside a "literal" brace → error
    }
})
```

## Root cause

Two bugs in `brace_classifier::classify()`:

1. `has_paren_group` counted `$N(...)`'s paren as a function-signature paren, causing the `= { ... }` pattern to be classified as control flow (then re-classified back to literal, but with `$C_each` already trapped inside).

2. The `=` exception didn't account for object literals containing statement-level markers (`$C_each`, `$for`, etc.) — it only handled function signatures.

## Fix

1. **`is_interpolation_paren()`** — excludes paren groups belonging to sigil-stitch interpolation markers (`$N(...)`, `$V(...)`, etc.) from `has_paren_group`.

2. **`has_statement_marker()`** — narrower than `has_meta_marker()`, only matches `$C_each`, `$for`, `$if`, `$let` (not `$S`, `$V`, `$L` which work fine in literal context). Used for `is_eq_object_with_stmt` to allow `$C_each` inside `= { ... }`.

## Test results

```
test result: ok. 1726 passed; 0 failed
```