### PR TITLE
feat: parse parenthesized block delimiters in sigil_quote! for Go

### DIFF
--- a/examples/go_codegen.rs
+++ b/examples/go_codegen.rs
@@ -1,7 +1,9 @@
 //! Generate a Go file — builder API vs `sigil_quote!` comparison.
 //!
 //! Demonstrates: struct with tags, embedded types (composition), interface,
-//! `[]T` slices, `map[K]V` maps, receiver methods, and Go generics.
+//! `[]T` slices, `map[K]V` maps, receiver methods, Go generics,
+//! `$T_join` for interface composition, and `const ( ... )` paren blocks
+//! with `$for`.
 //!
 //! Run: `cargo run --example go_codegen`
 
@@ -137,6 +139,41 @@ fn builder_approach() -> String {
         .build()
         .unwrap();
 
+    // --- $T_join comparison: manual interface embedding ---
+    let reader = TypeName::importable("io", "Reader");
+    let writer = TypeName::importable("io", "Writer");
+    let closer = TypeName::importable("io", "Closer");
+    let mut join_body = CodeBlock::builder();
+    join_body.add("type FileOps interface {", ());
+    join_body.add_line();
+    join_body.add("    %T", (reader,));
+    join_body.add_line();
+    join_body.add("    %T", (writer,));
+    join_body.add_line();
+    join_body.add("    %T", (closer,));
+    join_body.add_line();
+    join_body.add("}", ());
+
+    // --- const paren block comparison: manual enum generation ---
+    let mut enum_body = CodeBlock::builder();
+    let variants = ["Alpha", "Beta", "Gamma"];
+    enum_body.add("const (", ());
+    enum_body.add_line();
+    enum_body.add("%>", ());
+    for v in &variants {
+        enum_body.add(
+            "%L %L = %S",
+            (
+                *v,
+                format!("{v}Kind").as_str(),
+                StringLitArg(v.to_lowercase()),
+            ),
+        );
+        enum_body.add_line();
+    }
+    enum_body.add("%<", ());
+    enum_body.add(")", ());
+
     FileSpec::builder_with("server.go", GoLang::new())
         .header(CodeBlock::of("package server", ()).unwrap())
         .add_type(logger)
@@ -144,6 +181,8 @@ fn builder_approach() -> String {
         .add_function(start_fn)
         .add_function(add_route)
         .add_function(sort_fn)
+        .add_code(join_body.build().unwrap())
+        .add_code(enum_body.build().unwrap())
         .build()
         .unwrap()
         .render(100)
@@ -203,6 +242,30 @@ fn macro_approach() -> String {
         .build()
         .unwrap();
 
+    // --- $T_join: interface composition with import tracking ---
+    let ifaces = vec![
+        TypeName::importable("io", "Reader"),
+        TypeName::importable("io", "Writer"),
+        TypeName::importable("io", "Closer"),
+    ];
+    let join_body = sigil_quote!(GoLang {
+        type FileOps interface {
+            $T_join("\n", &ifaces)
+        }
+    })
+    .unwrap();
+
+    // --- const paren block: generate enum-like constants with $for ---
+    let variants = ["Alpha", "Beta", "Gamma"];
+    let enum_body = sigil_quote!(GoLang {
+        const (
+        $for(v in &variants) {
+            $L("@{v} @{v}Kind = \"@{v}\"")
+        }
+        )
+    })
+    .unwrap();
+
     FileSpec::builder_with("server.go", GoLang::new())
         .header(CodeBlock::of("package server", ()).unwrap())
         .add_type(logger)
@@ -210,6 +273,8 @@ fn macro_approach() -> String {
         .add_function(start_fn)
         .add_function(add_route)
         .add_function(sort_fn)
+        .add_code(join_body)
+        .add_code(enum_body)
         .build()
         .unwrap()
         .render(100)

--- a/macros/src/codegen.rs
+++ b/macros/src/codegen.rs
@@ -121,6 +121,24 @@ fn generate_statements(statements: &[Statement]) -> Vec<TokenStream> {
                     let #binding;
                 });
             }
+            Statement::ParenBlock {
+                header_format,
+                header_args,
+                body,
+            } => {
+                let header_args_tuple = build_args_tuple(header_args);
+                let body_calls = generate_statements(body);
+                calls.push(quote! {
+                    __sigil_builder.add(#header_format, #header_args_tuple);
+                    __sigil_builder.add_line();
+                    __sigil_builder.add("%>", ());
+                });
+                calls.extend(body_calls);
+                calls.push(quote! {
+                    __sigil_builder.add("%<", ());
+                    __sigil_builder.add(")", ());
+                });
+            }
         }
     }
     calls

--- a/macros/src/parse/statements.rs
+++ b/macros/src/parse/statements.rs
@@ -138,6 +138,15 @@ pub(super) fn parse_one_statement(
             return Ok((stmt, next_pos));
         }
 
+        // Check for paren group — potential declaration block (Go: const, var, import, type).
+        if let TokenTree::Group(g) = tt
+            && g.delimiter() == Delimiter::Parenthesis
+            && is_paren_block_start(&collected, lang)
+        {
+            let (stmt, next_pos) = parse_paren_block(&collected, g, pos, lang)?;
+            return Ok((stmt, next_pos));
+        }
+
         // Line-break detection: split statement when tokens span multiple lines.
         if !collected.is_empty()
             && let Some(pel) = prev_end_line
@@ -750,6 +759,44 @@ fn try_parse_attr(
         next += 1;
     }
     Ok(Some((text, next)))
+}
+
+/// Check whether the collected prefix tokens and language indicate a
+/// paren-delimited declaration block (Go: `const`, `var`, `import`, `type`).
+fn is_paren_block_start(collected: &[TokenTree], lang: MacroLang) -> bool {
+    if lang != MacroLang::GoLang {
+        return false;
+    }
+    collected.last().is_some_and(|tt| {
+        let s = tt.to_string();
+        matches!(s.as_str(), "const" | "var" | "import" | "type")
+    })
+}
+
+/// Parse a parenthesized declaration block.
+///
+/// Formats the header tokens (e.g., `"const"`) as `"const ("`, then recursively
+/// parses the body inside the paren group.
+fn parse_paren_block(
+    header_tokens: &[TokenTree],
+    paren_group: &proc_macro2::Group,
+    _paren_pos: usize,
+    lang: MacroLang,
+) -> Result<(Statement, usize), CompileError> {
+    let (header_format, header_args) = tokens_to_format(header_tokens, lang)?;
+    let header_format = format!("{header_format} (");
+
+    let body_tokens: Vec<TokenTree> = paren_group.stream().into_iter().collect();
+    let body = parse_body(&body_tokens, lang)?;
+
+    Ok((
+        Statement::ParenBlock {
+            header_format,
+            header_args,
+            body,
+        },
+        _paren_pos + 1,
+    ))
 }
 
 #[cfg(test)]

