### PR TITLE
chore: bump version to 0.6.4 and update docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## 0.6.4
+
+### Added
+
+- `$attr("text")` directive in `sigil_quote!` — structural annotations/attributes
+  that render with the target language's prefix/suffix. Rust: `#[text]`,
+  Java/Python: `@text`, C++: `[[text]]`. Blank lines after `$attr(...)` are
+  automatically suppressed so the annotation attaches to the following declaration.
+- `$T_join(sep, iter)` interpolation — joins `TypeName` items with a separator,
+  tracking imports for each item via `%T` slots. Generates a nested `CodeBlock`
+  at compile time. Use for type unions (`str | int`) in Python, trait bounds
+  (`Read + Write`) in Rust, intersection types (`T & U`) in Java/TypeScript,
+  protocol composition (`Codable & Hashable`) in Swift, and interface embedding
+  in Go.
+- **Go paren-delimited blocks** — `sigil_quote!(GoLang { ... })` now recognizes
+  `const ( ... )`, `var ( ... )`, `import ( ... )`, and `type ( ... )` as
+  structural blocks. `$for`, `$if`, `$C_each`, etc. expand correctly inside.
+  Body content is auto-indented and the closing `)` is at the outer indent level.
+
+### Fixed
+
+- Blank lines after `$comment(...)` in `sigil_quote!` are now suppressed,
+  matching the spec-level behavior where doc comments attach to the following
+  declaration without a separator.
+- `$C_each` inside object literals after `$N(...) =` no longer fails — the brace
+  classifier now detects sigil-stitch statement markers inside brace groups.
+
 ## 0.6.3
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,7 +100,7 @@ dependencies = [
 
 [[package]]
 name = "sigil-stitch"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "pretty",
  "serde",
@@ -111,7 +111,7 @@ dependencies = [
 
 [[package]]
 name = "sigil-stitch-macros"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["macros"]
 resolver = "3"
 
 [workspace.package]
-version = "0.6.3"
+version = "0.6.4"
 edition = "2024"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"
@@ -35,7 +35,7 @@ exclude = [
 [dependencies]
 pretty = "0.12"
 snafu = "0.9"
-sigil-stitch-macros = { path = "macros", version = "0.6.3" }
+sigil-stitch-macros = { path = "macros", version = "0.6.4" }
 serde = { version = "1", features = ["derive"] }
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -67,13 +67,17 @@ let body = sigil_quote!(TypeScript {
 }).unwrap();
 ```
 
-The macro uses `$T`/`$S`/`$N`/`$L`/`$C`/`$W` interpolation markers that expand to
-the equivalent `%T`/`%S`/`%N`/`%L` format specifiers at compile time. It also
+The macro uses `$T`/`$S`/`$N`/`$L`/`$C`/`$V`/`$W` interpolation markers that expand to
+the equivalent `%T`/`%S`/`%N`/`%L`/`%V` format specifiers at compile time. It also
 supports `$V("@{expr}")` for compile-time interpolation in verbatim strings,
+`$attr("text")` for structural annotations with language-specific rendering,
+`$T_join(sep, iter)` for type-name joins with per-item import tracking,
 `$C_each` for splicing iterables of code blocks, `$if`/`$else_if`/`$else`
 for meta-conditionals, `$for` for compile-time iteration, `$let` for Rust-level
 variable bindings, `$join` for separator-joined lists, and `$+` for line
-continuation in multi-line expressions.
+continuation in multi-line expressions. Go `const (`, `var (`, `import (`, and
+`type (` paren-delimited blocks are recognized as structural blocks so `$for`,
+`$if`, and `$C_each` expand inside them.
 
 ## Format Specifiers
 
@@ -150,7 +154,7 @@ The [sigil-stitch book](docs/src/SUMMARY.md) covers everything in depth:
 - [Building Functions & Fields](docs/src/functions_and_fields.md) -- ParameterSpec, FieldSpec, FunSpec
 - [Building Types & Enums](docs/src/types_and_enums.md) -- TypeSpec, PropertySpec, AnnotationSpec, EnumVariantSpec
 - [Files & Projects](docs/src/files_and_projects.md) -- ImportSpec, FileSpec, ProjectSpec
-- [sigil_quote! Macro](docs/src/sigil_quote.md) -- inline code with `$T`/`$S`/`$N`/`$L`/`$C_each`/`$if`/`$for`/`$let`/`$join`/`$+` interpolation
+- [sigil_quote! Macro](docs/src/sigil_quote.md) -- inline code with `$T`/`$S`/`$N`/`$L`/`$V`/`$C_each`/`$if`/`$for`/`$let`/`$join`/`$+`/`$attr`/`$T_join` interpolation, plus Go paren-block support
 - [Code Templates](docs/src/code_templates.md) -- reusable `#{name:K}` templates
 - [Language Cookbook](docs/src/language_cookbook.md) -- idiomatic recipes per language
 

--- a/docs/src/cookbook_go.md
+++ b/docs/src/cookbook_go.md
@@ -145,3 +145,46 @@ func Max[T comparable](a T, b T) T {
 	return b
 }
 ```
+
+## Const block with enum generation
+
+Use `sigil_quote!` with a `$for` inside `const ( ... )` to generate enum-like
+const blocks:
+
+```rust
+# extern crate sigil_stitch;
+# use sigil_stitch::prelude::*;
+# use sigil_stitch::lang::go_lang::GoLang;
+# fn main() {
+let variants = vec!["Alpha", "Beta", "Gamma"];
+
+let const_block = sigil_quote!(GoLang {
+    const (
+    $for(v in &variants) {
+        $L("@{v}Kind @{v} = \"@{v}\"");
+    }
+    )
+}).unwrap();
+
+let file = FileSpec::builder("kind.go")
+    .header(CodeBlock::of("package main", ()).unwrap())
+    .add_code(const_block)
+    .build()
+    .unwrap();
+let output = file.render(80).unwrap();
+# }
+```
+
+```go
+package main
+
+const (
+	AlphaKind Alpha = "Alpha"
+	BetaKind Beta = "Beta"
+	GammaKind Gamma = "Gamma"
+)
+```
+
+The parser recognizes `const (`, `var (`, `import (`, and `type (` as structural
+blocks in GoLang, so `$for`, `$if`, `$C_each`, and interpolation markers all
+work inside the parentheses. The body is auto-indented with tabs.

--- a/docs/src/macrolang.md
+++ b/docs/src/macrolang.md
@@ -61,6 +61,10 @@ These share a common `is_shell()` check and enable:
 - **`<-` prefix receive**: When `-` follows a Joint `<` (not GenericOpen) and is span-adjacent
   to the next token, it gets `PrefixOp` annotation — suppressing the space to produce `<-ch`.
   When NOT adjacent (`ch <- 42`), the `-` stays `Normal` and the space is preserved.
+- **Paren-delimited blocks**: `const (`, `var (`, `import (`, and `type (` are detected as
+  structural blocks. The parser recursively processes the body so `$for`, `$if`, and other
+  directives expand inside. The codegen emits `%>` after the header and `%<` before the
+  closing `)` for proper indentation.
 
 ### Haskell
 

--- a/docs/src/sigil_quote.md
+++ b/docs/src/sigil_quote.md
@@ -45,6 +45,8 @@ It returns `Result<CodeBlock, SigilStitchError>`.
 | `$<` | `%<` | (none) | Decrease indent level |
 | `$$` | `$` | (none) | Literal dollar sign |
 | `$C_each(expr)` | — | `impl IntoIterator<Item: Into<CodeBlock>>` | Splice each code block from iterable |
+| `$attr("text")` | — | `impl ToString` | Structural annotation (language-specific prefix/suffix) |
+| `$T_join(sep, iter)` | `%T` | separator + `impl IntoIterator<Item: TypeName>` | Type name join with per-item import tracking |
 | `$if(cond) { ... }` | — | Rust expression | Meta-conditional (runtime codegen control) |
 | `$for(pat in expr) { ... }` | — | Rust pattern + iterable | Meta-loop (emit body per iteration) |
 | `$let(binding);` | — | Rust `let` binding | Rust-level variable binding inside macro body |
@@ -293,6 +295,97 @@ sigil_quote!(TypeScript {
 // Output:
 // // Initialize the connection pool
 // const pool = createPool();
+# Ok(())
+# }
+```
+
+### Annotations (`$attr`)
+
+`$attr("text")` emits a structural annotation/attribute rendered with the target
+language's syntax. This keeps the macro body language-agnostic — write `$attr("override")`
+and it renders as `@override` in TypeScript/Java, `#[override]` in Rust, or
+`[[override]]` in C++.
+
+```rust
+# extern crate sigil_stitch;
+# use sigil_stitch::prelude::*;
+# fn main() -> Result<(), Box<dyn std::error::Error>> {
+sigil_quote!(TypeScript {
+    $attr("injectable()");
+    class MyService {}
+})?;
+// Output:
+// @injectable()
+// class MyService {}
+# Ok(())
+# }
+```
+
+```rust
+# extern crate sigil_stitch;
+# use sigil_stitch::prelude::*;
+# use sigil_stitch::lang::rust_lang::RustLang;
+# fn main() -> Result<(), Box<dyn std::error::Error>> {
+sigil_quote!(RustLang {
+    $attr("derive(Debug, Clone, Serialize, Deserialize)");
+    struct Config {}
+})?;
+// Output:
+// #[derive(Debug, Clone, Serialize, Deserialize)]
+// struct Config {}
+# Ok(())
+# }
+```
+
+```rust
+# extern crate sigil_stitch;
+# use sigil_stitch::prelude::*;
+# use sigil_stitch::lang::cpp_lang::CppLang;
+# fn main() -> Result<(), Box<dyn std::error::Error>> {
+sigil_quote!(CppLang {
+    $attr("nodiscard");
+    Result compute();
+})?;
+// Output: [[nodiscard]] Result compute();
+# Ok(())
+# }
+```
+
+Each language defines its own prefix/suffix via `attribute_syntax()`. Stacking
+multiple `$attr` lines is common:
+
+```rust
+# extern crate sigil_stitch;
+# use sigil_stitch::prelude::*;
+# fn main() -> Result<(), Box<dyn std::error::Error>> {
+sigil_quote!(TypeScript {
+    $attr("injectable()");
+    $attr("singleton()");
+    class AppService {}
+})?;
+// Output:
+// @injectable()
+// @singleton()
+// class AppService {}
+# Ok(())
+# }
+```
+
+`$attr` works inside `$if` blocks for conditional annotations:
+
+```rust
+# extern crate sigil_stitch;
+# use sigil_stitch::prelude::*;
+# use sigil_stitch::lang::rust_lang::RustLang;
+# fn main() -> Result<(), Box<dyn std::error::Error>> {
+let needs_serde = true;
+sigil_quote!(RustLang {
+    $attr("derive(Debug, Clone)");
+    $if(needs_serde) {
+        $attr("serde(rename_all = \"camelCase\")");
+    }
+    struct Config {}
+})?;
 # Ok(())
 # }
 ```
@@ -784,6 +877,73 @@ sigil_quote!(TypeScript {
 # }
 ```
 
+### Type Join (`$T_join`)
+
+`$T_join(sep, iter)` joins `TypeName` items with a separator, tracking imports for
+each item. Unlike `$join` (which calls `.to_string()` on each element), `$T_join`
+uses `%T` slots so every type in the join contributes its import to the file.
+
+```rust
+# extern crate sigil_stitch;
+# use sigil_stitch::prelude::*;
+# fn main() -> Result<(), Box<dyn std::error::Error>> {
+let types = vec![
+    TypeName::importable_type("./models", "User"),
+    TypeName::importable_type("./models", "Admin"),
+    TypeName::primitive("null"),
+];
+sigil_quote!(TypeScript {
+    export type Actor = $T_join(" | ", &types);
+})?;
+// Output: export type Actor = User | Admin | null;
+// Imports: import type { Admin, User } from './models'
+# Ok(())
+# }
+```
+
+The separator can be any string — `" | "` for TypeScript unions, `" & "` for
+intersections, `" + "` for Rust trait bounds, `"\n"` for Go interface embedding:
+
+```rust
+# extern crate sigil_stitch;
+# use sigil_stitch::prelude::*;
+# use sigil_stitch::lang::rust_lang::RustLang;
+# fn main() -> Result<(), Box<dyn std::error::Error>> {
+let traits = vec![
+    TypeName::importable_type("./traits", "Serializable"),
+    TypeName::importable_type("./traits", "Cloneable"),
+];
+sigil_quote!(RustLang {
+    fn process(stream: &mut (dyn $T_join(" + ", &traits))) {}
+})?;
+// Output: fn process(stream: &mut (dyn Serializable + Cloneable)) {}
+# Ok(())
+# }
+```
+
+```rust
+# extern crate sigil_stitch;
+# use sigil_stitch::prelude::*;
+# use sigil_stitch::lang::go_lang::GoLang;
+# fn main() -> Result<(), Box<dyn std::error::Error>> {
+let ifaces = vec![
+    TypeName::importable_type("./io", "Reader"),
+    TypeName::importable_type("./io", "Writer"),
+];
+sigil_quote!(GoLang {
+    type FileOps interface {
+        $T_join("\n", &ifaces)
+    }
+})?;
+// Output:
+// type FileOps interface {
+//     Reader
+//     Writer
+// }
+# Ok(())
+# }
+```
+
 ## Line Continuation (`$+`)
 
 `sigil_quote!` splits statements on line breaks — each source line becomes a
@@ -867,6 +1027,45 @@ sigil_quote!(RustLang {
 # Ok(())
 # }
 ```
+
+## Paren-Delimited Blocks (Go)
+
+Go uses parenthesized blocks for multi-line declarations — `const ( ... )`,
+`var ( ... )`, `import ( ... )`, and `type ( ... )`. `sigil_quote!` recognizes
+these as structural blocks, so `$for`, `$if`, `$C_each`, and other directives
+expand inside them:
+
+```rust
+# extern crate sigil_stitch;
+# use sigil_stitch::prelude::*;
+# use sigil_stitch::lang::go_lang::GoLang;
+# fn main() -> Result<(), Box<dyn std::error::Error>> {
+let variants = vec!["A", "B", "C"];
+
+sigil_quote!(GoLang {
+    const (
+    $for(v in &variants) {
+        $L("@{v}Kind @{v} = \"@{v}\"");
+    }
+    )
+})?;
+// Output:
+// const (
+//     AKind A = "A"
+//     BKind B = "B"
+//     CKind C = "C"
+// )
+# Ok(())
+# }
+```
+
+The paren-block body is indented automatically (the codegen emits `%>` after the
+opening header and `%<` before the closing `)`). Interpolation markers, meta-loops,
+and meta-conditionals all work normally inside the block.
+
+This detection is language-aware — only `GoLang` recognizes `const`, `var`,
+`import`, and `type` as paren-block headers. In other languages, `const ( ... )`
+is treated as a plain statement.
 
 ## Known Limitations and Quirks
 


### PR DESCRIPTION
## Summary
- Bump version to 0.6.4 in Cargo.toml (workspace + macros dependency)
- Add 0.6.4 section to CHANGELOG.md (`$attr`, `$T_join`, Go paren blocks, fixes)
- Document `$attr` and `$T_join` in README and sigil_quote.md
- Document Go paren-delimited blocks in sigil_quote.md, macrolang.md, and cookbook_go.md

## Test plan
- [x] mdbook builds clean
- [x] cargo fmt passes
- [x] cargo clippy passes (--workspace --tests -- -D warnings)