### PR TITLE
chore: bump version to 0.6.5 and update docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 0.6.5
+
+### Added
+
+- `$comment(expr)` now accepts any Rust expression, not just string literals.
+  `$comment(my_var)`, `$comment(format!("Class: {name}"))`, and
+  `$comment(code.to_string())` all work. The expression result is converted via
+  `.to_string()` at runtime.
+- `@{expr}` interpolation inside `$comment` string literals — `$comment("Hello @{name}")`
+  resolves Rust expressions at compile time, matching the `$V` / `$L` pattern.
+  Works in both statement-level (`$comment("...")`) and inline
+  (`doStuff() $comment("processed @{count} items")`) positions.
+- `@@` escape in `$comment` — `$comment("user@@host")` emits `// user@host`.
+- `CommentArg` wrapper and `%R` specifier for inline comments in the builder API
+  (`add_statement("return x; %R", (CommentArg("validate".to_string()),))`).
+  `CommentArg` is re-exported in the prelude.
+- `$V` `@{...}` interpolation and `$attr()` demonstrations in all 17 language
+  example files.
+
 ## 0.6.4
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,7 +100,7 @@ dependencies = [
 
 [[package]]
 name = "sigil-stitch"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "pretty",
  "serde",
@@ -111,7 +111,7 @@ dependencies = [
 
 [[package]]
 name = "sigil-stitch-macros"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["macros"]
 resolver = "3"
 
 [workspace.package]
-version = "0.6.4"
+version = "0.6.5"
 edition = "2024"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"
@@ -35,7 +35,7 @@ exclude = [
 [dependencies]
 pretty = "0.12"
 snafu = "0.9"
-sigil-stitch-macros = { path = "macros", version = "0.6.4" }
+sigil-stitch-macros = { path = "macros", version = "0.6.5" }
 serde = { version = "1", features = ["derive"] }
 
 [dev-dependencies]

--- a/docs/src/format_specifiers.md
+++ b/docs/src/format_specifiers.md
@@ -10,6 +10,7 @@
 | `%N` | Name | `NameArg` | Emit identifier name |
 | `%S` | String | `StringLitArg` | Emit escaped string literal |
 | `%V` | Verbatim | `VerbatimStrArg` | Emit string with interpolation preserved |
+| `%R` | Remark | `CommentArg` | Emit inline comment |
 | `%L` | Literal | `&str`, `String`, `CodeBlock` | Emit raw value or nested block |
 | `%W` | Wrap | (none) | Soft line break point |
 | `%>` | Indent | (none) | Increase indent level |
@@ -170,6 +171,41 @@ Per-language behavior:
 For Bash/Zsh, `%V` is pure passthrough — the string is emitted as-is with no wrapping quotes and no escaping. Shell interpolates by default, and users control quoting in the `%V` content itself (include `"..."` in the string when quoting is desired in the output).
 
 For languages without string interpolation (C, C++, Go, Rust, Java, Haskell, OCaml, Lua), `%V` falls back to `%S` behavior (full escaping).
+
+## `%R` -- Inline Comment
+
+Emits a language-specific inline comment. Requires the `CommentArg` wrapper.
+
+```rust
+# extern crate sigil_stitch;
+# use sigil_stitch::code_block::{CodeBlock, CommentArg};
+# use sigil_stitch::prelude::*;
+# fn main() {
+let mut cb = CodeBlock::builder();
+cb.add_statement("const x = 42; %R", (CommentArg("TODO: validate".to_string()),));
+let block = cb.build().unwrap();
+// TypeScript: const x = 42; // TODO: validate
+// Python:     const x = 42; # TODO: validate
+# }
+```
+
+The comment prefix (`//`, `#`, `--`, etc.) is determined by the target language's
+`comment_syntax()`. The comment text is emitted verbatim after the prefix with a
+single space separator.
+
+In `sigil_quote!`, inline `$comment(expr)` after a statement expands to `%R`:
+
+```rust
+# extern crate sigil_stitch;
+# use sigil_stitch::prelude::*;
+# fn main() {
+sigil_quote!(TypeScript {
+    doStuff() $comment("cleanup")
+}).unwrap();
+// Equivalent builder call:
+//   cb.add("doStuff() %R", (CommentArg("cleanup".to_string()),));
+# }
+```
 
 ### `@{expr}` interpolation in `$V` and `$L`
 
@@ -369,6 +405,7 @@ The critical rule: **bare strings map to `Arg::Literal`** (consumed by `%L`), no
 | `NameArg(String)` | `Arg::Name` | `%N` |
 | `StringLitArg(String)` | `Arg::StringLit` | `%S` |
 | `VerbatimStrArg(String)` | `Arg::VerbatimStr` | `%V` |
+| `CommentArg(String)` | `Arg::Comment` | `%R` |
 | `Vec<Arg>` | passthrough | any |
 
 ### Single Argument

--- a/docs/src/sigil_quote.md
+++ b/docs/src/sigil_quote.md
@@ -279,10 +279,14 @@ sigil_quote!(TypeScript {
 # }
 ```
 
-### Comments: `$comment("text")`
+### Comments: `$comment(expr)`
 
 Rust's proc macro tokenizer strips `//` comments, so they're invisible to the macro.
-Use `$comment()` instead:
+Use `$comment()` instead. The argument can be any Rust expression that evaluates to
+something displayable — a string literal, a variable, `format!(...)`, or any type
+implementing `ToString`.
+
+**Statement-level comments** appear at the start of a line:
 
 ```rust
 # extern crate sigil_stitch;
@@ -298,6 +302,100 @@ sigil_quote!(TypeScript {
 # Ok(())
 # }
 ```
+
+**Dynamic expressions** work as the argument:
+
+```rust
+# extern crate sigil_stitch;
+# use sigil_stitch::prelude::*;
+# fn main() -> Result<(), Box<dyn std::error::Error>> {
+let msg = "Initialize the connection pool";
+sigil_quote!(TypeScript {
+    $comment(msg);
+    const pool = createPool();
+})?;
+# Ok(())
+# }
+```
+
+```rust
+# extern crate sigil_stitch;
+# use sigil_stitch::prelude::*;
+# fn main() -> Result<(), Box<dyn std::error::Error>> {
+let name = "Foo";
+sigil_quote!(TypeScript {
+    $comment(format!("Class: {name}"));
+    const x = 0;
+})?;
+# Ok(())
+# }
+```
+
+**Inline comments** appear after a statement on the same line:
+
+```rust
+# extern crate sigil_stitch;
+# use sigil_stitch::prelude::*;
+# fn main() -> Result<(), Box<dyn std::error::Error>> {
+let msg = "cleanup";
+sigil_quote!(TypeScript {
+    doStuff($S("x")) $comment(msg)
+})?;
+// Output: doStuff('x') // cleanup
+# Ok(())
+# }
+```
+
+#### `@{expr}` interpolation
+
+Embed Rust expressions inside `$comment` string literals with `@{expr}`. These are
+resolved at compile time:
+
+```rust
+# extern crate sigil_stitch;
+# use sigil_stitch::prelude::*;
+# fn main() -> Result<(), Box<dyn std::error::Error>> {
+let name = "World";
+sigil_quote!(TypeScript {
+    $comment("Hello @{name}");
+    const x = 0;
+})?;
+// Output: // Hello World
+# Ok(())
+# }
+```
+
+`@{...}` interpolation also works in inline comments:
+
+```rust
+# extern crate sigil_stitch;
+# use sigil_stitch::prelude::*;
+# fn main() -> Result<(), Box<dyn std::error::Error>> {
+let count = 42;
+sigil_quote!(TypeScript {
+    doStuff() $comment("processed @{count} items")
+})?;
+// Output: doStuff() // processed 42 items
+# Ok(())
+# }
+```
+
+Use `@@` to emit a literal `@`:
+
+```rust
+# extern crate sigil_stitch;
+# use sigil_stitch::prelude::*;
+# fn main() -> Result<(), Box<dyn std::error::Error>> {
+sigil_quote!(TypeScript {
+    $comment("user@@host");
+})?;
+// Output: // user@host
+# Ok(())
+# }
+```
+
+An optional trailing `;` after `$comment(...)` is consumed silently and does not
+affect the output.
 
 ### Annotations (`$attr`)
 


### PR DESCRIPTION
## Summary
- Bump version 0.6.4 → 0.6.5
- Add CHANGELOG entry for `$comment(expr)` dynamic expressions, `@{...}` interpolation, and `CommentArg`/`%R`
- Expand `$comment` docs in sigil_quote.md with dynamic expression, inline, and `@{...}` examples
- Add `%R` specifier documentation to format_specifiers.md