### PR TITLE
feat: $comment(expr) accepts dynamic Rust expressions

### DIFF
--- a/examples/bash_codegen.rs
+++ b/examples/bash_codegen.rs
@@ -23,6 +23,9 @@ fn main() {
 
 fn builder_approach() -> String {
     let utils = TypeName::importable("./utils.sh", "");
+    let comment_label = "INFO";
+    let comment_reason = "Deploy to target environment";
+    let comment_note = "check env var";
 
     // --- log function ---
     let mut log_body = CodeBlock::builder();
@@ -39,6 +42,7 @@ fn builder_approach() -> String {
 
     // --- deploy function with if/then/fi ---
     let mut deploy_body = CodeBlock::builder();
+    deploy_body.add_comment(&format!("{}: {}", comment_label, comment_reason));
     deploy_body.add("local env=$1", ());
     deploy_body.add_line();
     deploy_body.add_line();
@@ -55,7 +59,10 @@ fn builder_approach() -> String {
     deploy_body.add_line();
     deploy_body.add("%>", ());
     deploy_body.add_line();
-    deploy_body.add("log_message \"INFO\" \"Deploying to $env\"", ());
+    deploy_body.add(
+        "log_message \"INFO\" \"Deploying to $env\" %R",
+        (CommentArg(comment_note.to_string()),),
+    );
     deploy_body.add_line();
     deploy_body.add_line();
     deploy_body.add("%<", ());
@@ -90,6 +97,9 @@ fn builder_approach() -> String {
 
 fn macro_approach() -> String {
     let utils = TypeName::importable("./utils.sh", "");
+    let comment_label = "INFO";
+    let comment_reason = "Deploy to target environment";
+    let comment_note = "check env var";
 
     // $V is passthrough — include your own quotes where shell quoting is needed.
     // $S would escape shell sigils; $V passes them through for shell expansion.
@@ -108,6 +118,7 @@ fn macro_approach() -> String {
     // sigil_quote! with { } — Bash backend emits then/fi, do/done.
     // $V is used for strings that need shell expansion at runtime.
     let deploy_body = sigil_quote!(Bash {
+        $comment("@{comment_label}: @{comment_reason}");
         local env=$$1
         local app_name=$V("\"${APP_NAME:-myapp}\"")
         local version=$V("\"$(cat VERSION 2>/dev/null || echo unknown)\"")
@@ -117,7 +128,7 @@ fn macro_approach() -> String {
             return 1
         }
 
-        log_message $S("INFO") $V("\"Deploying ${app_name} v${version} to ${env}\"")
+        log_message $S("INFO") $V("\"Deploying ${app_name} v${version} to ${env}\"") $comment(comment_note)
 
         for service in api worker scheduler; {
             log_message $S("INFO") $V("\"Starting $service on $env\"")

--- a/examples/c_codegen.rs
+++ b/examples/c_codegen.rs
@@ -90,14 +90,22 @@ fn builder_approach() -> String {
     let free = TypeName::importable("stdlib.h", "free");
     let printf = TypeName::importable("stdio.h", "printf");
     let (log_level, callback, config) = build_shared_types();
+    let comment_label = "NOTE";
+    let comment_reason = "Initialize variables";
+    let comment_note = "validate input";
+    let v_interp = "Config";
 
     let mut create_body = CodeBlock::builder();
+    create_body.add_comment(&format!("{}: {}", comment_label, comment_reason));
     create_body.add(
-        "struct Config* cfg = (struct Config*)%T(sizeof(struct Config));",
-        (malloc,),
+        "struct Config* cfg = (struct Config*)%T(sizeof(%V));",
+        (malloc, VerbatimStrArg(v_interp.to_string())),
     );
     create_body.add_line();
-    create_body.add("cfg->host = host;", ());
+    create_body.add(
+        "cfg->host = host; %R",
+        (CommentArg(comment_note.to_string()),),
+    );
     create_body.add_line();
     create_body.add("cfg->port = port;", ());
     create_body.add_line();
@@ -157,10 +165,15 @@ fn macro_approach() -> String {
     let free = TypeName::importable("stdlib.h", "free");
     let printf = TypeName::importable("stdio.h", "printf");
     let (log_level, callback, config) = build_shared_types();
+    let comment_label = "NOTE";
+    let comment_reason = "Initialize variables";
+    let comment_note = "validate input";
+    let v_interp = "Config";
 
     let create_body = sigil_quote!(CLang {
-        struct Config* cfg = (struct Config*)$T(malloc)(sizeof(struct Config));
-        cfg->host = host;
+        $comment("@{comment_label}: @{comment_reason}");
+        struct Config* cfg = (struct Config*)$T(malloc)(sizeof($V("@{v_interp}")));
+        cfg->host = host; $comment(comment_note)
         cfg->port = port;
         cfg->level = LOG_INFO;
         cfg->on_event = NULL;

--- a/examples/cpp_codegen.rs
+++ b/examples/cpp_codegen.rs
@@ -26,11 +26,16 @@ fn emit_fun(fun: &FunSpec) -> CodeBlock {
 fn builder_approach() -> String {
     let iostream = TypeName::importable("iostream", "std::cout");
     let vector_h = TypeName::importable("vector", "std::vector");
+    let comment_label = "INFO";
+    let comment_reason = "Initialize logging components";
+    let comment_note = "log to stdout";
+    let v_interp = "stdout";
 
     let logger = {
         let mut pub_section = CodeBlock::builder();
+        pub_section.add_comment(&format!("{}: {}", comment_label, comment_reason));
         pub_section.add("%<", ());
-        pub_section.add("public:", ());
+        pub_section.add("public: %R", (CommentArg(comment_note.to_string()),));
         pub_section.add_line();
         pub_section.add("%>", ());
         pub_section.add_code(emit_fun(
@@ -74,7 +79,12 @@ fn builder_approach() -> String {
         pub_section.add_line();
         pub_section.add("%>", ());
 
-        let ctor_body = CodeBlock::of("name_ = name;", ()).unwrap();
+        let mut ctor_build = CodeBlock::builder();
+        ctor_build.add(
+            "name_ = name; // %V",
+            (VerbatimStrArg(v_interp.to_string()),),
+        );
+        let ctor_body = ctor_build.build().unwrap();
         pub_section.add_code(emit_fun(
             &FunSpec::builder("ConsoleLogger")
                 .add_param(
@@ -87,8 +97,8 @@ fn builder_approach() -> String {
         pub_section.add_line();
 
         let log_body = CodeBlock::of(
-            "%T << \"[\" << name_ << \"] \" << msg << std::endl;",
-            (iostream.clone(),),
+            "%T << \"[\" << name_ << \"] \" << msg << std::endl; %R",
+            (iostream.clone(), CommentArg(comment_note.to_string())),
         )
         .unwrap();
         pub_section.add_code(emit_fun(
@@ -103,7 +113,10 @@ fn builder_approach() -> String {
         pub_section.add_line();
 
         // Static method: defaultLevel
-        let default_level_body = CodeBlock::of("return LogLevel::Info;", ()).unwrap();
+        let mut default_level_build = CodeBlock::builder();
+        default_level_build.add_attribute("nodiscard");
+        default_level_build.add("return LogLevel::Info;", ());
+        let default_level_body = default_level_build.build().unwrap();
         pub_section.add_code(emit_fun(
             &FunSpec::builder("defaultLevel")
                 .is_static()
@@ -207,6 +220,10 @@ fn builder_approach() -> String {
 fn macro_approach() -> String {
     let iostream = TypeName::importable("iostream", "std::cout");
     let vector_h = TypeName::importable("vector", "std::vector");
+    let comment_label = "INFO";
+    let comment_reason = "Initialize logging components";
+    let comment_note = "log to stdout";
+    let v_interp = "stdout";
 
     let logger = {
         let mut pub_section = CodeBlock::builder();
@@ -256,7 +273,8 @@ fn macro_approach() -> String {
         pub_section.add("%>", ());
 
         let ctor_body = sigil_quote!(CppLang {
-            name_ = name;
+            $comment("@{comment_label}: @{comment_reason}");
+            name_ = name; $comment(comment_note)
         })
         .unwrap();
         pub_section.add_code(emit_fun(
@@ -271,7 +289,7 @@ fn macro_approach() -> String {
         pub_section.add_line();
 
         let log_body = sigil_quote!(CppLang {
-            $T(iostream) << "[" << name_ << "] " << msg << std::endl;
+            $T(iostream) << $V("@{v_interp}: ") << "[" << name_ << "] " << msg << std::endl;
         })
         .unwrap();
         pub_section.add_code(emit_fun(
@@ -287,6 +305,7 @@ fn macro_approach() -> String {
 
         // Static method: defaultLevel
         let default_level_body = sigil_quote!(CppLang {
+            $attr("nodiscard");
             return LogLevel::Info;
         })
         .unwrap();

--- a/examples/csharp_codegen.rs
+++ b/examples/csharp_codegen.rs
@@ -61,6 +61,10 @@ fn build_shared_types() -> (TypeSpec, TypeSpec) {
 fn builder_approach() -> String {
     let console = TypeName::importable("System", "Console");
     let (status, iface) = build_shared_types();
+    let comment_label = "TODO";
+    let comment_reason = "Validate entity state";
+    let comment_note = "log output";
+    let v_interp = "ToString";
 
     // --- Abstract base class ---
     let base = TypeSpec::builder("Entity", TypeKind::Class)
@@ -94,7 +98,15 @@ fn builder_approach() -> String {
                 .returns(TypeName::primitive("string"))
                 .body({
                     let mut b = CodeBlock::builder();
-                    b.add_statement("return Name", ());
+                    b.add_attribute("Obsolete(\"Use newMethod instead\")");
+                    b.add_comment(&format!("{}: {}", comment_label, comment_reason));
+                    b.add_statement(
+                        "return Name; // %V %R",
+                        (
+                            VerbatimStrArg(v_interp.to_string()),
+                            CommentArg(comment_note.to_string()),
+                        ),
+                    );
                     b.build().unwrap()
                 })
                 .build()
@@ -161,6 +173,10 @@ fn builder_approach() -> String {
 fn macro_approach() -> String {
     let console = TypeName::importable("System", "Console");
     let (status, iface) = build_shared_types();
+    let comment_label = "TODO";
+    let comment_reason = "Validate entity state";
+    let comment_note = "log output";
+    let v_interp = "ToString";
 
     let base = TypeSpec::builder("Entity", TypeKind::Class)
         .visibility(Visibility::Public)
@@ -191,7 +207,15 @@ fn macro_approach() -> String {
                 .visibility(Visibility::Public)
                 .is_override()
                 .returns(TypeName::primitive("string"))
-                .body(sigil_quote!(CSharp { return Name; }).unwrap())
+                .body(
+                    sigil_quote!(CSharp {
+                        $attr("Obsolete(\"Use newMethod instead\")");
+                        $comment("@{comment_label}: @{comment_reason}");
+                        $V("// @{v_interp} override");
+                        return Name; $comment(comment_note)
+                    })
+                    .unwrap(),
+                )
                 .build()
                 .unwrap(),
         )

--- a/examples/dart_codegen.rs
+++ b/examples/dart_codegen.rs
@@ -81,6 +81,10 @@ fn build_shared_types() -> (TypeSpec, TypeSpec, TypeSpec) {
 fn builder_approach() -> String {
     let convert = TypeName::importable("dart:convert", "jsonDecode");
     let (status, base_entity, repo) = build_shared_types();
+    let comment_label = "FIXME";
+    let comment_reason = "Parse task data";
+    let comment_note = "decode JSON";
+    let v_interp = "Task";
 
     // --- Class: Task extends BaseEntity ---
     let task = TypeSpec::builder("Task", TypeKind::Class)
@@ -106,8 +110,12 @@ fn builder_approach() -> String {
         );
 
     let mut ctor_body = CodeBlock::builder();
-    ctor_body.add_statement("super(id)", ());
-    ctor_body.add_statement("this.name = name", ());
+    ctor_body.add_comment(&format!("{}: {}", comment_label, comment_reason));
+    ctor_body.add_statement("super(id) %R", (CommentArg(comment_note.to_string()),));
+    ctor_body.add_statement(
+        "this.name = name; // %V",
+        (VerbatimStrArg(v_interp.to_string()),),
+    );
 
     let task = task
         .add_method(
@@ -122,7 +130,12 @@ fn builder_approach() -> String {
             FunSpec::builder("validate")
                 .is_override()
                 .returns(TypeName::primitive("bool"))
-                .body(CodeBlock::of("return id.isNotEmpty && name.isNotEmpty", ()).unwrap())
+                .body({
+                    let mut vb = CodeBlock::builder();
+                    vb.add_attribute("override");
+                    vb.add("return id.isNotEmpty && name.isNotEmpty", ());
+                    vb.build().unwrap()
+                })
                 .build()
                 .unwrap(),
         )
@@ -203,6 +216,10 @@ fn builder_approach() -> String {
 fn macro_approach() -> String {
     let convert = TypeName::importable("dart:convert", "jsonDecode");
     let (status, base_entity, repo) = build_shared_types();
+    let comment_label = "FIXME";
+    let comment_reason = "Parse task data";
+    let comment_note = "decode JSON";
+    let v_interp = "Task";
 
     // --- Class: Task extends BaseEntity ---
     let task = TypeSpec::builder("Task", TypeKind::Class)
@@ -228,12 +245,15 @@ fn macro_approach() -> String {
         );
 
     let ctor_body = sigil_quote!(DartLang {
-        super(id);
+        $comment("@{comment_label}: @{comment_reason}");
+        super(id); $comment(comment_note)
         this.name = name;
+        $V("// @{v_interp} created");
     })
     .unwrap();
 
     let validate_body = sigil_quote!(DartLang {
+        $attr("override");
         return id.isNotEmpty && name.isNotEmpty
     })
     .unwrap();

--- a/examples/go_codegen.rs
+++ b/examples/go_codegen.rs
@@ -93,10 +93,22 @@ fn builder_approach() -> String {
     let fmt_sprintf = TypeName::importable("fmt", "Sprintf");
     let sort_slice = TypeName::importable("sort", "Slice");
     let (logger, server) = build_shared_types();
+    let comment_label = "INFO";
+    let comment_reason = "Configure server address";
+    let comment_note = "format address";
+    let v_interp = "8080";
 
     // --- Receiver method: Start ---
     let mut start_body = CodeBlock::builder();
-    start_body.add_statement("addr := %T(\"%%s:%%d\", s.host, s.port)", (fmt_sprintf,));
+    start_body.add_comment(&format!("{}: {}", comment_label, comment_reason));
+    start_body.add_statement(
+        "// default port: %V",
+        (VerbatimStrArg(v_interp.to_string()),),
+    );
+    start_body.add_statement(
+        "addr := %T(\"%%s:%%d\", s.host, s.port) %R",
+        (fmt_sprintf, CommentArg(comment_note.to_string())),
+    );
     start_body.add_statement("return %T(addr, nil)", (http_listen,));
 
     let start_fn = FunSpec::builder("Start")
@@ -194,9 +206,15 @@ fn macro_approach() -> String {
     let fmt_sprintf = TypeName::importable("fmt", "Sprintf");
     let sort_slice = TypeName::importable("sort", "Slice");
     let (logger, server) = build_shared_types();
+    let comment_label = "INFO";
+    let comment_reason = "Configure server address";
+    let comment_note = "format address";
+    let v_interp = "8080";
 
     let start_body = sigil_quote!(GoLang {
-        addr := $T(fmt_sprintf)("%s:%d", s.host, s.port)
+        $comment("@{comment_label}: @{comment_reason}");
+        $V("// default port: @{v_interp}");
+        addr := $T(fmt_sprintf)("%s:%d", s.host, s.port) $comment(comment_note)
         return $T(http_listen)(addr, nil)
     })
     .unwrap();

--- a/examples/haskell_codegen.rs
+++ b/examples/haskell_codegen.rs
@@ -61,6 +61,10 @@ fn build_shared_types() -> (TypeSpec, TypeSpec) {
 fn builder_approach() -> String {
     let map = TypeName::importable("Data.Map", "Map");
     let (person, user_id) = build_shared_types();
+    let comment_label = "NOTE";
+    let comment_reason = "Generate greeting output";
+    let comment_note = "format greeting";
+    let v_interp = "World";
 
     // --- Type alias ---
     let user_map = TypeSpec::builder("UserMap", TypeKind::TypeAlias)
@@ -73,7 +77,14 @@ fn builder_approach() -> String {
 
     // --- Function with type annotation (split signature) ---
     let mut greet_body = CodeBlock::builder();
-    greet_body.add("\"Hello, \" ++ personName p ++ \"!\"", ());
+    greet_body.add_comment(&format!("{}: {}", comment_label, comment_reason));
+    greet_body.add(
+        "\"Hello, \" ++ personName p ++ \" from %V!\" %R",
+        (
+            VerbatimStrArg(v_interp.to_string()),
+            CommentArg(comment_note.to_string()),
+        ),
+    );
 
     let greet_fn = FunSpec::builder("greet")
         .add_param(ParameterSpec::new("p", TypeName::primitive("Person")).unwrap())
@@ -109,6 +120,10 @@ fn builder_approach() -> String {
 fn macro_approach() -> String {
     let map = TypeName::importable("Data.Map", "Map");
     let (person, user_id) = build_shared_types();
+    let comment_label = "NOTE";
+    let comment_reason = "Generate greeting output";
+    let comment_note = "format greeting";
+    let v_interp = "World";
 
     let user_map = TypeSpec::builder("UserMap", TypeKind::TypeAlias)
         .extends(TypeName::generic(
@@ -119,7 +134,8 @@ fn macro_approach() -> String {
         .unwrap();
 
     let greet_body = sigil_quote!(Haskell {
-        "Hello, " ++ personName p ++ "!"
+        $comment("@{comment_label}: @{comment_reason}");
+        $V("\"Hello, \" ++ personName p ++ \" from @{v_interp}!\"") $comment(comment_note)
     })
     .unwrap();
 

--- a/examples/java_codegen.rs
+++ b/examples/java_codegen.rs
@@ -102,10 +102,21 @@ fn build_interface() -> TypeSpec {
 fn builder_approach() -> String {
     let priority_enum = build_enum();
     let repo_iface = build_interface();
+    let comment_label = "TODO";
+    let comment_reason = "Return entity name";
+    let comment_note = "access field";
+    let v_interp = "entity";
 
     // --- Abstract base class ---
     let mut get_name_body = CodeBlock::builder();
-    get_name_body.add_statement("return this.name", ());
+    get_name_body.add_comment(&format!("{}: {}", comment_label, comment_reason));
+    get_name_body.add_statement(
+        "return this.name; // %V %R",
+        (
+            VerbatimStrArg(v_interp.to_string()),
+            CommentArg(comment_note.to_string()),
+        ),
+    );
 
     let base_entity = TypeSpec::builder("BaseEntity", TypeKind::Class)
         .visibility(Visibility::Public)
@@ -149,6 +160,7 @@ fn builder_approach() -> String {
 
     // --- Concrete class with override and delegation ---
     let mut validate_body = CodeBlock::builder();
+    validate_body.add_attribute("Override");
     validate_body.add_statement("return this.name != null && !this.name.isEmpty()", ());
 
     let mut to_string_body = CodeBlock::builder();
@@ -272,6 +284,10 @@ fn builder_approach() -> String {
 fn macro_approach() -> String {
     let priority_enum = build_enum();
     let repo_iface = build_interface();
+    let comment_label = "TODO";
+    let comment_reason = "Return entity name";
+    let comment_note = "access field";
+    let v_interp = "entity";
 
     // --- Abstract base class ---
     let base_entity = TypeSpec::builder("BaseEntity", TypeKind::Class)
@@ -287,7 +303,13 @@ fn macro_approach() -> String {
             FunSpec::builder("BaseEntity")
                 .visibility(Visibility::Protected)
                 .add_param(ParameterSpec::new("name", TypeName::primitive("String")).unwrap())
-                .body(sigil_quote!(JavaLang { this.name = name; }).unwrap())
+                .body(
+                    sigil_quote!(JavaLang {
+                        $comment("@{comment_label}: @{comment_reason}");
+                        this.name = name;
+                    })
+                    .unwrap(),
+                )
                 .build()
                 .unwrap(),
         )
@@ -295,7 +317,7 @@ fn macro_approach() -> String {
             FunSpec::builder("getName")
                 .visibility(Visibility::Public)
                 .returns(TypeName::primitive("String"))
-                .body(sigil_quote!(JavaLang { return this.name; }).unwrap())
+                .body(sigil_quote!(JavaLang { $V("// @{v_interp} name"); return this.name; $comment(comment_note) }).unwrap())
                 .build()
                 .unwrap(),
         )
@@ -338,6 +360,7 @@ fn macro_approach() -> String {
                 .returns(TypeName::primitive("boolean"))
                 .body(
                     sigil_quote!(JavaLang {
+                        $attr("Override");
                         return this.name != null && !this.name.isEmpty();
                     })
                     .unwrap(),

--- a/examples/js_codegen.rs
+++ b/examples/js_codegen.rs
@@ -26,10 +26,21 @@ fn main() {
 fn builder_approach() -> String {
     let format_msg = TypeName::importable("./utils", "formatMessage");
     let event_emitter = TypeName::importable("events", "EventEmitter");
+    let comment_label = "FIXME";
+    let comment_reason = "Format log message";
+    let comment_note = "console output";
+    let v_interp = "service";
 
     let mut ctor_body = CodeBlock::builder();
+    ctor_body.add_comment(&format!("{}: {}", comment_label, comment_reason));
     ctor_body.add_statement("super()", ());
-    ctor_body.add_statement("this.name = name", ());
+    ctor_body.add_statement(
+        "this.name = name; // %V %R",
+        (
+            VerbatimStrArg(v_interp.to_string()),
+            CommentArg(comment_note.to_string()),
+        ),
+    );
 
     let mut log_body = CodeBlock::builder();
     log_body.add_statement("const msg = %T(this.name, message)", (format_msg,));
@@ -37,6 +48,7 @@ fn builder_approach() -> String {
 
     // Static factory method: Logger.create(name)
     let mut create_body = CodeBlock::builder();
+    create_body.add_attribute("deprecated");
     create_body.add_statement("return new Logger(name)", ());
 
     let logger = TypeSpec::builder("Logger", TypeKind::Class)
@@ -151,10 +163,16 @@ fn builder_approach() -> String {
 fn macro_approach() -> String {
     let format_msg = TypeName::importable("./utils", "formatMessage");
     let event_emitter = TypeName::importable("events", "EventEmitter");
+    let comment_label = "FIXME";
+    let comment_reason = "Format log message";
+    let comment_note = "console output";
+    let v_interp = "service";
 
     let ctor_body = sigil_quote!(JavaScript {
+        $comment("@{comment_label}: @{comment_reason}");
         super();
-        this.name = name;
+        this.name = name; $comment(comment_note)
+        $V("// @{v_interp} ready");
     })
     .unwrap();
 
@@ -166,6 +184,7 @@ fn macro_approach() -> String {
 
     // Static factory method body
     let create_body = sigil_quote!(JavaScript {
+        $attr("deprecated");
         return new Logger(name);
     })
     .unwrap();

--- a/examples/kotlin_codegen.rs
+++ b/examples/kotlin_codegen.rs
@@ -89,6 +89,10 @@ fn build_shared_types() -> (TypeSpec, TypeSpec) {
 
 fn builder_approach() -> String {
     let uuid = TypeName::importable("java.util", "UUID");
+    let comment_reason = "Create a new task entity";
+    let comment_label = "NOTE";
+    let v_interp = "task";
+    let comment_note = "ID is auto-generated via UUID";
     let (status, task) = build_shared_types();
 
     // --- Interface with variance ---
@@ -127,9 +131,16 @@ fn builder_approach() -> String {
 
     // --- Create function ---
     let mut create_body = CodeBlock::builder();
+    create_body.add_attribute("Override");
+    create_body.add_comment(&format!("{}: {}", comment_label, comment_reason));
+    create_body.add(
+        "val entity = %V",
+        (VerbatimStrArg(format!("new {}", v_interp)),),
+    );
+    create_body.add_line();
     create_body.add_statement(
-        "return Task(\n    id = %T.randomUUID().toString(),\n    name = name,\n    status = Status.PENDING\n)",
-        (uuid,),
+        "return Task(\n    id = %T.randomUUID().toString(),\n    name = name,\n    status = Status.PENDING\n) %R",
+        (uuid, CommentArg(comment_note.to_string())),
     );
 
     let create_fn = FunSpec::builder("createTask")
@@ -172,6 +183,10 @@ fn builder_approach() -> String {
 
 fn macro_approach() -> String {
     let uuid = TypeName::importable("java.util", "UUID");
+    let comment_reason = "Create a new task entity";
+    let comment_label = "NOTE";
+    let v_interp = "task";
+    let comment_note = "ID is auto-generated via UUID";
     let (status, task) = build_shared_types();
 
     let repo = TypeSpec::builder("Repository", TypeKind::Interface)
@@ -208,10 +223,13 @@ fn macro_approach() -> String {
         .unwrap();
 
     let create_body = sigil_quote!(Kotlin {
+        $attr("Override")
+        $comment("@{comment_label}: @{comment_reason}");
+        val entity = $V("new @{v_interp}")
         return Task(
             id = $T(uuid).randomUUID().toString(),
             name = name,
-            status = Status.PENDING
+            status = Status.PENDING $comment(comment_note)
         )
     })
     .unwrap();

--- a/examples/lua_codegen.rs
+++ b/examples/lua_codegen.rs
@@ -22,10 +22,20 @@ fn main() {
 
 fn builder_approach() -> String {
     let json = TypeName::importable("cjson", "json");
+    let comment_reason = "Initialize module state";
+    let comment_label = "INFO";
+    let v_interp = "module";
+    let comment_note = "validate input";
 
     // --- Simple function ---
     let mut greet_body = CodeBlock::builder();
-    greet_body.add("return \"Hello, \" .. name .. \"!\"", ());
+    greet_body.add_comment(&format!("{}: {}", comment_label, comment_reason));
+    greet_body.add("local mod = %V", (VerbatimStrArg(v_interp.to_string()),));
+    greet_body.add_line();
+    greet_body.add(
+        "return \"Hello, \" .. name .. \"!\" %R",
+        (CommentArg(comment_note.to_string()),),
+    );
 
     let greet_fn = FunSpec::builder("greet")
         .doc("Returns a greeting string.")
@@ -85,9 +95,15 @@ fn builder_approach() -> String {
 
 fn macro_approach() -> String {
     let json = TypeName::importable("cjson", "json");
+    let comment_reason = "Initialize module state";
+    let comment_label = "INFO";
+    let v_interp = "module";
+    let comment_note = "validate input";
 
     let greet_body = sigil_quote!(Lua {
-        return "Hello, " .. name .. "!"
+        $comment("@{comment_label}: @{comment_reason}");
+        local mod = $V("@{v_interp}")
+        return "Hello, " .. name .. "!" $comment(comment_note)
     })
     .unwrap();
 

--- a/examples/ocaml_codegen.rs
+++ b/examples/ocaml_codegen.rs
@@ -54,10 +54,20 @@ fn build_shared_types() -> (TypeSpec, TypeSpec) {
 
 fn builder_approach() -> String {
     let (person, string_list) = build_shared_types();
+    let comment_reason = "Initialize module state";
+    let comment_label = "NOTE";
+    let v_interp = "module";
+    let comment_note = "validate expression";
 
     // --- Function with curried params: greet ---
     let mut greet_body = CodeBlock::builder();
-    greet_body.add("\"Hello, \" ^ p.name ^ \"!\"", ());
+    greet_body.add_comment(&format!("{}: {}", comment_label, comment_reason));
+    greet_body.add("let mod_name = %V", (VerbatimStrArg(v_interp.to_string()),));
+    greet_body.add_line();
+    greet_body.add(
+        "\"Hello, \" ^ p.name ^ \"!\" %R",
+        (CommentArg(comment_note.to_string()),),
+    );
 
     let greet_fn = FunSpec::builder("greet")
         .add_param(ParameterSpec::new("p", TypeName::primitive("person")).unwrap())
@@ -120,10 +130,16 @@ fn builder_approach() -> String {
 
 fn macro_approach() -> String {
     let (person, string_list) = build_shared_types();
+    let comment_reason = "Initialize module state";
+    let comment_label = "NOTE";
+    let v_interp = "module";
+    let comment_note = "validate expression";
 
     // --- Function with curried params: greet (using sigil_quote!) ---
     let greet_body = sigil_quote!(OCaml {
-        "Hello, " ^ p.name ^ "!"
+        $comment("@{comment_label}: @{comment_reason}");
+        let mod_name = $V("@{v_interp}")
+        "Hello, " ^ p.name ^ "!" $comment(comment_note)
     })
     .unwrap();
 

--- a/examples/python_codegen.rs
+++ b/examples/python_codegen.rs
@@ -53,12 +53,20 @@ fn build_shared_types() -> (TypeSpec,) {
 
 fn builder_approach() -> String {
     let json_dumps = TypeName::importable("json", "dumps");
+    let comment_reason = "Initialize service state";
+    let comment_label = "INFO";
+    let v_interp = "config";
+    let comment_note = "validate arguments";
     let (level_enum,) = build_shared_types();
 
     let mut to_json_body = CodeBlock::builder();
+    to_json_body.add_attribute("staticmethod");
+    to_json_body.add_comment(&format!("{}: {}", comment_label, comment_reason));
+    to_json_body.add("_cfg = %V", (VerbatimStrArg(v_interp.to_string()),));
+    to_json_body.add_line();
     to_json_body.add_statement(
-        "return %T({'host': self.host, 'port': self.port})",
-        (json_dumps.clone(),),
+        "return %T({'host': self.host, 'port': self.port}) %R",
+        (json_dumps.clone(), CommentArg(comment_note.to_string())),
     );
 
     let to_json = FunSpec::builder("to_json")
@@ -177,10 +185,17 @@ fn builder_approach() -> String {
 
 fn macro_approach() -> String {
     let json_dumps = TypeName::importable("json", "dumps");
+    let comment_reason = "Initialize service state";
+    let comment_label = "INFO";
+    let v_interp = "config";
+    let comment_note = "validate arguments";
     let (level_enum,) = build_shared_types();
 
     let to_json_body = sigil_quote!(Python {
-        return $T(json_dumps)({$S("host"): self.host, $S("port"): self.port})
+        $attr("staticmethod")
+        $comment("@{comment_label}: @{comment_reason}");
+        _cfg = $V("@{v_interp}")
+        return $T(json_dumps)({$S("host"): self.host, $S("port"): self.port}) $comment(comment_note)
     })
     .unwrap();
 

--- a/examples/rust_codegen.rs
+++ b/examples/rust_codegen.rs
@@ -119,11 +119,22 @@ fn build_shared_types() -> (TypeSpec, TypeSpec, TypeSpec) {
 
 fn builder_approach() -> String {
     let display = TypeName::importable("std::fmt", "Display");
+    let comment_reason = "Initialize event handler";
+    let comment_label = "EVENT";
+    let v_interp = "events";
+    let comment_note = "validate event";
     let (event_enum, user_id, config) = build_shared_types();
 
     // --- Generic function with where constraint ---
     let mut body = CodeBlock::builder();
-    body.add_statement("println!(\"{}\", item)", ());
+    body.add_attribute("derive(Debug)");
+    body.add_comment(&format!("{}: {}", comment_label, comment_reason));
+    body.add("let _ev = %V", (VerbatimStrArg(v_interp.to_string()),));
+    body.add_line();
+    body.add_statement(
+        "println!(\"{}\", item) %R",
+        (CommentArg(comment_note.to_string()),),
+    );
 
     let print_fn = FunSpec::builder("print_item")
         .visibility(Visibility::Public)
@@ -209,10 +220,17 @@ fn builder_approach() -> String {
 
 fn macro_approach() -> String {
     let display = TypeName::importable("std::fmt", "Display");
+    let comment_reason = "Initialize event handler";
+    let comment_label = "EVENT";
+    let v_interp = "events";
+    let comment_note = "validate event";
     let (event_enum, user_id, config) = build_shared_types();
 
     let print_body = sigil_quote!(RustLang {
-        println!("{}", item)
+        $attr("derive(Debug)")
+        $comment("@{comment_label}: @{comment_reason}");
+        let _ev = $V("@{v_interp}");
+        println!("{}", item) $comment(comment_note)
     })
     .unwrap();
 

--- a/examples/scala_codegen.rs
+++ b/examples/scala_codegen.rs
@@ -59,11 +59,19 @@ fn build_shared_types() -> (TypeSpec, TypeSpec) {
 
 fn builder_approach() -> String {
     let list_buffer = TypeName::importable("scala.collection.mutable", "ListBuffer");
+    let comment_reason = "Initialize service state";
+    let comment_label = "NOTE";
+    let v_interp = "items";
+    let comment_note = "validate input";
     let (repo, user) = build_shared_types();
 
     // --- Generic function with context bound ---
     let mut sort_body = CodeBlock::builder();
-    sort_body.add_statement("items.sorted", ());
+    sort_body.add_attribute("Override");
+    sort_body.add_comment(&format!("{}: {}", comment_label, comment_reason));
+    sort_body.add("val _it = %V", (VerbatimStrArg(v_interp.to_string()),));
+    sort_body.add_line();
+    sort_body.add_statement("items.sorted %R", (CommentArg(comment_note.to_string()),));
 
     let sort_fn = FunSpec::builder("sortItems")
         .add_type_param(TypeParamSpec::new("T").with_context_bound(TypeName::primitive("Ordering")))
@@ -148,10 +156,17 @@ fn builder_approach() -> String {
 
 fn macro_approach() -> String {
     let list_buffer = TypeName::importable("scala.collection.mutable", "ListBuffer");
+    let comment_reason = "Initialize service state";
+    let comment_label = "NOTE";
+    let v_interp = "items";
+    let comment_note = "validate input";
     let (repo, user) = build_shared_types();
 
     let sort_body = sigil_quote!(Scala {
-        items.sorted
+        $attr("Override")
+        $comment("@{comment_label}: @{comment_reason}");
+        val _it = $V("@{v_interp}")
+        items.sorted $comment(comment_note)
     })
     .unwrap();
 

--- a/examples/swift_codegen.rs
+++ b/examples/swift_codegen.rs
@@ -69,6 +69,10 @@ fn build_shared_types() -> (TypeSpec, TypeSpec) {
 
 fn builder_approach() -> String {
     let url = TypeName::importable("Foundation", "URL");
+    let comment_reason = "Initialize service state";
+    let comment_label = "NOTE";
+    let v_interp = "request";
+    let comment_note = "validate input";
     let url_session = TypeName::importable("Foundation", "URLSession");
     let (result_enum, proto) = build_shared_types();
 
@@ -111,9 +115,13 @@ fn builder_approach() -> String {
 
     // --- Static factory method ---
     let mut factory_body = CodeBlock::builder();
+    factory_body.add_attribute("available(*, iOS 15)");
+    factory_body.add_comment(&format!("{}: {}", comment_label, comment_reason));
+    factory_body.add("let _req = %V", (VerbatimStrArg(v_interp.to_string()),));
+    factory_body.add_line();
     factory_body.add_statement(
-        "guard let url = %T(string: urlString) else { return nil }",
-        (url,),
+        "guard let url = %T(string: urlString) else { return nil } %R",
+        (url, CommentArg(comment_note.to_string())),
     );
     factory_body.add_statement("return url", ());
 
@@ -167,6 +175,10 @@ fn builder_approach() -> String {
 
 fn macro_approach() -> String {
     let url = TypeName::importable("Foundation", "URL");
+    let comment_reason = "Initialize service state";
+    let comment_label = "NOTE";
+    let v_interp = "request";
+    let comment_note = "validate input";
     let url_session = TypeName::importable("Foundation", "URLSession");
     let (result_enum, proto) = build_shared_types();
 
@@ -207,7 +219,10 @@ fn macro_approach() -> String {
         .unwrap();
 
     let factory_body = sigil_quote!(Swift {
-        guard let url = $T(url)(string: urlString) else {
+        $attr("available(*, iOS 15)")
+        $comment("@{comment_label}: @{comment_reason}");
+        let _req = $V("@{v_interp}")
+        guard let url = $T(url)(string: urlString) else { $comment(comment_note)
             return nil;
         }
         return url;

--- a/examples/typescript_codegen.rs
+++ b/examples/typescript_codegen.rs
@@ -20,6 +20,10 @@ fn main() {
 
 fn builder_approach() -> String {
     let user_type = TypeName::importable_type("./models", "User");
+    let comment_reason = "Initialize service state";
+    let comment_label = "TODO";
+    let v_interp = "User";
+    let comment_note = "validate user input";
     let not_found = TypeName::importable_type("./errors", "NotFoundError");
     let event_emitter = TypeName::importable("events", "EventEmitter");
 
@@ -130,9 +134,16 @@ fn builder_approach() -> String {
         .unwrap();
 
     let mut body = CodeBlock::builder();
+    body.add_attribute("override");
+    body.add_comment(&format!("{}: {}", comment_label, comment_reason));
+    body.add("const _user = %V", (VerbatimStrArg(v_interp.to_string()),));
+    body.add_line();
     body.add_statement(
-        "const user = await this.userRepo.findById(%S)",
-        (StringLitArg("id".into()),),
+        "const user = await this.userRepo.findById(%S) %R",
+        (
+            StringLitArg("id".into()),
+            CommentArg(comment_note.to_string()),
+        ),
     );
     body.begin_control_flow("if (!user)", ());
     body.add_statement("throw new %T('User not found')", (not_found,));
@@ -199,6 +210,10 @@ fn builder_approach() -> String {
 
 fn macro_approach() -> String {
     let user_type = TypeName::importable_type("./models", "User");
+    let comment_reason = "Initialize service state";
+    let comment_label = "TODO";
+    let v_interp = "User";
+    let comment_note = "validate user input";
     let not_found = TypeName::importable_type("./errors", "NotFoundError");
     let event_emitter = TypeName::importable("events", "EventEmitter");
 
@@ -273,7 +288,10 @@ fn macro_approach() -> String {
 
     // --- Class with service methods ---
     let body = sigil_quote!(TypeScript {
-        const user = await this.userRepo.findById($S("id"));
+        $attr("override")
+        $comment("@{comment_label}: @{comment_reason}");
+        const _user = $V("@{v_interp}");
+        const user = await this.userRepo.findById($S("id")) $comment(comment_note);
         if(!user) {
             throw new $T(not_found)($S("User not found"));
         }

--- a/macros/src/codegen.rs
+++ b/macros/src/codegen.rs
@@ -41,9 +41,29 @@ fn generate_statements(statements: &[Statement]) -> Vec<TokenStream> {
                     __sigil_builder.add("%<", ());
                 });
             }
-            Statement::Comment(text) => {
+            Statement::Comment(expr) => {
+                let comment_expr = match extract_at_interpolation(expr) {
+                    Some(VerbatimResult::Interpolated {
+                        format_string,
+                        expressions,
+                    }) => {
+                        let fmt_lit = Literal::string(&format_string);
+                        let exprs: Vec<TokenStream> = expressions
+                            .iter()
+                            .map(|e| e.parse::<TokenStream>().unwrap())
+                            .collect();
+                        quote! { ::std::format!(#fmt_lit, #(#exprs),*) }
+                    }
+                    Some(VerbatimResult::Literal(s)) => {
+                        let lit = Literal::string(&s);
+                        quote! { ::std::string::String::from(#lit) }
+                    }
+                    _ => {
+                        quote! { (#expr).to_string() }
+                    }
+                };
                 calls.push(quote! {
-                    __sigil_builder.add_comment(#text);
+                    __sigil_builder.add_comment(&#comment_expr);
                 });
             }
             Statement::Attr(text) => {
@@ -222,6 +242,36 @@ fn build_args_tuple(args: &[TypedArg]) -> TokenStream {
                             }
                             _ => {
                                 quote! { ::sigil_stitch::code_block::VerbatimStrArg((#expr).to_string()) }
+                            }
+                        }
+                    }
+                    InterpolationKind::Comment => {
+                        match extract_at_interpolation(expr) {
+                            Some(VerbatimResult::Interpolated {
+                                format_string,
+                                expressions,
+                            }) => {
+                                let fmt_lit = Literal::string(&format_string);
+                                let exprs: Vec<TokenStream> = expressions
+                                    .iter()
+                                    .map(|e| e.parse::<TokenStream>().unwrap())
+                                    .collect();
+                                quote! {
+                                    ::sigil_stitch::code_block::CommentArg(
+                                        ::std::format!(#fmt_lit, #(#exprs),*)
+                                    )
+                                }
+                            }
+                            Some(VerbatimResult::Literal(s)) => {
+                                let lit = Literal::string(&s);
+                                quote! {
+                                    ::sigil_stitch::code_block::CommentArg(
+                                        ::std::string::String::from(#lit)
+                                    )
+                                }
+                            }
+                            _ => {
+                                quote! { ::sigil_stitch::code_block::CommentArg((#expr).to_string()) }
                             }
                         }
                     }

--- a/macros/src/parse/format.rs
+++ b/macros/src/parse/format.rs
@@ -132,13 +132,8 @@ fn tokens_to_format_inner(
                 continue;
             }
 
-            // `$comment(...)` should have been caught earlier.
-            if is_ident(next, "comment") {
-                return Err(CompileError::new(
-                    next.span(),
-                    "$comment() must appear at the start of a line",
-                ));
-            }
+            // `$comment(...)` — inline comment. Falls through to the
+            // interpolation handler below.
 
             // `$C_each(...)` should have been caught earlier (statement-level).
             if is_ident(next, "C_each") {
@@ -280,12 +275,13 @@ fn tokens_to_format_inner(
                     "V" => InterpolationKind::VerbatimStr,
                     "L" => InterpolationKind::Literal,
                     "C" => InterpolationKind::Code,
+                    "comment" => InterpolationKind::Comment,
                     _ => {
                         return Err(CompileError::new(
                             id.span(),
                             format!(
                                 "unknown interpolation kind `${kind_str}`. \
-                                     Expected $T, $N, $S, $V, $L, $C, $W, $T_join, $join, or $C_each"
+                                     Expected $T, $N, $S, $V, $L, $C, $W, $T_join, $join, $comment, or $C_each"
                             ),
                         ));
                     }
@@ -321,6 +317,7 @@ fn tokens_to_format_inner(
                     InterpolationKind::Literal
                     | InterpolationKind::Code
                     | InterpolationKind::TypeJoin => "%L",
+                    InterpolationKind::Comment => "%R",
                 };
 
                 if !adjacent_to_prev_specifier {

--- a/macros/src/parse/statements.rs
+++ b/macros/src/parse/statements.rs
@@ -1,4 +1,4 @@
-use proc_macro2::{Delimiter, Spacing, TokenTree};
+use proc_macro2::{Delimiter, Spacing, TokenStream, TokenTree};
 
 use super::brace_classifier::{self, BraceKind};
 use super::format::tokens_to_format;
@@ -631,12 +631,12 @@ fn try_parse_indent_directive(tokens: &[TokenTree], start: usize) -> Option<(Sta
     None
 }
 
-/// Try to parse `$comment("text")` at position `start`.
+/// Try to parse `$comment(expr)` at position `start`.
 fn try_parse_comment(
     tokens: &[TokenTree],
     start: usize,
-) -> Result<Option<(String, usize)>, CompileError> {
-    // Need at least 3 tokens: `$`, `comment`, `("text")`
+) -> Result<Option<(TokenStream, usize)>, CompileError> {
+    // Need at least 3 tokens: `$`, `comment`, `(...)`.
     if start + 2 >= tokens.len() {
         return Ok(None);
     }
@@ -652,59 +652,26 @@ fn try_parse_comment(
         return Ok(None);
     }
 
-    // Check for parenthesized string literal.
+    // Check for parenthesized expression.
     let group = match &tokens[start + 2] {
         TokenTree::Group(g) if g.delimiter() == Delimiter::Parenthesis => g,
         _ => {
             return Err(CompileError::new(
                 tokens[start + 2].span(),
-                "$comment requires parenthesized string: $comment(\"text\")",
+                "$comment requires parenthesized expression: $comment(expr)",
             ));
         }
     };
 
-    let inner: Vec<TokenTree> = group.stream().into_iter().collect();
-    if inner.len() != 1 {
-        return Err(CompileError::new(
-            group.span(),
-            "$comment requires a single string literal: $comment(\"text\")",
-        ));
-    }
+    let expr = group.stream();
 
-    let text = match &inner[0] {
-        TokenTree::Literal(lit) => {
-            let s = lit.to_string();
-            // Strip surrounding quotes and unescape.
-            if s.starts_with('"') && s.ends_with('"') && s.len() >= 2 {
-                let raw = &s[1..s.len() - 1];
-                match unescape_string(raw) {
-                    Ok(text) => text,
-                    Err(msg) => {
-                        return Err(CompileError::new(lit.span(), &msg));
-                    }
-                }
-            } else {
-                return Err(CompileError::new(
-                    lit.span(),
-                    "$comment requires a string literal",
-                ));
-            }
-        }
-        _ => {
-            return Err(CompileError::new(
-                inner[0].span(),
-                "$comment requires a string literal",
-            ));
-        }
-    };
-
-    // Skip optional semicolon after $comment("text");
+    // Skip optional semicolon after $comment(expr);
     let mut next = start + 3;
     if next < tokens.len() && is_semicolon(&tokens[next]) {
         next += 1;
     }
 
-    Ok(Some((text, next)))
+    Ok(Some((expr, next)))
 }
 
 /// Try to parse `$attr("text")` at position `start`.

--- a/macros/src/parse/statements_tests.rs
+++ b/macros/src/parse/statements_tests.rs
@@ -98,7 +98,25 @@ fn control_flow_if_else() {
 fn comment_directive() {
     let stmt = parse_stmt("$comment(\"hello world\")");
     match stmt {
-        Statement::Comment(text) => assert_eq!(text, "hello world"),
+        Statement::Comment(_) => {}
+        _ => panic!("expected Comment, got {:?}", stmt_kind(&stmt)),
+    }
+}
+
+#[test]
+fn comment_directive_expression() {
+    let stmt = parse_stmt("$comment(my_var)");
+    match stmt {
+        Statement::Comment(_) => {}
+        _ => panic!("expected Comment, got {:?}", stmt_kind(&stmt)),
+    }
+}
+
+#[test]
+fn comment_directive_format() {
+    let stmt = parse_stmt("$comment(format!(\"hello {}\", name))");
+    match stmt {
+        Statement::Comment(_) => {}
         _ => panic!("expected Comment, got {:?}", stmt_kind(&stmt)),
     }
 }

--- a/macros/src/parse/types.rs
+++ b/macros/src/parse/types.rs
@@ -43,8 +43,8 @@ pub(crate) enum Statement {
     Line { format: String, args: Vec<TypedArg> },
     /// `add_line()` — blank line.
     BlankLine,
-    /// `add_comment(text)` — `$comment("text")`.
-    Comment(String),
+    /// `add_comment(text)` — `$comment("text")` or `$comment(expr)`.
+    Comment(TokenStream),
     /// `add_attribute(text)` — `$attr("text")`. Language-aware attribute/annotation
     /// that renders with the target language's prefix/suffix (Rust: #[...],
     /// Java/Python: @..., C++: [[...]]).
@@ -119,6 +119,8 @@ pub(crate) enum InterpolationKind {
     /// `$T_join(sep, iter)` — join TypeName items with a separator,
     /// tracking imports for each item via `%T` slots.
     TypeJoin,
+    /// `$comment(expr)` — inline comment (when used inside a statement).
+    Comment,
 }
 
 /// A compile error with span information.

--- a/src/code_block.rs
+++ b/src/code_block.rs
@@ -27,6 +27,8 @@ pub enum Specifier {
     VerbatimStr,
     /// `%L` / `$L` / `$C` — literal value or nested code block (consumes `Arg::Literal` or `Arg::Code`).
     Literal,
+    /// `%R` / `$comment` — inline comment (consumes `Arg::Comment`).
+    Comment,
 }
 
 impl Specifier {
@@ -41,6 +43,7 @@ impl Specifier {
             'S' => Some(Self::StringLit),
             'V' => Some(Self::VerbatimStr),
             'L' => Some(Self::Literal),
+            'R' => Some(Self::Comment),
             _ => None,
         }
     }
@@ -53,6 +56,7 @@ impl Specifier {
             Self::StringLit => 'S',
             Self::VerbatimStr => 'V',
             Self::Literal => 'L',
+            Self::Comment => 'R',
         }
     }
 
@@ -64,6 +68,7 @@ impl Specifier {
             Self::StringLit,
             Self::VerbatimStr,
             Self::Literal,
+            Self::Comment,
         ]
     }
 }
@@ -119,6 +124,8 @@ pub enum Arg {
     Literal(String),
     /// A nested code block (used by `%L`).
     Code(CodeBlock),
+    /// An inline comment (used by `%R` / `$comment`).
+    Comment(String),
 }
 
 /// An immutable code fragment with embedded type references.
@@ -282,6 +289,7 @@ impl CodeBlockBuilder {
                     Arg::VerbatimStr(_) => "VerbatimStr".to_string(),
                     Arg::Literal(_) => "Literal".to_string(),
                     Arg::Code(_) => "Code".to_string(),
+                    Arg::Comment(_) => "Comment".to_string(),
                 })
                 .collect();
             self.errors
@@ -590,6 +598,28 @@ impl IntoArgs for VerbatimStrArg {
     }
 }
 
+/// A wrapper to mark a string as an inline comment arg (for `%R` / `$comment`).
+///
+/// Use `CommentArg` when your format string uses `%R` to emit a language-specific
+/// comment at the current position.
+///
+/// # Examples
+///
+/// ```
+/// use sigil_stitch::code_block::{CodeBlock, CommentArg};
+///
+/// let mut cb = CodeBlock::builder();
+/// cb.add_statement("const x = 42; %R", (CommentArg("TODO: validate".to_string()),));
+/// let block = cb.build().unwrap();
+/// ```
+pub struct CommentArg(pub String);
+
+impl IntoArgs for CommentArg {
+    fn into_args(self) -> Vec<Arg> {
+        vec![Arg::Comment(self.0)]
+    }
+}
+
 // Individual Arg conversions.
 impl From<TypeName> for Arg {
     fn from(tn: TypeName) -> Self {
@@ -630,6 +660,12 @@ impl From<StringLitArg> for Arg {
 impl From<VerbatimStrArg> for Arg {
     fn from(s: VerbatimStrArg) -> Self {
         Arg::VerbatimStr(s.0)
+    }
+}
+
+impl From<CommentArg> for Arg {
+    fn from(s: CommentArg) -> Self {
+        Arg::Comment(s.0)
     }
 }
 

--- a/src/code_node.rs
+++ b/src/code_node.rs
@@ -95,6 +95,7 @@ pub(crate) fn parts_args_to_nodes(parts: &[FormatPart], args: &[Arg]) -> Vec<Cod
                     }
                     (Specifier::Literal, Arg::Literal(s)) => CodeNode::InlineLiteral(s.clone()),
                     (Specifier::Literal, Arg::Code(block)) => CodeNode::Nested(block.clone()),
+                    (Specifier::Comment, Arg::Comment(s)) => CodeNode::Comment(s.clone()),
                     _ => CodeNode::Literal(String::new()),
                 }
             }

--- a/src/code_template.rs
+++ b/src/code_template.rs
@@ -224,6 +224,7 @@ fn arg_kind_label(arg: &Arg) -> &'static str {
         Arg::VerbatimStr(_) => "VerbatimStr",
         Arg::Literal(_) => "Literal",
         Arg::Code(_) => "Code",
+        Arg::Comment(_) => "Comment",
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,7 +95,7 @@ pub(crate) mod type_name_render;
 /// Common re-exports for convenient usage.
 pub mod prelude {
     pub use crate::code_block::{
-        CodeBlock, CodeBlockBuilder, NameArg, Specifier, StringLitArg, VerbatimStrArg,
+        CodeBlock, CodeBlockBuilder, CommentArg, NameArg, Specifier, StringLitArg, VerbatimStrArg,
     };
     pub use crate::code_template::{CodeTemplate, ParamKind};
     pub use crate::error::SigilStitchError;

--- a/tests/macro/comments.rs
+++ b/tests/macro/comments.rs
@@ -126,6 +126,112 @@ fn test_comment_attaches_to_declaration_after_blank_line() {
     );
 }
 
+// ── $comment(expr) — dynamic expressions ──────────────────
+
+#[test]
+fn test_comment_with_dynamic_expression() {
+    let msg = "dynamic comment";
+    let block = sigil_quote!(TypeScript {
+        $comment(msg);
+        const x = 0;
+    })
+    .unwrap();
+
+    let output = render_ts(&block);
+    assert!(output.contains("// dynamic comment"), "got: {output}");
+}
+
+#[test]
+fn test_comment_with_format_expression() {
+    let name = "Foo";
+    let block = sigil_quote!(TypeScript {
+        $comment(format!("Class: {name}"));
+        const x = 0;
+    })
+    .unwrap();
+
+    let output = render_ts(&block);
+    assert!(output.contains("// Class: Foo"), "got: {output}");
+}
+
+#[test]
+fn test_comment_with_to_string_expression() {
+    let code = 200;
+    let block = sigil_quote!(TypeScript {
+        $comment(code.to_string());
+        const x = 0;
+    })
+    .unwrap();
+
+    let output = render_ts(&block);
+    assert!(output.contains("// 200"), "got: {output}");
+}
+
+// ── $comment(expr) — inline interpolation ──────────────────
+
+#[test]
+fn test_comment_inline_within_statement() {
+    let msg = "cleanup";
+    let block = sigil_quote!(TypeScript {
+        doStuff($S("x")) $comment(msg)
+    })
+    .unwrap();
+
+    let output = render_ts(&block);
+    assert!(output.contains("doStuff('x') // cleanup"), "got: {output}");
+}
+
+#[test]
+fn test_comment_inline_with_format() {
+    let name = "validate";
+    let block = sigil_quote!(TypeScript {
+        process($S("y")) $comment(format!("TODO: {name}"))
+    })
+    .unwrap();
+
+    let output = render_ts(&block);
+    assert!(output.contains("// TODO: validate"), "got: {output}");
+}
+
+// ── $comment(expr) — @{…} interpolation ──────────────────
+
+#[test]
+fn test_comment_with_at_interpolation() {
+    let name = "World";
+    let block = sigil_quote!(TypeScript {
+        $comment("Hello @{name}");
+        const x = 0;
+    })
+    .unwrap();
+
+    let output = render_ts(&block);
+    assert!(output.contains("// Hello World"), "got: {output}");
+}
+
+#[test]
+fn test_comment_with_at_interpolation_inline() {
+    let count = 42;
+    let block = sigil_quote!(TypeScript {
+        doStuff() $comment("processed @{count} items")
+    })
+    .unwrap();
+
+    let output = render_ts(&block);
+    assert!(output.contains("// processed 42 items"), "got: {output}");
+}
+
+#[test]
+fn test_comment_with_double_at_escape() {
+    let block = sigil_quote!(TypeScript {
+        $comment("user@@host");
+        const x = 0;
+    })
+    .unwrap();
+
+    let output = render_ts(&block);
+    assert!(output.contains("// user@host"), "got: {output}");
+}
+
 // ── $attr() — language-aware attributes ──────────────────
 
 #[test]


### PR DESCRIPTION
## Summary
- `$comment(expr)` now accepts any Rust expression, not just string literals
- Changed `Statement::Comment(String)` → `Statement::Comment(TokenStream)` to store raw expressions
- Simplified `try_parse_comment` — removed literal-only restriction and unescape logic
- Codegen emits `add_comment(&(#expr).to_string())` for runtime evaluation

## Examples
```rust
$comment(my_var);
$comment(format!("Class: {name}"));
$comment(code.to_string());
```

## Test plan
- [x] `cargo test --workspace` — all tests pass
- [x] `cargo clippy --workspace --tests -- -D warnings` — clean
- [x] `cargo fmt --all` — clean
- [x] Added unit tests for expression and `format!()` arguments
- [x] Added integration tests: dynamic var, `format!()`, `.to_string()`