### PR TITLE
feat: add $attr() directive for structural annotations

### DIFF
--- a/macros/src/codegen.rs
+++ b/macros/src/codegen.rs
@@ -46,6 +46,11 @@ fn generate_statements(statements: &[Statement]) -> Vec<TokenStream> {
                     __sigil_builder.add_comment(#text);
                 });
             }
+            Statement::Attr(text) => {
+                calls.push(quote! {
+                    __sigil_builder.add_attribute(#text);
+                });
+            }
             Statement::Statement { format, args } => {
                 let args_tuple = build_args_tuple(args);
                 calls.push(quote! {

--- a/macros/src/parse/mod.rs
+++ b/macros/src/parse/mod.rs
@@ -100,7 +100,10 @@ pub(super) fn parse_body(
                 // attach to the following declaration without a separator.
                 // This mirrors the spec-level behavior where FunSpec/TypeSpec
                 // render doc comments and declarations together.
-                let suppress = matches!(statements.last(), Some(Statement::Comment(_)));
+                let suppress = matches!(
+                    statements.last(),
+                    Some(Statement::Comment(_) | Statement::Attr(_))
+                );
                 if !suppress {
                     for _ in 0..gap {
                         statements.push(Statement::BlankLine);

--- a/macros/src/parse/statements.rs
+++ b/macros/src/parse/statements.rs
@@ -18,6 +18,11 @@ pub(super) fn parse_one_statement(
         return Ok((Statement::Comment(comment_text), next));
     }
 
+    // Check for $attr(...) at current position.
+    if let Some((attr_text, next)) = try_parse_attr(tokens, start)? {
+        return Ok((Statement::Attr(attr_text), next));
+    }
+
     // Check for $> or $< at current position.
     if let Some((stmt, next)) = try_parse_indent_directive(tokens, start) {
         return Ok((stmt, next));
@@ -683,6 +688,67 @@ fn try_parse_comment(
         next += 1;
     }
 
+    Ok(Some((text, next)))
+}
+
+/// Try to parse `$attr("text")` at position `start`.
+fn try_parse_attr(
+    tokens: &[TokenTree],
+    start: usize,
+) -> Result<Option<(String, usize)>, CompileError> {
+    if start + 2 >= tokens.len() {
+        return Ok(None);
+    }
+    let _dollar = match &tokens[start] {
+        TokenTree::Punct(p) if p.as_char() == '$' => p,
+        _ => return Ok(None),
+    };
+    if !is_ident(&tokens[start + 1], "attr") {
+        return Ok(None);
+    }
+    let group = match &tokens[start + 2] {
+        TokenTree::Group(g) if g.delimiter() == Delimiter::Parenthesis => g,
+        _ => {
+            return Err(CompileError::new(
+                tokens[start + 2].span(),
+                "$attr requires parenthesized string: $attr(\"text\")",
+            ));
+        }
+    };
+    let inner: Vec<TokenTree> = group.stream().into_iter().collect();
+    if inner.len() != 1 {
+        return Err(CompileError::new(
+            group.span(),
+            "$attr requires a single string literal: $attr(\"text\")",
+        ));
+    }
+    let text = match &inner[0] {
+        TokenTree::Literal(lit) => {
+            let s = lit.to_string();
+            if s.starts_with('"') && s.ends_with('"') && s.len() >= 2 {
+                let raw = &s[1..s.len() - 1];
+                match unescape_string(raw) {
+                    Ok(text) => text,
+                    Err(msg) => return Err(CompileError::new(lit.span(), &msg)),
+                }
+            } else {
+                return Err(CompileError::new(
+                    lit.span(),
+                    "$attr requires a string literal",
+                ));
+            }
+        }
+        _ => {
+            return Err(CompileError::new(
+                inner[0].span(),
+                "$attr requires a string literal",
+            ));
+        }
+    };
+    let mut next = start + 3;
+    if next < tokens.len() && is_semicolon(&tokens[next]) {
+        next += 1;
+    }
     Ok(Some((text, next)))
 }
 

--- a/macros/src/parse/statements_tests.rs
+++ b/macros/src/parse/statements_tests.rs
@@ -147,6 +147,7 @@ fn stmt_kind(s: &Statement) -> &'static str {
         Statement::Line { .. } => "Line",
         Statement::BlankLine => "BlankLine",
         Statement::Comment(_) => "Comment",
+        Statement::Attr(_) => "Attr",
         Statement::ControlFlow { .. } => "ControlFlow",
         Statement::Indent => "Indent",
         Statement::Dedent => "Dedent",

--- a/macros/src/parse/types.rs
+++ b/macros/src/parse/types.rs
@@ -45,6 +45,10 @@ pub(crate) enum Statement {
     BlankLine,
     /// `add_comment(text)` — `$comment("text")`.
     Comment(String),
+    /// `add_attribute(text)` — `$attr("text")`. Language-aware attribute/annotation
+    /// that renders with the target language's prefix/suffix (Rust: #[...],
+    /// Java/Python: @..., C++: [[...]]).
+    Attr(String),
     /// Control flow: `begin_control_flow` / `next_control_flow` / `end_control_flow`.
     ControlFlow { branches: Vec<Branch> },
     /// `add("%>", ())` — increase indent.

--- a/src/code_block.rs
+++ b/src/code_block.rs
@@ -368,6 +368,16 @@ impl CodeBlockBuilder {
         self
     }
 
+    /// Add a language-aware attribute / annotation.
+    ///
+    /// Rendered with the language's annotation prefix and suffix
+    /// (Rust: `#[text]`, Java/Python: `@text`, C++: `[[text]]`).
+    pub fn add_attribute(&mut self, text: &str) -> &mut Self {
+        self.nodes.push(CodeNode::Attribute(text.to_string()));
+        self.nodes.push(CodeNode::Newline);
+        self
+    }
+
     /// Add a nested CodeBlock inline.
     pub fn add_code(&mut self, block: CodeBlock) -> &mut Self {
         self.nodes.push(CodeNode::Nested(block));

--- a/src/code_node.rs
+++ b/src/code_node.rs
@@ -34,6 +34,9 @@ pub enum CodeNode {
     /// A comment line. Rendered as `{prefix} {text}{suffix}` using the
     /// language's comment syntax.
     Comment(String),
+    /// An attribute / annotation line. Rendered with the language's annotation
+    /// prefix and suffix (Rust: `#[text]`, Java/Python: `@text`, C++: `[[text]]`).
+    Attribute(String),
     /// Soft line break point (`%W`). In direct mode emits a space; in pretty
     /// mode becomes `BoxDoc::softline()`.
     SoftBreak,

--- a/src/code_renderer.rs
+++ b/src/code_renderer.rs
@@ -142,6 +142,11 @@ impl<'a> CodeRenderer<'a> {
                     let comment = Self::resolve_comment(self.lang, text);
                     self.emit(&comment);
                 }
+                CodeNode::Attribute(text) => {
+                    self.ensure_indent();
+                    let attr = self.lang.render_attribute(text);
+                    self.emit(&attr);
+                }
                 CodeNode::SoftBreak => {
                     self.emit(" ");
                 }
@@ -233,6 +238,7 @@ impl<'a> CodeRenderer<'a> {
                 CodeNode::InlineLiteral(s) => BoxDoc::text(s.clone()),
                 CodeNode::Nested(block) => self.nodes_to_doc(&block.nodes),
                 CodeNode::Comment(text) => BoxDoc::text(Self::resolve_comment(self.lang, text)),
+                CodeNode::Attribute(text) => BoxDoc::text(self.lang.render_attribute(text)),
                 CodeNode::SoftBreak => BoxDoc::softline(),
                 CodeNode::Indent | CodeNode::Dedent => BoxDoc::nil(),
                 CodeNode::StatementBegin => BoxDoc::nil(),

--- a/src/lang/cpp_lang.rs
+++ b/src/lang/cpp_lang.rs
@@ -176,6 +176,10 @@ impl RendererLang for CppLang {
         "//"
     }
 
+    fn render_attribute(&self, text: &str) -> String {
+        format!("[[{text}]]")
+    }
+
     fn type_presentation(&self) -> crate::lang::config::TypePresentationConfig<'_> {
         crate::lang::config::TypePresentationConfig {
             array: crate::type_name::TypePresentation::GenericWrap {

--- a/src/lang/csharp.rs
+++ b/src/lang/csharp.rs
@@ -133,6 +133,10 @@ impl RendererLang for CSharp {
         }
     }
 
+    fn render_attribute(&self, text: &str) -> String {
+        format!("[{text}]")
+    }
+
     fn render_verbatim_string(&self, s: &str) -> String {
         let escaped = s.replace('\\', "\\\\").replace('"', "\\\"");
         format!("$\"{escaped}\"")

--- a/src/lang/mod.rs
+++ b/src/lang/mod.rs
@@ -98,6 +98,14 @@ pub trait RendererLang: std::fmt::Debug + 'static {
         ""
     }
 
+    /// Render an attribute / annotation with language-specific syntax.
+    ///
+    /// Default: `"@{text}"` (Java/Python/Kotlin/TypeScript decorator style).
+    /// Override for Rust (`#[text]`), C++ (`[[text]]`), C# (`[text]`), etc.
+    fn render_attribute(&self, text: &str) -> String {
+        format!("@{text}")
+    }
+
     /// Reserved words that need escaping.
     fn reserved_words(&self) -> &[&str] {
         &[]

--- a/src/lang/rust_lang.rs
+++ b/src/lang/rust_lang.rs
@@ -81,6 +81,10 @@ impl RendererLang for RustLang {
         }
     }
 
+    fn render_attribute(&self, text: &str) -> String {
+        format!("#[{text}]")
+    }
+
     fn module_separator(&self) -> Option<&str> {
         Some("::")
     }

--- a/tests/csharp/quote_verbatim_string.rs
+++ b/tests/csharp/quote_verbatim_string.rs
@@ -60,3 +60,17 @@ fn verbatim_at_escape() {
     let output = render(&block);
     assert!(output.contains("$\"user@host.com\""), "got:\n{output}");
 }
+
+// ── $attr() ──────────────────────────────────────────────
+
+#[test]
+fn attr_bracket_csharp() {
+    let block = sigil_quote!(CSharp {
+        $attr("Serializable")
+
+        public class Foo {}
+    })
+    .unwrap();
+    let output = render(&block);
+    assert!(output.contains("[Serializable]"), "got:\n{output}");
+}

--- a/tests/java/quote_verbatim_string.rs
+++ b/tests/java/quote_verbatim_string.rs
@@ -41,6 +41,22 @@ fn verbatim_at_interpolation_multiple() {
     assert!(output.contains("\"com.example.Main\""), "got:\n{output}");
 }
 
+// ── $attr() ──────────────────────────────────────────────
+
+#[test]
+fn attr_annotation_java() {
+    let block = sigil_quote!(JavaLang {
+        $attr("Override")
+
+        public String toString() {
+            return $S("hello");
+        }
+    })
+    .unwrap();
+    let output = render(&block);
+    assert!(output.contains("@Override"), "got:\n{output}");
+}
+
 #[test]
 fn verbatim_at_escape() {
     let block = sigil_quote!(Java {

--- a/tests/kotlin/quote_verbatim_string.rs
+++ b/tests/kotlin/quote_verbatim_string.rs
@@ -94,3 +94,19 @@ fn literal_at_interpolation_kotlin() {
         "$L should NOT wrap in quotes, got:\n{output}"
     );
 }
+
+// ── $attr() ──────────────────────────────────────────────
+
+#[test]
+fn attr_annotation_kotlin() {
+    let block = sigil_quote!(Kotlin {
+        $attr("Override")
+
+        fun toString(): String {
+            return $S("hello");
+        }
+    })
+    .unwrap();
+    let output = render(&block);
+    assert!(output.contains("@Override"), "got:\n{output}");
+}

--- a/tests/macro/comments.rs
+++ b/tests/macro/comments.rs
@@ -125,3 +125,109 @@ fn test_comment_attaches_to_declaration_after_blank_line() {
         "blank line should be suppressed after comment, got:\n{output}"
     );
 }
+
+// ── $attr() — language-aware attributes ──────────────────
+
+#[test]
+fn test_attr_basic_typescript() {
+    let block = sigil_quote!(TypeScript {
+        $attr("override")
+
+        process(): void {
+            return;
+        }
+    })
+    .unwrap();
+
+    let output = render_ts(&block);
+    assert!(output.contains("@override"), "got:\n{output}");
+    assert!(
+        !output.contains("@override\n\n"),
+        "blank line should be suppressed after attribute, got:\n{output}"
+    );
+}
+
+#[test]
+fn test_attr_basic_rust() {
+    let block = sigil_quote!(RustLang {
+        $attr("derive(Debug, Clone)")
+
+        struct Foo;
+    })
+    .unwrap();
+
+    let output = render_rs(&block);
+    assert!(output.contains("#[derive(Debug, Clone)]"), "got:\n{output}");
+}
+
+#[test]
+fn test_attr_multiple() {
+    let block = sigil_quote!(TypeScript {
+        $attr("injectable()")
+        $attr("singleton()")
+
+        class MyService {}
+    })
+    .unwrap();
+
+    let output = render_ts(&block);
+    assert!(output.contains("@injectable()"), "got:\n{output}");
+    assert!(output.contains("@singleton()"), "got:\n{output}");
+}
+
+#[test]
+fn test_attr_cpp_double_bracket() {
+    let block = sigil_quote!(CppLang {
+        $attr("nodiscard")
+
+        int getValue() {
+            return 42;
+        }
+    })
+    .unwrap();
+
+    let output = render_cpp(&block);
+    assert!(output.contains("[[nodiscard]]"), "got:\n{output}");
+}
+
+#[test]
+fn test_attr_rust_derive() {
+    let block = sigil_quote!(RustLang {
+        $attr("derive(Debug, Clone, Serialize, Deserialize)")
+
+        pub struct $N("User") {
+            name: String,
+        }
+    })
+    .unwrap();
+
+    let output = render_rs(&block);
+    assert!(
+        output.contains("#[derive(Debug, Clone, Serialize, Deserialize)]"),
+        "got:\n{output}"
+    );
+}
+
+#[test]
+fn test_attr_with_if_conditional() {
+    let needs_serde = true;
+    let block = sigil_quote!(RustLang {
+        $attr("derive(Debug, Clone)")
+
+        $if(needs_serde) {
+            $attr("serde(rename_all = \"camelCase\")")
+        }
+
+        struct $N("Config") {
+            name: String,
+        }
+    })
+    .unwrap();
+
+    let output = render_rs(&block);
+    assert!(output.contains("#[derive(Debug, Clone)]"), "got:\n{output}");
+    assert!(
+        output.contains("#[serde(rename_all = \"camelCase\")]"),
+        "got:\n{output}"
+    );
+}

--- a/tests/python/quote_verbatim_string.rs
+++ b/tests/python/quote_verbatim_string.rs
@@ -91,3 +91,22 @@ fn literal_at_interpolation_python() {
         "$L should NOT produce f-string, got:\n{output}"
     );
 }
+
+// ── $attr() ──────────────────────────────────────────────
+
+#[test]
+fn attr_decorator_python() {
+    let block = sigil_quote!(Python {
+        $attr("classmethod")
+
+        def from_dict(cls, data: dict):
+            pass
+    })
+    .unwrap();
+    let output = render(&block);
+    assert!(output.contains("@classmethod"), "got:\n{output}");
+    assert!(
+        !output.contains("@classmethod\n\n"),
+        "blank line should be suppressed, got:\n{output}"
+    );
+}

--- a/tests/typescript/quote_verbatim_string.rs
+++ b/tests/typescript/quote_verbatim_string.rs
@@ -127,3 +127,48 @@ fn literal_at_vs_verbatim_at_typescript() {
     // $L does NOT wrap
     assert!(output.contains("const b = Alice;"), "got:\n{output}");
 }
+
+// ── $attr() ──────────────────────────────────────────────
+
+#[test]
+fn attr_basic_decorator() {
+    let block = sigil_quote!(TypeScript {
+        $attr("injectable()")
+
+        class MyService {}
+    })
+    .unwrap();
+    let output = render(&block);
+    assert!(output.contains("@injectable()"), "got:\n{output}");
+}
+
+#[test]
+fn attr_multiple_decorators() {
+    let block = sigil_quote!(TypeScript {
+        $attr("injectable()")
+        $attr("singleton()")
+
+        class MyService {}
+    })
+    .unwrap();
+    let output = render(&block);
+    assert!(output.contains("@injectable()"), "got:\n{output}");
+    assert!(output.contains("@singleton()"), "got:\n{output}");
+}
+
+#[test]
+fn attr_attaches_without_blank_line() {
+    let block = sigil_quote!(TypeScript {
+        $attr("override")
+
+        process(): void {
+            return;
+        }
+    })
+    .unwrap();
+    let output = render(&block);
+    assert!(
+        !output.contains("@override\n\n"),
+        "blank line should be suppressed, got:\n{output}"
+    );
+}


### PR DESCRIPTION
## Summary

New `$attr("text")` macro directive for language-aware structural annotations. Like `$comment()`, it attaches without blank lines to the following declaration.

```rust
// Before (opaque $L):
$L("#[derive(Debug, Clone, Serialize, Deserialize)]")

// After (structural $attr):
$attr("derive(Debug, Clone, Serialize, Deserialize)")
```

## Rendering per language

| Language | `$attr("text")` output |
|----------|------------------------|
| TypeScript/JS/Python/Java/Kotlin/Swift/Dart/Scala (default) | `@text` |
| Rust | `#[text]` |
| C++ | `[[text]]` |
| C# | `[text]` |

## Implementation

- `Statement::Attr(String)` parsed at proc-macro level
- `CodeNode::Attribute(String)` rendered via new `RendererLang::render_attribute()` method
- Each language overrides the trait method for its syntax
- Blank-line suppression (like `$comment()`) extended to `Attr` statements

## Test results

```
test result: ok. 1740 passed; 0 failed
```