--- a/macros/src/parse/statements_tests.rs
+++ b/macros/src/parse/statements_tests.rs
@@ -141,6 +141,85 @@ fn go_for_with_embedded_semicolons() {
     }
 }
 
+#[test]
+fn go_const_paren_block() {
+    let stmt = parse_stmt_lang("const ( x = 1 )", MacroLang::GoLang);
+    match stmt {
+        Statement::ParenBlock {
+            header_format,
+            header_args,
+            body,
+        } => {
+            assert_eq!(header_format, "const (");
+            assert!(header_args.is_empty());
+            assert_eq!(body.len(), 1);
+        }
+        _ => panic!("expected ParenBlock, got {:?}", stmt_kind(&stmt)),
+    }
+}
+
+#[test]
+fn go_var_paren_block() {
+    let stmt = parse_stmt_lang("var ( x int )", MacroLang::GoLang);
+    match stmt {
+        Statement::ParenBlock { header_format, .. } => {
+            assert_eq!(header_format, "var (");
+        }
+        _ => panic!("expected ParenBlock, got {:?}", stmt_kind(&stmt)),
+    }
+}
+
+#[test]
+fn go_import_paren_block() {
+    let stmt = parse_stmt_lang("import ( \"fmt\" )", MacroLang::GoLang);
+    match stmt {
+        Statement::ParenBlock { header_format, .. } => {
+            assert_eq!(header_format, "import (");
+        }
+        _ => panic!("expected ParenBlock, got {:?}", stmt_kind(&stmt)),
+    }
+}
+
+#[test]
+fn go_type_paren_block() {
+    let stmt = parse_stmt_lang("type ( A struct{} )", MacroLang::GoLang);
+    match stmt {
+        Statement::ParenBlock { header_format, .. } => {
+            assert_eq!(header_format, "type (");
+        }
+        _ => panic!("expected ParenBlock, got {:?}", stmt_kind(&stmt)),
+    }
+}
+
+#[test]
+fn go_paren_block_with_metafor() {
+    // Verify that $for inside a Go const paren block is parsed recursively.
+    let stmt = parse_stmt_lang(
+        "const ( $for(v in items) { $L(\"x\") } )",
+        MacroLang::GoLang,
+    );
+    match stmt {
+        Statement::ParenBlock { body, .. } => {
+            assert_eq!(body.len(), 1);
+            assert!(matches!(body[0], Statement::MetaFor { .. }));
+        }
+        _ => panic!("expected ParenBlock, got {:?}", stmt_kind(&stmt)),
+    }
+}
+
+#[test]
+fn non_go_paren_block_is_literal() {
+    // Without MacroLang::GoLang, `const ( ... )` stays as a literal line.
+    let stmt = parse_stmt_lang("const ( x = 1 )", MacroLang::Unaware);
+    match stmt {
+        Statement::Line { format, .. } => {
+            assert!(format.contains("const"));
+            assert!(format.contains("("));
+        }
+        _ => panic!("expected Line, got {:?}", stmt_kind(&stmt)),
+    }
+}
+
 fn stmt_kind(s: &Statement) -> &'static str {
     match s {
         Statement::Statement { .. } => "Statement",
@@ -155,5 +234,6 @@ fn stmt_kind(s: &Statement) -> &'static str {
         Statement::MetaIf { .. } => "MetaIf",
         Statement::MetaFor { .. } => "MetaFor",
         Statement::MetaLet { .. } => "MetaLet",
+        Statement::ParenBlock { .. } => "ParenBlock",
     }
 }

