### PR TITLE
feat: add $T_join(sep, iter) for type join with import tracking

### DIFF
--- a/examples/dart_codegen.rs
+++ b/examples/dart_codegen.rs
@@ -2,7 +2,8 @@
 //!
 //! Demonstrates: abstract class with abstract method, class inheritance with
 //! override, enum with simple variants, async function returning `Future<T>`,
-//! generic method with multiple type parameters, and interface with generics.
+//! generic method with multiple type parameters, interface with generics,
+//! and `$T_join` for mixin composition.
 //!
 //! Run: `cargo run --example dart_codegen`
 
@@ -174,6 +175,16 @@ fn builder_approach() -> String {
         .build()
         .unwrap();
 
+    // --- $T_join comparison: manual mixin list ---
+    let mixin1 = TypeName::importable("./mixins", "JsonSerializable");
+    let mixin2 = TypeName::importable("./mixins", "EquatableMixin");
+    let mut join_body = CodeBlock::builder();
+    join_body.add("class User extends BaseModel with ", ());
+    join_body.add("%T", (mixin1,));
+    join_body.add(", ", ());
+    join_body.add("%T", (mixin2,));
+    join_body.add(" {\n  final String name;\n  User(this.name);\n}", ());
+
     FileSpec::builder_with("task.dart", DartLang::new())
         .add_type(status)
         .add_type(base_entity)
@@ -182,6 +193,7 @@ fn builder_approach() -> String {
         .add_function(parse_task)
         .add_function(fetch_task)
         .add_function(transform)
+        .add_code(join_body.build().unwrap())
         .build()
         .unwrap()
         .render(80)
@@ -292,6 +304,19 @@ fn macro_approach() -> String {
         .build()
         .unwrap();
 
+    // --- $T_join: mixin composition with import tracking ---
+    let mixins = vec![
+        TypeName::importable("./mixins", "JsonSerializable"),
+        TypeName::importable("./mixins", "EquatableMixin"),
+    ];
+    let join_body = sigil_quote!(DartLang {
+        class User extends BaseModel with $T_join(", ", &mixins) {
+            final String name;
+            User(this.name);
+        }
+    })
+    .unwrap();
+
     FileSpec::builder_with("task.dart", DartLang::new())
         .add_type(status)
         .add_type(base_entity)
@@ -300,6 +325,7 @@ fn macro_approach() -> String {
         .add_function(parse_task)
         .add_function(fetch_task)
         .add_function(transform)
+        .add_code(join_body)
         .build()
         .unwrap()
         .render(80)

--- a/examples/java_codegen.rs
+++ b/examples/java_codegen.rs
@@ -2,8 +2,8 @@
 //!
 //! Demonstrates: interface with generics, abstract class, enum with constructor-arg
 //! values, static/override methods, constructor delegation (`super()`), wildcard
-//! type bounds (`? extends T`, `? super T`), protected visibility, and
-//! import-tracked annotations.
+//! type bounds (`? extends T`, `? super T`), protected visibility,
+//! import-tracked annotations, and `$T_join` for intersection bounds.
 //!
 //! Run: `cargo run --example java_codegen`
 
@@ -243,12 +243,26 @@ fn builder_approach() -> String {
         .build()
         .unwrap();
 
+    // --- $T_join comparison: manual intersection bounds ---
+    let serializable = TypeName::importable("java.io", "Serializable");
+    let comparable_bound = TypeName::importable("java.lang", "Comparable");
+    let mut join_body = CodeBlock::builder();
+    join_body.add("class Box<T extends ", ());
+    join_body.add("%T", (serializable,));
+    join_body.add(" & ", ());
+    join_body.add("%T", (comparable_bound,));
+    join_body.add(
+        "> {\n    private T value;\n    Box(T value) { this.value = value; }\n}",
+        (),
+    );
+
     FileSpec::builder_with("User.java", JavaLang::new())
         .add_type(priority_enum)
         .add_type(repo_iface)
         .add_type(base_entity)
         .add_type(user_cls)
         .add_function(sort_fn)
+        .add_code(join_body.build().unwrap())
         .build()
         .unwrap()
         .render(80)
@@ -386,12 +400,26 @@ fn macro_approach() -> String {
         .build()
         .unwrap();
 
+    // --- $T_join: intersection bounds with import tracking ---
+    let bounds = vec![
+        TypeName::importable("java.io", "Serializable"),
+        TypeName::importable("java.lang", "Comparable"),
+    ];
+    let join_body = sigil_quote!(JavaLang {
+        class Box<T extends $T_join(" & ", &bounds)> {
+            private T value;
+            Box(T value) { this.value = value; }
+        }
+    })
+    .unwrap();
+
     FileSpec::builder_with("User.java", JavaLang::new())
         .add_type(priority_enum)
         .add_type(repo_iface)
         .add_type(base_entity)
         .add_type(user_cls)
         .add_function(sort_fn)
+        .add_code(join_body)
         .build()
         .unwrap()
         .render(80)

--- a/examples/macro_features.rs
+++ b/examples/macro_features.rs
@@ -235,4 +235,22 @@ fn else_if_chain() {
 
     println!("With env = \"staging\":");
     println!("{}", render_ts(&block));
+
+    // ── $T_join — type join with import tracking ──────────
+    println!();
+    println!("--- $T_join: Type Union with Import Tracking ---");
+    println!();
+
+    let variants = vec![
+        TypeName::importable_type("./events", "UserCreated"),
+        TypeName::importable_type("./events", "UserDeleted"),
+        TypeName::primitive("null"),
+    ];
+
+    let block = sigil_quote!(TypeScript {
+        export type UserEvent = $T_join(" | ", &variants);
+    })
+    .unwrap();
+
+    println!("{}", render_ts(&block));
 }

--- a/examples/python_codegen.rs
+++ b/examples/python_codegen.rs
@@ -1,7 +1,8 @@
 //! Generate a Python file — builder API vs `sigil_quote!` comparison.
 //!
 //! Demonstrates: dataclass with decorator, enum, optional types (`T | None`),
-//! default parameter values, static methods, and standalone functions.
+//! default parameter values, static methods, standalone functions,
+//! and `$T_join` for type unions.
 //!
 //! Run: `cargo run --example python_codegen`
 
@@ -157,10 +158,17 @@ fn builder_approach() -> String {
         .build()
         .unwrap();
 
+    // --- $T_join comparison: manual type union ---
+    let date = TypeName::importable("datetime", "date");
+    let mut join_body = CodeBlock::builder();
+    join_body.add("JsonValue = str | int | float | bool | None | ", ());
+    join_body.add("%T", (date,));
+
     FileSpec::builder_with("config.py", Python::new())
         .add_type(level_enum)
         .add_type(config_with_methods)
         .add_function(greet)
+        .add_code(join_body.build().unwrap())
         .build()
         .unwrap()
         .render(80)
@@ -265,7 +273,7 @@ fn macro_approach() -> String {
         .unwrap();
 
     let greet_body = sigil_quote!(Python {
-        return $L("f'Hello, {name}!'")
+        return $V("Hello, {name}!")
     })
     .unwrap();
 
@@ -276,10 +284,25 @@ fn macro_approach() -> String {
         .build()
         .unwrap();
 
+    // --- $T_join: type union with import tracking ---
+    let types = vec![
+        TypeName::primitive("str"),
+        TypeName::primitive("int"),
+        TypeName::primitive("float"),
+        TypeName::primitive("bool"),
+        TypeName::primitive("None"),
+        TypeName::importable("datetime", "date"),
+    ];
+    let join_body = sigil_quote!(Python {
+        JsonValue = $T_join(" | ", &types)
+    })
+    .unwrap();
+
     FileSpec::builder_with("config.py", Python::new())
         .add_type(level_enum)
         .add_type(config_with_methods)
         .add_function(greet)
+        .add_code(join_body)
         .build()
         .unwrap()
         .render(80)

--- a/examples/rust_codegen.rs
+++ b/examples/rust_codegen.rs
@@ -2,7 +2,7 @@
 //!
 //! Demonstrates: enum with tuple/struct variants, newtype, references with lifetimes,
 //! `impl Trait` / `dyn Trait`, where constraints, generic functions, `pub(crate)`,
-//! `Option<T>`, tuples, and derive annotations.
+//! `Option<T>`, tuples, derive annotations, and `$T_join` for trait bounds.
 //!
 //! Run: `cargo run --example rust_codegen`
 
@@ -180,6 +180,19 @@ fn builder_approach() -> String {
         .build()
         .unwrap();
 
+    // --- $T_join comparison: manual trait join ---
+    let read = TypeName::importable("std::io", "Read");
+    let write = TypeName::importable("std::io", "Write");
+    let mut join_body = CodeBlock::builder();
+    join_body.add("fn process(stream: &mut (dyn ", ());
+    join_body.add("%T", (read,));
+    join_body.add(" + ", ());
+    join_body.add("%T", (write,));
+    join_body.add(
+        " + Send)) {\n    let mut buf = [0u8; 1024];\n    stream.read(&mut buf).unwrap();\n}",
+        (),
+    );
+
     FileSpec::builder_with("events.rs", RustLang::new())
         .add_type(event_enum)
         .add_type(user_id)
@@ -187,6 +200,7 @@ fn builder_approach() -> String {
         .add_function(print_fn)
         .add_function(handler_fn)
         .add_function(dispatch_fn)
+        .add_code(join_body.build().unwrap())
         .build()
         .unwrap()
         .render(100)
@@ -257,6 +271,18 @@ fn macro_approach() -> String {
         .build()
         .unwrap();
 
+    // --- $T_join: trait bounds with import tracking ---
+    let read = TypeName::importable("std::io", "Read");
+    let write = TypeName::importable("std::io", "Write");
+    let traits = vec![read, write, TypeName::primitive("Send")];
+    let join_body = sigil_quote!(RustLang {
+        fn process(stream: &mut (dyn $T_join(" + ", &traits))) {
+            let mut buf = [0u8; 1024];
+            stream.read(&mut buf).unwrap();
+        }
+    })
+    .unwrap();
+
     FileSpec::builder_with("events.rs", RustLang::new())
         .add_type(event_enum)
         .add_type(user_id)
@@ -264,6 +290,7 @@ fn macro_approach() -> String {
         .add_function(print_fn)
         .add_function(handler_fn)
         .add_function(dispatch_fn)
+        .add_code(join_body)
         .build()
         .unwrap()
         .render(100)

--- a/examples/swift_codegen.rs
+++ b/examples/swift_codegen.rs
@@ -2,7 +2,7 @@
 //!
 //! Demonstrates: struct, protocol with associated type, enum with associated
 //! values, static methods, optional types (`T?`), array types (`[T]`),
-//! and async functions.
+//! async functions, and `$T_join` for protocol composition.
 //!
 //! Run: `cargo run --example swift_codegen`
 
@@ -143,12 +143,22 @@ fn builder_approach() -> String {
         .build()
         .unwrap();
 
+    // --- $T_join comparison: manual protocol composition ---
+    let codable = TypeName::importable("Foundation", "Codable");
+    let hashable = TypeName::importable("Foundation", "Hashable");
+    let mut join_body = CodeBlock::builder();
+    join_body.add("typealias Model = ", ());
+    join_body.add("%T", (codable,));
+    join_body.add(" & ", ());
+    join_body.add("%T", (hashable,));
+
     FileSpec::builder_with("Task.swift", Swift::new())
         .add_type(result_enum)
         .add_type(proto)
         .add_type(task)
         .add_function(make_url)
         .add_function(fetch_fn)
+        .add_code(join_body.build().unwrap())
         .build()
         .unwrap()
         .render(80)
@@ -228,12 +238,23 @@ fn macro_approach() -> String {
         .build()
         .unwrap();
 
+    // --- $T_join: protocol composition with import tracking ---
+    let protocols = vec![
+        TypeName::importable("Foundation", "Codable"),
+        TypeName::importable("Foundation", "Hashable"),
+    ];
+    let join_body = sigil_quote!(Swift {
+        typealias Model = $T_join(" & ", &protocols)
+    })
+    .unwrap();
+
     FileSpec::builder_with("Task.swift", Swift::new())
         .add_type(result_enum)
         .add_type(proto)
         .add_type(task)
         .add_function(make_url)
         .add_function(fetch_fn)
+        .add_code(join_body)
         .build()
         .unwrap()
         .render(80)

--- a/macros/src/codegen.rs
+++ b/macros/src/codegen.rs
@@ -144,7 +144,9 @@ fn build_args_tuple(args: &[TypedArg]) -> TokenStream {
             .map(|arg| {
                 let expr = &arg.expr;
                 match arg.kind {
-                    InterpolationKind::Type | InterpolationKind::Code => {
+                    InterpolationKind::Type
+                    | InterpolationKind::Code
+                    | InterpolationKind::TypeJoin => {
                         quote! { #expr }
                     }
                     InterpolationKind::Literal => {

--- a/macros/src/parse/format.rs
+++ b/macros/src/parse/format.rs
@@ -161,6 +161,62 @@ fn tokens_to_format_inner(
                 ));
             }
 
+            // `$T_join(sep, iter)` — inline type join; each item tracked via %T.
+            if is_ident(next, "T_join") {
+                pos += 1;
+                if pos >= tokens.len() {
+                    return Err(CompileError::new(
+                        next.span(),
+                        "$T_join requires parenthesized arguments: $T_join(sep, iter)",
+                    ));
+                }
+                let group = match &tokens[pos] {
+                    TokenTree::Group(g) if g.delimiter() == Delimiter::Parenthesis => g,
+                    _ => {
+                        return Err(CompileError::new(
+                            tokens[pos].span(),
+                            "$T_join requires parenthesized arguments: $T_join(sep, iter)",
+                        ));
+                    }
+                };
+                let (sep_expr, iter_expr) = split_join_args(group)?;
+
+                if !adjacent_to_prev_specifier {
+                    maybe_space(
+                        format,
+                        state,
+                        PrevTokenKind::Specifier,
+                        TokenAnnotation::Normal,
+                    );
+                }
+                format.push_str("%L");
+                state.prev = PrevTokenKind::Specifier;
+                let group_end = group.span().end();
+                state.prev_specifier_end = Some((group_end.line, group_end.column));
+
+                let join_expr: TokenStream = quote::quote! {
+                    {
+                        let mut __sigil_cb =
+                            ::sigil_stitch::code_block::CodeBlock::builder();
+                        for (__sigil_idx, __sigil_i) in (#iter_expr).into_iter().enumerate() {
+                            if __sigil_idx > 0 {
+                                __sigil_cb.add("%L", (#sep_expr).to_string());
+                            }
+                            __sigil_cb.add("%T", __sigil_i.clone());
+                        }
+                        __sigil_cb.build().unwrap()
+                    }
+                };
+
+                args.push(TypedArg {
+                    kind: InterpolationKind::TypeJoin,
+                    expr: join_expr,
+                });
+
+                pos += 1;
+                continue;
+            }
+
             // `$join(sep, iter)` — inline join expression, emits as %L.
             if is_ident(next, "join") {
                 pos += 1;
@@ -229,7 +285,7 @@ fn tokens_to_format_inner(
                             id.span(),
                             format!(
                                 "unknown interpolation kind `${kind_str}`. \
-                                     Expected $T, $N, $S, $V, $L, $C, $W, $join, or $C_each"
+                                     Expected $T, $N, $S, $V, $L, $C, $W, $T_join, $join, or $C_each"
                             ),
                         ));
                     }
@@ -262,7 +318,9 @@ fn tokens_to_format_inner(
                     InterpolationKind::Name => "%N",
                     InterpolationKind::StringLit => "%S",
                     InterpolationKind::VerbatimStr => "%V",
-                    InterpolationKind::Literal | InterpolationKind::Code => "%L",
+                    InterpolationKind::Literal
+                    | InterpolationKind::Code
+                    | InterpolationKind::TypeJoin => "%L",
                 };
 
                 if !adjacent_to_prev_specifier {
@@ -289,7 +347,7 @@ fn tokens_to_format_inner(
 
             return Err(CompileError::new(
                 next.span(),
-                "expected interpolation kind after `$`: $T, $N, $S, $L, $C, $W, $join, $C_each, $for, or $$",
+                "expected interpolation kind after `$`: $T, $N, $S, $V, $L, $C, $W, $T_join, $join, $C_each, $for, or $$",
             ));
         }
 

--- a/macros/src/parse/types.rs
+++ b/macros/src/parse/types.rs
@@ -108,6 +108,9 @@ pub(crate) enum InterpolationKind {
     Literal,
     /// `$C(expr)` — nested code block.
     Code,
+    /// `$T_join(sep, iter)` — join TypeName items with a separator,
+    /// tracking imports for each item via `%T` slots.
+    TypeJoin,
 }
 
 /// A compile error with span information.

--- a/tests/macro/meta_for.rs
+++ b/tests/macro/meta_for.rs
@@ -52,6 +52,262 @@ fn test_meta_for_with_string_literal() {
     assert!(output.contains("console.log('world')"), "got: {output}");
 }
 
+// ── $T_join — type join with import tracking ─────────────
+
+#[test]
+fn test_t_join_basic() {
+    let types = vec![
+        TypeName::importable_type("./models", "User"),
+        TypeName::importable_type("./models", "Admin"),
+        TypeName::primitive("null"),
+    ];
+
+    let block = sigil_quote!(TypeScript {
+        export type MyType = $T_join(" | ", &types);
+    })
+    .unwrap();
+
+    let output = render_ts(&block);
+    assert!(
+        output.contains("export type MyType = User | Admin | null;"),
+        "got:\n{output}"
+    );
+    // Verify imports are tracked (dedup merges same-module imports)
+    assert!(
+        output.contains("import type { Admin, User } from './models'"),
+        "imports should be tracked, got:\n{output}"
+    );
+}
+
+#[test]
+fn test_t_join_single_item() {
+    let types = vec![TypeName::primitive("string")];
+
+    let block = sigil_quote!(TypeScript {
+        export type MyType = $T_join(" | ", &types);
+    })
+    .unwrap();
+
+    let output = render_ts(&block);
+    assert!(
+        output.contains("export type MyType = string;"),
+        "got:\n{output}"
+    );
+}
+
+#[test]
+fn test_t_join_empty() {
+    let types: Vec<TypeName> = vec![];
+
+    let block = sigil_quote!(TypeScript {
+        export type MyType = $T_join(" | ", &types);
+    })
+    .unwrap();
+
+    let output = render_ts(&block);
+    assert!(output.contains("export type MyType = ;"), "got:\n{output}");
+}
+
+#[test]
+fn test_t_join_typescript_intersection() {
+    let types = vec![
+        TypeName::importable_type("./types", "Serializable"),
+        TypeName::importable_type("./types", "Comparable"),
+    ];
+
+    let block = sigil_quote!(TypeScript {
+        export type MyType = $T_join(" & ", &types);
+    })
+    .unwrap();
+
+    let output = render_ts(&block);
+    assert!(
+        output.contains("export type MyType = Serializable & Comparable;"),
+        "got:\n{output}"
+    );
+    assert!(
+        output.contains("import type { Comparable, Serializable }"),
+        "got:\n{output}"
+    );
+}
+
+#[test]
+fn test_t_join_python_union() {
+    let types = vec![
+        TypeName::primitive("str"),
+        TypeName::primitive("int"),
+        TypeName::primitive("None"),
+    ];
+
+    let block = sigil_quote!(Python {
+        MyType = $T_join(" | ", &types)
+    })
+    .unwrap();
+
+    let output = render_py(&block);
+    assert!(
+        output.contains("MyType = str | int | None"),
+        "got:\n{output}"
+    );
+}
+
+#[test]
+fn test_t_join_swift_protocol() {
+    let types = vec![
+        TypeName::primitive("Codable"),
+        TypeName::primitive("Hashable"),
+    ];
+
+    let block = sigil_quote!(Swift {
+        typealias MyType = $T_join(" & ", &types)
+    })
+    .unwrap();
+
+    let output = render_swift(&block);
+    assert!(
+        output.contains("typealias MyType = Codable & Hashable"),
+        "got:\n{output}"
+    );
+}
+
+#[test]
+fn test_t_join_scala_mixin() {
+    let types = vec![
+        TypeName::primitive("A"),
+        TypeName::primitive("B"),
+        TypeName::primitive("C"),
+    ];
+
+    let block = sigil_quote!(Scala {
+        trait Foo extends $T_join(" with ", &types)
+    })
+    .unwrap();
+
+    let output = render_scala(&block);
+    assert!(
+        output.contains("trait Foo extends A with B with C"),
+        "got:\n{output}"
+    );
+}
+
+#[test]
+fn test_t_join_rust_trait_bounds() {
+    let traits = vec![
+        TypeName::importable_type("./traits", "Serializable"),
+        TypeName::importable_type("./traits", "Cloneable"),
+        TypeName::primitive("Send"),
+    ];
+
+    let block = sigil_quote!(Rust {
+        fn process(x: &(dyn $T_join(" + ", &traits))) -> Result<(), Error>;
+    })
+    .unwrap();
+
+    let output = render_rs(&block);
+    assert!(
+        output.contains("fn process(x: &(dyn Serializable + Cloneable + Send))"),
+        "got:\n{output}"
+    );
+    assert!(
+        output.contains("use ./traits::{Cloneable, Serializable};"),
+        "got:\n{output}"
+    );
+}
+
+#[test]
+fn test_t_join_java_intersection() {
+    let bounds = vec![
+        TypeName::importable_type("./io", "Serializable"),
+        TypeName::importable_type("./util", "Comparable"),
+    ];
+
+    let block = sigil_quote!(Java {
+        class Foo<T extends $T_join(" & ", &bounds)> {}
+    })
+    .unwrap();
+
+    let output = render_java(&block);
+    assert!(
+        output.contains("class Foo<T extends Serializable & Comparable>"),
+        "got:\n{output}"
+    );
+    assert!(
+        output.contains("import ./io.Serializable;"),
+        "got:\n{output}"
+    );
+    assert!(
+        output.contains("import ./util.Comparable;"),
+        "got:\n{output}"
+    );
+}
+
+#[test]
+fn test_t_join_dart_mixins() {
+    let mixins = vec![
+        TypeName::importable_type("./mixins", "JsonSerializable"),
+        TypeName::importable_type("./mixins", "EquatableMixin"),
+    ];
+
+    let block = sigil_quote!(Dart {
+        class User extends BaseModel with $T_join(", ", &mixins) {}
+    })
+    .unwrap();
+
+    let output = render_dart(&block);
+    assert!(
+        output.contains("class User extends BaseModel with JsonSerializable, EquatableMixin"),
+        "got:\n{output}"
+    );
+    assert!(output.contains("import './mixins'"), "got:\n{output}");
+}
+
+#[test]
+fn test_t_join_kotlin_supertypes() {
+    let interfaces = vec![
+        TypeName::importable_type("./interfaces", "Serializable"),
+        TypeName::importable_type("./interfaces", "Parcelable"),
+    ];
+
+    let block = sigil_quote!(Kotlin {
+        class User : $T_join(", ", &interfaces)
+    })
+    .unwrap();
+
+    let output = render_kt(&block);
+    assert!(
+        output.contains("class User: Serializable, Parcelable"),
+        "got:\n{output}"
+    );
+    assert!(
+        output.contains("import ./interfaces.Parcelable"),
+        "got:\n{output}"
+    );
+    assert!(
+        output.contains("import ./interfaces.Serializable"),
+        "got:\n{output}"
+    );
+}
+
+#[test]
+fn test_t_join_csharp_constraints() {
+    let constraints = vec![
+        TypeName::importable_type("./interfaces", "IDisposable"),
+        TypeName::importable_type("./interfaces", "IComparable"),
+    ];
+
+    let block = sigil_quote!(CSharp {
+        class Foo<T> where T : $T_join(", ", &constraints)
+    })
+    .unwrap();
+
+    let output = render_cs(&block);
+    assert!(
+        output.contains("class Foo<T> where T: IDisposable, IComparable"),
+        "got:\n{output}"
+    );
+    assert!(output.contains("using ./interfaces;"), "got:\n{output}");
+}
+
 #[test]
 fn test_meta_for_with_type_interpolation() {
     let types = vec![TypeName::primitive("string"), TypeName::primitive("number")];


### PR DESCRIPTION
## Summary
- `$T_join(sep, iter)` — inline type join via `%T` slots with import tracking
- Tests for 9 languages: TypeScript (`|`, `&`), Python (`|`), Swift (`&`), Scala (`with`), Rust (`+`), Java (`&`), Dart (`,`), Kotlin (`,`), C# (`,`)
- Fix stale error message missing `$V` and `$T_join`
- Example demo in `examples/macro_features.rs`

## Test plan
- 12 `$T_join` tests verifying join output and import tracking per language
- Full workspace: 1770+ tests pass, clippy clean