### PR TITLE
fix: suppress blank lines after $comment in sigil_quote!

### DIFF
--- a/macros/src/parse/mod.rs
+++ b/macros/src/parse/mod.rs
@@ -94,8 +94,18 @@ pub(super) fn parse_body(
         // Detect blank lines via span-location gaps.
         let current_line = tokens[pos].span().start().line;
         if let Some(pl) = prev_line {
-            for _ in 0..(current_line.saturating_sub(pl).saturating_sub(1)) {
-                statements.push(Statement::BlankLine);
+            let gap = current_line.saturating_sub(pl).saturating_sub(1);
+            if gap > 0 {
+                // Suppress blank lines after comments — doc comments must
+                // attach to the following declaration without a separator.
+                // This mirrors the spec-level behavior where FunSpec/TypeSpec
+                // render doc comments and declarations together.
+                let suppress = matches!(statements.last(), Some(Statement::Comment(_)));
+                if !suppress {
+                    for _ in 0..gap {
+                        statements.push(Statement::BlankLine);
+                    }
+                }
             }
         }
 

--- a/tests/macro/comments.rs
+++ b/tests/macro/comments.rs
@@ -102,3 +102,26 @@ fn test_comment_golden() {
     let output = render_ts(&block);
     golden::assert_golden("macro/quote_comment.txt", &output);
 }
+
+// ── Comment attachment (no blank line after comment) ──────
+
+#[test]
+fn test_comment_attaches_to_declaration_after_blank_line() {
+    // A blank line in the macro body (for readability) should NOT
+    // produce a blank line between the comment and the declaration.
+    let block = sigil_quote!(TypeScript {
+        $comment("Doc comment for Foo")
+
+        const x = 0;
+    })
+    .unwrap();
+
+    let output = render_ts(&block);
+    assert!(output.contains("// Doc comment for Foo"), "got:\n{output}");
+    assert!(output.contains("const x = 0;"), "got:\n{output}");
+    // The comment must attach directly — no blank line
+    assert!(
+        !output.contains("// Doc comment for Foo\n\n"),
+        "blank line should be suppressed after comment, got:\n{output}"
+    );
+}


### PR DESCRIPTION
## Summary

`$comment(...)` followed by a visual blank line (for readability) was producing an unwanted blank line in output, detaching the comment from the following declaration. Doc comments must attach without separator spacing — universal across Go, Rust, Python, TypeScript, etc.

## Fix

In `parse_body`, skip `BlankLine` insertion when the previous statement was a `Comment`. Mirrors spec-layer behavior where `FunSpec`/`TypeSpec` render doc comments inline with declarations.

## Context

`$comment()` is language-aware — uses `line_comment_prefix` and `line_comment_suffix` from `RendererLang`:

| Language | `$comment("text")` output |
|----------|--------------------------|
| TS/JS/Go/Java/Rust/C | `// text` |
| Python/Bash/Zsh | `# text` |
| Haskell/Lua | `-- text` |
| OCaml | `(* text *)` |

## Test results

```
test result: ok. 1727 passed; 0 failed
```