--- a/macros/src/parse/types.rs
+++ b/macros/src/parse/types.rs
@@ -67,6 +67,14 @@ pub(crate) enum Statement {
     },
     /// `$let(binding);` — Rust-level `let` binding inside macro body.
     MetaLet { binding: TokenStream },
+    /// A parenthesized declaration block (Go: `const (...)`, `var (...)`,
+    /// `import (...)`, `type (...)`). The body is recursively parsed so
+    /// `$for`, `$if`, etc. expand inside.
+    ParenBlock {
+        header_format: String,
+        header_args: Vec<TypedArg>,
+        body: Vec<Statement>,
+    },
 }
 
 /// A single branch in a control flow chain.

--- a/test-goldens/go/quote_const_paren_block.go
+++ b/test-goldens/go/quote_const_paren_block.go
@@ -1,0 +1,5 @@
+const (
+	aConst = "a"
+	bConst = "b"
+	cConst = "c"
+)

--- a/tests/go/quote_control_flow.rs
+++ b/tests/go/quote_control_flow.rs
@@ -52,3 +52,17 @@ fn test_switch_init_semicolon() {
     .unwrap();
     golden::assert_golden("go/quote_switch_init.go", &render(&block));
 }
+
+#[test]
+fn test_const_paren_block_with_for() {
+    let items = vec!["a", "b", "c"];
+    let block = sigil_quote!(GoLang {
+        const (
+        $for(v in &items) {
+            $L("@{v}Const = \"@{v}\"")
+        }
+        )
+    })
+    .unwrap();
+    golden::assert_golden("go/quote_const_paren_block.go", &render(&block));
+}


### PR DESCRIPTION
## Summary
- `sigil_quote!(GoLang { ... })` now recognizes `const ( ... )`, `var ( ... )`, `import ( ... )`, and `type ( ... )` as structural blocks
- `$for`/`$if`/`$C_each`/etc. expand correctly inside these paren-delimited blocks
- Body content is auto-indented (tab) and closing `)` is at the outer indent level

## Example
```rust
let variants = ["Alpha", "Beta", "Gamma"];
sigil_quote!(GoLang {
    const (
    $for(v in &variants) {
        $L("@{v} @{v}Kind = \"@{v}\"")
    }
    )
})
```

Produces:
```go
const (
    Alpha AlphaKind = "Alpha"
    Beta BetaKind = "Beta"
    Gamma GammaKind = "Gamma"
)
```

## Test plan
- [x] Parser unit tests for all 4 Go paren-block keywords
- [x] `$for` inside paren block parsed recursively
- [x] Non-GoLang `const ( ... )` stays literal (no false positive)
- [x] Golden end-to-end test with rendering verification
- [x] Go example (`go_codegen.rs`) updated with builder-vs-macro comparison
- [x] Full test suite: 0 failures, clippy clean