### PR TITLE
refactor: eliminate trailing_semicolon flag, separate brace expressions from control flow

### DIFF
--- a/macros/src/codegen.rs
+++ b/macros/src/codegen.rs
@@ -42,13 +42,13 @@ fn generate_statements(statements: &[Statement]) -> Vec<TokenStream> {
                 });
             }
             Statement::Comment(expr) => {
-                let comment_expr = resolve_verbatim_interpolation(expr);
+                let comment_expr = resolve_at_interpolation(expr);
                 calls.push(quote! {
                     __sigil_builder.add_comment(&#comment_expr);
                 });
             }
             Statement::Attr(expr) => {
-                let attr_expr = resolve_verbatim_interpolation(expr);
+                let attr_expr = resolve_at_interpolation(expr);
                 calls.push(quote! {
                     __sigil_builder.add_attribute(&#attr_expr);
                 });
@@ -320,7 +320,7 @@ fn generate_meta_if(branches: &[MetaBranch]) -> TokenStream {
 /// If the expression is a string literal containing `@{...}` patterns,
 /// emits a `format!()` call. If it's a plain string literal, emits a
 /// `String::from()` call. Otherwise, emits `(#expr).to_string()`.
-fn resolve_verbatim_interpolation(expr: &TokenStream) -> TokenStream {
+fn resolve_at_interpolation(expr: &TokenStream) -> TokenStream {
     match extract_at_interpolation(expr) {
         Some(VerbatimResult::Interpolated {
             format_string,

--- a/macros/src/codegen.rs
+++ b/macros/src/codegen.rs
@@ -42,33 +42,15 @@ fn generate_statements(statements: &[Statement]) -> Vec<TokenStream> {
                 });
             }
             Statement::Comment(expr) => {
-                let comment_expr = match extract_at_interpolation(expr) {
-                    Some(VerbatimResult::Interpolated {
-                        format_string,
-                        expressions,
-                    }) => {
-                        let fmt_lit = Literal::string(&format_string);
-                        let exprs: Vec<TokenStream> = expressions
-                            .iter()
-                            .map(|e| e.parse::<TokenStream>().unwrap())
-                            .collect();
-                        quote! { ::std::format!(#fmt_lit, #(#exprs),*) }
-                    }
-                    Some(VerbatimResult::Literal(s)) => {
-                        let lit = Literal::string(&s);
-                        quote! { ::std::string::String::from(#lit) }
-                    }
-                    _ => {
-                        quote! { (#expr).to_string() }
-                    }
-                };
+                let comment_expr = resolve_verbatim_interpolation(expr);
                 calls.push(quote! {
                     __sigil_builder.add_comment(&#comment_expr);
                 });
             }
-            Statement::Attr(text) => {
+            Statement::Attr(expr) => {
+                let attr_expr = resolve_verbatim_interpolation(expr);
                 calls.push(quote! {
-                    __sigil_builder.add_attribute(#text);
+                    __sigil_builder.add_attribute(&#attr_expr);
                 });
             }
             Statement::Statement { format, args } => {
@@ -275,6 +257,21 @@ fn build_args_tuple(args: &[TypedArg]) -> TokenStream {
                             }
                         }
                     }
+                    InterpolationKind::ParsedBlock => {
+                        let body_stmts = arg.parsed_body.as_ref()
+                            .expect("ParsedBlock must have parsed_body");
+                        let body_calls = generate_statements(body_stmts);
+                        quote! {
+                            {
+                                let mut __sigil_builder =
+                                    ::sigil_stitch::code_block::CodeBlock::builder();
+                                __sigil_builder.begin_control_flow("", ());
+                                #(#body_calls)*
+                                __sigil_builder.end_control_flow_no_newline();
+                                __sigil_builder.build().unwrap()
+                            }
+                        }
+                    }
                 }
             })
             .collect();
@@ -316,6 +313,32 @@ fn generate_meta_if(branches: &[MetaBranch]) -> TokenStream {
     }
 
     result
+}
+
+/// Resolve a string literal expression, handling `@{expr}` interpolation.
+///
+/// If the expression is a string literal containing `@{...}` patterns,
+/// emits a `format!()` call. If it's a plain string literal, emits a
+/// `String::from()` call. Otherwise, emits `(#expr).to_string()`.
+fn resolve_verbatim_interpolation(expr: &TokenStream) -> TokenStream {
+    match extract_at_interpolation(expr) {
+        Some(VerbatimResult::Interpolated {
+            format_string,
+            expressions,
+        }) => {
+            let fmt_lit = Literal::string(&format_string);
+            let exprs: Vec<TokenStream> = expressions
+                .iter()
+                .map(|e| e.parse::<TokenStream>().unwrap())
+                .collect();
+            quote! { ::std::format!(#fmt_lit, #(#exprs),*) }
+        }
+        Some(VerbatimResult::Literal(s)) => {
+            let lit = Literal::string(&s);
+            quote! { ::std::string::String::from(#lit) }
+        }
+        _ => quote! { (#expr).to_string() },
+    }
 }
 
 /// Try to extract a string literal from a token stream and parse `@{expr}` interpolation.

--- a/macros/src/parse/format.rs
+++ b/macros/src/parse/format.rs
@@ -206,6 +206,7 @@ fn tokens_to_format_inner(
                 args.push(TypedArg {
                     kind: InterpolationKind::TypeJoin,
                     expr: join_expr,
+                    parsed_body: None,
                 });
 
                 pos += 1;
@@ -259,6 +260,7 @@ fn tokens_to_format_inner(
                 args.push(TypedArg {
                     kind: InterpolationKind::Literal,
                     expr: join_expr,
+                    parsed_body: None,
                 });
 
                 pos += 1;
@@ -316,7 +318,8 @@ fn tokens_to_format_inner(
                     InterpolationKind::VerbatimStr => "%V",
                     InterpolationKind::Literal
                     | InterpolationKind::Code
-                    | InterpolationKind::TypeJoin => "%L",
+                    | InterpolationKind::TypeJoin
+                    | InterpolationKind::ParsedBlock => "%L",
                     InterpolationKind::Comment => "%R",
                 };
 
@@ -336,6 +339,7 @@ fn tokens_to_format_inner(
                 args.push(TypedArg {
                     kind,
                     expr: group.stream(),
+                    parsed_body: None,
                 });
 
                 pos += 1;

--- a/macros/src/parse/statements.rs
+++ b/macros/src/parse/statements.rs
@@ -3,8 +3,10 @@ use proc_macro2::{Delimiter, Spacing, TokenStream, TokenTree};
 use super::brace_classifier::{self, BraceKind};
 use super::format::tokens_to_format;
 use super::parse_body;
-use super::types::{Branch, CompileError, MacroLang, MetaBranch, Statement};
-use super::util::{is_ident, is_semicolon, unescape_string};
+use super::types::{
+    Branch, CompileError, InterpolationKind, MacroLang, MetaBranch, Statement, TypedArg,
+};
+use super::util::{is_ident, is_semicolon};
 
 /// Parse a single statement starting at `pos`.
 /// Returns the statement and the position after the consumed tokens.
@@ -96,7 +98,13 @@ pub(super) fn parse_one_statement(
                 // must be recursively parsed so $C_each/$for/$if are recognized.
                 // Fall through to the classify() path instead of inlining.
                 if brace_classifier::has_statement_marker(g) {
-                    // fall through to classify + parse_control_flow below
+                    // Expression brace with statement markers:
+                    // e.g., `return { $C_each(items); };`
+                    // Recursively parse the body and inline as %L + ParsedBlock.
+                    // The `;` at pos+1 is the statement terminator (consumed below
+                    // by the normal semicolon path — we skip it via pos+2).
+                    let (format, args) = handle_expression_brace_with_markers(&collected, g, lang)?;
+                    return Ok((Statement::Statement { format, args }, pos + 2));
                 } else {
                     // Part of a statement: `const x = { ... };`
                     collected.push(tt.clone());
@@ -136,9 +144,11 @@ pub(super) fn parse_one_statement(
                 BraceKind::ControlFlow => {}
             }
 
-            // Control flow detected.
+            // Control flow detected (if/for/while/function/class).
             let (stmt, mut next_pos) = parse_control_flow(tokens, &collected, g, pos, lang)?;
-            // Consume optional trailing `;` after the control flow block.
+            // Consume trailing `;` as DSL statement terminator only.
+            // Control flow constructs (if/for/while) don't have `;` in
+            // generated code.
             if next_pos < tokens.len() && is_semicolon(&tokens[next_pos]) {
                 next_pos += 1;
             }
@@ -674,65 +684,77 @@ fn try_parse_comment(
     Ok(Some((expr, next)))
 }
 
-/// Try to parse `$attr("text")` at position `start`.
+/// Try to parse `$attr(expr)` at position `start`.
 fn try_parse_attr(
     tokens: &[TokenTree],
     start: usize,
-) -> Result<Option<(String, usize)>, CompileError> {
+) -> Result<Option<(TokenStream, usize)>, CompileError> {
+    // Need at least 3 tokens: `$`, `attr`, `(...)`.
     if start + 2 >= tokens.len() {
         return Ok(None);
     }
+
+    // Check for `$` punct.
     let _dollar = match &tokens[start] {
         TokenTree::Punct(p) if p.as_char() == '$' => p,
         _ => return Ok(None),
     };
+
+    // Check for `attr` ident.
     if !is_ident(&tokens[start + 1], "attr") {
         return Ok(None);
     }
+
+    // Check for parenthesized expression.
     let group = match &tokens[start + 2] {
         TokenTree::Group(g) if g.delimiter() == Delimiter::Parenthesis => g,
         _ => {
             return Err(CompileError::new(
                 tokens[start + 2].span(),
-                "$attr requires parenthesized string: $attr(\"text\")",
+                "$attr requires a parenthesized expression: $attr(expr)",
             ));
         }
     };
-    let inner: Vec<TokenTree> = group.stream().into_iter().collect();
-    if inner.len() != 1 {
-        return Err(CompileError::new(
-            group.span(),
-            "$attr requires a single string literal: $attr(\"text\")",
-        ));
-    }
-    let text = match &inner[0] {
-        TokenTree::Literal(lit) => {
-            let s = lit.to_string();
-            if s.starts_with('"') && s.ends_with('"') && s.len() >= 2 {
-                let raw = &s[1..s.len() - 1];
-                match unescape_string(raw) {
-                    Ok(text) => text,
-                    Err(msg) => return Err(CompileError::new(lit.span(), &msg)),
-                }
-            } else {
-                return Err(CompileError::new(
-                    lit.span(),
-                    "$attr requires a string literal",
-                ));
-            }
-        }
-        _ => {
-            return Err(CompileError::new(
-                inner[0].span(),
-                "$attr requires a string literal",
-            ));
-        }
-    };
+
+    let expr = group.stream();
+
+    // Skip optional semicolon after $attr(expr);
     let mut next = start + 3;
     if next < tokens.len() && is_semicolon(&tokens[next]) {
         next += 1;
     }
-    Ok(Some((text, next)))
+
+    Ok(Some((expr, next)))
+}
+
+/// Handle a brace group containing statement-level markers in an expression
+/// position (e.g., `return { $C_each(items); };`).
+///
+/// Recursively parses the body inside the brace group, formats the prefix
+/// tokens, and produces a `(format, args)` pair with `ParsedBlock` for the body.
+fn handle_expression_brace_with_markers(
+    prefix_tokens: &[TokenTree],
+    brace_group: &proc_macro2::Group,
+    lang: MacroLang,
+) -> Result<(String, Vec<TypedArg>), CompileError> {
+    let body_tokens: Vec<TokenTree> = brace_group.stream().into_iter().collect();
+    let body_stmts = parse_body(&body_tokens, lang)?;
+
+    let (prefix_format, mut prefix_args) = tokens_to_format(prefix_tokens, lang)?;
+
+    let format = if prefix_format.is_empty() {
+        "%L".to_string()
+    } else {
+        format!("{prefix_format}%L")
+    };
+
+    prefix_args.push(TypedArg {
+        kind: InterpolationKind::ParsedBlock,
+        expr: TokenStream::new(),
+        parsed_body: Some(body_stmts),
+    });
+
+    Ok((format, prefix_args))
 }
 
 /// Check whether the collected prefix tokens and language indicate a

--- a/macros/src/parse/types.rs
+++ b/macros/src/parse/types.rs
@@ -45,11 +45,13 @@ pub(crate) enum Statement {
     BlankLine,
     /// `add_comment(text)` — `$comment("text")` or `$comment(expr)`.
     Comment(TokenStream),
-    /// `add_attribute(text)` — `$attr("text")`. Language-aware attribute/annotation
+    /// `add_attribute(text)` — `$attr(expr)`. Language-aware attribute/annotation
     /// that renders with the target language's prefix/suffix (Rust: #[...],
     /// Java/Python: @..., C++: [[...]]).
-    Attr(String),
+    Attr(TokenStream),
     /// Control flow: `begin_control_flow` / `next_control_flow` / `end_control_flow`.
+    /// Only for actual control flow (`if`/`for`/`while`/`class`/`function`).
+    /// Expression braces are routed through `Statement::Statement` + `ParsedBlock`.
     ControlFlow { branches: Vec<Branch> },
     /// `add("%>", ())` — increase indent.
     Indent,
@@ -99,6 +101,8 @@ pub(crate) struct MetaBranch {
 pub(crate) struct TypedArg {
     pub kind: InterpolationKind,
     pub expr: TokenStream,
+    /// Pre-parsed body for `InterpolationKind::ParsedBlock`.
+    pub parsed_body: Option<Vec<Statement>>,
 }
 
 /// The kind of an interpolation marker.
@@ -121,6 +125,10 @@ pub(crate) enum InterpolationKind {
     TypeJoin,
     /// `$comment(expr)` — inline comment (when used inside a statement).
     Comment,
+    /// Parsed brace group containing statement markers
+    /// (`$C_each`, `$for`, `$if`, `$let`). Emitted as a nested
+    /// `CodeBlock` via `%L`.
+    ParsedBlock,
 }
 
 /// A compile error with span information.

--- a/macros/src/parse/util.rs
+++ b/macros/src/parse/util.rs
@@ -7,29 +7,3 @@ pub(super) fn is_semicolon(tt: &TokenTree) -> bool {
 pub(super) fn is_ident(tt: &TokenTree, name: &str) -> bool {
     matches!(tt, TokenTree::Ident(id) if *id == name)
 }
-
-pub(super) fn unescape_string(s: &str) -> Result<String, String> {
-    let mut out = String::with_capacity(s.len());
-    let mut chars = s.chars();
-    while let Some(c) = chars.next() {
-        if c == '\\' {
-            match chars.next() {
-                Some('n') => out.push('\n'),
-                Some('t') => out.push('\t'),
-                Some('r') => out.push('\r'),
-                Some('0') => out.push('\0'),
-                Some('\\') => out.push('\\'),
-                Some('"') => out.push('"'),
-                Some(other) => {
-                    return Err(format!("unknown escape sequence: \\{other}"));
-                }
-                None => {
-                    return Err("unexpected end of string after \\".to_string());
-                }
-            }
-        } else {
-            out.push(c);
-        }
-    }
-    Ok(out)
-}

--- a/src/code_block.rs
+++ b/src/code_block.rs
@@ -100,7 +100,7 @@ pub(crate) enum FormatPart {
     /// Terminal block close delimiter — resolved at render time via
     /// `lang.block_close_for(condition)` falling back to `lang.block_syntax().block_close`.
     /// Carries the condition from the matching `begin_control_flow`.
-    /// Emits: closer + newline.
+    /// Emits: closer only.
     BlockClose(String),
     /// Non-terminal block close before a branch keyword (`else`, `elif`, `catch`).
     /// Like `BlockClose` but emits closer + space (not newline) so the branch
@@ -354,8 +354,24 @@ impl CodeBlockBuilder {
         self
     }
 
-    /// End a control flow block (emits "}" or language-specific closer, and decreases indent).
+    /// End a control flow block (emits language-specific closer + newline,
+    /// decreases indent).
     pub fn end_control_flow(&mut self) -> &mut Self {
+        let condition = self.block_stack.pop().unwrap_or_default();
+        self.nodes.push(CodeNode::Dedent);
+        self.indent_depth -= 1;
+        self.nodes.push(CodeNode::BlockClose(condition));
+        self.nodes.push(CodeNode::Newline);
+        self
+    }
+
+    /// End a control flow block without a trailing newline.
+    ///
+    /// Used when the block is nested inside a `Statement::Statement` via
+    /// `%L` (e.g., expression braces in format strings). The outer
+    /// `add_statement` provides both `;` via `StatementEnd` and `\n` via
+    /// `Newline`.
+    pub fn end_control_flow_no_newline(&mut self) -> &mut Self {
         let condition = self.block_stack.pop().unwrap_or_default();
         self.nodes.push(CodeNode::Dedent);
         self.indent_depth -= 1;

--- a/src/code_node.rs
+++ b/src/code_node.rs
@@ -60,7 +60,8 @@ pub enum CodeNode {
     /// `begin_control_flow` call. At render time the renderer calls
     /// `lang.block_close_for(condition)` — if it returns `Some(s)`, emit `s`;
     /// otherwise fall back to `lang.block_syntax().block_close`.
-    /// Emits: closer + newline.
+    /// Emits: the closer only (no semicolon, no newline — those come from
+    /// `StatementEnd` and `Newline` nodes that follow).
     BlockClose(String),
     /// Non-terminal block close before a branch keyword (`else`, `elif`, `catch`).
     /// Like `BlockClose` but emits closer + space (not newline) so the branch

--- a/src/code_renderer.rs
+++ b/src/code_renderer.rs
@@ -79,7 +79,16 @@ impl<'a> CodeRenderer<'a> {
     fn resolve_comment(lang: &dyn RendererLang, text: &str) -> String {
         let prefix = lang.line_comment_prefix();
         let suffix = lang.line_comment_suffix();
-        format!("{prefix} {text}{suffix}")
+        text.split('\n')
+            .map(|line| {
+                if line.is_empty() {
+                    format!("{prefix}{suffix}")
+                } else {
+                    format!("{prefix} {line}{suffix}")
+                }
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
     }
 
     /// Direct string rendering (no SoftBreak in this segment).
@@ -173,12 +182,11 @@ impl<'a> CodeRenderer<'a> {
                         self.emit(open);
                     }
                 }
-                CodeNode::BlockClose(cond) => {
-                    let close = Self::resolve_block_close(self.lang, cond);
+                CodeNode::BlockClose(condition) => {
+                    let close = Self::resolve_block_close(self.lang, condition);
                     if !close.is_empty() {
                         self.ensure_indent();
                         self.emit(close);
-                        self.emit_newline();
                     }
                 }
                 CodeNode::BranchClose(cond) => {
@@ -258,12 +266,12 @@ impl<'a> CodeRenderer<'a> {
                         BoxDoc::text(open.to_string())
                     }
                 }
-                CodeNode::BlockClose(cond) => {
-                    let close = Self::resolve_block_close(self.lang, cond);
+                CodeNode::BlockClose(condition) => {
+                    let close = Self::resolve_block_close(self.lang, condition);
                     if close.is_empty() {
                         BoxDoc::nil()
                     } else {
-                        BoxDoc::text(close.to_string()).append(BoxDoc::hardline())
+                        BoxDoc::text(close.to_string())
                     }
                 }
                 CodeNode::BranchClose(cond) => {

--- a/src/lang/cpp_lang.rs
+++ b/src/lang/cpp_lang.rs
@@ -112,16 +112,18 @@ impl CppLang {
         use crate::code_node::CodeNode;
         let mut i = 0;
         while i < nodes.len() {
-            let is_lambda_close =
-                matches!(&nodes[i], CodeNode::BlockClose(cond) if cond.contains('['));
+            let is_lambda_close = matches!(&nodes[i], CodeNode::BlockClose(s) if s.contains('['));
             if is_lambda_close {
-                // Insert a Literal(";") after the BlockClose, before Newline
-                // The renderer will emit "}" then we want ";" immediately after
-                // Actually, we need to replace BlockClose with Literal("};\n")
-                // because BlockClose already emits "}" + newline.
-                // Instead: replace BlockClose with Literal("};") + Newline
+                // BlockClose is now followed by a Newline from end_control_flow().
+                // Consume both BlockClose and the trailing Newline.
+                let remove_count =
+                    if i + 1 < nodes.len() && matches!(&nodes[i + 1], CodeNode::Newline) {
+                        2
+                    } else {
+                        1
+                    };
                 let replacement = vec![CodeNode::Literal("};".to_string()), CodeNode::Newline];
-                nodes.splice(i..i + 1, replacement);
+                nodes.splice(i..i + remove_count, replacement);
                 i += 2;
                 continue;
             }

--- a/src/lang/go_lang.rs
+++ b/src/lang/go_lang.rs
@@ -119,25 +119,32 @@ impl GoLang {
         let mut i = 0;
         while i < nodes.len() {
             let is_func_block_close =
-                matches!(&nodes[i], CodeNode::BlockClose(cond) if cond.contains("func"));
+                matches!(&nodes[i], CodeNode::BlockClose(s) if s.contains("func"));
             if !is_func_block_close {
                 i += 1;
                 continue;
             }
 
-            // Check if next nodes are: StatementBegin, Literal(...), StatementEnd, Newline
-            // The call arguments might span multiple literal nodes.
-            let remaining = nodes.len() - i - 1;
-            if remaining >= 3 && matches!(&nodes[i + 1], CodeNode::StatementBegin) {
+            // end_control_flow() now pushes [Dedent, BlockClose, Newline].
+            // Skip past BlockClose and the trailing Newline to find the
+            // call statement (StatementBegin).
+            let call_start = if i + 1 < nodes.len() && matches!(&nodes[i + 1], CodeNode::Newline) {
+                i + 2
+            } else {
+                i + 1
+            };
+
+            let remaining = nodes.len() - call_start;
+            if remaining >= 3 && matches!(&nodes[call_start], CodeNode::StatementBegin) {
                 // Find StatementEnd
-                let end_idx = nodes[(i + 2)..]
+                let end_idx = nodes[(call_start + 1)..]
                     .iter()
                     .position(|n| matches!(n, CodeNode::StatementEnd))
-                    .map(|pos| pos + i + 2);
+                    .map(|pos| pos + call_start + 1);
 
                 if let Some(stmt_end) = end_idx {
                     // Collect the call literal nodes between StatementBegin and StatementEnd
-                    let call_nodes: Vec<CodeNode> = nodes[(i + 2)..stmt_end].to_vec();
+                    let call_nodes: Vec<CodeNode> = nodes[(call_start + 1)..stmt_end].to_vec();
 
                     // Check that this looks like a call (starts with "(")
                     let looks_like_call = call_nodes
@@ -145,9 +152,9 @@ impl GoLang {
                         .any(|n| matches!(n, CodeNode::Literal(s) if s.starts_with('(')));
 
                     if looks_like_call {
-                        // Determine how many nodes to remove after BlockClose
-                        // Remove: StatementBegin, ...call_nodes..., StatementEnd
-                        // Optionally also remove the following Newline (BlockClose already emitted one)
+                        // Remove: BlockClose, Newline(from end_control_flow),
+                        // StatementBegin, ...call_nodes..., StatementEnd,
+                        // and optionally the trailing Newline from add_statement
                         let mut remove_end = stmt_end + 1; // exclusive
                         if remove_end < nodes.len()
                             && matches!(&nodes[remove_end], CodeNode::Newline)
@@ -155,7 +162,7 @@ impl GoLang {
                             remove_end += 1;
                         }
 
-                        // Replace BlockClose with Literal("}") + call_nodes + Newline
+                        // Replace with Literal("}") + call_nodes + Newline
                         let mut replacement = Vec::with_capacity(2 + call_nodes.len());
                         replacement.push(CodeNode::Literal("}".to_string()));
                         replacement.extend(call_nodes);

--- a/test-goldens/haskell/macro_control_flow.hs
+++ b/test-goldens/haskell/macro_control_flow.hs
@@ -2,3 +2,4 @@ if x > 0 then
   return True
 else
   return False
+

--- a/test-goldens/haskell/macro_open_where.hs
+++ b/test-goldens/haskell/macro_open_where.hs
@@ -1,2 +1,3 @@
 class Functor f where
   fmap :: (a -> b) -> f a -> f b
+

--- a/test-goldens/haskell/quote_do_notation.hs
+++ b/test-goldens/haskell/quote_do_notation.hs
@@ -3,3 +3,4 @@ main = do
   putStrLn "Enter name:"
   name <- getLine
   putStrLn ("Hello, " ++ name)
+

--- a/test-goldens/haskell/quote_typeclass_instance.hs
+++ b/test-goldens/haskell/quote_typeclass_instance.hs
@@ -1,2 +1,3 @@
 instance Show Point where
   show (Point x y) = "(" ++ show x ++ ", " ++ show y ++ ")"
+

--- a/test-goldens/haskell/type_class_where.hs
+++ b/test-goldens/haskell/type_class_where.hs
@@ -1,2 +1,3 @@
 class Functor f where
   fmap :: (a -> b) -> f a -> f b
+

--- a/test-goldens/haskell/where_block.hs
+++ b/test-goldens/haskell/where_block.hs
@@ -1,2 +1,3 @@
 circleArea r =
   pi * r * r
+

--- a/test-goldens/ocaml/let_binding.ml
+++ b/test-goldens/ocaml/let_binding.ml
@@ -1,2 +1,3 @@
 let add x y =
   x + y
+

--- a/test-goldens/ocaml/macro_control_flow.ml
+++ b/test-goldens/ocaml/macro_control_flow.ml
@@ -2,3 +2,4 @@ if x > 0 then
   return true
 else
   return false
+

--- a/test-goldens/ocaml/pattern_match.ml
+++ b/test-goldens/ocaml/pattern_match.ml
@@ -3,3 +3,5 @@ let describe color =
     | Red -> "red"
     | Green -> "green"
     | Blue -> "blue"
+
+

--- a/test-goldens/ocaml/quote_pattern_match.ml
+++ b/test-goldens/ocaml/quote_pattern_match.ml
@@ -1,3 +1,4 @@
 let describe x = match x with
   | Some(v) -> Printf.printf "value: %d" v
   | None -> print_endline "none"
+

--- a/test-goldens/python/control_flow.py
+++ b/test-goldens/python/control_flow.py
@@ -5,3 +5,4 @@ def classify(x: int) -> str:
         return 'negative'
     else:
         return 'zero'
+

--- a/test-goldens/python/macro_classmethod.py
+++ b/test-goldens/python/macro_classmethod.py
@@ -1,3 +1,4 @@
 @classmethod
 def from_dict(cls, data: dict) -> "User":
     return cls(data["name"], data["age"])
+

--- a/test-goldens/python/macro_control_flow.py
+++ b/test-goldens/python/macro_control_flow.py
@@ -2,3 +2,4 @@ if x > 0:
     return 'positive'
 else:
     return 'negative'
+

--- a/test-goldens/python/quote_async.py
+++ b/test-goldens/python/quote_async.py
@@ -2,3 +2,5 @@ async def fetch_data(url: str) -> bytes:
     async with aiohttp.ClientSession() as session:
         response = await session.get(url)
         return await response.read()
+
+

--- a/test-goldens/python/quote_decorator.py
+++ b/test-goldens/python/quote_decorator.py
@@ -1,3 +1,4 @@
 @app.route("/users")
 def get_users():
     return jsonify(users)
+

--- a/test-goldens/python/quote_type_hints.py
+++ b/test-goldens/python/quote_type_hints.py
@@ -1,3 +1,4 @@
 def process(items: list[str], count: int = 10) -> dict[str, int]:
     result: dict[str, int] = {}
     return result
+

--- a/test-goldens/python/quote_with.py
+++ b/test-goldens/python/quote_with.py
@@ -1,2 +1,3 @@
 with open('file.txt', 'r') as f:
     content = f.read()
+

--- a/tests/macro/c_each.rs
+++ b/tests/macro/c_each.rs
@@ -566,6 +566,7 @@ fn test_for_inside_object_literal_with_trailing_semicolon() {
 
     let output = render_ts(&block);
     assert!(output.contains("return {"), "got:\n{output}");
+    assert!(output.contains("};"), "got:\n{output}");
     assert!(output.contains("name: \"Alice\""), "got:\n{output}");
     assert!(output.contains("age: 30"), "got:\n{output}");
 }
@@ -585,6 +586,7 @@ fn test_for_inside_eq_object_literal_with_trailing_semicolon() {
 
     let output = render_ts(&block);
     assert!(output.contains("const config = {"), "got:\n{output}");
+    assert!(output.contains("};"), "got:\n{output}");
     assert!(output.contains("name: \"Alice\""), "got:\n{output}");
     assert!(output.contains("age: 30"), "got:\n{output}");
 }

--- a/tests/macro/comments.rs
+++ b/tests/macro/comments.rs
@@ -62,7 +62,7 @@ fn test_comment_with_newline_escape() {
 
     let output = render_ts(&block);
     assert!(
-        output.contains("// first line\nsecond line"),
+        output.contains("// first line\n// second line"),
         "got: {output}"
     );
 }
@@ -230,6 +230,85 @@ fn test_comment_with_double_at_escape() {
 
     let output = render_ts(&block);
     assert!(output.contains("// user@host"), "got: {output}");
+}
+
+// ── $attr(expr) — dynamic expressions ───────────────────
+
+#[test]
+fn test_attr_with_dynamic_expression() {
+    let attr_name = "override";
+    let block = sigil_quote!(TypeScript {
+        $attr(attr_name);
+
+        process(): void {
+            return;
+        }
+    })
+    .unwrap();
+
+    let output = render_ts(&block);
+    assert!(output.contains("@override"), "got:\n{output}");
+}
+
+#[test]
+fn test_attr_with_format_expression() {
+    let name = "Debug";
+    let block = sigil_quote!(RustLang {
+        $attr(format!("derive({name}, Clone)"));
+
+        struct Foo;
+    })
+    .unwrap();
+
+    let output = render_rs(&block);
+    assert!(output.contains("#[derive(Debug, Clone)]"), "got:\n{output}");
+}
+
+#[test]
+fn test_attr_with_to_string_expression() {
+    let code = 200;
+    let block = sigil_quote!(TypeScript {
+        $attr(code.to_string());
+
+        process(): void {
+            return;
+        }
+    })
+    .unwrap();
+
+    let output = render_ts(&block);
+    assert!(output.contains("@200"), "got:\n{output}");
+}
+
+// ── $attr(expr) — @{…} interpolation ────────────────────
+
+#[test]
+fn test_attr_with_at_interpolation() {
+    let trait_name = "Debug";
+    let block = sigil_quote!(RustLang {
+        $attr("derive(@{trait_name}, Clone)");
+
+        struct Foo;
+    })
+    .unwrap();
+
+    let output = render_rs(&block);
+    assert!(output.contains("#[derive(Debug, Clone)]"), "got:\n{output}");
+}
+
+#[test]
+fn test_attr_with_double_at_escape() {
+    let block = sigil_quote!(TypeScript {
+        $attr("user@@host");
+
+        process(): void {
+            return;
+        }
+    })
+    .unwrap();
+
+    let output = render_ts(&block);
+    assert!(output.contains("@user@host"), "got:\n{output}");
 }
 
 // ── $attr() — language-aware attributes ──────────────────


### PR DESCRIPTION
## Summary

- Eliminate the `trailing_semicolon: bool` flag from `Statement::ControlFlow`, `CodeNode::BlockClose`, and `end_control_flow()`
- Route expression braces (`return { $C_each(x); };`) through `Statement::Statement` + `ParsedBlock` interpolation, where `;` flows naturally through `StatementEnd` in the renderer
- Control flow (`if`/`for`/`while`) consumes `;` as DSL terminator only — `BlockClose` now renders just close text, no newline or semicolon
- Add `end_control_flow_no_newline()` for nested parsed blocks
- Add `$attr(expr)` dynamic expression support with `@{...}` interpolation
- Update Go IIFE and C++ lambda rewrites for new node layout
- Extract `resolve_at_interpolation` helper to deduplicate Comment/Attr codegen

## Test plan

- [x] `cargo test --workspace` — all pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `return { $C_each(items); };` emits `};`
- [x] `if (x) { body(); }` has no spurious `;` after `}`
- [x] `$attr(expr)` dynamic expressions work
- [x] Go `func() { ... }()` IIFE fusion works
- [x] C++ lambda `};` rewriting works