### PR TITLE
refactor: drop Lang suffix from language names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,7 @@
   (`Read + Write`) in Rust, intersection types (`T & U`) in Java/TypeScript,
   protocol composition (`Codable & Hashable`) in Swift, and interface embedding
   in Go.
-- **Go paren-delimited blocks** — `sigil_quote!(GoLang { ... })` now recognizes
+- **Go paren-delimited blocks** — `sigil_quote!(Go { ... })` now recognizes
   `const ( ... )`, `var ( ... )`, `import ( ... )`, and `type ( ... )` as
   structural blocks. `$for`, `$if`, `$C_each`, etc. expand correctly inside.
   Body content is auto-indented and the closing `)` is at the outer indent level.
@@ -527,11 +527,11 @@
   - JavaScript / Bash / Zsh → rendered without any optionality marker
 - `OptionalFieldStyle` enum and shared `QuoteStyle` enum in a new
   `sigil_stitch::lang::config` module.
-- Fluent config builders on `TypeScript`, `JavaScript`, `Python`, and `JavaLang`:
+- Fluent config builders on `TypeScript`, `JavaScript`, `Python`, and `Java`:
   `.with_quote_style()`, `.with_indent()`, `.with_semicolons()`,
   `.with_extension()` (available per-language as appropriate).
 - `.with_indent()` and `.with_extension()` on the remaining languages
-  (`RustLang`, `GoLang`, `Kotlin`, `Swift`, `DartLang`, `CLang`, `CppLang`,
+  (`Rust`, `Go`, `Kotlin`, `Swift`, `Dart`, `C`, `Cpp`,
   `Bash`, `Zsh`). Every language struct now has a public `extension: String`
   field; defaults are unchanged.
 
@@ -548,7 +548,7 @@
   semicolon-less output or `.tsx` files without a custom `CodeLang` impl.
 - `Python` gains `quote_style` and `extension` fields for `.pyi` stubs and
   Black-style double quotes.
-- `JavaLang` gains an `extension` field.
+- `Java` gains an `extension` field.
 
 ## 0.1.0
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,9 +25,9 @@ sigil-stitch/
 │   │   ├── config.rs       # Config structs (BlockSyntaxConfig, FunctionSyntaxConfig, etc.)
 │   │   ├── rewrite.rs      # Runtime node rewrite walker
 │   │   ├── typescript.rs   # One file per language: typescript, javascript,
-│   │   └── ...             # rust_lang, go_lang, python, java_lang, kotlin,
-│   │                       # swift, dart, scala, haskell, ocaml, c_lang,
-│   │                       # cpp_lang, bash, zsh, lua, csharp
+│   │   └── ...             # rust, go, python, java, kotlin,
+│   │                       # swift, dart, scala, haskell, ocaml, c,
+│   │                       # cpp, bash, zsh, lua, csharp
 │   └── spec/               # Structural builders (emit CodeBlocks)
 │       ├── type_spec.rs    # Class, struct, interface, trait, enum, type alias, newtype
 │       ├── fun_spec.rs     # Functions and methods

--- a/docs/src/adding_a_language.md
+++ b/docs/src/adding_a_language.md
@@ -44,7 +44,7 @@ These are enough for CodeBlock-level code generation:
 
 Override `render_verbatim_string()` if your language has string interpolation (e.g., Bash `"$x"`, TypeScript `` `${x}` ``, Python `f"{x}"`).
 
-`render_imports()` is the most complex. It receives an `ImportGroup` (deduplicated, with aliases resolved) and must emit the full import header string. Study `src/lang/typescript.rs` for ES module imports or `src/lang/rust_lang.rs` for `use` paths.
+`render_imports()` is the most complex. It receives an `ImportGroup` (deduplicated, with aliases resolved) and must emit the full import header string. Study `src/lang/typescript.rs` for ES module imports or `src/lang/rust.rs` for `use` paths.
 
 ## The CodeLang Trait
 
@@ -349,11 +349,11 @@ Study these existing implementations for patterns similar to your target:
 | Language | File | Notable Patterns |
 |----------|------|-----------------|
 | TypeScript | `src/lang/typescript.rs` | ES module imports, type-only imports, single-quoted strings |
-| Rust | `src/lang/rust_lang.rs` | `use` paths, struct+impl split, `pub(crate)` visibility |
+| Rust | `src/lang/rust.rs` | `use` paths, struct+impl split, `pub(crate)` visibility |
 | Python | `src/lang/python.rs` | Indent-only blocks (no braces), docstrings inside body, `from x import y` |
-| Go | `src/lang/go_lang.rs` | Package-qualified names (`http.Server`), bracket generics, `func` keyword |
-| C | `src/lang/c_lang.rs` | Type-before-name, `#include`, `__attribute__`, struct close semicolon |
-| C++ | `src/lang/cpp_lang.rs` | `virtual` instead of `abstract`, `#include` + `using`, `[[attributes]]` |
+| Go | `src/lang/go.rs` | Package-qualified names (`http.Server`), bracket generics, `func` keyword |
+| C | `src/lang/c.rs` | Type-before-name, `#include`, `__attribute__`, struct close semicolon |
+| C++ | `src/lang/cpp.rs` | `virtual` instead of `abstract`, `#include` + `using`, `[[attributes]]` |
 | Bash | `src/lang/bash.rs` | Keyword-based block closers (`fi`/`done`/`esac`), `source` imports, shell escaping |
 | Scala | `src/lang/scala.rs` | `case class`, `trait`, `[T]` generics, `<:` bounds, `= {`/`}` blocks |
 | Haskell | `src/lang/haskell.rs` | Split signature style, `where`/indentation blocks, postfix generics, `deriving` |

--- a/docs/src/code_templates.md
+++ b/docs/src/code_templates.md
@@ -73,7 +73,7 @@ Since templates are language-agnostic, the same template can target different la
 
 ```rust
 # extern crate sigil_stitch;
-# use sigil_stitch::lang::rust_lang::RustLang;
+# use sigil_stitch::lang::rust::Rust;
 # use sigil_stitch::prelude::*;
 # fn main() {
 let decl = CodeTemplate::new("#{name:N}: #{type:T} = #{value:L}").unwrap();

--- a/docs/src/cookbook_cpp.md
+++ b/docs/src/cookbook_cpp.md
@@ -99,10 +99,10 @@ C++ abstract classes with pure virtual methods require the `extra_member` escape
 ```rust
 # extern crate sigil_stitch;
 # use sigil_stitch::prelude::*;
-# use sigil_stitch::lang::cpp_lang::CppLang;
+# use sigil_stitch::lang::cpp::Cpp;
 # fn main() {
 fn emit_fun(fun: &FunSpec) -> CodeBlock {
-    let lang = CppLang::new();
+    let lang = Cpp::new();
     fun.emit(&lang, DeclarationContext::Member).unwrap()
 }
 

--- a/docs/src/cookbook_go.md
+++ b/docs/src/cookbook_go.md
@@ -154,11 +154,11 @@ const blocks:
 ```rust
 # extern crate sigil_stitch;
 # use sigil_stitch::prelude::*;
-# use sigil_stitch::lang::go_lang::GoLang;
+# use sigil_stitch::lang::go::Go;
 # fn main() {
 let variants = vec!["Alpha", "Beta", "Gamma"];
 
-let const_block = sigil_quote!(GoLang {
+let const_block = sigil_quote!(Go {
     const (
     $for(v in &variants) {
         $L("@{v}Kind @{v} = \"@{v}\"");
@@ -186,5 +186,5 @@ const (
 ```
 
 The parser recognizes `const (`, `var (`, `import (`, and `type (` as structural
-blocks in GoLang, so `$for`, `$if`, `$C_each`, and interpolation markers all
+blocks in Go, so `$for`, `$if`, `$C_each`, and interpolation markers all
 work inside the parentheses. The body is auto-indented with tabs.

--- a/docs/src/format_specifiers.md
+++ b/docs/src/format_specifiers.md
@@ -84,13 +84,13 @@ Reserved-word escaping happens at render time based on the target language:
 ```rust
 # extern crate sigil_stitch;
 # use sigil_stitch::code_block::{CodeBlock, NameArg};
-# use sigil_stitch::lang::rust_lang::RustLang;
+# use sigil_stitch::lang::rust::Rust;
 # use sigil_stitch::spec::file_spec::FileSpec;
 # use sigil_stitch::prelude::*;
 # fn main() {
 let field_name = "type"; // reserved in Rust
 let block = CodeBlock::of("let %N = value", NameArg(field_name.into())).unwrap();
-let file = FileSpec::builder_with("test.rs", RustLang::new())
+let file = FileSpec::builder_with("test.rs", Rust::new())
     .add_code(block)
     .build()
     .unwrap();

--- a/docs/src/functions_and_fields.md
+++ b/docs/src/functions_and_fields.md
@@ -76,7 +76,7 @@ A struct field or class property: name, type, visibility, static/readonly flags,
 # extern crate sigil_stitch;
 # use sigil_stitch::prelude::*;
 # use sigil_stitch::lang::typescript::TypeScript;
-# use sigil_stitch::lang::rust_lang::RustLang;
+# use sigil_stitch::lang::rust::Rust;
 # fn main() {
 let field = FieldSpec::builder("name", TypeName::primitive("string"))
     .visibility(Visibility::Private)

--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -133,7 +133,7 @@ The renderer and import collector only see `CodeBlock` trees. They don't know or
 
 ## Configuring a Language
 
-Each language type (`TypeScript`, `JavaScript`, `Python`, `JavaLang`, and so on)
+Each language type (`TypeScript`, `JavaScript`, `Python`, `Java`, and so on)
 is a struct with public fields. The ones you usually want to tweak are exposed
 as fluent `with_*` builders:
 
@@ -157,16 +157,16 @@ let ts = TypeScript::new()
 | `TypeScript` | yes | yes | yes | yes |
 | `JavaScript` | yes | yes | yes | yes |
 | `Python`     | yes | yes | n/a | yes (e.g. `pyi`) |
-| `JavaLang`   | n/a | yes | n/a | yes |
-| `RustLang`   | n/a | yes | n/a | yes |
-| `GoLang`     | n/a | yes | n/a | yes |
+| `Java`   | n/a | yes | n/a | yes |
+| `Rust`   | n/a | yes | n/a | yes |
+| `Go`     | n/a | yes | n/a | yes |
 | `Kotlin`     | n/a | yes | n/a | yes (e.g. `kts`) |
 | `Swift`      | n/a | yes | n/a | yes |
-| `DartLang`   | n/a | yes | n/a | yes |
+| `Dart`   | n/a | yes | n/a | yes |
 | `CSharp`     | n/a | yes | n/a | yes |
 | `Lua`        | n/a | yes | n/a | yes |
-| `CLang`      | n/a | yes | n/a | yes (e.g. `h`) |
-| `CppLang`    | n/a | yes | n/a | yes (e.g. `hpp`, `cxx`) |
+| `C`      | n/a | yes | n/a | yes (e.g. `h`) |
+| `Cpp`    | n/a | yes | n/a | yes (e.g. `hpp`, `cxx`) |
 | `Bash`       | n/a | yes | n/a | yes (e.g. `sh`) |
 | `Zsh`        | n/a | yes | n/a | yes |
 

--- a/docs/src/macrolang.md
+++ b/docs/src/macrolang.md
@@ -11,11 +11,11 @@ tokenizer annotation pass language-aware.
 The `sigil_quote!` macro pipeline has three stages:
 
 ```text
-sigil_quote!(GoLang { val := <-ch; })
+sigil_quote!(Go { val := <-ch; })
         │
         ▼
 ┌─ parse_input ─────────────────────────────────────┐
-│  1. Extract language: MacroLang::GoLang           │
+│  1. Extract language: MacroLang::Go           │
 │  2. Parse body tokens                             │
 │  3. annotate_tokens(tokens, lang)                 │
 │     └─ Pre-scan: classify each token              │
@@ -28,7 +28,7 @@ sigil_quote!(GoLang { val := <-ch; })
 ```
 
 The `MacroLang` enum is extracted from the first identifier in the macro invocation
-(`Bash`, `Zsh`, `GoLang`, `Haskell`, etc.) and threaded through the entire parse pipeline.
+(`Bash`, `Zsh`, `Go`, `Haskell`, etc.) and threaded through the entire parse pipeline.
 Languages not in the enum get `MacroLang::Unaware`, which applies only universal heuristics.
 
 ## MacroLang Variants
@@ -38,7 +38,7 @@ Languages not in the enum get `MacroLang::Unaware`, which applies only universal
 | `Unaware` | All other languages | Universal heuristics only |
 | `Bash` | `sigil_quote!(Bash { ... })` | Shell-specific (see below) |
 | `Zsh` | `sigil_quote!(Zsh { ... })` | Shell-specific (same as Bash) |
-| `GoLang` | `sigil_quote!(GoLang { ... })` | `<-` prefix receive |
+| `Go` | `sigil_quote!(Go { ... })` | `<-` prefix receive |
 | `Haskell` | `sigil_quote!(Haskell { ... })` | `$$` dollar operator spacing |
 
 ### Shell Languages (Bash, Zsh)

--- a/docs/src/sigil_quote.md
+++ b/docs/src/sigil_quote.md
@@ -422,9 +422,9 @@ sigil_quote!(TypeScript {
 ```rust
 # extern crate sigil_stitch;
 # use sigil_stitch::prelude::*;
-# use sigil_stitch::lang::rust_lang::RustLang;
+# use sigil_stitch::lang::rust::Rust;
 # fn main() -> Result<(), Box<dyn std::error::Error>> {
-sigil_quote!(RustLang {
+sigil_quote!(Rust {
     $attr("derive(Debug, Clone, Serialize, Deserialize)");
     struct Config {}
 })?;
@@ -438,9 +438,9 @@ sigil_quote!(RustLang {
 ```rust
 # extern crate sigil_stitch;
 # use sigil_stitch::prelude::*;
-# use sigil_stitch::lang::cpp_lang::CppLang;
+# use sigil_stitch::lang::cpp::Cpp;
 # fn main() -> Result<(), Box<dyn std::error::Error>> {
-sigil_quote!(CppLang {
+sigil_quote!(Cpp {
     $attr("nodiscard");
     Result compute();
 })?;
@@ -474,10 +474,10 @@ sigil_quote!(TypeScript {
 ```rust
 # extern crate sigil_stitch;
 # use sigil_stitch::prelude::*;
-# use sigil_stitch::lang::rust_lang::RustLang;
+# use sigil_stitch::lang::rust::Rust;
 # fn main() -> Result<(), Box<dyn std::error::Error>> {
 let needs_serde = true;
-sigil_quote!(RustLang {
+sigil_quote!(Rust {
     $attr("derive(Debug, Clone)");
     $if(needs_serde) {
         $attr("serde(rename_all = \"camelCase\")");
@@ -911,7 +911,7 @@ propagates to the enclosing function:
 
 ```rust,ignore
 fn emit_enum(en: &Enum) -> Option<FileSpec> {
-    let block = sigil_quote!(RustLang {
+    let block = sigil_quote!(Rust {
         $for(v in &en.values) {
             $let(s = v.value.as_str()?);
             $let(variant = s.to_pascal_case());
@@ -1005,13 +1005,13 @@ intersections, `" + "` for Rust trait bounds, `"\n"` for Go interface embedding:
 ```rust
 # extern crate sigil_stitch;
 # use sigil_stitch::prelude::*;
-# use sigil_stitch::lang::rust_lang::RustLang;
+# use sigil_stitch::lang::rust::Rust;
 # fn main() -> Result<(), Box<dyn std::error::Error>> {
 let traits = vec![
     TypeName::importable_type("./traits", "Serializable"),
     TypeName::importable_type("./traits", "Cloneable"),
 ];
-sigil_quote!(RustLang {
+sigil_quote!(Rust {
     fn process(stream: &mut (dyn $T_join(" + ", &traits))) {}
 })?;
 // Output: fn process(stream: &mut (dyn Serializable + Cloneable)) {}
@@ -1022,13 +1022,13 @@ sigil_quote!(RustLang {
 ```rust
 # extern crate sigil_stitch;
 # use sigil_stitch::prelude::*;
-# use sigil_stitch::lang::go_lang::GoLang;
+# use sigil_stitch::lang::go::Go;
 # fn main() -> Result<(), Box<dyn std::error::Error>> {
 let ifaces = vec![
     TypeName::importable_type("./io", "Reader"),
     TypeName::importable_type("./io", "Writer"),
 ];
-sigil_quote!(GoLang {
+sigil_quote!(Go {
     type FileOps interface {
         $T_join("\n", &ifaces)
     }
@@ -1104,10 +1104,10 @@ sigil_quote!(Python {
 
 ```rust
 # extern crate sigil_stitch;
-# use sigil_stitch::lang::go_lang::GoLang;
+# use sigil_stitch::lang::go::Go;
 # use sigil_stitch::prelude::*;
 # fn main() -> Result<(), Box<dyn std::error::Error>> {
-sigil_quote!(GoLang {
+sigil_quote!(Go {
     x := 42;
 })?;
 # Ok(())
@@ -1116,10 +1116,10 @@ sigil_quote!(GoLang {
 
 ```rust
 # extern crate sigil_stitch;
-# use sigil_stitch::lang::rust_lang::RustLang;
+# use sigil_stitch::lang::rust::Rust;
 # use sigil_stitch::prelude::*;
 # fn main() -> Result<(), Box<dyn std::error::Error>> {
-sigil_quote!(RustLang {
+sigil_quote!(Rust {
     let x: i32 = 42;
 })?;
 # Ok(())
@@ -1136,11 +1136,11 @@ expand inside them:
 ```rust
 # extern crate sigil_stitch;
 # use sigil_stitch::prelude::*;
-# use sigil_stitch::lang::go_lang::GoLang;
+# use sigil_stitch::lang::go::Go;
 # fn main() -> Result<(), Box<dyn std::error::Error>> {
 let variants = vec!["A", "B", "C"];
 
-sigil_quote!(GoLang {
+sigil_quote!(Go {
     const (
     $for(v in &variants) {
         $L("@{v}Kind @{v} = \"@{v}\"");
@@ -1161,7 +1161,7 @@ The paren-block body is indented automatically (the codegen emits `%>` after the
 opening header and `%<` before the closing `)`). Interpolation markers, meta-loops,
 and meta-conditionals all work normally inside the block.
 
-This detection is language-aware — only `GoLang` recognizes `const`, `var`,
+This detection is language-aware — only `Go` recognizes `const`, `var`,
 `import`, and `type` as paren-block headers. In other languages, `const ( ... )`
 is treated as a plain statement.
 

--- a/docs/src/types_and_enums.md
+++ b/docs/src/types_and_enums.md
@@ -56,7 +56,7 @@ When `methods_inside_type_body(kind)` returns `false` (Rust structs and enums), 
 ```rust
 # extern crate sigil_stitch;
 # use sigil_stitch::prelude::*;
-# use sigil_stitch::lang::rust_lang::RustLang;
+# use sigil_stitch::lang::rust::Rust;
 # fn main() {
 let body = CodeBlock::of("Self { name: name.to_string() }", ()).unwrap();
 
@@ -79,7 +79,7 @@ let type_spec = TypeSpec::builder("Config", TypeKind::Struct)
     )
     .build()
     .unwrap();
-let blocks = type_spec.emit(&RustLang::new()).unwrap();
+let blocks = type_spec.emit(&Rust::new()).unwrap();
 // blocks.len() == 2
 //
 // Block 0:
@@ -121,7 +121,7 @@ Use `add_embedded(TypeName)` for unnamed type references inside a struct body. T
 
 ```rust
 # extern crate sigil_stitch;
-# use sigil_stitch::lang::go_lang::GoLang;
+# use sigil_stitch::lang::go::Go;
 # use sigil_stitch::prelude::*;
 # fn main() {
 let type_spec = TypeSpec::builder("UserAdmin", TypeKind::Struct)
@@ -146,7 +146,7 @@ Embedded types render before regular fields. If the embedded type is `TypeName::
 
 ```rust
 # extern crate sigil_stitch;
-# use sigil_stitch::lang::go_lang::GoLang;
+# use sigil_stitch::lang::go::Go;
 # use sigil_stitch::prelude::*;
 # fn main() {
 let io_reader = TypeName::importable("io", "Reader");
@@ -172,7 +172,7 @@ let type_spec = TypeSpec::builder("ReadWriter", TypeKind::Interface)
 # extern crate sigil_stitch;
 # use sigil_stitch::prelude::*;
 # use sigil_stitch::lang::typescript::TypeScript;
-# use sigil_stitch::lang::rust_lang::RustLang;
+# use sigil_stitch::lang::rust::Rust;
 # fn main() {
 // TypeScript: export type UserId = string;
 let type_spec = TypeSpec::builder("UserId", TypeKind::TypeAlias)
@@ -224,8 +224,8 @@ let type_spec = TypeSpec::builder("Result", TypeKind::TypeAlias)
 ```rust
 # extern crate sigil_stitch;
 # use sigil_stitch::prelude::*;
-# use sigil_stitch::lang::rust_lang::RustLang;
-# use sigil_stitch::lang::go_lang::GoLang;
+# use sigil_stitch::lang::rust::Rust;
+# use sigil_stitch::lang::go::Go;
 # fn main() {
 // Rust: pub struct Meters(f64);
 let type_spec = TypeSpec::builder("Meters", TypeKind::Newtype)
@@ -328,7 +328,7 @@ Structured annotations that render with language-appropriate syntax. The prefix 
 ```rust
 # extern crate sigil_stitch;
 # use sigil_stitch::spec::annotation_spec::AnnotationSpec;
-# use sigil_stitch::lang::rust_lang::RustLang;
+# use sigil_stitch::lang::rust::Rust;
 # use sigil_stitch::prelude::*;
 # fn main() {
 // Simple annotation: #[allow(dead_code)]
@@ -371,7 +371,7 @@ Individual enum variants. Four forms are supported:
 ```rust
 # extern crate sigil_stitch;
 # use sigil_stitch::spec::enum_variant_spec::EnumVariantSpec;
-# use sigil_stitch::lang::rust_lang::RustLang;
+# use sigil_stitch::lang::rust::Rust;
 # use sigil_stitch::prelude::*;
 # fn main() {
 let v = EnumVariantSpec::new("Red").unwrap();
@@ -400,7 +400,7 @@ let variant = EnumVariantSpec::builder("Up")
 ```rust
 # extern crate sigil_stitch;
 # use sigil_stitch::spec::enum_variant_spec::EnumVariantSpec;
-# use sigil_stitch::lang::rust_lang::RustLang;
+# use sigil_stitch::lang::rust::Rust;
 # use sigil_stitch::prelude::*;
 # fn main() {
 let variant = EnumVariantSpec::builder("Literal")
@@ -425,7 +425,7 @@ let variant = EnumVariantSpec::builder("Pair")
 # extern crate sigil_stitch;
 # use sigil_stitch::spec::enum_variant_spec::EnumVariantSpec;
 # use sigil_stitch::spec::field_spec::FieldSpec;
-# use sigil_stitch::lang::rust_lang::RustLang;
+# use sigil_stitch::lang::rust::Rust;
 # use sigil_stitch::prelude::*;
 # fn main() {
 let variant = EnumVariantSpec::builder("Move")

--- a/examples/c_codegen.rs
+++ b/examples/c_codegen.rs
@@ -5,7 +5,7 @@
 //!
 //! Run: `cargo run --example c_codegen`
 
-use sigil_stitch::lang::c_lang::CLang;
+use sigil_stitch::lang::c::C;
 use sigil_stitch::prelude::*;
 
 fn main() {
@@ -146,7 +146,7 @@ fn builder_approach() -> String {
         .build()
         .unwrap();
 
-    FileSpec::builder_with("config.h", CLang::header())
+    FileSpec::builder_with("config.h", C::header())
         .header(CodeBlock::of("#pragma once", ()).unwrap())
         .add_type(log_level)
         .add_type(callback)
@@ -170,7 +170,7 @@ fn macro_approach() -> String {
     let comment_note = "validate input";
     let v_interp = "Config";
 
-    let create_body = sigil_quote!(CLang {
+    let create_body = sigil_quote!(C {
         $comment("@{comment_label}: @{comment_reason}");
         struct Config* cfg = (struct Config*)$T(malloc)(sizeof($V("@{v_interp}")));
         cfg->host = host; $comment(comment_note)
@@ -189,7 +189,7 @@ fn macro_approach() -> String {
         .build()
         .unwrap();
 
-    let destroy_body = sigil_quote!(CLang { $T(free)(cfg); }).unwrap();
+    let destroy_body = sigil_quote!(C { $T(free)(cfg); }).unwrap();
     let config_destroy = FunSpec::builder("config_destroy")
         .add_param(ParameterSpec::new("cfg", TypeName::primitive("struct Config*")).unwrap())
         .returns(TypeName::primitive("void"))
@@ -197,7 +197,7 @@ fn macro_approach() -> String {
         .build()
         .unwrap();
 
-    let print_body = sigil_quote!(CLang {
+    let print_body = sigil_quote!(C {
         $T(printf)($S("Config { host=%%s, port=%%d, level=%%d }\\n"), cfg->host, cfg->port, cfg->level);
     })
     .unwrap();
@@ -208,7 +208,7 @@ fn macro_approach() -> String {
         .build()
         .unwrap();
 
-    FileSpec::builder_with("config.h", CLang::header())
+    FileSpec::builder_with("config.h", C::header())
         .header(CodeBlock::of("#pragma once", ()).unwrap())
         .add_type(log_level)
         .add_type(callback)

--- a/examples/cpp_codegen.rs
+++ b/examples/cpp_codegen.rs
@@ -5,7 +5,7 @@
 //!
 //! Run: `cargo run --example cpp_codegen`
 
-use sigil_stitch::lang::cpp_lang::CppLang;
+use sigil_stitch::lang::cpp::Cpp;
 use sigil_stitch::prelude::*;
 
 fn main() {
@@ -19,8 +19,7 @@ fn main() {
 }
 
 fn emit_fun(fun: &FunSpec) -> CodeBlock {
-    fun.emit(&CppLang::new(), DeclarationContext::Member)
-        .unwrap()
+    fun.emit(&Cpp::new(), DeclarationContext::Member).unwrap()
 }
 
 fn builder_approach() -> String {
@@ -203,7 +202,7 @@ fn builder_approach() -> String {
         .build()
         .unwrap();
 
-    FileSpec::builder_with("logging.hpp", CppLang::header())
+    FileSpec::builder_with("logging.hpp", Cpp::header())
         .header(CodeBlock::of("#pragma once", ()).unwrap())
         .add_type(log_level)
         .add_type(config)
@@ -272,7 +271,7 @@ fn macro_approach() -> String {
         pub_section.add_line();
         pub_section.add("%>", ());
 
-        let ctor_body = sigil_quote!(CppLang {
+        let ctor_body = sigil_quote!(Cpp {
             $comment("@{comment_label}: @{comment_reason}");
             name_ = name; $comment(comment_note)
         })
@@ -288,7 +287,7 @@ fn macro_approach() -> String {
         ));
         pub_section.add_line();
 
-        let log_body = sigil_quote!(CppLang {
+        let log_body = sigil_quote!(Cpp {
             $T(iostream) << $V("@{v_interp}: ") << "[" << name_ << "] " << msg << std::endl;
         })
         .unwrap();
@@ -304,7 +303,7 @@ fn macro_approach() -> String {
         pub_section.add_line();
 
         // Static method: defaultLevel
-        let default_level_body = sigil_quote!(CppLang {
+        let default_level_body = sigil_quote!(Cpp {
             $attr("nodiscard");
             return LogLevel::Info;
         })
@@ -359,7 +358,7 @@ fn macro_approach() -> String {
         .unwrap();
 
     // --- Free function with reference and pointer params: logAll ---
-    let log_all_body = sigil_quote!(CppLang {
+    let log_all_body = sigil_quote!(Cpp {
         for (const auto& msg : messages) {
             logger->log(msg.c_str());
         }
@@ -382,7 +381,7 @@ fn macro_approach() -> String {
         .unwrap();
 
     // --- Template function: make_vector ---
-    let vec_body = sigil_quote!(CppLang {
+    let vec_body = sigil_quote!(Cpp {
         $T(vector_h)<T> result;
         result.push_back(first);
         result.push_back(second);
@@ -398,7 +397,7 @@ fn macro_approach() -> String {
         .build()
         .unwrap();
 
-    FileSpec::builder_with("logging.hpp", CppLang::header())
+    FileSpec::builder_with("logging.hpp", Cpp::header())
         .header(CodeBlock::of("#pragma once", ()).unwrap())
         .add_type(log_level)
         .add_type(config)

--- a/examples/dart_codegen.rs
+++ b/examples/dart_codegen.rs
@@ -7,7 +7,7 @@
 //!
 //! Run: `cargo run --example dart_codegen`
 
-use sigil_stitch::lang::dart::DartLang;
+use sigil_stitch::lang::dart::Dart;
 use sigil_stitch::prelude::*;
 
 fn main() {
@@ -198,7 +198,7 @@ fn builder_approach() -> String {
     join_body.add("%T", (mixin2,));
     join_body.add(" {\n  final String name;\n  User(this.name);\n}", ());
 
-    FileSpec::builder_with("task.dart", DartLang::new())
+    FileSpec::builder_with("task.dart", Dart::new())
         .add_type(status)
         .add_type(base_entity)
         .add_type(task)
@@ -244,7 +244,7 @@ fn macro_approach() -> String {
                 .unwrap(),
         );
 
-    let ctor_body = sigil_quote!(DartLang {
+    let ctor_body = sigil_quote!(Dart {
         $comment("@{comment_label}: @{comment_reason}");
         super(id); $comment(comment_note)
         this.name = name;
@@ -252,7 +252,7 @@ fn macro_approach() -> String {
     })
     .unwrap();
 
-    let validate_body = sigil_quote!(DartLang {
+    let validate_body = sigil_quote!(Dart {
         $attr("override");
         return id.isNotEmpty && name.isNotEmpty
     })
@@ -279,7 +279,7 @@ fn macro_approach() -> String {
         .unwrap();
 
     // --- parseTask function ---
-    let parse_body = sigil_quote!(DartLang {
+    let parse_body = sigil_quote!(Dart {
         final data = $T(convert)(json);
         return Task(data[$S("id")], data[$S("name")]);
     })
@@ -292,7 +292,7 @@ fn macro_approach() -> String {
         .unwrap();
 
     // --- Async function: fetchTask ---
-    let fetch_body = sigil_quote!(DartLang {
+    let fetch_body = sigil_quote!(Dart {
         final json = await http.get($S("https://api.example.com/task"))
         return parseTask(json.body)
     })
@@ -309,7 +309,7 @@ fn macro_approach() -> String {
         .unwrap();
 
     // --- Generic function: transform<T, R> ---
-    let transform_body = sigil_quote!(DartLang {
+    let transform_body = sigil_quote!(Dart {
         return mapper(input)
     })
     .unwrap();
@@ -329,7 +329,7 @@ fn macro_approach() -> String {
         TypeName::importable("./mixins", "JsonSerializable"),
         TypeName::importable("./mixins", "EquatableMixin"),
     ];
-    let join_body = sigil_quote!(DartLang {
+    let join_body = sigil_quote!(Dart {
         class User extends BaseModel with $T_join(", ", &mixins) {
             final String name;
             User(this.name);
@@ -337,7 +337,7 @@ fn macro_approach() -> String {
     })
     .unwrap();
 
-    FileSpec::builder_with("task.dart", DartLang::new())
+    FileSpec::builder_with("task.dart", Dart::new())
         .add_type(status)
         .add_type(base_entity)
         .add_type(task)

--- a/examples/go_codegen.rs
+++ b/examples/go_codegen.rs
@@ -7,7 +7,7 @@
 //!
 //! Run: `cargo run --example go_codegen`
 
-use sigil_stitch::lang::go_lang::GoLang;
+use sigil_stitch::lang::go::Go;
 use sigil_stitch::prelude::*;
 
 fn main() {
@@ -186,7 +186,7 @@ fn builder_approach() -> String {
     enum_body.add("%<", ());
     enum_body.add(")", ());
 
-    FileSpec::builder_with("server.go", GoLang::new())
+    FileSpec::builder_with("server.go", Go::new())
         .header(CodeBlock::of("package server", ()).unwrap())
         .add_type(logger)
         .add_type(server)
@@ -211,7 +211,7 @@ fn macro_approach() -> String {
     let comment_note = "format address";
     let v_interp = "8080";
 
-    let start_body = sigil_quote!(GoLang {
+    let start_body = sigil_quote!(Go {
         $comment("@{comment_label}: @{comment_reason}");
         $V("// default port: @{v_interp}");
         addr := $T(fmt_sprintf)("%s:%d", s.host, s.port) $comment(comment_note)
@@ -229,7 +229,7 @@ fn macro_approach() -> String {
         .build()
         .unwrap();
 
-    let add_body = sigil_quote!(GoLang {
+    let add_body = sigil_quote!(Go {
         s.routes[path] = handler
     })
     .unwrap();
@@ -244,7 +244,7 @@ fn macro_approach() -> String {
         .build()
         .unwrap();
 
-    let sort_body = sigil_quote!(GoLang {
+    let sort_body = sigil_quote!(Go {
         $T(sort_slice)(items, func(i, j int) bool {
             return items[i] < items[j]
         })
@@ -266,7 +266,7 @@ fn macro_approach() -> String {
         TypeName::importable("io", "Writer"),
         TypeName::importable("io", "Closer"),
     ];
-    let join_body = sigil_quote!(GoLang {
+    let join_body = sigil_quote!(Go {
         type FileOps interface {
             $T_join("\n", &ifaces)
         }
@@ -275,7 +275,7 @@ fn macro_approach() -> String {
 
     // --- const paren block: generate enum-like constants with $for ---
     let variants = ["Alpha", "Beta", "Gamma"];
-    let enum_body = sigil_quote!(GoLang {
+    let enum_body = sigil_quote!(Go {
         const (
         $for(v in &variants) {
             $L("@{v} @{v}Kind = \"@{v}\"")
@@ -284,7 +284,7 @@ fn macro_approach() -> String {
     })
     .unwrap();
 
-    FileSpec::builder_with("server.go", GoLang::new())
+    FileSpec::builder_with("server.go", Go::new())
         .header(CodeBlock::of("package server", ()).unwrap())
         .add_type(logger)
         .add_type(server)

--- a/examples/java_codegen.rs
+++ b/examples/java_codegen.rs
@@ -7,7 +7,7 @@
 //!
 //! Run: `cargo run --example java_codegen`
 
-use sigil_stitch::lang::java_lang::JavaLang;
+use sigil_stitch::lang::java::Java;
 use sigil_stitch::prelude::*;
 
 fn main() {
@@ -268,7 +268,7 @@ fn builder_approach() -> String {
         (),
     );
 
-    FileSpec::builder_with("User.java", JavaLang::new())
+    FileSpec::builder_with("User.java", Java::new())
         .add_type(priority_enum)
         .add_type(repo_iface)
         .add_type(base_entity)
@@ -304,7 +304,7 @@ fn macro_approach() -> String {
                 .visibility(Visibility::Protected)
                 .add_param(ParameterSpec::new("name", TypeName::primitive("String")).unwrap())
                 .body(
-                    sigil_quote!(JavaLang {
+                    sigil_quote!(Java {
                         $comment("@{comment_label}: @{comment_reason}");
                         this.name = name;
                     })
@@ -317,7 +317,7 @@ fn macro_approach() -> String {
             FunSpec::builder("getName")
                 .visibility(Visibility::Public)
                 .returns(TypeName::primitive("String"))
-                .body(sigil_quote!(JavaLang { $V("// @{v_interp} name"); return this.name; $comment(comment_note) }).unwrap())
+                .body(sigil_quote!(Java { $V("// @{v_interp} name"); return this.name; $comment(comment_note) }).unwrap())
                 .build()
                 .unwrap(),
         )
@@ -349,7 +349,7 @@ fn macro_approach() -> String {
                 .add_param(ParameterSpec::new("name", TypeName::primitive("String")).unwrap())
                 .add_param(ParameterSpec::new("email", TypeName::primitive("String")).unwrap())
                 .delegation(CodeBlock::of("super(name)", ()).unwrap())
-                .body(sigil_quote!(JavaLang { this.email = email; }).unwrap())
+                .body(sigil_quote!(Java { this.email = email; }).unwrap())
                 .build()
                 .unwrap(),
         )
@@ -359,7 +359,7 @@ fn macro_approach() -> String {
                 .is_override()
                 .returns(TypeName::primitive("boolean"))
                 .body(
-                    sigil_quote!(JavaLang {
+                    sigil_quote!(Java {
                         $attr("Override");
                         return this.name != null && !this.name.isEmpty();
                     })
@@ -372,7 +372,7 @@ fn macro_approach() -> String {
             FunSpec::builder("getEmail")
                 .visibility(Visibility::Public)
                 .returns(TypeName::primitive("String"))
-                .body(sigil_quote!(JavaLang { return this.email; }).unwrap())
+                .body(sigil_quote!(Java { return this.email; }).unwrap())
                 .build()
                 .unwrap(),
         )
@@ -382,7 +382,7 @@ fn macro_approach() -> String {
                 .is_override()
                 .returns(TypeName::primitive("String"))
                 .body(
-                    sigil_quote!(JavaLang {
+                    sigil_quote!(Java {
                         return "User{name=" + this.name + ", email=" + this.email + "}";
                     })
                     .unwrap(),
@@ -395,7 +395,7 @@ fn macro_approach() -> String {
 
     // --- Static generic method ---
     let collections = TypeName::importable("java.util", "Collections");
-    let sort_body = sigil_quote!(JavaLang {
+    let sort_body = sigil_quote!(Java {
         $T(collections).sort(list);
         return list;
     })
@@ -428,7 +428,7 @@ fn macro_approach() -> String {
         TypeName::importable("java.io", "Serializable"),
         TypeName::importable("java.lang", "Comparable"),
     ];
-    let join_body = sigil_quote!(JavaLang {
+    let join_body = sigil_quote!(Java {
         class Box<T extends $T_join(" & ", &bounds)> {
             private T value;
             Box(T value) { this.value = value; }
@@ -436,7 +436,7 @@ fn macro_approach() -> String {
     })
     .unwrap();
 
-    FileSpec::builder_with("User.java", JavaLang::new())
+    FileSpec::builder_with("User.java", Java::new())
         .add_type(priority_enum)
         .add_type(repo_iface)
         .add_type(base_entity)

--- a/examples/multi_language_project.rs
+++ b/examples/multi_language_project.rs
@@ -7,7 +7,7 @@
 //! Run: `cargo run --example multi_language_project`
 
 use sigil_stitch::lang::csharp::CSharp;
-use sigil_stitch::lang::go_lang::GoLang;
+use sigil_stitch::lang::go::Go;
 use sigil_stitch::lang::python::Python;
 use sigil_stitch::prelude::*;
 
@@ -192,7 +192,7 @@ fn build_go_handler(schema: &[SchemaField]) -> FileSpec {
 
     let trigger = CodeBlock::of("// %T", (http,)).unwrap();
 
-    FileSpec::builder_with("handler.go", GoLang::new())
+    FileSpec::builder_with("handler.go", Go::new())
         .header(CodeBlock::of("package api", ()).unwrap())
         .add_code(trigger)
         .add_type(ts.build().unwrap())

--- a/examples/rust_codegen.rs
+++ b/examples/rust_codegen.rs
@@ -6,7 +6,7 @@
 //!
 //! Run: `cargo run --example rust_codegen`
 
-use sigil_stitch::lang::rust_lang::RustLang;
+use sigil_stitch::lang::rust::Rust;
 use sigil_stitch::prelude::*;
 
 fn main() {
@@ -204,7 +204,7 @@ fn builder_approach() -> String {
         (),
     );
 
-    FileSpec::builder_with("events.rs", RustLang::new())
+    FileSpec::builder_with("events.rs", Rust::new())
         .add_type(event_enum)
         .add_type(user_id)
         .add_type(config)
@@ -226,7 +226,7 @@ fn macro_approach() -> String {
     let comment_note = "validate event";
     let (event_enum, user_id, config) = build_shared_types();
 
-    let print_body = sigil_quote!(RustLang {
+    let print_body = sigil_quote!(Rust {
         $attr("derive(Debug)")
         $comment("@{comment_label}: @{comment_reason}");
         let _ev = $V("@{v_interp}");
@@ -248,7 +248,7 @@ fn macro_approach() -> String {
         .build()
         .unwrap();
 
-    let handler_body = sigil_quote!(RustLang {
+    let handler_body = sigil_quote!(Rust {
         move |event: &Event| {
             println!("handling {:?}", event);
         }
@@ -265,7 +265,7 @@ fn macro_approach() -> String {
         .build()
         .unwrap();
 
-    let dispatch_body = sigil_quote!(RustLang {
+    let dispatch_body = sigil_quote!(Rust {
         handler.handle(event)
     })
     .unwrap();
@@ -293,7 +293,7 @@ fn macro_approach() -> String {
     let read = TypeName::importable("std::io", "Read");
     let write = TypeName::importable("std::io", "Write");
     let traits = vec![read, write, TypeName::primitive("Send")];
-    let join_body = sigil_quote!(RustLang {
+    let join_body = sigil_quote!(Rust {
         fn process(stream: &mut (dyn $T_join(" + ", &traits))) {
             let mut buf = [0u8; 1024];
             stream.read(&mut buf).unwrap();
@@ -301,7 +301,7 @@ fn macro_approach() -> String {
     })
     .unwrap();
 
-    FileSpec::builder_with("events.rs", RustLang::new())
+    FileSpec::builder_with("events.rs", Rust::new())
         .add_type(event_enum)
         .add_type(user_id)
         .add_type(config)

--- a/macros/src/parse/annotate.rs
+++ b/macros/src/parse/annotate.rs
@@ -255,7 +255,7 @@ pub(super) fn annotate_tokens(tokens: &[TokenTree], lang: MacroLang) -> Vec<Toke
                             // Go: `<-ch` is prefix receive — suppress space after
                             // if span-adjacent to next token. `ch <- 42` (send) has
                             // whitespace after `-`, so it keeps the space.
-                            if lang == MacroLang::GoLang && i + 1 < tokens.len() {
+                            if lang == MacroLang::Go && i + 1 < tokens.len() {
                                 let dash_end = p.span().end();
                                 let next_start = tokens[i + 1].span().start();
                                 if dash_end.line == next_start.line

--- a/macros/src/parse/annotate_tests.rs
+++ b/macros/src/parse/annotate_tests.rs
@@ -156,14 +156,14 @@ fn bash_slash_leading_path() {
 #[test]
 fn go_receive_adjacent() {
     // <-ch → < is Joint, - adjacent to ch → PrefixOp on -
-    let a = annotate_lang("<-ch", MacroLang::GoLang);
+    let a = annotate_lang("<-ch", MacroLang::Go);
     assert_eq!(ann_at(&a, 1), TokenAnnotation::PrefixOp);
 }
 
 #[test]
 fn go_send_not_prefix() {
     // ch <- 42 → - is NOT adjacent to 42 → stays Normal
-    let a = annotate_lang("ch <- 42", MacroLang::GoLang);
+    let a = annotate_lang("ch <- 42", MacroLang::Go);
     assert_eq!(ann_at(&a, 2), TokenAnnotation::Normal);
 }
 

--- a/macros/src/parse/format_tests.rs
+++ b/macros/src/parse/format_tests.rs
@@ -166,13 +166,10 @@ fn if_with_parens() {
 
 #[test]
 fn go_slice_type() {
-    assert_eq!(fmt_lang("[]byte", MacroLang::GoLang), "[]byte");
+    assert_eq!(fmt_lang("[]byte", MacroLang::Go), "[]byte");
 }
 
 #[test]
 fn go_map_type() {
-    assert_eq!(
-        fmt_lang("map[string]int", MacroLang::GoLang),
-        "map[string]int"
-    );
+    assert_eq!(fmt_lang("map[string]int", MacroLang::Go), "map[string]int");
 }

--- a/macros/src/parse/mod.rs
+++ b/macros/src/parse/mod.rs
@@ -25,7 +25,7 @@ fn parse_macro_lang(ts: &TokenStream) -> MacroLang {
         match id.to_string().as_str() {
             "Bash" => MacroLang::Bash,
             "Zsh" => MacroLang::Zsh,
-            "GoLang" => MacroLang::GoLang,
+            "Go" => MacroLang::Go,
             "Haskell" => MacroLang::Haskell,
             "OCaml" => MacroLang::OCaml,
             _ => MacroLang::Unaware,

--- a/macros/src/parse/statements.rs
+++ b/macros/src/parse/statements.rs
@@ -760,7 +760,7 @@ fn handle_expression_brace_with_markers(
 /// Check whether the collected prefix tokens and language indicate a
 /// paren-delimited declaration block (Go: `const`, `var`, `import`, `type`).
 fn is_paren_block_start(collected: &[TokenTree], lang: MacroLang) -> bool {
-    if lang != MacroLang::GoLang {
+    if lang != MacroLang::Go {
         return false;
     }
     collected.last().is_some_and(|tt| {

--- a/macros/src/parse/statements_tests.rs
+++ b/macros/src/parse/statements_tests.rs
@@ -149,7 +149,7 @@ fn statement_with_interpolation() {
 
 #[test]
 fn go_for_with_embedded_semicolons() {
-    let stmt = parse_stmt_lang("for i := 0; i < n; i++ { body(); }", MacroLang::GoLang);
+    let stmt = parse_stmt_lang("for i := 0; i < n; i++ { body(); }", MacroLang::Go);
     match stmt {
         Statement::ControlFlow { branches } => {
             assert!(branches[0].condition_format.contains("for"));
@@ -161,7 +161,7 @@ fn go_for_with_embedded_semicolons() {
 
 #[test]
 fn go_const_paren_block() {
-    let stmt = parse_stmt_lang("const ( x = 1 )", MacroLang::GoLang);
+    let stmt = parse_stmt_lang("const ( x = 1 )", MacroLang::Go);
     match stmt {
         Statement::ParenBlock {
             header_format,
@@ -178,7 +178,7 @@ fn go_const_paren_block() {
 
 #[test]
 fn go_var_paren_block() {
-    let stmt = parse_stmt_lang("var ( x int )", MacroLang::GoLang);
+    let stmt = parse_stmt_lang("var ( x int )", MacroLang::Go);
     match stmt {
         Statement::ParenBlock { header_format, .. } => {
             assert_eq!(header_format, "var (");
@@ -189,7 +189,7 @@ fn go_var_paren_block() {
 
 #[test]
 fn go_import_paren_block() {
-    let stmt = parse_stmt_lang("import ( \"fmt\" )", MacroLang::GoLang);
+    let stmt = parse_stmt_lang("import ( \"fmt\" )", MacroLang::Go);
     match stmt {
         Statement::ParenBlock { header_format, .. } => {
             assert_eq!(header_format, "import (");
@@ -200,7 +200,7 @@ fn go_import_paren_block() {
 
 #[test]
 fn go_type_paren_block() {
-    let stmt = parse_stmt_lang("type ( A struct{} )", MacroLang::GoLang);
+    let stmt = parse_stmt_lang("type ( A struct{} )", MacroLang::Go);
     match stmt {
         Statement::ParenBlock { header_format, .. } => {
             assert_eq!(header_format, "type (");
@@ -212,10 +212,7 @@ fn go_type_paren_block() {
 #[test]
 fn go_paren_block_with_metafor() {
     // Verify that $for inside a Go const paren block is parsed recursively.
-    let stmt = parse_stmt_lang(
-        "const ( $for(v in items) { $L(\"x\") } )",
-        MacroLang::GoLang,
-    );
+    let stmt = parse_stmt_lang("const ( $for(v in items) { $L(\"x\") } )", MacroLang::Go);
     match stmt {
         Statement::ParenBlock { body, .. } => {
             assert_eq!(body.len(), 1);
@@ -227,7 +224,7 @@ fn go_paren_block_with_metafor() {
 
 #[test]
 fn non_go_paren_block_is_literal() {
-    // Without MacroLang::GoLang, `const ( ... )` stays as a literal line.
+    // Without MacroLang::Go, `const ( ... )` stays as a literal line.
     let stmt = parse_stmt_lang("const ( x = 1 )", MacroLang::Unaware);
     match stmt {
         Statement::Line { format, .. } => {

--- a/macros/src/parse/types.rs
+++ b/macros/src/parse/types.rs
@@ -9,7 +9,7 @@ pub(crate) enum MacroLang {
     Unaware,
     Bash,
     Zsh,
-    GoLang,
+    Go,
     Haskell,
     OCaml,
 }

--- a/src/lang/c.rs
+++ b/src/lang/c.rs
@@ -33,14 +33,14 @@ use crate::spec::modifiers::{DeclarationContext, TypeKind, Visibility};
 /// fb.header(CodeBlock::of("#pragma once", ()).unwrap());
 /// ```
 #[derive(Debug, Clone)]
-pub struct CLang {
+pub struct C {
     /// Indent with this string (default: "    " — 4 spaces).
     pub indent: String,
     /// File extension (default: "c"). Set to "h" for header files.
     pub extension: String,
 }
 
-impl Default for CLang {
+impl Default for C {
     fn default() -> Self {
         Self {
             indent: "    ".to_string(),
@@ -49,13 +49,13 @@ impl Default for CLang {
     }
 }
 
-impl CLang {
+impl C {
     /// Create a new C language instance.
     pub fn new() -> Self {
         Self::default()
     }
 
-    /// Create a CLang configured for header files (.h extension).
+    /// Create a C configured for header files (.h extension).
     pub fn header() -> Self {
         Self {
             indent: "    ".to_string(),
@@ -134,7 +134,7 @@ fn strip_local_prefix(module: &str) -> &str {
     module.strip_prefix("./").unwrap_or(module)
 }
 
-impl RendererLang for CLang {
+impl RendererLang for C {
     fn file_extension(&self) -> &str {
         &self.extension
     }
@@ -183,7 +183,7 @@ impl RendererLang for CLang {
     }
 }
 
-impl CodeLang for CLang {
+impl CodeLang for C {
     fn render_imports(&self, imports: &ImportGroup) -> String {
         if imports.entries().is_empty() {
             return String::new();
@@ -311,19 +311,19 @@ mod tests {
 
     #[test]
     fn test_file_extension() {
-        let c = CLang::new();
+        let c = C::new();
         assert_eq!(c.file_extension(), "c");
     }
 
     #[test]
     fn test_header_extension() {
-        let c = CLang::header();
+        let c = C::header();
         assert_eq!(c.file_extension(), "h");
     }
 
     #[test]
     fn test_escape_reserved() {
-        let c = CLang::new();
+        let c = C::new();
         assert_eq!(c.escape_reserved("int"), "int_");
         assert_eq!(c.escape_reserved("struct"), "struct_");
         assert_eq!(c.escape_reserved("name"), "name");
@@ -331,7 +331,7 @@ mod tests {
 
     #[test]
     fn test_render_imports_system() {
-        let c = CLang::new();
+        let c = C::new();
         let imports = ImportGroup {
             entries: vec![ImportEntry {
                 module: "stdio.h".into(),
@@ -347,7 +347,7 @@ mod tests {
 
     #[test]
     fn test_render_imports_local() {
-        let c = CLang::new();
+        let c = C::new();
         let imports = ImportGroup {
             entries: vec![ImportEntry {
                 module: "./config.h".into(),
@@ -363,7 +363,7 @@ mod tests {
 
     #[test]
     fn test_render_imports_grouped() {
-        let c = CLang::new();
+        let c = C::new();
         let imports = ImportGroup {
             entries: vec![
                 ImportEntry {
@@ -402,7 +402,7 @@ mod tests {
 
     #[test]
     fn test_render_imports_dedup() {
-        let c = CLang::new();
+        let c = C::new();
         let imports = ImportGroup {
             entries: vec![
                 ImportEntry {
@@ -428,7 +428,7 @@ mod tests {
 
     #[test]
     fn test_doc_comment_single() {
-        let c = CLang::new();
+        let c = C::new();
         assert_eq!(
             c.render_doc_comment(&["A brief description."]),
             "/* A brief description. */"
@@ -437,7 +437,7 @@ mod tests {
 
     #[test]
     fn test_doc_comment_multi() {
-        let c = CLang::new();
+        let c = C::new();
         let doc = c.render_doc_comment(&["Configuration struct.", "", "Thread-safe."]);
         assert!(doc.starts_with("/*"));
         assert!(doc.ends_with(" */"));
@@ -448,7 +448,7 @@ mod tests {
 
     #[test]
     fn test_string_literal() {
-        let c = CLang::new();
+        let c = C::new();
         assert_eq!(c.render_string_literal("hello"), "\"hello\"");
         assert_eq!(c.render_string_literal("it\"s"), "\"it\\\"s\"");
         assert_eq!(c.render_string_literal("new\nline"), "\"new\\nline\"");
@@ -456,19 +456,19 @@ mod tests {
 
     #[test]
     fn test_type_before_name() {
-        let c = CLang::new();
+        let c = C::new();
         assert!(c.type_decl_syntax().type_before_name);
     }
 
     #[test]
     fn test_return_type_is_prefix() {
-        let c = CLang::new();
+        let c = C::new();
         assert!(c.type_decl_syntax().return_type_is_prefix);
     }
 
     #[test]
     fn test_type_close_terminator() {
-        let c = CLang::new();
+        let c = C::new();
         assert_eq!(c.block_syntax().type_close_terminator, ";");
     }
 
@@ -483,14 +483,14 @@ mod tests {
 
     #[test]
     fn test_c_builder_fluent() {
-        let c = CLang::new().with_indent("\t").with_extension("h");
+        let c = C::new().with_indent("\t").with_extension("h");
         assert_eq!(c.file_extension(), "h");
         assert_eq!(c.block_syntax().indent_unit, "\t");
     }
 
     #[test]
     fn test_module_separator() {
-        let c = CLang::new();
+        let c = C::new();
         assert_eq!(c.module_separator(), None);
     }
 }

--- a/src/lang/cpp.rs
+++ b/src/lang/cpp.rs
@@ -56,14 +56,14 @@ use crate::spec::modifiers::{DeclarationContext, TypeKind, Visibility};
 /// fb.suffix("= 0");       // emits "= 0" after params
 /// ```
 #[derive(Debug, Clone)]
-pub struct CppLang {
+pub struct Cpp {
     /// Indent with this string (default: "    " — 4 spaces).
     pub indent: String,
     /// File extension (default: "cpp"). Set to "hpp" or "h" for header files.
     pub extension: String,
 }
 
-impl Default for CppLang {
+impl Default for Cpp {
     fn default() -> Self {
         Self {
             indent: "    ".to_string(),
@@ -72,13 +72,13 @@ impl Default for CppLang {
     }
 }
 
-impl CppLang {
+impl Cpp {
     /// Create a new C++ language instance.
     pub fn new() -> Self {
         Self::default()
     }
 
-    /// Create a CppLang configured for header files (.hpp extension).
+    /// Create a Cpp configured for header files (.hpp extension).
     pub fn header() -> Self {
         Self {
             indent: "    ".to_string(),
@@ -86,7 +86,7 @@ impl CppLang {
         }
     }
 
-    /// Create a CppLang configured for .h header files.
+    /// Create a Cpp configured for .h header files.
     pub fn header_h() -> Self {
         Self {
             indent: "    ".to_string(),
@@ -165,7 +165,7 @@ fn strip_local_prefix(module: &str) -> &str {
     module.strip_prefix("./").unwrap_or(module)
 }
 
-impl RendererLang for CppLang {
+impl RendererLang for Cpp {
     fn file_extension(&self) -> &str {
         &self.extension
     }
@@ -239,7 +239,7 @@ impl RendererLang for CppLang {
     }
 }
 
-impl CodeLang for CppLang {
+impl CodeLang for Cpp {
     fn render_imports(&self, imports: &ImportGroup) -> String {
         if imports.entries().is_empty() {
             return String::new();
@@ -372,25 +372,25 @@ mod tests {
 
     #[test]
     fn test_file_extension() {
-        let cpp = CppLang::new();
+        let cpp = Cpp::new();
         assert_eq!(cpp.file_extension(), "cpp");
     }
 
     #[test]
     fn test_header_extension() {
-        let cpp = CppLang::header();
+        let cpp = Cpp::header();
         assert_eq!(cpp.file_extension(), "hpp");
     }
 
     #[test]
     fn test_header_h_extension() {
-        let cpp = CppLang::header_h();
+        let cpp = Cpp::header_h();
         assert_eq!(cpp.file_extension(), "h");
     }
 
     #[test]
     fn test_escape_reserved() {
-        let cpp = CppLang::new();
+        let cpp = Cpp::new();
         assert_eq!(cpp.escape_reserved("class"), "class_");
         assert_eq!(cpp.escape_reserved("virtual"), "virtual_");
         assert_eq!(cpp.escape_reserved("template"), "template_");
@@ -399,7 +399,7 @@ mod tests {
 
     #[test]
     fn test_render_imports_system() {
-        let cpp = CppLang::new();
+        let cpp = Cpp::new();
         let imports = ImportGroup {
             entries: vec![ImportEntry {
                 module: "iostream".into(),
@@ -415,7 +415,7 @@ mod tests {
 
     #[test]
     fn test_render_imports_local() {
-        let cpp = CppLang::new();
+        let cpp = Cpp::new();
         let imports = ImportGroup {
             entries: vec![ImportEntry {
                 module: "./myclass.hpp".into(),
@@ -431,7 +431,7 @@ mod tests {
 
     #[test]
     fn test_render_imports_grouped() {
-        let cpp = CppLang::new();
+        let cpp = Cpp::new();
         let imports = ImportGroup {
             entries: vec![
                 ImportEntry {
@@ -470,7 +470,7 @@ mod tests {
 
     #[test]
     fn test_render_imports_dedup() {
-        let cpp = CppLang::new();
+        let cpp = Cpp::new();
         let imports = ImportGroup {
             entries: vec![
                 ImportEntry {
@@ -496,7 +496,7 @@ mod tests {
 
     #[test]
     fn test_doc_comment_single() {
-        let cpp = CppLang::new();
+        let cpp = Cpp::new();
         assert_eq!(
             cpp.render_doc_comment(&["A brief description."]),
             "/// A brief description."
@@ -505,14 +505,14 @@ mod tests {
 
     #[test]
     fn test_doc_comment_multi() {
-        let cpp = CppLang::new();
+        let cpp = Cpp::new();
         let doc = cpp.render_doc_comment(&["Container class.", "", "Thread-safe."]);
         assert_eq!(doc, "/// Container class.\n///\n/// Thread-safe.");
     }
 
     #[test]
     fn test_string_literal() {
-        let cpp = CppLang::new();
+        let cpp = Cpp::new();
         assert_eq!(cpp.render_string_literal("hello"), "\"hello\"");
         assert_eq!(cpp.render_string_literal("it\"s"), "\"it\\\"s\"");
         assert_eq!(cpp.render_string_literal("new\nline"), "\"new\\nline\"");
@@ -520,25 +520,25 @@ mod tests {
 
     #[test]
     fn test_type_before_name() {
-        let cpp = CppLang::new();
+        let cpp = Cpp::new();
         assert!(cpp.type_decl_syntax().type_before_name);
     }
 
     #[test]
     fn test_return_type_is_prefix() {
-        let cpp = CppLang::new();
+        let cpp = Cpp::new();
         assert!(cpp.type_decl_syntax().return_type_is_prefix);
     }
 
     #[test]
     fn test_type_close_terminator() {
-        let cpp = CppLang::new();
+        let cpp = Cpp::new();
         assert_eq!(cpp.block_syntax().type_close_terminator, ";");
     }
 
     #[test]
     fn test_type_keyword() {
-        let cpp = CppLang::new();
+        let cpp = Cpp::new();
         assert_eq!(cpp.type_keyword(TypeKind::Class), "class");
         assert_eq!(cpp.type_keyword(TypeKind::Struct), "struct");
         assert_eq!(cpp.type_keyword(TypeKind::Enum), "enum class");
@@ -547,25 +547,25 @@ mod tests {
 
     #[test]
     fn test_abstract_keyword() {
-        let cpp = CppLang::new();
+        let cpp = Cpp::new();
         assert_eq!(cpp.function_syntax().abstract_keyword, "virtual ");
     }
 
     #[test]
     fn test_super_type_keyword() {
-        let cpp = CppLang::new();
+        let cpp = Cpp::new();
         assert_eq!(cpp.type_decl_syntax().super_type_keyword, " : public ");
     }
 
     #[test]
     fn test_super_type_separator() {
-        let cpp = CppLang::new();
+        let cpp = Cpp::new();
         assert_eq!(cpp.type_decl_syntax().super_type_separator, ", public ");
     }
 
     #[test]
     fn test_methods_inside_type_body() {
-        let cpp = CppLang::new();
+        let cpp = Cpp::new();
         assert!(cpp.methods_inside_type_body(TypeKind::Class));
         assert!(cpp.methods_inside_type_body(TypeKind::Interface));
         assert!(!cpp.methods_inside_type_body(TypeKind::Struct));
@@ -583,14 +583,14 @@ mod tests {
 
     #[test]
     fn test_cpp_builder_fluent() {
-        let cpp = CppLang::new().with_indent("  ").with_extension("cxx");
+        let cpp = Cpp::new().with_indent("  ").with_extension("cxx");
         assert_eq!(cpp.file_extension(), "cxx");
         assert_eq!(cpp.block_syntax().indent_unit, "  ");
     }
 
     #[test]
     fn test_module_separator() {
-        let cpp = CppLang::new();
+        let cpp = Cpp::new();
         assert_eq!(cpp.module_separator(), Some("::"));
     }
 }

--- a/src/lang/dart.rs
+++ b/src/lang/dart.rs
@@ -51,14 +51,14 @@ use crate::spec::modifiers::{DeclarationContext, TypeKind, Visibility};
 ///   .is_async();
 /// ```
 #[derive(Debug, Clone)]
-pub struct DartLang {
+pub struct Dart {
     /// Indent with this string (default: "  " — 2 spaces per Dart style guide).
     pub indent: String,
     /// File extension (default: "dart").
     pub extension: String,
 }
 
-impl Default for DartLang {
+impl Default for Dart {
     fn default() -> Self {
         Self {
             indent: "  ".to_string(),
@@ -67,7 +67,7 @@ impl Default for DartLang {
     }
 }
 
-impl DartLang {
+impl Dart {
     /// Create a new Dart language instance.
     pub fn new() -> Self {
         Self::default()
@@ -112,7 +112,7 @@ fn import_group_order(module: &str) -> u8 {
     }
 }
 
-impl RendererLang for DartLang {
+impl RendererLang for Dart {
     fn file_extension(&self) -> &str {
         &self.extension
     }
@@ -186,7 +186,7 @@ impl RendererLang for DartLang {
     }
 }
 
-impl CodeLang for DartLang {
+impl CodeLang for Dart {
     fn render_imports(&self, imports: &ImportGroup) -> String {
         if imports.entries().is_empty() {
             return String::new();
@@ -310,13 +310,13 @@ mod tests {
 
     #[test]
     fn test_file_extension() {
-        let d = DartLang::new();
+        let d = Dart::new();
         assert_eq!(d.file_extension(), "dart");
     }
 
     #[test]
     fn test_escape_reserved() {
-        let d = DartLang::new();
+        let d = Dart::new();
         assert_eq!(d.escape_reserved("class"), "class_");
         assert_eq!(d.escape_reserved("import"), "import_");
         assert_eq!(d.escape_reserved("final"), "final_");
@@ -325,7 +325,7 @@ mod tests {
 
     #[test]
     fn test_render_imports_single() {
-        let d = DartLang::new();
+        let d = Dart::new();
         let imports = ImportGroup {
             entries: vec![ImportEntry {
                 module: "dart:async".into(),
@@ -341,7 +341,7 @@ mod tests {
 
     #[test]
     fn test_render_imports_grouped() {
-        let d = DartLang::new();
+        let d = Dart::new();
         let imports = ImportGroup {
             entries: vec![
                 ImportEntry {
@@ -381,7 +381,7 @@ mod tests {
 
     #[test]
     fn test_render_imports_sorted_within_group() {
-        let d = DartLang::new();
+        let d = Dart::new();
         let imports = ImportGroup {
             entries: vec![
                 ImportEntry {
@@ -419,7 +419,7 @@ mod tests {
 
     #[test]
     fn test_render_imports_dedup() {
-        let d = DartLang::new();
+        let d = Dart::new();
         let imports = ImportGroup {
             entries: vec![
                 ImportEntry {
@@ -445,7 +445,7 @@ mod tests {
 
     #[test]
     fn test_doc_comment_single() {
-        let d = DartLang::new();
+        let d = Dart::new();
         assert_eq!(
             d.render_doc_comment(&["A brief description."]),
             "/// A brief description."
@@ -454,14 +454,14 @@ mod tests {
 
     #[test]
     fn test_doc_comment_multi() {
-        let d = DartLang::new();
+        let d = Dart::new();
         let doc = d.render_doc_comment(&["Container class.", "", "See also [OtherClass]."]);
         assert_eq!(doc, "/// Container class.\n///\n/// See also [OtherClass].");
     }
 
     #[test]
     fn test_string_literal() {
-        let d = DartLang::new();
+        let d = Dart::new();
         assert_eq!(d.render_string_literal("hello"), "'hello'");
         assert_eq!(d.render_string_literal("it's"), "'it\\'s'");
         assert_eq!(d.render_string_literal("new\nline"), "'new\\nline'");
@@ -471,7 +471,7 @@ mod tests {
 
     #[test]
     fn test_type_keyword() {
-        let d = DartLang::new();
+        let d = Dart::new();
         assert_eq!(d.type_keyword(TypeKind::Class), "class");
         assert_eq!(d.type_keyword(TypeKind::Struct), "class");
         assert_eq!(d.type_keyword(TypeKind::Interface), "abstract class");
@@ -481,7 +481,7 @@ mod tests {
 
     #[test]
     fn test_no_visibility_keywords() {
-        let d = DartLang::new();
+        let d = Dart::new();
         assert_eq!(
             d.render_visibility(Visibility::Public, DeclarationContext::TopLevel),
             ""
@@ -498,31 +498,31 @@ mod tests {
 
     #[test]
     fn test_type_before_name() {
-        let d = DartLang::new();
+        let d = Dart::new();
         assert!(d.type_decl_syntax().type_before_name);
     }
 
     #[test]
     fn test_return_type_is_prefix() {
-        let d = DartLang::new();
+        let d = Dart::new();
         assert!(d.type_decl_syntax().return_type_is_prefix);
     }
 
     #[test]
     fn test_readonly_keyword() {
-        let d = DartLang::new();
+        let d = Dart::new();
         assert_eq!(d.enum_and_annotation().readonly_keyword, "final ");
     }
 
     #[test]
     fn test_no_async_keyword() {
-        let d = DartLang::new();
+        let d = Dart::new();
         assert_eq!(d.function_syntax().async_keyword, "");
     }
 
     #[test]
     fn test_async_suffix() {
-        let d = DartLang::new();
+        let d = Dart::new();
         assert_eq!(d.function_syntax().async_suffix, " async");
     }
 
@@ -538,14 +538,14 @@ mod tests {
 
     #[test]
     fn test_dart_builder_fluent() {
-        let d = DartLang::new().with_indent("    ").with_extension("g.dart");
+        let d = Dart::new().with_indent("    ").with_extension("g.dart");
         assert_eq!(d.file_extension(), "g.dart");
         assert_eq!(d.block_syntax().indent_unit, "    ");
     }
 
     #[test]
     fn test_module_separator() {
-        let d = DartLang::new();
+        let d = Dart::new();
         assert_eq!(d.module_separator(), Some("."));
     }
 }

--- a/src/lang/go.rs
+++ b/src/lang/go.rs
@@ -28,14 +28,14 @@ use crate::type_name::{FunctionPresentation, TypePresentation, WildcardPresentat
 /// fb.returns(TypeName::raw("(int, error)"));
 /// ```
 #[derive(Debug, Clone)]
-pub struct GoLang {
+pub struct Go {
     /// Indent with this string (default: "\t").
     pub indent: String,
     /// File extension (default: "go").
     pub extension: String,
 }
 
-impl Default for GoLang {
+impl Default for Go {
     fn default() -> Self {
         Self {
             indent: "\t".to_string(),
@@ -44,7 +44,7 @@ impl Default for GoLang {
     }
 }
 
-impl GoLang {
+impl Go {
     /// Create a new Go language instance.
     pub fn new() -> Self {
         Self::default()
@@ -107,7 +107,7 @@ fn is_stdlib(module: &str) -> bool {
     !first_segment.contains('.')
 }
 
-impl GoLang {
+impl Go {
     /// Rewrite IIFE continuation: fuse `}` + `()` onto the same line.
     ///
     /// The pattern `go func() { ... }();` produces nodes:
@@ -201,7 +201,7 @@ impl GoLang {
     }
 }
 
-impl RendererLang for GoLang {
+impl RendererLang for Go {
     fn file_extension(&self) -> &str {
         &self.extension
     }
@@ -294,7 +294,7 @@ impl RendererLang for GoLang {
     }
 }
 
-impl CodeLang for GoLang {
+impl CodeLang for Go {
     fn render_imports(&self, imports: &ImportGroup) -> String {
         if imports.entries().is_empty() {
             return String::new();
@@ -452,13 +452,13 @@ mod tests {
 
     #[test]
     fn test_file_extension() {
-        let go = GoLang::new();
+        let go = Go::new();
         assert_eq!(go.file_extension(), "go");
     }
 
     #[test]
     fn test_escape_reserved() {
-        let go = GoLang::new();
+        let go = Go::new();
         assert_eq!(go.escape_reserved("type"), "type_");
         assert_eq!(go.escape_reserved("name"), "name");
         assert_eq!(go.escape_reserved("func"), "func_");
@@ -466,7 +466,7 @@ mod tests {
 
     #[test]
     fn test_render_imports_single() {
-        let go = GoLang::new();
+        let go = Go::new();
         let imports = ImportGroup {
             entries: vec![ImportEntry {
                 module: "fmt".into(),
@@ -482,7 +482,7 @@ mod tests {
 
     #[test]
     fn test_render_imports_multiple_grouped() {
-        let go = GoLang::new();
+        let go = Go::new();
         let imports = ImportGroup {
             entries: vec![
                 ImportEntry {
@@ -524,7 +524,7 @@ mod tests {
 
     #[test]
     fn test_render_imports_dedup_same_package() {
-        let go = GoLang::new();
+        let go = Go::new();
         let imports = ImportGroup {
             entries: vec![
                 ImportEntry {
@@ -552,7 +552,7 @@ mod tests {
 
     #[test]
     fn test_qualify_import_name() {
-        let go = GoLang::new();
+        let go = Go::new();
         assert_eq!(go.qualify_import_name("net/http", "Server"), "http.Server");
         assert_eq!(go.qualify_import_name("fmt", "Println"), "fmt.Println");
         assert_eq!(
@@ -563,7 +563,7 @@ mod tests {
 
     #[test]
     fn test_doc_comment() {
-        let go = GoLang::new();
+        let go = Go::new();
         let doc = go.render_doc_comment(&["Config holds configuration.", "", "It is thread-safe."]);
         assert!(doc.contains("// Config holds configuration."));
         assert!(doc.contains("//\n"));
@@ -572,7 +572,7 @@ mod tests {
 
     #[test]
     fn test_string_literal() {
-        let go = GoLang::new();
+        let go = Go::new();
         assert_eq!(go.render_string_literal("hello"), "\"hello\"");
         assert_eq!(go.render_string_literal("it\"s"), "\"it\\\"s\"");
     }
@@ -596,14 +596,14 @@ mod tests {
 
     #[test]
     fn test_generic_delimiters() {
-        let go = GoLang::new();
+        let go = Go::new();
         assert_eq!(go.generic_syntax().open, "[");
         assert_eq!(go.generic_syntax().close, "]");
     }
 
     #[test]
     fn test_type_kind_suffix() {
-        let go = GoLang::new();
+        let go = Go::new();
         assert_eq!(go.type_kind_suffix(TypeKind::Struct), "struct");
         assert_eq!(go.type_kind_suffix(TypeKind::Interface), "interface");
         assert_eq!(go.type_kind_suffix(TypeKind::Enum), "");
@@ -611,14 +611,14 @@ mod tests {
 
     #[test]
     fn test_go_builder_fluent() {
-        let go = GoLang::new().with_indent("    ").with_extension("go2");
+        let go = Go::new().with_indent("    ").with_extension("go2");
         assert_eq!(go.file_extension(), "go2");
         assert_eq!(go.block_syntax().indent_unit, "    ");
     }
 
     #[test]
     fn test_module_separator() {
-        let go = GoLang::new();
+        let go = Go::new();
         assert_eq!(go.module_separator(), Some("."));
     }
 }

--- a/src/lang/java.rs
+++ b/src/lang/java.rs
@@ -41,14 +41,14 @@ use crate::spec::modifiers::{DeclarationContext, TypeKind, Visibility};
 /// Omit `.returns()` — with `return_type_is_prefix()`, no return type means
 /// the signature starts with modifiers then name: `public ClassName(...)`.
 #[derive(Debug, Clone)]
-pub struct JavaLang {
+pub struct Java {
     /// Indent with this string (default: "    " — 4 spaces).
     pub indent: String,
     /// File extension (default: "java").
     pub extension: String,
 }
 
-impl Default for JavaLang {
+impl Default for Java {
     fn default() -> Self {
         Self {
             indent: "    ".to_string(),
@@ -57,7 +57,7 @@ impl Default for JavaLang {
     }
 }
 
-impl JavaLang {
+impl Java {
     /// Create a new Java language instance.
     pub fn new() -> Self {
         Self::default()
@@ -100,7 +100,7 @@ fn import_group_order(module: &str) -> u8 {
     }
 }
 
-impl RendererLang for JavaLang {
+impl RendererLang for Java {
     fn file_extension(&self) -> &str {
         &self.extension
     }
@@ -145,7 +145,7 @@ impl RendererLang for JavaLang {
     }
 }
 
-impl CodeLang for JavaLang {
+impl CodeLang for Java {
     fn render_imports(&self, imports: &ImportGroup) -> String {
         if imports.entries().is_empty() {
             return String::new();
@@ -303,13 +303,13 @@ mod tests {
 
     #[test]
     fn test_file_extension() {
-        let java = JavaLang::new();
+        let java = Java::new();
         assert_eq!(java.file_extension(), "java");
     }
 
     #[test]
     fn test_escape_reserved() {
-        let java = JavaLang::new();
+        let java = Java::new();
         assert_eq!(java.escape_reserved("class"), "class_");
         assert_eq!(java.escape_reserved("import"), "import_");
         assert_eq!(java.escape_reserved("synchronized"), "synchronized_");
@@ -318,7 +318,7 @@ mod tests {
 
     #[test]
     fn test_render_imports_single() {
-        let java = JavaLang::new();
+        let java = Java::new();
         let imports = ImportGroup {
             entries: vec![ImportEntry {
                 module: "java.util".into(),
@@ -334,7 +334,7 @@ mod tests {
 
     #[test]
     fn test_render_imports_grouped() {
-        let java = JavaLang::new();
+        let java = Java::new();
         let imports = ImportGroup {
             entries: vec![
                 ImportEntry {
@@ -374,7 +374,7 @@ mod tests {
 
     #[test]
     fn test_render_imports_sorted_within_group() {
-        let java = JavaLang::new();
+        let java = Java::new();
         let imports = ImportGroup {
             entries: vec![
                 ImportEntry {
@@ -412,7 +412,7 @@ mod tests {
 
     #[test]
     fn test_render_imports_dedup() {
-        let java = JavaLang::new();
+        let java = Java::new();
         let imports = ImportGroup {
             entries: vec![
                 ImportEntry {
@@ -438,7 +438,7 @@ mod tests {
 
     #[test]
     fn test_doc_comment_single() {
-        let java = JavaLang::new();
+        let java = Java::new();
         assert_eq!(
             java.render_doc_comment(&["A brief description."]),
             "/**\n * A brief description.\n */"
@@ -447,7 +447,7 @@ mod tests {
 
     #[test]
     fn test_doc_comment_multi() {
-        let java = JavaLang::new();
+        let java = Java::new();
         let doc = java.render_doc_comment(&["Container class.", "", "@param <T> the element type"]);
         assert_eq!(
             doc,
@@ -457,7 +457,7 @@ mod tests {
 
     #[test]
     fn test_string_literal() {
-        let java = JavaLang::new();
+        let java = Java::new();
         assert_eq!(java.render_string_literal("hello"), "\"hello\"");
         assert_eq!(java.render_string_literal("it\"s"), "\"it\\\"s\"");
         assert_eq!(java.render_string_literal("new\nline"), "\"new\\nline\"");
@@ -465,7 +465,7 @@ mod tests {
 
     #[test]
     fn test_type_keyword() {
-        let java = JavaLang::new();
+        let java = Java::new();
         assert_eq!(java.type_keyword(TypeKind::Class), "class");
         assert_eq!(java.type_keyword(TypeKind::Struct), "class");
         assert_eq!(java.type_keyword(TypeKind::Interface), "interface");
@@ -475,7 +475,7 @@ mod tests {
 
     #[test]
     fn test_visibility_top_level() {
-        let java = JavaLang::new();
+        let java = Java::new();
         assert_eq!(
             java.render_visibility(Visibility::Public, DeclarationContext::TopLevel),
             "public "
@@ -488,7 +488,7 @@ mod tests {
 
     #[test]
     fn test_visibility_member() {
-        let java = JavaLang::new();
+        let java = Java::new();
         assert_eq!(
             java.render_visibility(Visibility::Public, DeclarationContext::Member),
             "public "
@@ -505,25 +505,25 @@ mod tests {
 
     #[test]
     fn test_type_before_name() {
-        let java = JavaLang::new();
+        let java = Java::new();
         assert!(java.type_decl_syntax().type_before_name);
     }
 
     #[test]
     fn test_return_type_is_prefix() {
-        let java = JavaLang::new();
+        let java = Java::new();
         assert!(java.type_decl_syntax().return_type_is_prefix);
     }
 
     #[test]
     fn test_readonly_keyword() {
-        let java = JavaLang::new();
+        let java = Java::new();
         assert_eq!(java.enum_and_annotation().readonly_keyword, "final ");
     }
 
     #[test]
     fn test_no_async() {
-        let java = JavaLang::new();
+        let java = Java::new();
         assert_eq!(java.function_syntax().async_keyword, "");
     }
 
@@ -538,20 +538,20 @@ mod tests {
 
     #[test]
     fn test_java_builder_fluent() {
-        let java = JavaLang::new().with_indent("\t").with_extension("jav");
+        let java = Java::new().with_indent("\t").with_extension("jav");
         assert_eq!(java.file_extension(), "jav");
         assert_eq!(java.block_syntax().indent_unit, "\t");
     }
 
     #[test]
     fn test_module_separator() {
-        let java = JavaLang::new();
+        let java = Java::new();
         assert_eq!(java.module_separator(), Some("."));
     }
 
     #[test]
     fn test_enum_and_annotation_config() {
-        let java = JavaLang::new();
+        let java = Java::new();
         let ea = java.enum_and_annotation();
         assert_eq!(
             ea.variant_value_format,

--- a/src/lang/mod.rs
+++ b/src/lang/mod.rs
@@ -1,21 +1,21 @@
 /// Bash shell language support.
 pub mod bash;
 /// C language support.
-pub mod c_lang;
+pub mod c;
 /// Shared configuration types (quote style, optional-field rendering).
 pub mod config;
 /// C++ language support.
-pub mod cpp_lang;
+pub mod cpp;
 /// C# language support.
 pub mod csharp;
 /// Dart language support.
 pub mod dart;
 /// Go language support.
-pub mod go_lang;
+pub mod go;
 /// Haskell language support.
 pub mod haskell;
 /// Java language support.
-pub mod java_lang;
+pub mod java;
 /// JavaScript language support.
 pub mod javascript;
 /// Kotlin language support.
@@ -27,7 +27,7 @@ pub mod ocaml;
 /// Python language support.
 pub mod python;
 /// Rust language support.
-pub mod rust_lang;
+pub mod rust;
 /// Scala language support.
 pub mod scala;
 /// Swift language support.
@@ -399,18 +399,18 @@ pub fn lang_from_extension(ext: &str) -> Option<Box<dyn CodeLang>> {
     match ext {
         "ts" | "tsx" => Some(Box::new(typescript::TypeScript::default())),
         "js" | "jsx" | "mjs" | "cjs" => Some(Box::new(javascript::JavaScript::default())),
-        "rs" => Some(Box::new(rust_lang::RustLang::default())),
-        "go" => Some(Box::new(go_lang::GoLang::default())),
+        "rs" => Some(Box::new(rust::Rust::default())),
+        "go" => Some(Box::new(go::Go::default())),
         "py" | "pyi" => Some(Box::new(python::Python::default())),
-        "java" => Some(Box::new(java_lang::JavaLang::default())),
+        "java" => Some(Box::new(java::Java::default())),
         "kt" | "kts" => Some(Box::new(kotlin::Kotlin::default())),
         "swift" => Some(Box::new(swift::Swift::default())),
-        "dart" => Some(Box::new(dart::DartLang::default())),
+        "dart" => Some(Box::new(dart::Dart::default())),
         "scala" | "sc" => Some(Box::new(scala::Scala::default())),
         "hs" => Some(Box::new(haskell::Haskell::default())),
         "ml" | "mli" => Some(Box::new(ocaml::OCaml::default())),
-        "c" | "h" => Some(Box::new(c_lang::CLang::default())),
-        "cpp" | "cxx" | "cc" | "hpp" | "hxx" => Some(Box::new(cpp_lang::CppLang::default())),
+        "c" | "h" => Some(Box::new(c::C::default())),
+        "cpp" | "cxx" | "cc" | "hpp" | "hxx" => Some(Box::new(cpp::Cpp::default())),
         "cs" => Some(Box::new(csharp::CSharp::default())),
         "lua" => Some(Box::new(lua::Lua::default())),
         "sh" | "bash" => Some(Box::new(bash::Bash::default())),

--- a/src/lang/rust.rs
+++ b/src/lang/rust.rs
@@ -10,14 +10,14 @@ use crate::type_name::{FunctionPresentation, TypePresentation, WildcardPresentat
 
 /// Rust language implementation.
 #[derive(Debug, Clone)]
-pub struct RustLang {
+pub struct Rust {
     /// Indent with this string (default: "    ").
     pub indent: String,
     /// File extension (default: "rs").
     pub extension: String,
 }
 
-impl Default for RustLang {
+impl Default for Rust {
     fn default() -> Self {
         Self {
             indent: "    ".to_string(),
@@ -26,7 +26,7 @@ impl Default for RustLang {
     }
 }
 
-impl RustLang {
+impl Rust {
     /// Create a new Rust language instance.
     pub fn new() -> Self {
         Self::default()
@@ -56,7 +56,7 @@ const RUST_RESERVED: &[&str] = &[
     "unsized", "virtual", "yield",
 ];
 
-impl RendererLang for RustLang {
+impl RendererLang for Rust {
     fn file_extension(&self) -> &str {
         &self.extension
     }
@@ -138,7 +138,7 @@ impl RendererLang for RustLang {
     }
 }
 
-impl CodeLang for RustLang {
+impl CodeLang for Rust {
     fn render_imports(&self, imports: &ImportGroup) -> String {
         if imports.entries().is_empty() {
             return String::new();
@@ -317,13 +317,13 @@ mod tests {
 
     #[test]
     fn test_file_extension() {
-        let rs = RustLang::new();
+        let rs = Rust::new();
         assert_eq!(rs.file_extension(), "rs");
     }
 
     #[test]
     fn test_escape_reserved() {
-        let rs = RustLang::new();
+        let rs = Rust::new();
         assert_eq!(rs.escape_reserved("type"), "r#type");
         assert_eq!(rs.escape_reserved("my_var"), "my_var");
         // 2024 edition: gen is reserved
@@ -332,7 +332,7 @@ mod tests {
 
     #[test]
     fn test_render_imports_grouped() {
-        let rs = RustLang::new();
+        let rs = Rust::new();
         let imports = ImportGroup {
             entries: vec![
                 ImportEntry {
@@ -385,7 +385,7 @@ mod tests {
 
     #[test]
     fn test_render_imports_with_alias() {
-        let rs = RustLang::new();
+        let rs = Rust::new();
         let imports = ImportGroup {
             entries: vec![ImportEntry {
                 module: "models".into(),
@@ -402,7 +402,7 @@ mod tests {
 
     #[test]
     fn test_doc_comment() {
-        let rs = RustLang::new();
+        let rs = Rust::new();
         let doc = rs.render_doc_comment(&["Get the user.", "", "Returns None if not found."]);
         assert!(doc.contains("/// Get the user."));
         assert!(doc.contains("///\n"));
@@ -411,21 +411,21 @@ mod tests {
 
     #[test]
     fn test_string_literal() {
-        let rs = RustLang::new();
+        let rs = Rust::new();
         assert_eq!(rs.render_string_literal("hello"), "\"hello\"");
         assert_eq!(rs.render_string_literal("it\"s"), "\"it\\\"s\"");
     }
 
     #[test]
     fn test_rust_builder_fluent() {
-        let rs = RustLang::new().with_indent("\t").with_extension("rsi");
+        let rs = Rust::new().with_indent("\t").with_extension("rsi");
         assert_eq!(rs.file_extension(), "rsi");
         assert_eq!(rs.block_syntax().indent_unit, "\t");
     }
 
     #[test]
     fn test_module_separator() {
-        let rs = RustLang::new();
+        let rs = Rust::new();
         assert_eq!(rs.module_separator(), Some("::"));
     }
 }

--- a/src/spec/annotation_spec.rs
+++ b/src/spec/annotation_spec.rs
@@ -29,7 +29,7 @@ use crate::type_name::TypeName;
 ///
 /// ```
 /// use sigil_stitch::spec::annotation_spec::AnnotationSpec;
-/// use sigil_stitch::lang::rust_lang::RustLang;
+/// use sigil_stitch::lang::rust::Rust;
 ///
 /// // Simple: #[allow(dead_code)]
 /// let ann = AnnotationSpec::new("allow").arg("dead_code");
@@ -160,7 +160,7 @@ impl AnnotationSpec {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::lang::rust_lang::RustLang;
+    use crate::lang::rust::Rust;
     use crate::lang::typescript::TypeScript;
 
     #[test]
@@ -181,7 +181,7 @@ mod tests {
 
     #[test]
     fn test_rust_prefix() {
-        let rs = RustLang::new();
+        let rs = Rust::new();
         let ann = AnnotationSpec::new("allow").arg("dead_code");
         let cb = ann.emit(&rs).unwrap();
         assert!(!cb.is_empty());
@@ -198,7 +198,7 @@ mod tests {
 
     #[test]
     fn test_arg_chaining() {
-        let rs = RustLang::new();
+        let rs = Rust::new();
         let ann = AnnotationSpec::new("cfg")
             .arg("test")
             .arg("feature = \"nightly\"");

--- a/src/spec/enum_variant_spec.rs
+++ b/src/spec/enum_variant_spec.rs
@@ -315,7 +315,7 @@ impl EnumVariantSpecBuilder {
 mod tests {
     use super::*;
     use crate::lang::CodeLang;
-    use crate::lang::rust_lang::RustLang;
+    use crate::lang::rust::Rust;
     use crate::lang::swift::Swift;
     use crate::lang::typescript::TypeScript;
     use crate::spec::field_spec::FieldSpec;
@@ -345,7 +345,7 @@ mod tests {
             .add_variant(EnumVariantSpec::new("Blue").unwrap())
             .build()
             .unwrap();
-        let output = render_enum(&ts, &RustLang::new());
+        let output = render_enum(&ts, &Rust::new());
         assert!(output.contains("Red,"));
         assert!(output.contains("Green,"));
         assert!(output.contains("Blue,"));
@@ -386,7 +386,7 @@ mod tests {
             .add_variant(EnumVariantSpec::new("Red").unwrap())
             .build()
             .unwrap();
-        let output = render_enum(&ts, &RustLang::new());
+        let output = render_enum(&ts, &Rust::new());
         // Rust has trailing comma.
         assert!(output.contains("Red,"));
     }
@@ -398,7 +398,7 @@ mod tests {
             .add_variant(EnumVariantSpec::new("GREEN").unwrap())
             .build()
             .unwrap();
-        let output = render_enum(&ts, &crate::lang::c_lang::CLang::new());
+        let output = render_enum(&ts, &crate::lang::c::C::new());
         assert!(output.contains("RED,"));
         // Last variant has no trailing comma in C.
         assert!(output.contains("GREEN\n"));
@@ -441,7 +441,7 @@ mod tests {
             .add_variant(EnumVariantSpec::new("Unit").unwrap())
             .build()
             .unwrap();
-        let output = render_enum(&ts, &RustLang::new());
+        let output = render_enum(&ts, &Rust::new());
         assert!(output.contains("Literal(i64),"));
         assert!(output.contains("Unit,"));
     }
@@ -458,7 +458,7 @@ mod tests {
             )
             .build()
             .unwrap();
-        let output = render_enum(&ts, &RustLang::new());
+        let output = render_enum(&ts, &Rust::new());
         assert!(output.contains("Both(String, i32),"));
     }
 
@@ -483,7 +483,7 @@ mod tests {
             )
             .build()
             .unwrap();
-        let output = render_enum(&ts, &RustLang::new());
+        let output = render_enum(&ts, &Rust::new());
         assert!(output.contains("Quit,"));
         assert!(output.contains("Move {"));
         assert!(output.contains("x: i32,"));

--- a/src/type_name.rs
+++ b/src/type_name.rs
@@ -885,8 +885,8 @@ mod tests {
 
     #[test]
     fn test_tuple_with_lang_rust() {
-        use crate::lang::rust_lang::RustLang;
-        let lang = RustLang::new();
+        use crate::lang::rust::Rust;
+        let lang = Rust::new();
         let t = TypeName::tuple(vec![
             TypeName::primitive("String"),
             TypeName::primitive("i32"),
@@ -910,8 +910,8 @@ mod tests {
 
     #[test]
     fn test_tuple_with_lang_cpp() {
-        use crate::lang::cpp_lang::CppLang;
-        let lang = CppLang::new();
+        use crate::lang::cpp::Cpp;
+        let lang = Cpp::new();
         let t = TypeName::tuple(vec![
             TypeName::primitive("int"),
             TypeName::primitive("std::string"),
@@ -927,8 +927,8 @@ mod tests {
 
     #[test]
     fn test_unit_tuple_with_lang_rust() {
-        use crate::lang::rust_lang::RustLang;
-        let lang = RustLang::new();
+        use crate::lang::rust::Rust;
+        let lang = Rust::new();
         let t = TypeName::unit();
         let doc = t.to_doc_with_lang(&identity_resolve, &lang);
         let mut buf = Vec::new();
@@ -959,8 +959,8 @@ mod tests {
 
     #[test]
     fn test_reference_with_lang_rust() {
-        use crate::lang::rust_lang::RustLang;
-        let lang = RustLang::new();
+        use crate::lang::rust::Rust;
+        let lang = Rust::new();
         let t = TypeName::reference(TypeName::primitive("String"));
         let doc = t.to_doc_with_lang(&identity_resolve, &lang);
         let mut buf = Vec::new();
@@ -970,8 +970,8 @@ mod tests {
 
     #[test]
     fn test_reference_mut_with_lang_rust() {
-        use crate::lang::rust_lang::RustLang;
-        let lang = RustLang::new();
+        use crate::lang::rust::Rust;
+        let lang = Rust::new();
         let t = TypeName::reference_mut(TypeName::primitive("String"));
         let doc = t.to_doc_with_lang(&identity_resolve, &lang);
         let mut buf = Vec::new();
@@ -981,8 +981,8 @@ mod tests {
 
     #[test]
     fn test_reference_with_lang_cpp() {
-        use crate::lang::cpp_lang::CppLang;
-        let lang = CppLang::new();
+        use crate::lang::cpp::Cpp;
+        let lang = Cpp::new();
         let t = TypeName::reference(TypeName::primitive("std::string"));
         let doc = t.to_doc_with_lang(&identity_resolve, &lang);
         let mut buf = Vec::new();
@@ -992,8 +992,8 @@ mod tests {
 
     #[test]
     fn test_reference_mut_with_lang_cpp() {
-        use crate::lang::cpp_lang::CppLang;
-        let lang = CppLang::new();
+        use crate::lang::cpp::Cpp;
+        let lang = Cpp::new();
         let t = TypeName::reference_mut(TypeName::primitive("std::string"));
         let doc = t.to_doc_with_lang(&identity_resolve, &lang);
         let mut buf = Vec::new();
@@ -1013,8 +1013,8 @@ mod tests {
 
     #[test]
     fn test_reference_mut_with_lang_go() {
-        use crate::lang::go_lang::GoLang;
-        let lang = GoLang::new();
+        use crate::lang::go::Go;
+        let lang = Go::new();
         let t = TypeName::reference_mut(TypeName::primitive("int"));
         let doc = t.to_doc_with_lang(&identity_resolve, &lang);
         let mut buf = Vec::new();
@@ -1024,8 +1024,8 @@ mod tests {
 
     #[test]
     fn test_reference_with_lang_go() {
-        use crate::lang::go_lang::GoLang;
-        let lang = GoLang::new();
+        use crate::lang::go::Go;
+        let lang = Go::new();
         let t = TypeName::reference(TypeName::primitive("int"));
         let doc = t.to_doc_with_lang(&identity_resolve, &lang);
         let mut buf = Vec::new();
@@ -1035,8 +1035,8 @@ mod tests {
 
     #[test]
     fn test_reference_with_lang_c() {
-        use crate::lang::c_lang::CLang;
-        let lang = CLang::new();
+        use crate::lang::c::C;
+        let lang = C::new();
         let t = TypeName::reference(TypeName::primitive("int"));
         let doc = t.to_doc_with_lang(&identity_resolve, &lang);
         let mut buf = Vec::new();
@@ -1046,8 +1046,8 @@ mod tests {
 
     #[test]
     fn test_reference_mut_with_lang_c() {
-        use crate::lang::c_lang::CLang;
-        let lang = CLang::new();
+        use crate::lang::c::C;
+        let lang = C::new();
         let t = TypeName::reference_mut(TypeName::primitive("int"));
         let doc = t.to_doc_with_lang(&identity_resolve, &lang);
         let mut buf = Vec::new();
@@ -1143,8 +1143,8 @@ mod tests {
 
     #[test]
     fn test_associated_type_rust_qualified() {
-        use crate::lang::rust_lang::RustLang;
-        let lang = RustLang::new();
+        use crate::lang::rust::Rust;
+        let lang = Rust::new();
         let t = TypeName::associated_type(
             TypeName::primitive("T"),
             Some(TypeName::primitive("Iterator")),
@@ -1158,8 +1158,8 @@ mod tests {
 
     #[test]
     fn test_associated_type_rust_simple() {
-        use crate::lang::rust_lang::RustLang;
-        let lang = RustLang::new();
+        use crate::lang::rust::Rust;
+        let lang = Rust::new();
         let t = TypeName::member_type(TypeName::primitive("Self"), "Output");
         let doc = t.to_doc_with_lang(&identity_resolve, &lang);
         let mut buf = Vec::new();
@@ -1183,8 +1183,8 @@ mod tests {
 
     #[test]
     fn test_associated_type_java_dot() {
-        use crate::lang::java_lang::JavaLang;
-        let lang = JavaLang::new();
+        use crate::lang::java::Java;
+        let lang = Java::new();
         let t = TypeName::member_type(TypeName::primitive("Map"), "Entry");
         let doc = t.to_doc_with_lang(&identity_resolve, &lang);
         let mut buf = Vec::new();
@@ -1208,8 +1208,8 @@ mod tests {
 
     #[test]
     fn test_impl_trait_rust() {
-        use crate::lang::rust_lang::RustLang;
-        let lang = RustLang::new();
+        use crate::lang::rust::Rust;
+        let lang = Rust::new();
         let t = TypeName::impl_trait(vec![
             TypeName::primitive("Display"),
             TypeName::primitive("Debug"),
@@ -1222,8 +1222,8 @@ mod tests {
 
     #[test]
     fn test_dyn_trait_rust() {
-        use crate::lang::rust_lang::RustLang;
-        let lang = RustLang::new();
+        use crate::lang::rust::Rust;
+        let lang = Rust::new();
         let t = TypeName::dyn_trait(vec![TypeName::primitive("Error")]);
         let doc = t.to_doc_with_lang(&identity_resolve, &lang);
         let mut buf = Vec::new();
@@ -1246,8 +1246,8 @@ mod tests {
 
     #[test]
     fn test_wildcard_java_unbounded() {
-        use crate::lang::java_lang::JavaLang;
-        let lang = JavaLang::new();
+        use crate::lang::java::Java;
+        let lang = Java::new();
         let t = TypeName::wildcard();
         let doc = t.to_doc_with_lang(&identity_resolve, &lang);
         let mut buf = Vec::new();
@@ -1257,8 +1257,8 @@ mod tests {
 
     #[test]
     fn test_wildcard_java_extends() {
-        use crate::lang::java_lang::JavaLang;
-        let lang = JavaLang::new();
+        use crate::lang::java::Java;
+        let lang = Java::new();
         let t = TypeName::wildcard_extends(TypeName::primitive("Comparable"));
         let doc = t.to_doc_with_lang(&identity_resolve, &lang);
         let mut buf = Vec::new();
@@ -1268,8 +1268,8 @@ mod tests {
 
     #[test]
     fn test_wildcard_java_super() {
-        use crate::lang::java_lang::JavaLang;
-        let lang = JavaLang::new();
+        use crate::lang::java::Java;
+        let lang = Java::new();
         let t = TypeName::wildcard_super(TypeName::primitive("Number"));
         let doc = t.to_doc_with_lang(&identity_resolve, &lang);
         let mut buf = Vec::new();
@@ -1312,8 +1312,8 @@ mod tests {
 
     #[test]
     fn test_wildcard_go() {
-        use crate::lang::go_lang::GoLang;
-        let lang = GoLang::new();
+        use crate::lang::go::Go;
+        let lang = Go::new();
         let t = TypeName::wildcard();
         let doc = t.to_doc_with_lang(&identity_resolve, &lang);
         let mut buf = Vec::new();
@@ -1323,8 +1323,8 @@ mod tests {
 
     #[test]
     fn test_wildcard_rust() {
-        use crate::lang::rust_lang::RustLang;
-        let lang = RustLang::new();
+        use crate::lang::rust::Rust;
+        let lang = Rust::new();
         let t = TypeName::wildcard();
         let doc = t.to_doc_with_lang(&identity_resolve, &lang);
         let mut buf = Vec::new();
@@ -1417,8 +1417,8 @@ mod tests {
 
     #[test]
     fn test_reference_with_lifetime_rust() {
-        use crate::lang::rust_lang::RustLang;
-        let lang = RustLang::new();
+        use crate::lang::rust::Rust;
+        let lang = Rust::new();
         let t = TypeName::reference_with_lifetime(TypeName::primitive("str"), "'a");
         let doc = t.to_doc_with_lang(&identity_resolve, &lang);
         let mut buf = Vec::new();
@@ -1428,8 +1428,8 @@ mod tests {
 
     #[test]
     fn test_reference_mut_with_lifetime_rust() {
-        use crate::lang::rust_lang::RustLang;
-        let lang = RustLang::new();
+        use crate::lang::rust::Rust;
+        let lang = Rust::new();
         let t = TypeName::reference_mut_with_lifetime(TypeName::primitive("String"), "'a");
         let doc = t.to_doc_with_lang(&identity_resolve, &lang);
         let mut buf = Vec::new();
@@ -1445,8 +1445,8 @@ mod tests {
 
     #[test]
     fn test_reference_without_lifetime_unchanged() {
-        use crate::lang::rust_lang::RustLang;
-        let lang = RustLang::new();
+        use crate::lang::rust::Rust;
+        let lang = Rust::new();
         let t = TypeName::reference(TypeName::primitive("String"));
         let doc = t.to_doc_with_lang(&identity_resolve, &lang);
         let mut buf = Vec::new();
@@ -1456,8 +1456,8 @@ mod tests {
 
     #[test]
     fn test_qualified_renders_with_rust_separator() {
-        use crate::lang::rust_lang::RustLang;
-        let lang = RustLang::new();
+        use crate::lang::rust::Rust;
+        let lang = Rust::new();
         let t = TypeName::qualified("serde_json", "Value");
         let doc = t.to_doc_with_lang(&identity_resolve, &lang);
         let mut buf = Vec::new();
@@ -1467,8 +1467,8 @@ mod tests {
 
     #[test]
     fn test_qualified_renders_with_go_separator() {
-        use crate::lang::go_lang::GoLang;
-        let lang = GoLang::new();
+        use crate::lang::go::Go;
+        let lang = Go::new();
         let t = TypeName::qualified("net/http", "Server");
         let doc = t.to_doc_with_lang(&identity_resolve, &lang);
         let mut buf = Vec::new();
@@ -1491,8 +1491,8 @@ mod tests {
         t.collect_imports(&mut imports);
         assert!(imports.is_empty());
 
-        use crate::lang::rust_lang::RustLang;
-        let lang = RustLang::new();
+        use crate::lang::rust::Rust;
+        let lang = Rust::new();
         let doc = t.to_doc_with_lang(&identity_resolve, &lang);
         let mut buf = Vec::new();
         doc.render(80, &mut buf).unwrap();
@@ -1501,8 +1501,8 @@ mod tests {
 
     #[test]
     fn test_qualified_in_generic() {
-        use crate::lang::rust_lang::RustLang;
-        let lang = RustLang::new();
+        use crate::lang::rust::Rust;
+        let lang = Rust::new();
         let t = TypeName::generic(
             TypeName::qualified("std::collections", "HashMap"),
             vec![

--- a/tests/annotation_spec_tests.rs
+++ b/tests/annotation_spec_tests.rs
@@ -1,10 +1,10 @@
 use sigil_stitch::code_block::CodeBlock;
-use sigil_stitch::lang::c_lang::CLang;
-use sigil_stitch::lang::cpp_lang::CppLang;
-use sigil_stitch::lang::java_lang::JavaLang;
+use sigil_stitch::lang::c::C;
+use sigil_stitch::lang::cpp::Cpp;
+use sigil_stitch::lang::java::Java;
 use sigil_stitch::lang::kotlin::Kotlin;
 use sigil_stitch::lang::python::Python;
-use sigil_stitch::lang::rust_lang::RustLang;
+use sigil_stitch::lang::rust::Rust;
 use sigil_stitch::lang::typescript::TypeScript;
 use sigil_stitch::spec::annotation_spec::AnnotationSpec;
 use sigil_stitch::spec::enum_variant_spec::EnumVariantSpec;
@@ -121,7 +121,7 @@ fn test_ts_annotation_on_field() {
 
 #[test]
 fn test_rust_derive_annotation() {
-    let rs = RustLang::new();
+    let rs = Rust::new();
     let output = render_type(
         &TypeSpec::builder("Config", TypeKind::Struct)
             .annotate(AnnotationSpec::new("derive").arg("Debug, Clone, Serialize"))
@@ -136,7 +136,7 @@ fn test_rust_derive_annotation() {
 
 #[test]
 fn test_rust_allow_annotation() {
-    let rs = RustLang::new();
+    let rs = Rust::new();
     let output = render_fun(
         &FunSpec::builder("old_func")
             .annotate(AnnotationSpec::new("allow").arg("dead_code"))
@@ -152,7 +152,7 @@ fn test_rust_allow_annotation() {
 
 #[test]
 fn test_rust_no_args_annotation() {
-    let rs = RustLang::new();
+    let rs = Rust::new();
     let output = render_fun(
         &FunSpec::builder("my_test")
             .annotate(AnnotationSpec::new("test"))
@@ -167,7 +167,7 @@ fn test_rust_no_args_annotation() {
 
 #[test]
 fn test_rust_annotation_on_field() {
-    let rs = RustLang::new();
+    let rs = Rust::new();
     let output = render_field(
         &FieldSpec::builder("name", TypeName::primitive("String"))
             .annotate(AnnotationSpec::new("serde").arg("rename = \"user_name\""))
@@ -183,7 +183,7 @@ fn test_rust_annotation_on_field() {
 
 #[test]
 fn test_rust_annotation_on_enum_variant() {
-    let rs = RustLang::new();
+    let rs = Rust::new();
     let output = render_type(
         &TypeSpec::builder("Color", TypeKind::Enum)
             .add_variant(
@@ -206,7 +206,7 @@ fn test_rust_annotation_on_enum_variant() {
 
 #[test]
 fn test_cpp_nodiscard_annotation() {
-    let cpp = CppLang::new();
+    let cpp = Cpp::new();
     let output = render_fun(
         &FunSpec::builder("compute")
             .annotate(AnnotationSpec::new("nodiscard"))
@@ -222,7 +222,7 @@ fn test_cpp_nodiscard_annotation() {
 
 #[test]
 fn test_cpp_deprecated_with_reason() {
-    let cpp = CppLang::new();
+    let cpp = Cpp::new();
     let output = render_fun(
         &FunSpec::builder("oldFunc")
             .annotate(AnnotationSpec::new("deprecated").arg("\"use newFunc instead\""))
@@ -240,7 +240,7 @@ fn test_cpp_deprecated_with_reason() {
 
 #[test]
 fn test_c_attribute_annotation() {
-    let c = CLang::new();
+    let c = C::new();
     let output = render_fun(
         &FunSpec::builder("init")
             .annotate(AnnotationSpec::new("constructor"))
@@ -256,7 +256,7 @@ fn test_c_attribute_annotation() {
 
 #[test]
 fn test_c_attribute_with_args() {
-    let c = CLang::new();
+    let c = C::new();
     let output = render_fun(
         &FunSpec::builder("alloc")
             .annotate(AnnotationSpec::new("malloc").arg("free, 1"))
@@ -274,7 +274,7 @@ fn test_c_attribute_with_args() {
 
 #[test]
 fn test_java_override_annotation() {
-    let java = JavaLang::new();
+    let java = Java::new();
     let output = render_fun(
         &FunSpec::builder("toString")
             .annotate(AnnotationSpec::new("Override"))
@@ -292,7 +292,7 @@ fn test_java_override_annotation() {
 
 #[test]
 fn test_java_suppress_warnings() {
-    let java = JavaLang::new();
+    let java = Java::new();
     let output = render_fun(
         &FunSpec::builder("process")
             .annotate(AnnotationSpec::new("SuppressWarnings").arg("\"unchecked\""))
@@ -358,7 +358,7 @@ fn test_python_dataclass_decorator() {
 
 #[test]
 fn test_mixed_annotation_and_codeblock() {
-    let rs = RustLang::new();
+    let rs = Rust::new();
     let fb = FunSpec::builder("test_it")
         .annotate(AnnotationSpec::new("cfg").arg("test"))
         .annotation(CodeBlock::of("#[ignore]", ()).unwrap())
@@ -419,7 +419,7 @@ fn test_importable_annotation_java() {
 
 #[test]
 fn test_multiple_annotations_on_fun() {
-    let rs = RustLang::new();
+    let rs = Rust::new();
     let output = render_fun(
         &FunSpec::builder("bench_it")
             .annotate(AnnotationSpec::new("cfg").arg("test"))
@@ -439,7 +439,7 @@ fn test_multiple_annotations_on_fun() {
 
 #[test]
 fn test_multiple_args() {
-    let rs = RustLang::new();
+    let rs = Rust::new();
     let output = render_fun(
         &FunSpec::builder("handler")
             .annotate(
@@ -460,7 +460,7 @@ fn test_multiple_args() {
 
 #[test]
 fn test_rust_args_bulk_derive() {
-    let rs = RustLang::new();
+    let rs = Rust::new();
     let ann = AnnotationSpec::new("derive").args(["Debug", "Clone", "Serialize"]);
     let block = ann.emit(&rs).unwrap();
     let imports = sigil_stitch::import::ImportGroup::new();
@@ -471,7 +471,7 @@ fn test_rust_args_bulk_derive() {
 
 #[test]
 fn test_args_combined_with_arg() {
-    let rs = RustLang::new();
+    let rs = Rust::new();
     let ann = AnnotationSpec::new("serde")
         .arg("rename_all = \"camelCase\"")
         .args(["deny_unknown_fields"]);
@@ -487,7 +487,7 @@ fn test_args_combined_with_arg() {
 
 #[test]
 fn test_args_empty_iter_no_parens() {
-    let rs = RustLang::new();
+    let rs = Rust::new();
     let ann = AnnotationSpec::new("test").args(Vec::<&str>::new());
     let block = ann.emit(&rs).unwrap();
     let imports = sigil_stitch::import::ImportGroup::new();
@@ -500,7 +500,7 @@ fn test_args_empty_iter_no_parens() {
 
 #[test]
 fn test_name_ref_escapes_rust_keyword() {
-    let rs = RustLang::new();
+    let rs = Rust::new();
     let block = CodeBlock::of(
         "let %N = 1",
         sigil_stitch::code_block::NameArg("type".into()),
@@ -514,8 +514,8 @@ fn test_name_ref_escapes_rust_keyword() {
 
 #[test]
 fn test_name_ref_escapes_go_keyword() {
-    use sigil_stitch::lang::go_lang::GoLang;
-    let go = GoLang::new();
+    use sigil_stitch::lang::go::Go;
+    let go = Go::new();
     let block = CodeBlock::of(
         "var %N int",
         sigil_stitch::code_block::NameArg("func".into()),
@@ -529,7 +529,7 @@ fn test_name_ref_escapes_go_keyword() {
 
 #[test]
 fn test_name_ref_no_escape_non_keyword() {
-    let rs = RustLang::new();
+    let rs = Rust::new();
     let block = CodeBlock::of(
         "let %N = 1",
         sigil_stitch::code_block::NameArg("myVar".into()),

--- a/tests/c/builder_control_flow.rs
+++ b/tests/c/builder_control_flow.rs
@@ -1,5 +1,5 @@
 use sigil_stitch::code_block::CodeBlock;
-use sigil_stitch::lang::c_lang::CLang;
+use sigil_stitch::lang::c::C;
 use sigil_stitch::spec::file_spec::FileSpec;
 
 use super::golden;
@@ -16,7 +16,7 @@ fn test_control_flow() {
     b.end_control_flow();
     let block = b.build().unwrap();
 
-    let file = FileSpec::builder_with("flow.c", CLang::new())
+    let file = FileSpec::builder_with("flow.c", C::new())
         .add_code(block)
         .build()
         .unwrap();

--- a/tests/c/builder_edge_cases.rs
+++ b/tests/c/builder_edge_cases.rs
@@ -1,5 +1,5 @@
 use sigil_stitch::code_block::{CodeBlock, StringLitArg};
-use sigil_stitch::lang::c_lang::CLang;
+use sigil_stitch::lang::c::C;
 use sigil_stitch::spec::annotation_spec::AnnotationSpec;
 use sigil_stitch::spec::field_spec::FieldSpec;
 use sigil_stitch::spec::file_spec::FileSpec;
@@ -19,7 +19,7 @@ fn test_arrow_and_pointer_spacing() {
     b.add_statement("cfg->port = 8080", ());
     let block = b.build().unwrap();
 
-    let file = FileSpec::builder_with("test.c", CLang::new())
+    let file = FileSpec::builder_with("test.c", C::new())
         .add_code(block)
         .build()
         .unwrap();
@@ -42,7 +42,7 @@ fn test_struct_basic() {
     b.add_line();
     let block = b.build().unwrap();
 
-    let file = FileSpec::builder_with("point.c", CLang::new())
+    let file = FileSpec::builder_with("point.c", C::new())
         .add_code(block)
         .build()
         .unwrap();
@@ -76,7 +76,7 @@ fn test_struct_with_function() {
         .build()
         .unwrap();
 
-    let file = FileSpec::builder_with("point.c", CLang::new())
+    let file = FileSpec::builder_with("point.c", C::new())
         .add_type(ts)
         .add_function(fun)
         .build()
@@ -124,7 +124,7 @@ fn test_top_level_with_includes() {
         .build()
         .unwrap();
 
-    let file = FileSpec::builder_with("server.h", CLang::header())
+    let file = FileSpec::builder_with("server.h", C::header())
         .header(CodeBlock::of("#pragma once", ()).unwrap())
         .add_type(ts)
         .add_function(fun)
@@ -152,7 +152,7 @@ fn test_annotation_attribute() {
         .build()
         .unwrap();
 
-    let file = FileSpec::builder_with("packed.h", CLang::header())
+    let file = FileSpec::builder_with("packed.h", C::header())
         .add_type(ts)
         .build()
         .unwrap();

--- a/tests/c/builder_functions.rs
+++ b/tests/c/builder_functions.rs
@@ -1,5 +1,5 @@
 use sigil_stitch::code_block::{CodeBlock, StringLitArg};
-use sigil_stitch::lang::c_lang::CLang;
+use sigil_stitch::lang::c::C;
 use sigil_stitch::spec::file_spec::FileSpec;
 use sigil_stitch::spec::fun_spec::FunSpec;
 use sigil_stitch::spec::modifiers::Visibility;
@@ -19,7 +19,7 @@ fn test_function_with_params() {
         .build()
         .unwrap();
 
-    let file = FileSpec::builder_with("math.c", CLang::new())
+    let file = FileSpec::builder_with("math.c", C::new())
         .add_function(fun)
         .build()
         .unwrap();
@@ -43,7 +43,7 @@ fn test_void_function() {
         .build()
         .unwrap();
 
-    let file = FileSpec::builder_with("greet.c", CLang::new())
+    let file = FileSpec::builder_with("greet.c", C::new())
         .add_function(fun)
         .build()
         .unwrap();
@@ -64,7 +64,7 @@ fn test_static_function() {
         .build()
         .unwrap();
 
-    let file = FileSpec::builder_with("helpers.c", CLang::new())
+    let file = FileSpec::builder_with("helpers.c", C::new())
         .add_function(fun)
         .build()
         .unwrap();
@@ -83,7 +83,7 @@ fn test_function_declaration() {
         .build()
         .unwrap();
 
-    let file = FileSpec::builder_with("api.h", CLang::header())
+    let file = FileSpec::builder_with("api.h", C::header())
         .add_function(fun)
         .build()
         .unwrap();
@@ -104,7 +104,7 @@ fn test_function_with_doc() {
         .build()
         .unwrap();
 
-    let file = FileSpec::builder_with("math_doc.c", CLang::new())
+    let file = FileSpec::builder_with("math_doc.c", C::new())
         .add_function(fun)
         .build()
         .unwrap();

--- a/tests/c/builder_imports.rs
+++ b/tests/c/builder_imports.rs
@@ -1,5 +1,5 @@
 use sigil_stitch::code_block::{CodeBlock, StringLitArg};
-use sigil_stitch::lang::c_lang::CLang;
+use sigil_stitch::lang::c::C;
 use sigil_stitch::spec::file_spec::FileSpec;
 use sigil_stitch::type_name::TypeName;
 
@@ -26,7 +26,7 @@ fn test_function_with_includes() {
     b.add_line();
     let block = b.build().unwrap();
 
-    let file = FileSpec::builder_with("main.c", CLang::new())
+    let file = FileSpec::builder_with("main.c", C::new())
         .add_code(block)
         .build()
         .unwrap();
@@ -57,7 +57,7 @@ fn test_include_grouping() {
     b.add_statement("%T()", (utils,));
     let block = b.build().unwrap();
 
-    let file = FileSpec::builder_with("test.c", CLang::new())
+    let file = FileSpec::builder_with("test.c", C::new())
         .add_code(block)
         .build()
         .unwrap();

--- a/tests/c/builder_types.rs
+++ b/tests/c/builder_types.rs
@@ -1,5 +1,5 @@
 use sigil_stitch::code_block::CodeBlock;
-use sigil_stitch::lang::c_lang::CLang;
+use sigil_stitch::lang::c::C;
 use sigil_stitch::spec::enum_variant_spec::EnumVariantSpec;
 use sigil_stitch::spec::field_spec::FieldSpec;
 use sigil_stitch::spec::file_spec::FileSpec;
@@ -31,7 +31,7 @@ fn test_struct_with_fields() {
         .build()
         .unwrap();
 
-    let file = FileSpec::builder_with("config.h", CLang::header())
+    let file = FileSpec::builder_with("config.h", C::header())
         .header(CodeBlock::of("#pragma once", ()).unwrap())
         .add_type(ts)
         .build()
@@ -52,7 +52,7 @@ fn test_enum() {
         .build()
         .unwrap();
 
-    let file = FileSpec::builder_with("direction.h", CLang::header())
+    let file = FileSpec::builder_with("direction.h", C::header())
         .add_type(ts)
         .build()
         .unwrap();
@@ -74,7 +74,7 @@ fn test_typedef_function_pointer() {
         .build()
         .unwrap();
 
-    let file = FileSpec::builder_with("callback.h", CLang::header())
+    let file = FileSpec::builder_with("callback.h", C::header())
         .add_type(callback)
         .build()
         .unwrap();
@@ -90,7 +90,7 @@ fn test_typedef_non_function() {
         .build()
         .unwrap();
 
-    let file = FileSpec::builder_with("types.h", CLang::header())
+    let file = FileSpec::builder_with("types.h", C::header())
         .add_type(size)
         .build()
         .unwrap();

--- a/tests/c/quote_basic.rs
+++ b/tests/c/quote_basic.rs
@@ -1,12 +1,12 @@
 use sigil_stitch::code_block::CodeBlock;
-use sigil_stitch::lang::c_lang::CLang;
+use sigil_stitch::lang::c::C;
 use sigil_stitch::prelude::*;
 use sigil_stitch::spec::file_spec::FileSpec;
 
 use super::golden;
 
 fn render(block: &CodeBlock) -> String {
-    FileSpec::builder_with("test.c", CLang::new())
+    FileSpec::builder_with("test.c", C::new())
         .add_code(block.clone())
         .build()
         .unwrap()
@@ -21,7 +21,7 @@ fn test_basic() {
 
 #[test]
 fn test_function_pointer_usage() {
-    let block = sigil_quote!(CLang {
+    let block = sigil_quote!(C {
         typedef void (*Callback)(int, const char*);
         Callback cb = NULL;
         cb(42, $S("hello"));
@@ -32,7 +32,7 @@ fn test_function_pointer_usage() {
 
 #[test]
 fn test_arrow_and_pointer_spacing() {
-    let block = sigil_quote!(CLang {
+    let block = sigil_quote!(C {
         struct Config* cfg = create_config();
         cfg->host = $S("localhost");
         cfg->port = 8080;

--- a/tests/c/quote_edge_cases.rs
+++ b/tests/c/quote_edge_cases.rs
@@ -1,12 +1,12 @@
 use sigil_stitch::code_block::CodeBlock;
-use sigil_stitch::lang::c_lang::CLang;
+use sigil_stitch::lang::c::C;
 use sigil_stitch::prelude::*;
 use sigil_stitch::spec::file_spec::FileSpec;
 
 use super::golden;
 
 fn render(block: &CodeBlock) -> String {
-    FileSpec::builder_with("test.c", CLang::new())
+    FileSpec::builder_with("test.c", C::new())
         .add_code(block.clone())
         .build()
         .unwrap()
@@ -16,7 +16,7 @@ fn render(block: &CodeBlock) -> String {
 
 #[test]
 fn test_pointer_declaration() {
-    let block = sigil_quote!(CLang {
+    let block = sigil_quote!(C {
         int* ptr = malloc(sizeof(int));
         const char* msg = "hello";
         void* data = NULL;
@@ -27,7 +27,7 @@ fn test_pointer_declaration() {
 
 #[test]
 fn test_struct_access() {
-    let block = sigil_quote!(CLang {
+    let block = sigil_quote!(C {
         node->next = NULL;
         node->data = value;
         result.x = node->point.x;
@@ -38,7 +38,7 @@ fn test_struct_access() {
 
 #[test]
 fn test_preprocessor_define() {
-    let block = sigil_quote!(CLang {
+    let block = sigil_quote!(C {
         #define MAX_SIZE 1024
         #define MIN(a, b) ((a) < (b) ? (a) : (b))
     })
@@ -48,7 +48,7 @@ fn test_preprocessor_define() {
 
 #[test]
 fn test_cast_and_sizeof() {
-    let block = sigil_quote!(CLang {
+    let block = sigil_quote!(C {
         size_t size = sizeof(struct Node);
         int* arr = (int*)malloc(size * sizeof(int));
     })
@@ -58,7 +58,7 @@ fn test_cast_and_sizeof() {
 
 #[test]
 fn test_for_loop_with_pointer() {
-    let block = sigil_quote!(CLang {
+    let block = sigil_quote!(C {
         for (int i = 0; i < n; i++) {
             arr[i] = i * 2;
         }
@@ -70,7 +70,7 @@ fn test_for_loop_with_pointer() {
 #[test]
 fn test_name_keyword_escape_in_macro() {
     let name = "auto";
-    let block = sigil_quote!(CLang {
+    let block = sigil_quote!(C {
         $N(name) = 1;
     })
     .unwrap();

--- a/tests/c/quote_imports.rs
+++ b/tests/c/quote_imports.rs
@@ -1,5 +1,5 @@
 use sigil_stitch::code_block::CodeBlock;
-use sigil_stitch::lang::c_lang::CLang;
+use sigil_stitch::lang::c::C;
 use sigil_stitch::prelude::*;
 use sigil_stitch::spec::file_spec::FileSpec;
 use sigil_stitch::type_name::TypeName;
@@ -7,7 +7,7 @@ use sigil_stitch::type_name::TypeName;
 use super::golden;
 
 fn render(block: &CodeBlock) -> String {
-    FileSpec::builder_with("test.c", CLang::new())
+    FileSpec::builder_with("test.c", C::new())
         .add_code(block.clone())
         .build()
         .unwrap()
@@ -19,7 +19,7 @@ fn render(block: &CodeBlock) -> String {
 fn test_imports() {
     let stdio = TypeName::importable("stdio.h", "printf");
     let stdlib = TypeName::importable("stdlib.h", "malloc");
-    let block = sigil_quote!(CLang {
+    let block = sigil_quote!(C {
         $T(stdio)($S("hello"));
         void* p = $T(stdlib)(sizeof(int));
     })

--- a/tests/c/quote_suite.rs
+++ b/tests/c/quote_suite.rs
@@ -1,5 +1,5 @@
 use sigil_stitch::code_block::CodeBlock;
-use sigil_stitch::lang::c_lang::CLang;
+use sigil_stitch::lang::c::C;
 use sigil_stitch::prelude::*;
 use sigil_stitch::spec::file_spec::FileSpec;
 
@@ -9,7 +9,7 @@ pub struct CSuite;
 
 impl LanguageTestSuite for CSuite {
     fn control_flow_block() -> CodeBlock {
-        sigil_quote!(CLang {
+        sigil_quote!(C {
             if(x > 0) {
                 return 1;
             } else if (x < 0) {
@@ -26,7 +26,7 @@ impl LanguageTestSuite for CSuite {
     }
 
     fn basic_block() -> CodeBlock {
-        sigil_quote!(CLang {
+        sigil_quote!(C {
             int x = 42;
             float y = 3.14;
             printf($S("x=%d y=%f"), x, y);
@@ -39,7 +39,7 @@ impl LanguageTestSuite for CSuite {
     }
 
     fn render(block: CodeBlock) -> String {
-        FileSpec::builder_with("test.c", CLang::new())
+        FileSpec::builder_with("test.c", C::new())
             .add_code(block)
             .build()
             .unwrap()

--- a/tests/constructor_spec_tests.rs
+++ b/tests/constructor_spec_tests.rs
@@ -1,11 +1,11 @@
 use sigil_stitch::code_block::CodeBlock;
-use sigil_stitch::lang::cpp_lang::CppLang;
-use sigil_stitch::lang::dart::DartLang;
-use sigil_stitch::lang::java_lang::JavaLang;
+use sigil_stitch::lang::cpp::Cpp;
+use sigil_stitch::lang::dart::Dart;
+use sigil_stitch::lang::java::Java;
 use sigil_stitch::lang::javascript::JavaScript;
 use sigil_stitch::lang::kotlin::Kotlin;
 use sigil_stitch::lang::python::Python;
-use sigil_stitch::lang::rust_lang::RustLang;
+use sigil_stitch::lang::rust::Rust;
 use sigil_stitch::lang::swift::Swift;
 use sigil_stitch::lang::typescript::TypeScript;
 use sigil_stitch::spec::fun_spec::FunSpec;
@@ -107,7 +107,7 @@ fn test_js_constructor() {
 
 #[test]
 fn test_java_constructor() {
-    let java = JavaLang::new();
+    let java = Java::new();
     let output = render_fun(
         &FunSpec::builder("UserService")
             .is_constructor()
@@ -128,7 +128,7 @@ fn test_java_constructor() {
 
 #[test]
 fn test_cpp_constructor() {
-    let cpp = CppLang::new();
+    let cpp = Cpp::new();
     let output = render_fun(
         &FunSpec::builder("Counter")
             .is_constructor()
@@ -147,7 +147,7 @@ fn test_cpp_constructor() {
 
 #[test]
 fn test_dart_constructor() {
-    let dart = DartLang::new();
+    let dart = Dart::new();
     let output = render_fun(
         &FunSpec::builder("Task")
             .is_constructor()
@@ -269,7 +269,7 @@ fn test_python_constructor() {
 
 #[test]
 fn test_rust_constructor() {
-    let rs = RustLang::new();
+    let rs = Rust::new();
     let output = render_fun(
         &FunSpec::builder("new")
             .is_constructor()
@@ -309,7 +309,7 @@ fn test_js_constructor_with_super() {
 
 #[test]
 fn test_java_constructor_with_super() {
-    let java = JavaLang::new();
+    let java = Java::new();
     let output = render_fun(
         &FunSpec::builder("Dog")
             .is_constructor()
@@ -347,7 +347,7 @@ fn test_backward_compat_ts_constructor_without_flag() {
 #[test]
 fn test_backward_compat_java_constructor_without_flag() {
     // Existing pattern: FunSpec with class name and no is_constructor flag.
-    let java = JavaLang::new();
+    let java = Java::new();
     let output = render_fun(
         &FunSpec::builder("UserService")
             .visibility(Visibility::Public)
@@ -406,7 +406,7 @@ fn test_ts_constructor_with_this_delegation() {
 
 #[test]
 fn test_java_constructor_with_super_delegation() {
-    let java = JavaLang::new();
+    let java = Java::new();
     let output = render_fun(
         &FunSpec::builder("Dog")
             .is_constructor()
@@ -430,7 +430,7 @@ fn test_java_constructor_with_super_delegation() {
 
 #[test]
 fn test_java_constructor_with_this_delegation() {
-    let java = JavaLang::new();
+    let java = Java::new();
     let output = render_fun(
         &FunSpec::builder("Config")
             .is_constructor()
@@ -510,7 +510,7 @@ fn test_swift_constructor_with_super_delegation() {
 
 #[test]
 fn test_dart_constructor_with_super_delegation() {
-    let dart = DartLang::new();
+    let dart = Dart::new();
     let output = render_fun(
         &FunSpec::builder("Dog")
             .is_constructor()
@@ -549,7 +549,7 @@ fn test_python_constructor_with_super_delegation() {
 
 #[test]
 fn test_cpp_constructor_with_super_delegation() {
-    let cpp = CppLang::new();
+    let cpp = Cpp::new();
     let output = render_fun(
         &FunSpec::builder("Dog")
             .is_constructor()

--- a/tests/cpp/builder_control_flow.rs
+++ b/tests/cpp/builder_control_flow.rs
@@ -1,5 +1,5 @@
 use sigil_stitch::code_block::CodeBlock;
-use sigil_stitch::lang::cpp_lang::CppLang;
+use sigil_stitch::lang::cpp::Cpp;
 use sigil_stitch::spec::file_spec::FileSpec;
 
 use super::golden;
@@ -16,7 +16,7 @@ fn test_control_flow() {
     b.end_control_flow();
     let block = b.build().unwrap();
 
-    let file = FileSpec::builder_with("flow.cpp", CppLang::new())
+    let file = FileSpec::builder_with("flow.cpp", Cpp::new())
         .add_code(block)
         .build()
         .unwrap();

--- a/tests/cpp/builder_edge_cases.rs
+++ b/tests/cpp/builder_edge_cases.rs
@@ -1,5 +1,5 @@
 use sigil_stitch::code_block::CodeBlock;
-use sigil_stitch::lang::cpp_lang::CppLang;
+use sigil_stitch::lang::cpp::Cpp;
 use sigil_stitch::spec::annotation_spec::AnnotationSpec;
 use sigil_stitch::spec::field_spec::FieldSpec;
 use sigil_stitch::spec::file_spec::FileSpec;
@@ -12,13 +12,13 @@ use super::golden;
 
 /// Helper: emit a FunSpec as a CodeBlock for embedding in extra_member.
 fn emit_fun(fun: &FunSpec) -> CodeBlock {
-    let lang = CppLang::new();
+    let lang = Cpp::new();
     fun.emit(&lang, DeclarationContext::Member).unwrap()
 }
 
 /// Helper: emit a FieldSpec as a CodeBlock for embedding in extra_member.
 fn emit_field(field: &FieldSpec) -> CodeBlock {
-    let lang = CppLang::new();
+    let lang = Cpp::new();
     field.emit(&lang, DeclarationContext::Member).unwrap()
 }
 
@@ -35,7 +35,7 @@ fn test_namespace_wrapping() {
     b.add_line();
     let block = b.build().unwrap();
 
-    let file = FileSpec::builder_with("math.hpp", CppLang::header())
+    let file = FileSpec::builder_with("math.hpp", Cpp::header())
         .header(CodeBlock::of("#pragma once", ()).unwrap())
         .add_raw("namespace math {\n")
         .add_code(block)
@@ -129,7 +129,7 @@ fn test_full_header() {
     let import_trigger =
         CodeBlock::of("// Uses %T", (TypeName::importable("./base.hpp", "Base"),)).unwrap();
 
-    let file = FileSpec::builder_with("logger.hpp", CppLang::header())
+    let file = FileSpec::builder_with("logger.hpp", Cpp::header())
         .header(CodeBlock::of("#pragma once", ()).unwrap())
         .add_code(import_trigger)
         .add_type(ts)
@@ -150,7 +150,7 @@ fn test_annotation_attribute() {
         .unwrap();
 
     let rendered = emit_fun(&fun);
-    let file = FileSpec::builder_with("compute.hpp", CppLang::header())
+    let file = FileSpec::builder_with("compute.hpp", Cpp::header())
         .add_code(rendered)
         .build()
         .unwrap();

--- a/tests/cpp/builder_functions.rs
+++ b/tests/cpp/builder_functions.rs
@@ -1,5 +1,5 @@
 use sigil_stitch::code_block::CodeBlock;
-use sigil_stitch::lang::cpp_lang::CppLang;
+use sigil_stitch::lang::cpp::Cpp;
 use sigil_stitch::spec::file_spec::FileSpec;
 use sigil_stitch::spec::fun_spec::FunSpec;
 use sigil_stitch::spec::parameter_spec::ParameterSpec;
@@ -16,7 +16,7 @@ fn test_const_method() {
         .build()
         .unwrap();
 
-    let file = FileSpec::builder_with("api.hpp", CppLang::header())
+    let file = FileSpec::builder_with("api.hpp", Cpp::header())
         .add_function(fun)
         .build()
         .unwrap();
@@ -37,7 +37,7 @@ fn test_template_function() {
         .build()
         .unwrap();
 
-    let file = FileSpec::builder_with("algo.hpp", CppLang::header())
+    let file = FileSpec::builder_with("algo.hpp", Cpp::header())
         .add_function(fun)
         .build()
         .unwrap();
@@ -56,7 +56,7 @@ fn test_static_method() {
         .build()
         .unwrap();
 
-    let file = FileSpec::builder_with("helpers.cpp", CppLang::new())
+    let file = FileSpec::builder_with("helpers.cpp", Cpp::new())
         .add_function(fun)
         .build()
         .unwrap();
@@ -77,7 +77,7 @@ fn test_function_with_doc() {
         .build()
         .unwrap();
 
-    let file = FileSpec::builder_with("math_doc.cpp", CppLang::new())
+    let file = FileSpec::builder_with("math_doc.cpp", Cpp::new())
         .add_function(fun)
         .build()
         .unwrap();

--- a/tests/cpp/builder_imports.rs
+++ b/tests/cpp/builder_imports.rs
@@ -1,5 +1,5 @@
 use sigil_stitch::code_block::{CodeBlock, StringLitArg};
-use sigil_stitch::lang::cpp_lang::CppLang;
+use sigil_stitch::lang::cpp::Cpp;
 use sigil_stitch::spec::file_spec::FileSpec;
 use sigil_stitch::type_name::TypeName;
 
@@ -17,7 +17,7 @@ fn test_includes() {
     b.add_statement("%T obj", (myclass,));
     let block = b.build().unwrap();
 
-    let file = FileSpec::builder_with("test.cpp", CppLang::new())
+    let file = FileSpec::builder_with("test.cpp", Cpp::new())
         .add_code(block)
         .build()
         .unwrap();

--- a/tests/cpp/builder_types.rs
+++ b/tests/cpp/builder_types.rs
@@ -1,5 +1,5 @@
 use sigil_stitch::code_block::CodeBlock;
-use sigil_stitch::lang::cpp_lang::CppLang;
+use sigil_stitch::lang::cpp::Cpp;
 use sigil_stitch::spec::enum_variant_spec::EnumVariantSpec;
 use sigil_stitch::spec::field_spec::FieldSpec;
 use sigil_stitch::spec::file_spec::FileSpec;
@@ -13,13 +13,13 @@ use super::golden;
 
 /// Helper: emit a FunSpec as a CodeBlock for embedding in extra_member.
 fn emit_fun(fun: &FunSpec) -> CodeBlock {
-    let lang = CppLang::new();
+    let lang = Cpp::new();
     fun.emit(&lang, DeclarationContext::Member).unwrap()
 }
 
 /// Helper: emit a FieldSpec as a CodeBlock for embedding in extra_member.
 fn emit_field(field: &FieldSpec) -> CodeBlock {
-    let lang = CppLang::new();
+    let lang = Cpp::new();
     field.emit(&lang, DeclarationContext::Member).unwrap()
 }
 
@@ -82,7 +82,7 @@ fn test_class_with_methods() {
         .build()
         .unwrap();
 
-    let file = FileSpec::builder_with("counter.hpp", CppLang::header())
+    let file = FileSpec::builder_with("counter.hpp", Cpp::header())
         .header(CodeBlock::of("#pragma once", ()).unwrap())
         .add_type(ts)
         .build()
@@ -114,7 +114,7 @@ fn test_struct_with_fields() {
         .build()
         .unwrap();
 
-    let file = FileSpec::builder_with("point.hpp", CppLang::header())
+    let file = FileSpec::builder_with("point.hpp", Cpp::header())
         .add_type(ts)
         .build()
         .unwrap();
@@ -133,7 +133,7 @@ fn test_enum_class() {
         .build()
         .unwrap();
 
-    let file = FileSpec::builder_with("color.hpp", CppLang::header())
+    let file = FileSpec::builder_with("color.hpp", Cpp::header())
         .add_type(ts)
         .build()
         .unwrap();
@@ -179,7 +179,7 @@ fn test_virtual_method() {
         .build()
         .unwrap();
 
-    let file = FileSpec::builder_with("shape.hpp", CppLang::header())
+    let file = FileSpec::builder_with("shape.hpp", Cpp::header())
         .add_type(ts)
         .build()
         .unwrap();
@@ -240,7 +240,7 @@ fn test_template_class() {
         .build()
         .unwrap();
 
-    let file = FileSpec::builder_with("stack.hpp", CppLang::header())
+    let file = FileSpec::builder_with("stack.hpp", Cpp::header())
         .header(CodeBlock::of("#pragma once", ()).unwrap())
         .add_type(ts)
         .build()
@@ -295,7 +295,7 @@ fn test_inheritance() {
         .build()
         .unwrap();
 
-    let file = FileSpec::builder_with("animals.hpp", CppLang::header())
+    let file = FileSpec::builder_with("animals.hpp", Cpp::header())
         .add_type(base)
         .add_type(derived)
         .build()

--- a/tests/cpp/quote_edge_cases.rs
+++ b/tests/cpp/quote_edge_cases.rs
@@ -1,5 +1,5 @@
 use sigil_stitch::code_block::CodeBlock;
-use sigil_stitch::lang::cpp_lang::CppLang;
+use sigil_stitch::lang::cpp::Cpp;
 use sigil_stitch::prelude::*;
 use sigil_stitch::spec::file_spec::FileSpec;
 use sigil_stitch::type_name::TypeName;
@@ -7,7 +7,7 @@ use sigil_stitch::type_name::TypeName;
 use super::golden;
 
 fn render(block: &CodeBlock) -> String {
-    FileSpec::builder_with("test.cpp", CppLang::new())
+    FileSpec::builder_with("test.cpp", Cpp::new())
         .add_code(block.clone())
         .build()
         .unwrap()
@@ -19,7 +19,7 @@ fn render(block: &CodeBlock) -> String {
 fn test_includes() {
     let iostream = TypeName::importable("iostream", "cout");
     let memory = TypeName::importable("memory", "unique_ptr");
-    let block = sigil_quote!(CppLang {
+    let block = sigil_quote!(Cpp {
         auto ptr = std::make_unique<int>(42);
         $T(iostream) << $T(memory)(ptr.get()) << std::endl;
     })
@@ -29,7 +29,7 @@ fn test_includes() {
 
 #[test]
 fn test_lambda() {
-    let block = sigil_quote!(CppLang {
+    let block = sigil_quote!(Cpp {
         auto fn = [&](int x) {
             return x * 2;
         };
@@ -41,7 +41,7 @@ fn test_lambda() {
 
 #[test]
 fn test_template_angle_brackets() {
-    let block = sigil_quote!(CppLang {
+    let block = sigil_quote!(Cpp {
         std::vector<std::pair<int, std::string>> items;
         std::map<std::string, std::vector<int>> index;
     })
@@ -51,7 +51,7 @@ fn test_template_angle_brackets() {
 
 #[test]
 fn test_range_for() {
-    let block = sigil_quote!(CppLang {
+    let block = sigil_quote!(Cpp {
         for (const auto& item : items) {
             std::cout << item << std::endl;
         }
@@ -62,7 +62,7 @@ fn test_range_for() {
 
 #[test]
 fn test_smart_pointers() {
-    let block = sigil_quote!(CppLang {
+    let block = sigil_quote!(Cpp {
         auto ptr = std::make_unique<Config>();
         auto shared = std::make_shared<Node>(42);
         std::weak_ptr<Node> weak = shared;
@@ -74,7 +74,7 @@ fn test_smart_pointers() {
 #[test]
 fn test_name_keyword_escape_in_macro() {
     let name = "class";
-    let block = sigil_quote!(CppLang {
+    let block = sigil_quote!(Cpp {
         $N(name) = 1;
     })
     .unwrap();

--- a/tests/cpp/quote_imports.rs
+++ b/tests/cpp/quote_imports.rs
@@ -1,5 +1,5 @@
 use sigil_stitch::code_block::CodeBlock;
-use sigil_stitch::lang::cpp_lang::CppLang;
+use sigil_stitch::lang::cpp::Cpp;
 use sigil_stitch::prelude::*;
 use sigil_stitch::spec::file_spec::FileSpec;
 use sigil_stitch::type_name::TypeName;
@@ -7,7 +7,7 @@ use sigil_stitch::type_name::TypeName;
 use super::golden;
 
 fn render(block: &CodeBlock) -> String {
-    FileSpec::builder_with("test.cpp", CppLang::new())
+    FileSpec::builder_with("test.cpp", Cpp::new())
         .add_code(block.clone())
         .build()
         .unwrap()
@@ -22,7 +22,7 @@ fn test_imports() {
         vec![TypeName::primitive("int")],
     );
     let string = TypeName::importable("string", "std::string");
-    let block = sigil_quote!(CppLang {
+    let block = sigil_quote!(Cpp {
         $T(vector) items;
         $T(string) name = $S("Alice");
     })

--- a/tests/cpp/quote_suite.rs
+++ b/tests/cpp/quote_suite.rs
@@ -1,5 +1,5 @@
 use sigil_stitch::code_block::CodeBlock;
-use sigil_stitch::lang::cpp_lang::CppLang;
+use sigil_stitch::lang::cpp::Cpp;
 use sigil_stitch::prelude::*;
 use sigil_stitch::spec::file_spec::FileSpec;
 
@@ -9,7 +9,7 @@ pub struct CppSuite;
 
 impl LanguageTestSuite for CppSuite {
     fn control_flow_block() -> CodeBlock {
-        sigil_quote!(CppLang {
+        sigil_quote!(Cpp {
             if(x > 0) {
                 return true;
             } else {
@@ -24,7 +24,7 @@ impl LanguageTestSuite for CppSuite {
     }
 
     fn basic_block() -> CodeBlock {
-        sigil_quote!(CppLang {
+        sigil_quote!(Cpp {
             int x = 42;
             std::string name = $S("Alice");
             std::cout << name << std::endl;
@@ -37,7 +37,7 @@ impl LanguageTestSuite for CppSuite {
     }
 
     fn render(block: CodeBlock) -> String {
-        FileSpec::builder_with("test.cpp", CppLang::new())
+        FileSpec::builder_with("test.cpp", Cpp::new())
             .add_code(block)
             .build()
             .unwrap()

--- a/tests/dart/builder_control_flow.rs
+++ b/tests/dart/builder_control_flow.rs
@@ -1,5 +1,5 @@
 use sigil_stitch::code_block::CodeBlock;
-use sigil_stitch::lang::dart::DartLang;
+use sigil_stitch::lang::dart::Dart;
 use sigil_stitch::spec::file_spec::FileSpec;
 
 use super::golden;
@@ -16,7 +16,7 @@ fn test_control_flow() {
     b.end_control_flow();
     let block = b.build().unwrap();
 
-    let file = FileSpec::builder_with("flow.dart", DartLang::new())
+    let file = FileSpec::builder_with("flow.dart", Dart::new())
         .add_code(block)
         .build()
         .unwrap();

--- a/tests/dart/builder_edge_cases.rs
+++ b/tests/dart/builder_edge_cases.rs
@@ -1,5 +1,5 @@
 use sigil_stitch::code_block::{CodeBlock, StringLitArg};
-use sigil_stitch::lang::dart::DartLang;
+use sigil_stitch::lang::dart::Dart;
 use sigil_stitch::spec::field_spec::FieldSpec;
 use sigil_stitch::spec::file_spec::FileSpec;
 use sigil_stitch::spec::fun_spec::FunSpec;
@@ -91,7 +91,7 @@ fn test_full_module() {
     // Trigger Future import.
     let future_trigger = CodeBlock::of("// %T", (future,)).unwrap();
 
-    let file = FileSpec::builder_with("user_repo.dart", DartLang::new())
+    let file = FileSpec::builder_with("user_repo.dart", Dart::new())
         .add_code(future_trigger)
         .add_type(iface_spec)
         .add_type(cls_spec)
@@ -119,7 +119,7 @@ fn test_string_dollar_escape() {
         .build()
         .unwrap();
 
-    let file = FileSpec::builder_with("greet.dart", DartLang::new())
+    let file = FileSpec::builder_with("greet.dart", Dart::new())
         .add_function(fun)
         .build()
         .unwrap();

--- a/tests/dart/builder_functions.rs
+++ b/tests/dart/builder_functions.rs
@@ -1,5 +1,5 @@
 use sigil_stitch::code_block::CodeBlock;
-use sigil_stitch::lang::dart::DartLang;
+use sigil_stitch::lang::dart::Dart;
 use sigil_stitch::spec::file_spec::FileSpec;
 use sigil_stitch::spec::fun_spec::FunSpec;
 use sigil_stitch::spec::modifiers::TypeKind;
@@ -25,7 +25,7 @@ fn test_async_function() {
     // Trigger User import.
     let trigger = CodeBlock::of("// %T", (user,)).unwrap();
 
-    let file = FileSpec::builder_with("api.dart", DartLang::new())
+    let file = FileSpec::builder_with("api.dart", Dart::new())
         .add_code(trigger)
         .add_function(fun)
         .build()
@@ -55,7 +55,7 @@ fn test_annotated_method() {
         .build()
         .unwrap();
 
-    let file = FileSpec::builder_with("dog.dart", DartLang::new())
+    let file = FileSpec::builder_with("dog.dart", Dart::new())
         .add_type(ts)
         .build()
         .unwrap();

--- a/tests/dart/builder_imports.rs
+++ b/tests/dart/builder_imports.rs
@@ -1,5 +1,5 @@
 use sigil_stitch::code_block::CodeBlock;
-use sigil_stitch::lang::dart::DartLang;
+use sigil_stitch::lang::dart::Dart;
 use sigil_stitch::spec::file_spec::FileSpec;
 use sigil_stitch::type_name::TypeName;
 
@@ -14,7 +14,7 @@ fn test_function_with_imports() {
     b.add_statement("%T<%T> users = fetchAll()", (future, user));
     let block = b.build().unwrap();
 
-    let file = FileSpec::builder_with("app.dart", DartLang::new())
+    let file = FileSpec::builder_with("app.dart", Dart::new())
         .add_code(block)
         .build()
         .unwrap();
@@ -40,7 +40,7 @@ fn test_import_grouping() {
     b.add_line();
     let block = b.build().unwrap();
 
-    let file = FileSpec::builder_with("imports.dart", DartLang::new())
+    let file = FileSpec::builder_with("imports.dart", Dart::new())
         .add_code(block)
         .build()
         .unwrap();

--- a/tests/dart/builder_types.rs
+++ b/tests/dart/builder_types.rs
@@ -1,5 +1,5 @@
 use sigil_stitch::code_block::CodeBlock;
-use sigil_stitch::lang::dart::DartLang;
+use sigil_stitch::lang::dart::Dart;
 use sigil_stitch::spec::enum_variant_spec::EnumVariantSpec;
 use sigil_stitch::spec::field_spec::FieldSpec;
 use sigil_stitch::spec::file_spec::FileSpec;
@@ -54,7 +54,7 @@ fn test_class_with_fields() {
         .build()
         .unwrap();
 
-    let file = FileSpec::builder_with("user_service.dart", DartLang::new())
+    let file = FileSpec::builder_with("user_service.dart", Dart::new())
         .add_type(ts)
         .build()
         .unwrap();
@@ -88,7 +88,7 @@ fn test_abstract_class() {
         .build()
         .unwrap();
 
-    let file = FileSpec::builder_with("shape.dart", DartLang::new())
+    let file = FileSpec::builder_with("shape.dart", Dart::new())
         .add_type(ts)
         .build()
         .unwrap();
@@ -118,7 +118,7 @@ fn test_class_extends_implements() {
         .build()
         .unwrap();
 
-    let file = FileSpec::builder_with("admin_service.dart", DartLang::new())
+    let file = FileSpec::builder_with("admin_service.dart", Dart::new())
         .add_type(ts)
         .build()
         .unwrap();
@@ -137,7 +137,7 @@ fn test_enum() {
         .build()
         .unwrap();
 
-    let file = FileSpec::builder_with("color.dart", DartLang::new())
+    let file = FileSpec::builder_with("color.dart", Dart::new())
         .add_type(ts)
         .build()
         .unwrap();
@@ -171,7 +171,7 @@ fn test_generic_class() {
         .build()
         .unwrap();
 
-    let file = FileSpec::builder_with("sorted_list.dart", DartLang::new())
+    let file = FileSpec::builder_with("sorted_list.dart", Dart::new())
         .add_type(ts)
         .build()
         .unwrap();
@@ -208,7 +208,7 @@ fn test_static_final() {
         .build()
         .unwrap();
 
-    let file = FileSpec::builder_with("constants.dart", DartLang::new())
+    let file = FileSpec::builder_with("constants.dart", Dart::new())
         .add_type(ts)
         .build()
         .unwrap();

--- a/tests/dart/quote_edge_cases.rs
+++ b/tests/dart/quote_edge_cases.rs
@@ -1,12 +1,12 @@
 use sigil_stitch::code_block::CodeBlock;
-use sigil_stitch::lang::dart::DartLang;
+use sigil_stitch::lang::dart::Dart;
 use sigil_stitch::prelude::*;
 use sigil_stitch::spec::file_spec::FileSpec;
 
 use super::golden;
 
 fn render(block: &CodeBlock) -> String {
-    FileSpec::builder_with("test.dart", DartLang::new())
+    FileSpec::builder_with("test.dart", Dart::new())
         .add_code(block.clone())
         .build()
         .unwrap()
@@ -16,7 +16,7 @@ fn render(block: &CodeBlock) -> String {
 
 #[test]
 fn test_cascade() {
-    let block = sigil_quote!(DartLang {
+    let block = sigil_quote!(Dart {
         final builder = StringBuffer()
             ..write("hello")
             ..write(" world");
@@ -27,7 +27,7 @@ fn test_cascade() {
 
 #[test]
 fn test_named_params() {
-    let block = sigil_quote!(DartLang {
+    let block = sigil_quote!(Dart {
         void configure({required String host, int port = 8080}) {
             print(host);
         }
@@ -38,7 +38,7 @@ fn test_named_params() {
 
 #[test]
 fn test_null_aware() {
-    let block = sigil_quote!(DartLang {
+    let block = sigil_quote!(Dart {
         String name = user?.name ?? $S("anonymous");
         list ??= [];
         final length = items?.length ?? 0;
@@ -49,7 +49,7 @@ fn test_null_aware() {
 
 #[test]
 fn test_async_await() {
-    let block = sigil_quote!(DartLang {
+    let block = sigil_quote!(Dart {
         Future<String> fetchData(String url) async {
             final response = await http.get(Uri.parse(url));
             return response.body;

--- a/tests/dart/quote_imports.rs
+++ b/tests/dart/quote_imports.rs
@@ -18,7 +18,7 @@ fn render(block: &CodeBlock) -> String {
 fn test_imports() {
     let http = TypeName::importable("package:http/http.dart", "Client");
     let convert = TypeName::importable("dart:convert", "jsonDecode");
-    let block = sigil_quote!(DartLang {
+    let block = sigil_quote!(Dart {
         final client = $T(http)();
         final data = $T(convert)(response.body);
     })

--- a/tests/dart/quote_suite.rs
+++ b/tests/dart/quote_suite.rs
@@ -7,7 +7,7 @@ pub struct DartSuite;
 
 impl LanguageTestSuite for DartSuite {
     fn control_flow_block() -> CodeBlock {
-        sigil_quote!(DartLang {
+        sigil_quote!(Dart {
             if(x > 0) {
                 return true;
             } else {
@@ -22,7 +22,7 @@ impl LanguageTestSuite for DartSuite {
     }
 
     fn basic_block() -> CodeBlock {
-        sigil_quote!(DartLang {
+        sigil_quote!(Dart {
             final name = $S("Alice");
             final age = 30;
             print(name);

--- a/tests/field_spec_tests.rs
+++ b/tests/field_spec_tests.rs
@@ -1,7 +1,7 @@
 use sigil_stitch::code_renderer::CodeRenderer;
 use sigil_stitch::import::ImportGroup;
 use sigil_stitch::lang::CodeLang;
-use sigil_stitch::lang::rust_lang::RustLang;
+use sigil_stitch::lang::rust::Rust;
 use sigil_stitch::lang::typescript::TypeScript;
 use sigil_stitch::spec::field_spec::FieldSpec;
 use sigil_stitch::spec::modifiers::{DeclarationContext, Visibility};
@@ -16,7 +16,7 @@ fn emit_field_ts(spec: &FieldSpec, ctx: DeclarationContext) -> String {
 }
 
 fn emit_field_rs(spec: &FieldSpec, ctx: DeclarationContext) -> String {
-    let lang = RustLang::new();
+    let lang = Rust::new();
     let block = spec.emit(&lang, ctx).unwrap();
     let imports = ImportGroup::new();
     let mut renderer = CodeRenderer::new(&lang, &imports, 80);
@@ -99,15 +99,15 @@ fn test_ts_optional_field_uses_name_suffix() {
 #[test]
 fn test_rust_optional_field_wraps_with_option() {
     let field = optional_field(TypeName::primitive("String"));
-    let out = emit_for(&RustLang::new(), &field, DeclarationContext::Member);
+    let out = emit_for(&Rust::new(), &field, DeclarationContext::Member);
     assert_eq!(out.trim(), "name: Option<String>,");
 }
 
 #[test]
 fn test_go_optional_field_prefixes_type_with_pointer() {
-    use sigil_stitch::lang::go_lang::GoLang;
+    use sigil_stitch::lang::go::Go;
     let field = optional_field(TypeName::primitive("string"));
-    let out = emit_for(&GoLang::new(), &field, DeclarationContext::Member);
+    let out = emit_for(&Go::new(), &field, DeclarationContext::Member);
     assert_eq!(out.trim(), "name *string");
 }
 
@@ -121,9 +121,9 @@ fn test_python_optional_field_unions_with_none() {
 
 #[test]
 fn test_java_optional_field_wraps_with_optional() {
-    use sigil_stitch::lang::java_lang::JavaLang;
+    use sigil_stitch::lang::java::Java;
     let field = optional_field(TypeName::primitive("String"));
-    let out = emit_for(&JavaLang::new(), &field, DeclarationContext::Member);
+    let out = emit_for(&Java::new(), &field, DeclarationContext::Member);
     assert_eq!(out.trim(), "Optional<String> name;");
 }
 
@@ -151,25 +151,25 @@ fn test_swift_optional_field_suffixes_type() {
 
 #[test]
 fn test_dart_optional_field_suffixes_type() {
-    use sigil_stitch::lang::dart::DartLang;
+    use sigil_stitch::lang::dart::Dart;
     let field = optional_field(TypeName::primitive("String"));
-    let out = emit_for(&DartLang::new(), &field, DeclarationContext::Member);
+    let out = emit_for(&Dart::new(), &field, DeclarationContext::Member);
     assert_eq!(out.trim(), "String? name;");
 }
 
 #[test]
 fn test_c_optional_field_prefixes_name_with_pointer() {
-    use sigil_stitch::lang::c_lang::CLang;
+    use sigil_stitch::lang::c::C;
     let field = optional_field(TypeName::primitive("int"));
-    let out = emit_for(&CLang::new(), &field, DeclarationContext::Member);
+    let out = emit_for(&C::new(), &field, DeclarationContext::Member);
     assert_eq!(out.trim(), "int *name;");
 }
 
 #[test]
 fn test_cpp_optional_field_wraps_with_std_optional() {
-    use sigil_stitch::lang::cpp_lang::CppLang;
+    use sigil_stitch::lang::cpp::Cpp;
     let field = optional_field(TypeName::primitive("int"));
-    let out = emit_for(&CppLang::new(), &field, DeclarationContext::Member);
+    let out = emit_for(&Cpp::new(), &field, DeclarationContext::Member);
     assert_eq!(out.trim(), "std::optional<int> name;");
 }
 
@@ -197,10 +197,10 @@ fn test_ts_reserved_word_field_not_escaped() {
 
 #[test]
 fn test_go_reserved_word_field_is_escaped() {
-    use sigil_stitch::lang::go_lang::GoLang;
+    use sigil_stitch::lang::go::Go;
     let field = FieldSpec::builder("type", TypeName::primitive("string"))
         .build()
         .unwrap();
-    let out = emit_for(&GoLang::new(), &field, DeclarationContext::Member);
+    let out = emit_for(&Go::new(), &field, DeclarationContext::Member);
     assert_eq!(out.trim(), "type_ string");
 }

--- a/tests/fun_spec_tests.rs
+++ b/tests/fun_spec_tests.rs
@@ -1,7 +1,7 @@
 use sigil_stitch::code_block::CodeBlock;
 use sigil_stitch::code_renderer::CodeRenderer;
 use sigil_stitch::import::ImportGroup;
-use sigil_stitch::lang::rust_lang::RustLang;
+use sigil_stitch::lang::rust::Rust;
 use sigil_stitch::lang::typescript::TypeScript;
 use sigil_stitch::spec::emittable::Emittable;
 use sigil_stitch::spec::fun_spec::FunSpec;
@@ -19,7 +19,7 @@ fn emit_fun_ts(spec: &FunSpec, ctx: DeclarationContext) -> String {
 }
 
 fn emit_fun_rs(spec: &FunSpec, ctx: DeclarationContext) -> String {
-    let lang = RustLang::new();
+    let lang = Rust::new();
     let block = spec.emit(&lang, ctx).unwrap();
     let imports = ImportGroup::new();
     let mut renderer = CodeRenderer::new(&lang, &imports, 80);

--- a/tests/go/builder_control_flow.rs
+++ b/tests/go/builder_control_flow.rs
@@ -1,5 +1,5 @@
 use sigil_stitch::code_block::CodeBlock;
-use sigil_stitch::lang::go_lang::GoLang;
+use sigil_stitch::lang::go::Go;
 use sigil_stitch::spec::file_spec::FileSpec;
 
 use super::golden;
@@ -22,7 +22,7 @@ fn test_control_flow() {
     b.add_line();
     let block = b.build().unwrap();
 
-    let file = FileSpec::builder_with("classify.go", GoLang::new())
+    let file = FileSpec::builder_with("classify.go", Go::new())
         .header(CodeBlock::of("package main", ()).unwrap())
         .add_code(block)
         .build()
@@ -40,7 +40,7 @@ fn test_if_init_semicolon() {
     b.end_control_flow();
     let block = b.build().unwrap();
 
-    let file = FileSpec::builder_with("test.go", GoLang::new())
+    let file = FileSpec::builder_with("test.go", Go::new())
         .add_code(block)
         .build()
         .unwrap();

--- a/tests/go/builder_edge_cases.rs
+++ b/tests/go/builder_edge_cases.rs
@@ -1,6 +1,6 @@
 use sigil_stitch::code_block::{CodeBlock, NameArg};
 use sigil_stitch::lang::CodeLang;
-use sigil_stitch::lang::go_lang::GoLang;
+use sigil_stitch::lang::go::Go;
 use sigil_stitch::spec::field_spec::FieldSpec;
 use sigil_stitch::spec::file_spec::FileSpec;
 use sigil_stitch::spec::fun_spec::FunSpec;
@@ -18,7 +18,7 @@ fn test_enum() {
     //   const ( North Direction = iota; East; ... )
     //
     // This doesn't fit TypeSpec, so we build it as a raw CodeBlock.
-    let go = GoLang::new();
+    let go = Go::new();
 
     let mut cb = CodeBlock::builder();
     let doc = go.render_doc_comment(&["Direction represents a cardinal direction."]);
@@ -43,7 +43,7 @@ fn test_enum() {
     cb.add_line();
     let block = cb.build().unwrap();
 
-    let file = FileSpec::builder_with("direction.go", GoLang::new())
+    let file = FileSpec::builder_with("direction.go", Go::new())
         .header(CodeBlock::of("package direction", ()).unwrap())
         .add_code(block)
         .build()
@@ -60,7 +60,7 @@ fn test_name_escapes_go_keywords() {
     let keywords = ["func", "type", "var", "map", "range", "select", "chan"];
     for kw in keywords {
         let block = CodeBlock::of("var %N int", NameArg(kw.into())).unwrap();
-        let file = FileSpec::builder_with("test.go", GoLang::new())
+        let file = FileSpec::builder_with("test.go", Go::new())
             .add_code(block)
             .build()
             .unwrap();
@@ -72,7 +72,7 @@ fn test_name_escapes_go_keywords() {
     }
     // Non-reserved word should not be escaped.
     let block = CodeBlock::of("var %N int", NameArg("myVar".into())).unwrap();
-    let file = FileSpec::builder_with("test.go", GoLang::new())
+    let file = FileSpec::builder_with("test.go", Go::new())
         .add_code(block)
         .build()
         .unwrap();
@@ -95,7 +95,7 @@ fn test_name_escape_in_struct_context() {
     cb.add_line();
     let block = cb.build().unwrap();
 
-    let file = FileSpec::builder_with("test.go", GoLang::new())
+    let file = FileSpec::builder_with("test.go", Go::new())
         .header(CodeBlock::of("package models", ()).unwrap())
         .add_code(block)
         .build()
@@ -109,7 +109,7 @@ fn test_name_escape_in_struct_context() {
 
 #[test]
 fn test_embedded_struct_basic() {
-    let file = FileSpec::builder_with("models.go", GoLang::new())
+    let file = FileSpec::builder_with("models.go", Go::new())
         .header(CodeBlock::of("package models", ()).unwrap())
         .add_type(
             TypeSpec::builder("ReadWriter", TypeKind::Struct)
@@ -128,7 +128,7 @@ fn test_embedded_struct_basic() {
 #[test]
 fn test_embedded_with_methods() {
     let body = CodeBlock::of("return fmt.Sprintf(\"%%s/%%s\", a.Host, a.Path)", ()).unwrap();
-    let file = FileSpec::builder_with("models.go", GoLang::new())
+    let file = FileSpec::builder_with("models.go", Go::new())
         .header(CodeBlock::of("package models", ()).unwrap())
         .add_type(
             TypeSpec::builder("Endpoint", TypeKind::Struct)
@@ -161,7 +161,7 @@ fn test_embedded_with_methods() {
 
 #[test]
 fn test_embedded_only_no_fields() {
-    let file = FileSpec::builder_with("compose.go", GoLang::new())
+    let file = FileSpec::builder_with("compose.go", Go::new())
         .header(CodeBlock::of("package compose", ()).unwrap())
         .add_type(
             TypeSpec::builder("Combined", TypeKind::Struct)
@@ -187,7 +187,7 @@ fn test_embedded_with_importable_type() {
     let io_reader = TypeName::importable("io", "Reader");
     let io_writer = TypeName::importable("io", "Writer");
 
-    let file = FileSpec::builder_with("rw.go", GoLang::new())
+    let file = FileSpec::builder_with("rw.go", Go::new())
         .header(CodeBlock::of("package rw", ()).unwrap())
         .add_type(
             TypeSpec::builder("ReadWriter", TypeKind::Interface)

--- a/tests/go/builder_functions.rs
+++ b/tests/go/builder_functions.rs
@@ -1,5 +1,5 @@
 use sigil_stitch::code_block::CodeBlock;
-use sigil_stitch::lang::go_lang::GoLang;
+use sigil_stitch::lang::go::Go;
 use sigil_stitch::spec::file_spec::FileSpec;
 use sigil_stitch::spec::fun_spec::FunSpec;
 use sigil_stitch::spec::modifiers::Visibility;
@@ -12,7 +12,7 @@ use super::golden;
 fn test_top_level_function() {
     let fmt_sprintf = TypeName::importable("fmt", "Sprintf");
 
-    let file = FileSpec::builder_with("greet.go", GoLang::new())
+    let file = FileSpec::builder_with("greet.go", Go::new())
         .header(CodeBlock::of("package greet", ()).unwrap())
         .add_function(
             FunSpec::builder("Greet")
@@ -42,7 +42,7 @@ fn test_function_with_doc() {
         .build()
         .unwrap();
 
-    let file = FileSpec::builder_with("add.go", GoLang::new())
+    let file = FileSpec::builder_with("add.go", Go::new())
         .add_function(fun)
         .build()
         .unwrap();

--- a/tests/go/builder_imports.rs
+++ b/tests/go/builder_imports.rs
@@ -1,5 +1,5 @@
 use sigil_stitch::code_block::CodeBlock;
-use sigil_stitch::lang::go_lang::GoLang;
+use sigil_stitch::lang::go::Go;
 use sigil_stitch::spec::file_spec::FileSpec;
 use sigil_stitch::type_name::TypeName;
 
@@ -22,7 +22,7 @@ fn test_function_with_imports() {
     b.add_line();
     let block = b.build().unwrap();
 
-    let file = FileSpec::builder_with("server.go", GoLang::new())
+    let file = FileSpec::builder_with("server.go", Go::new())
         .header(CodeBlock::of("package main", ()).unwrap())
         .add_code(block)
         .build()
@@ -44,7 +44,7 @@ fn test_import_grouping() {
     b.add_statement("_ = %T{}", (gin_ctx,));
     let block = b.build().unwrap();
 
-    let file = FileSpec::builder_with("main.go", GoLang::new())
+    let file = FileSpec::builder_with("main.go", Go::new())
         .header(CodeBlock::of("package main", ()).unwrap())
         .add_code(block)
         .build()
@@ -66,7 +66,7 @@ fn test_same_package_symbols() {
     b.add_statement("_ = %T", (listen,));
     let block = b.build().unwrap();
 
-    let file = FileSpec::builder_with("http.go", GoLang::new())
+    let file = FileSpec::builder_with("http.go", Go::new())
         .header(CodeBlock::of("package main", ()).unwrap())
         .add_code(block)
         .build()

--- a/tests/go/builder_types.rs
+++ b/tests/go/builder_types.rs
@@ -1,5 +1,5 @@
 use sigil_stitch::code_block::CodeBlock;
-use sigil_stitch::lang::go_lang::GoLang;
+use sigil_stitch::lang::go::Go;
 use sigil_stitch::spec::field_spec::FieldSpec;
 use sigil_stitch::spec::file_spec::FileSpec;
 use sigil_stitch::spec::fun_spec::FunSpec;
@@ -13,7 +13,7 @@ use super::golden;
 
 #[test]
 fn test_struct_with_tags() {
-    let file = FileSpec::builder_with("config.go", GoLang::new())
+    let file = FileSpec::builder_with("config.go", Go::new())
         .header(CodeBlock::of("package config", ()).unwrap())
         .add_type(
             TypeSpec::builder("Config", TypeKind::Struct)
@@ -73,7 +73,7 @@ fn test_struct_with_methods() {
         .body(CodeBlock::of("return nil", ()).unwrap());
 
     // Method 2: ToJSON.
-    let file = FileSpec::builder_with("server.go", GoLang::new())
+    let file = FileSpec::builder_with("server.go", Go::new())
         .header(CodeBlock::of("package server", ()).unwrap())
         .add_type(tb.build().unwrap())
         .add_function(m1.build().unwrap())
@@ -97,7 +97,7 @@ fn test_struct_with_methods() {
 
 #[test]
 fn test_interface() {
-    let file = FileSpec::builder_with("repo.go", GoLang::new())
+    let file = FileSpec::builder_with("repo.go", Go::new())
         .header(CodeBlock::of("package repo", ()).unwrap())
         .add_type(
             TypeSpec::builder("Repository", TypeKind::Interface)
@@ -146,7 +146,7 @@ fn test_generic_function() {
         .returns(TypeName::primitive("T"))
         .body(body);
 
-    let file = FileSpec::builder_with("max.go", GoLang::new())
+    let file = FileSpec::builder_with("max.go", Go::new())
         .header(CodeBlock::of("package main", ()).unwrap())
         .add_function(fb.build().unwrap())
         .build()
@@ -158,7 +158,7 @@ fn test_generic_function() {
 
 #[test]
 fn test_embedded_struct() {
-    let file = FileSpec::builder_with("admin.go", GoLang::new())
+    let file = FileSpec::builder_with("admin.go", Go::new())
         .header(CodeBlock::of("package models", ()).unwrap())
         .add_type(
             TypeSpec::builder("UserAdmin", TypeKind::Struct)

--- a/tests/go/quote_control_flow.rs
+++ b/tests/go/quote_control_flow.rs
@@ -1,12 +1,12 @@
 use sigil_stitch::code_block::CodeBlock;
-use sigil_stitch::lang::go_lang::GoLang;
+use sigil_stitch::lang::go::Go;
 use sigil_stitch::prelude::*;
 use sigil_stitch::spec::file_spec::FileSpec;
 
 use super::golden;
 
 fn render(block: &CodeBlock) -> String {
-    FileSpec::builder_with("test.go", GoLang::new())
+    FileSpec::builder_with("test.go", Go::new())
         .add_code(block.clone())
         .build()
         .unwrap()
@@ -21,7 +21,7 @@ fn test_control_flow() {
 
 #[test]
 fn test_if_init_semicolon() {
-    let block = sigil_quote!(GoLang {
+    let block = sigil_quote!(Go {
         if err := doStuff(); err != nil {
             return err;
         }
@@ -32,7 +32,7 @@ fn test_if_init_semicolon() {
 
 #[test]
 fn test_for_init_semicolon() {
-    let block = sigil_quote!(GoLang {
+    let block = sigil_quote!(Go {
         for i := 0; i < 10; i++ {
             fmt.Println(i);
         }
@@ -43,7 +43,7 @@ fn test_for_init_semicolon() {
 
 #[test]
 fn test_switch_init_semicolon() {
-    let block = sigil_quote!(GoLang {
+    let block = sigil_quote!(Go {
         switch v := getValue(); v {
         case "hello":
             fmt.Println(v);
@@ -56,7 +56,7 @@ fn test_switch_init_semicolon() {
 #[test]
 fn test_const_paren_block_with_for() {
     let items = vec!["a", "b", "c"];
-    let block = sigil_quote!(GoLang {
+    let block = sigil_quote!(Go {
         const (
         $for(v in &items) {
             $L("@{v}Const = \"@{v}\"")

--- a/tests/go/quote_edge_cases.rs
+++ b/tests/go/quote_edge_cases.rs
@@ -1,12 +1,12 @@
 use sigil_stitch::code_block::CodeBlock;
-use sigil_stitch::lang::go_lang::GoLang;
+use sigil_stitch::lang::go::Go;
 use sigil_stitch::prelude::*;
 use sigil_stitch::spec::file_spec::FileSpec;
 
 use super::golden;
 
 fn render(block: &CodeBlock) -> String {
-    FileSpec::builder_with("test.go", GoLang::new())
+    FileSpec::builder_with("test.go", Go::new())
         .add_code(block.clone())
         .build()
         .unwrap()
@@ -16,7 +16,7 @@ fn render(block: &CodeBlock) -> String {
 
 #[test]
 fn test_indent() {
-    let block = sigil_quote!(GoLang {
+    let block = sigil_quote!(Go {
         func printDirections() {
         $>
         fmt.Println("North");
@@ -33,7 +33,7 @@ fn test_indent() {
 #[test]
 fn test_name_escape_in_macro() {
     let name = "type";
-    let block = sigil_quote!(GoLang {
+    let block = sigil_quote!(Go {
         var $N(name) string
     })
     .unwrap();
@@ -50,7 +50,7 @@ fn test_name_escape_in_macro() {
 fn test_name_escape_multiple_keywords_in_macro() {
     let pkg = "package";
     let ret = "return";
-    let block = sigil_quote!(GoLang {
+    let block = sigil_quote!(Go {
         $N(pkg) = $N(ret)
     })
     .unwrap();
@@ -64,7 +64,7 @@ fn test_name_escape_multiple_keywords_in_macro() {
 #[test]
 fn test_name_no_escape_in_macro() {
     let name = "myHandler";
-    let block = sigil_quote!(GoLang {
+    let block = sigil_quote!(Go {
         func $N(name)()
     })
     .unwrap();
@@ -79,7 +79,7 @@ fn test_name_no_escape_in_macro() {
 
 #[test]
 fn test_goroutine() {
-    let block = sigil_quote!(GoLang {
+    let block = sigil_quote!(Go {
         go func() {
             fmt.Println($S("hello from goroutine"));
         }();
@@ -90,7 +90,7 @@ fn test_goroutine() {
 
 #[test]
 fn test_channel() {
-    let block = sigil_quote!(GoLang {
+    let block = sigil_quote!(Go {
         ch := make(chan int, 10);
         ch <- 42;
         val := <-ch;
@@ -101,7 +101,7 @@ fn test_channel() {
 
 #[test]
 fn test_interface() {
-    let block = sigil_quote!(GoLang {
+    let block = sigil_quote!(Go {
         type Reader interface {
             Read(p []byte) (int, error);
         }
@@ -112,7 +112,7 @@ fn test_interface() {
 
 #[test]
 fn test_defer() {
-    let block = sigil_quote!(GoLang {
+    let block = sigil_quote!(Go {
         f, err := os.Open(path);
         defer f.Close();
     })
@@ -124,7 +124,7 @@ fn test_defer() {
 
 #[test]
 fn test_channel_receive_tight() {
-    let block = sigil_quote!(GoLang { val := <-ch; }).unwrap();
+    let block = sigil_quote!(Go { val := <-ch; }).unwrap();
     let output = render(&block);
     assert!(
         output.contains("<-ch"),
@@ -138,7 +138,7 @@ fn test_channel_receive_tight() {
 
 #[test]
 fn test_channel_send_has_space() {
-    let block = sigil_quote!(GoLang { ch <- 42; }).unwrap();
+    let block = sigil_quote!(Go { ch <- 42; }).unwrap();
     let output = render(&block);
     assert!(
         output.contains("<- 42") || output.contains("ch <- 42"),
@@ -148,7 +148,7 @@ fn test_channel_send_has_space() {
 
 #[test]
 fn test_channel_receive_standalone() {
-    let block = sigil_quote!(GoLang { <-done; }).unwrap();
+    let block = sigil_quote!(Go { <-done; }).unwrap();
     let output = render(&block);
     assert!(
         output.contains("<-done"),

--- a/tests/go/quote_imports.rs
+++ b/tests/go/quote_imports.rs
@@ -1,5 +1,5 @@
 use sigil_stitch::code_block::CodeBlock;
-use sigil_stitch::lang::go_lang::GoLang;
+use sigil_stitch::lang::go::Go;
 use sigil_stitch::prelude::*;
 use sigil_stitch::spec::file_spec::FileSpec;
 use sigil_stitch::type_name::TypeName;
@@ -7,7 +7,7 @@ use sigil_stitch::type_name::TypeName;
 use super::golden;
 
 fn render(block: &CodeBlock) -> String {
-    FileSpec::builder_with("test.go", GoLang::new())
+    FileSpec::builder_with("test.go", Go::new())
         .add_code(block.clone())
         .build()
         .unwrap()
@@ -19,7 +19,7 @@ fn render(block: &CodeBlock) -> String {
 fn test_imports() {
     let fmt_println = TypeName::importable("fmt", "Println");
     let http_server = TypeName::importable("net/http", "Server");
-    let block = sigil_quote!(GoLang {
+    let block = sigil_quote!(Go {
         srv := &$T(http_server){};
         $T(fmt_println)(srv);
     })

--- a/tests/go/quote_suite.rs
+++ b/tests/go/quote_suite.rs
@@ -1,5 +1,5 @@
 use sigil_stitch::code_block::CodeBlock;
-use sigil_stitch::lang::go_lang::GoLang;
+use sigil_stitch::lang::go::Go;
 use sigil_stitch::prelude::*;
 use sigil_stitch::spec::file_spec::FileSpec;
 
@@ -9,7 +9,7 @@ pub struct GoSuite;
 
 impl LanguageTestSuite for GoSuite {
     fn control_flow_block() -> CodeBlock {
-        sigil_quote!(GoLang {
+        sigil_quote!(Go {
             if x > 0 {
                 return $S("positive");
             } else {
@@ -24,7 +24,7 @@ impl LanguageTestSuite for GoSuite {
     }
 
     fn basic_block() -> CodeBlock {
-        sigil_quote!(GoLang {
+        sigil_quote!(Go {
             x := 42;
             name := $S("Alice");
             fmt.Println(name, x);
@@ -37,7 +37,7 @@ impl LanguageTestSuite for GoSuite {
     }
 
     fn render(block: CodeBlock) -> String {
-        FileSpec::builder_with("test.go", GoLang::new())
+        FileSpec::builder_with("test.go", Go::new())
             .add_code(block)
             .build()
             .unwrap()

--- a/tests/go/quote_verbatim_string.rs
+++ b/tests/go/quote_verbatim_string.rs
@@ -21,7 +21,7 @@ fn render(block: &CodeBlock) -> String {
 #[test]
 fn verbatim_at_interpolation_simple() {
     let name = "world";
-    let block = sigil_quote!(GoLang {
+    let block = sigil_quote!(Go {
         msg := $V("hello @{name}")
     })
     .unwrap();
@@ -33,7 +33,7 @@ fn verbatim_at_interpolation_simple() {
 fn verbatim_at_interpolation_multiple() {
     let host = "localhost";
     let port = "8080";
-    let block = sigil_quote!(GoLang {
+    let block = sigil_quote!(Go {
         addr := $V("@{host}:@{port}")
     })
     .unwrap();
@@ -43,7 +43,7 @@ fn verbatim_at_interpolation_multiple() {
 
 #[test]
 fn verbatim_at_escape() {
-    let block = sigil_quote!(GoLang {
+    let block = sigil_quote!(Go {
         email := $V("user@@host.com")
     })
     .unwrap();

--- a/tests/import_spec_tests.rs
+++ b/tests/import_spec_tests.rs
@@ -1,11 +1,11 @@
 use sigil_stitch::code_block::CodeBlock;
-use sigil_stitch::lang::dart::DartLang;
-use sigil_stitch::lang::go_lang::GoLang;
-use sigil_stitch::lang::java_lang::JavaLang;
+use sigil_stitch::lang::dart::Dart;
+use sigil_stitch::lang::go::Go;
+use sigil_stitch::lang::java::Java;
 use sigil_stitch::lang::javascript::JavaScript;
 use sigil_stitch::lang::kotlin::Kotlin;
 use sigil_stitch::lang::python::Python;
-use sigil_stitch::lang::rust_lang::RustLang;
+use sigil_stitch::lang::rust::Rust;
 use sigil_stitch::lang::swift::Swift;
 use sigil_stitch::spec::file_spec::FileSpec;
 use sigil_stitch::spec::import_spec::ImportSpec;
@@ -151,7 +151,7 @@ fn test_js_wildcard_import() {
 
 #[test]
 fn test_rust_forced_named_import() {
-    let output = FileSpec::builder_with("main.rs", RustLang::new())
+    let output = FileSpec::builder_with("main.rs", Rust::new())
         .add_import(ImportSpec::named("std::collections", "HashMap"))
         .add_code(CodeBlock::of("// code", ()).unwrap())
         .build()
@@ -164,7 +164,7 @@ fn test_rust_forced_named_import() {
 
 #[test]
 fn test_rust_wildcard_import() {
-    let output = FileSpec::builder_with("main.rs", RustLang::new())
+    let output = FileSpec::builder_with("main.rs", Rust::new())
         .add_import(ImportSpec::wildcard("std::collections"))
         .add_code(CodeBlock::of("// code", ()).unwrap())
         .build()
@@ -179,7 +179,7 @@ fn test_rust_wildcard_import() {
 
 #[test]
 fn test_go_side_effect_import() {
-    let output = FileSpec::builder_with("main.go", GoLang::new())
+    let output = FileSpec::builder_with("main.go", Go::new())
         .header(CodeBlock::of("package main", ()).unwrap())
         .add_import(ImportSpec::side_effect("database/sql"))
         .add_code(CodeBlock::of("// init", ()).unwrap())
@@ -193,7 +193,7 @@ fn test_go_side_effect_import() {
 
 #[test]
 fn test_go_wildcard_import() {
-    let output = FileSpec::builder_with("main.go", GoLang::new())
+    let output = FileSpec::builder_with("main.go", Go::new())
         .header(CodeBlock::of("package main", ()).unwrap())
         .add_import(ImportSpec::wildcard("math"))
         .add_code(CodeBlock::of("// use math", ()).unwrap())
@@ -209,7 +209,7 @@ fn test_go_wildcard_import() {
 fn test_go_mixed_side_effect_and_named() {
     let fmt = TypeName::importable("fmt", "Println");
 
-    let output = FileSpec::builder_with("main.go", GoLang::new())
+    let output = FileSpec::builder_with("main.go", Go::new())
         .header(CodeBlock::of("package main", ()).unwrap())
         .add_import(ImportSpec::side_effect("github.com/lib/pq"))
         .add_code(CodeBlock::of("%T(\"hello\")", (fmt,)).unwrap())
@@ -255,7 +255,7 @@ fn test_python_wildcard_import() {
 
 #[test]
 fn test_java_wildcard_import() {
-    let output = FileSpec::builder_with("App.java", JavaLang::new())
+    let output = FileSpec::builder_with("App.java", Java::new())
         .add_import(ImportSpec::wildcard("java.util"))
         .add_code(CodeBlock::of("// code", ()).unwrap())
         .build()
@@ -268,7 +268,7 @@ fn test_java_wildcard_import() {
 
 #[test]
 fn test_java_forced_named_import() {
-    let output = FileSpec::builder_with("App.java", JavaLang::new())
+    let output = FileSpec::builder_with("App.java", Java::new())
         .add_import(ImportSpec::named("java.util", "List"))
         .add_code(CodeBlock::of("// code", ()).unwrap())
         .build()
@@ -313,7 +313,7 @@ fn test_swift_forced_module_import() {
 
 #[test]
 fn test_dart_side_effect_import() {
-    let output = FileSpec::builder_with("app.dart", DartLang::new())
+    let output = FileSpec::builder_with("app.dart", Dart::new())
         .add_import(ImportSpec::side_effect("package:flutter/material.dart"))
         .add_code(CodeBlock::of("// code", ()).unwrap())
         .build()

--- a/tests/java/builder_control_flow.rs
+++ b/tests/java/builder_control_flow.rs
@@ -1,5 +1,5 @@
 use sigil_stitch::code_block::CodeBlock;
-use sigil_stitch::lang::java_lang::JavaLang;
+use sigil_stitch::lang::java::Java;
 use sigil_stitch::spec::file_spec::FileSpec;
 
 use super::golden;
@@ -16,7 +16,7 @@ fn test_control_flow() {
     b.end_control_flow();
     let block = b.build().unwrap();
 
-    let file = FileSpec::builder_with("Flow.java", JavaLang::new())
+    let file = FileSpec::builder_with("Flow.java", Java::new())
         .add_code(block)
         .build()
         .unwrap();

--- a/tests/java/builder_edge_cases.rs
+++ b/tests/java/builder_edge_cases.rs
@@ -1,5 +1,5 @@
 use sigil_stitch::code_block::CodeBlock;
-use sigil_stitch::lang::java_lang::JavaLang;
+use sigil_stitch::lang::java::Java;
 use sigil_stitch::spec::field_spec::FieldSpec;
 use sigil_stitch::spec::file_spec::FileSpec;
 use sigil_stitch::spec::fun_spec::FunSpec;
@@ -41,7 +41,7 @@ fn test_static_final_field() {
         .build()
         .unwrap();
 
-    let file = FileSpec::builder_with("Constants.java", JavaLang::new())
+    let file = FileSpec::builder_with("Constants.java", Java::new())
         .add_type(ts)
         .build()
         .unwrap();
@@ -68,7 +68,7 @@ fn test_annotated_method() {
         .build()
         .unwrap();
 
-    let file = FileSpec::builder_with("Dog.java", JavaLang::new())
+    let file = FileSpec::builder_with("Dog.java", Java::new())
         .add_type(ts)
         .build()
         .unwrap();
@@ -154,7 +154,7 @@ fn test_full_module() {
         .build()
         .unwrap();
 
-    let file = FileSpec::builder_with("UserRepo.java", JavaLang::new())
+    let file = FileSpec::builder_with("UserRepo.java", Java::new())
         .add_type(iface_spec)
         .add_type(cls_spec)
         .build()

--- a/tests/java/builder_functions.rs
+++ b/tests/java/builder_functions.rs
@@ -1,5 +1,5 @@
 use sigil_stitch::code_block::CodeBlock;
-use sigil_stitch::lang::java_lang::JavaLang;
+use sigil_stitch::lang::java::Java;
 use sigil_stitch::spec::file_spec::FileSpec;
 use sigil_stitch::spec::fun_spec::FunSpec;
 use sigil_stitch::spec::modifiers::{TypeKind, Visibility};
@@ -22,7 +22,7 @@ fn test_function_with_doc() {
         .build()
         .unwrap();
 
-    let file = FileSpec::builder_with("Greet.java", JavaLang::new())
+    let file = FileSpec::builder_with("Greet.java", Java::new())
         .add_function(fun)
         .build()
         .unwrap();
@@ -47,7 +47,7 @@ fn test_generic_type_params_before_return_type() {
         .build()
         .unwrap();
 
-    let file = FileSpec::builder_with("Sort.java", JavaLang::new())
+    let file = FileSpec::builder_with("Sort.java", Java::new())
         .add_function(fun)
         .build()
         .unwrap();
@@ -81,7 +81,7 @@ fn test_override_annotation() {
         .build()
         .unwrap();
 
-    let file = FileSpec::builder_with("Dog.java", JavaLang::new())
+    let file = FileSpec::builder_with("Dog.java", Java::new())
         .add_type(ts)
         .build()
         .unwrap();
@@ -111,7 +111,7 @@ fn test_generic_params_before_return_golden() {
         .build()
         .unwrap();
 
-    let file = FileSpec::builder_with("Utils.java", JavaLang::new())
+    let file = FileSpec::builder_with("Utils.java", Java::new())
         .add_type(ts)
         .build()
         .unwrap();

--- a/tests/java/builder_imports.rs
+++ b/tests/java/builder_imports.rs
@@ -1,5 +1,5 @@
 use sigil_stitch::code_block::CodeBlock;
-use sigil_stitch::lang::java_lang::JavaLang;
+use sigil_stitch::lang::java::Java;
 use sigil_stitch::spec::file_spec::FileSpec;
 use sigil_stitch::type_name::TypeName;
 
@@ -14,7 +14,7 @@ fn test_function_with_imports() {
     b.add_statement("%T<%T> users = getAll()", (list, user));
     let block = b.build().unwrap();
 
-    let file = FileSpec::builder_with("App.java", JavaLang::new())
+    let file = FileSpec::builder_with("App.java", Java::new())
         .add_code(block)
         .build()
         .unwrap();
@@ -36,7 +36,7 @@ fn test_import_grouping() {
     b.add_line();
     let block = b.build().unwrap();
 
-    let file = FileSpec::builder_with("Imports.java", JavaLang::new())
+    let file = FileSpec::builder_with("Imports.java", Java::new())
         .add_code(block)
         .build()
         .unwrap();

--- a/tests/java/builder_types.rs
+++ b/tests/java/builder_types.rs
@@ -1,5 +1,5 @@
 use sigil_stitch::code_block::CodeBlock;
-use sigil_stitch::lang::java_lang::JavaLang;
+use sigil_stitch::lang::java::Java;
 use sigil_stitch::spec::enum_variant_spec::EnumVariantSpec;
 use sigil_stitch::spec::field_spec::FieldSpec;
 use sigil_stitch::spec::file_spec::FileSpec;
@@ -59,7 +59,7 @@ fn test_class_with_methods() {
         .build()
         .unwrap();
 
-    let file = FileSpec::builder_with("UserService.java", JavaLang::new())
+    let file = FileSpec::builder_with("UserService.java", Java::new())
         .add_type(ts)
         .build()
         .unwrap();
@@ -100,7 +100,7 @@ fn test_interface() {
         .build()
         .unwrap();
 
-    let file = FileSpec::builder_with("Repository.java", JavaLang::new())
+    let file = FileSpec::builder_with("Repository.java", Java::new())
         .add_type(ts)
         .build()
         .unwrap();
@@ -137,7 +137,7 @@ fn test_abstract_class() {
         .build()
         .unwrap();
 
-    let file = FileSpec::builder_with("Shape.java", JavaLang::new())
+    let file = FileSpec::builder_with("Shape.java", Java::new())
         .add_type(ts)
         .build()
         .unwrap();
@@ -169,7 +169,7 @@ fn test_class_extends_implements() {
         .build()
         .unwrap();
 
-    let file = FileSpec::builder_with("AdminService.java", JavaLang::new())
+    let file = FileSpec::builder_with("AdminService.java", Java::new())
         .add_type(ts)
         .build()
         .unwrap();
@@ -189,7 +189,7 @@ fn test_enum() {
         .build()
         .unwrap();
 
-    let file = FileSpec::builder_with("Color.java", JavaLang::new())
+    let file = FileSpec::builder_with("Color.java", Java::new())
         .add_type(ts)
         .build()
         .unwrap();
@@ -245,7 +245,7 @@ fn test_enum_with_values() {
         .build()
         .unwrap();
 
-    let file = FileSpec::builder_with("PetStatus.java", JavaLang::new())
+    let file = FileSpec::builder_with("PetStatus.java", Java::new())
         .add_type(ts)
         .build()
         .unwrap();
@@ -283,7 +283,7 @@ fn test_generic_class() {
         .build()
         .unwrap();
 
-    let file = FileSpec::builder_with("SortedContainer.java", JavaLang::new())
+    let file = FileSpec::builder_with("SortedContainer.java", Java::new())
         .add_type(ts)
         .build()
         .unwrap();

--- a/tests/java/quote_basic.rs
+++ b/tests/java/quote_basic.rs
@@ -1,12 +1,12 @@
 use sigil_stitch::code_block::CodeBlock;
-use sigil_stitch::lang::java_lang::JavaLang;
+use sigil_stitch::lang::java::Java;
 use sigil_stitch::prelude::*;
 use sigil_stitch::spec::file_spec::FileSpec;
 
 use super::golden;
 
 fn render(block: &CodeBlock) -> String {
-    FileSpec::builder_with("Test.java", JavaLang::new())
+    FileSpec::builder_with("Test.java", Java::new())
         .add_code(block.clone())
         .build()
         .unwrap()
@@ -21,7 +21,7 @@ fn test_basic() {
 
 #[test]
 fn test_override_method() {
-    let block = sigil_quote!(JavaLang {
+    let block = sigil_quote!(Java {
         @Override
         public String speak() {
             return "Woof!";
@@ -33,7 +33,7 @@ fn test_override_method() {
 
 #[test]
 fn test_generic_static_method() {
-    let block = sigil_quote!(JavaLang {
+    let block = sigil_quote!(Java {
         public static <T extends Comparable> List<T> sortList(List<T> list) {
             Collections.sort(list);
             return list;

--- a/tests/java/quote_edge_cases.rs
+++ b/tests/java/quote_edge_cases.rs
@@ -1,12 +1,12 @@
 use sigil_stitch::code_block::CodeBlock;
-use sigil_stitch::lang::java_lang::JavaLang;
+use sigil_stitch::lang::java::Java;
 use sigil_stitch::prelude::*;
 use sigil_stitch::spec::file_spec::FileSpec;
 
 use super::golden;
 
 fn render(block: &CodeBlock) -> String {
-    FileSpec::builder_with("Test.java", JavaLang::new())
+    FileSpec::builder_with("Test.java", Java::new())
         .add_code(block.clone())
         .build()
         .unwrap()
@@ -16,7 +16,7 @@ fn render(block: &CodeBlock) -> String {
 
 #[test]
 fn test_ternary() {
-    let block = sigil_quote!(JavaLang {
+    let block = sigil_quote!(Java {
         String result = x != null ? x.toString() : "default";
         int value = flag ? 1 : 0;
     })
@@ -26,7 +26,7 @@ fn test_ternary() {
 
 #[test]
 fn test_generic_method() {
-    let block = sigil_quote!(JavaLang {
+    let block = sigil_quote!(Java {
         public <T> T fromJson(String json, Class<T> clazz) {
             return gson.fromJson(json, clazz);
         }
@@ -37,7 +37,7 @@ fn test_generic_method() {
 
 #[test]
 fn test_annotation() {
-    let block = sigil_quote!(JavaLang {
+    let block = sigil_quote!(Java {
         @Override
         public String toString() {
             return $S("MyClass");
@@ -49,7 +49,7 @@ fn test_annotation() {
 
 #[test]
 fn test_stream_api() {
-    let block = sigil_quote!(JavaLang {
+    let block = sigil_quote!(Java {
         List<String> names = users.stream()
             .filter(u -> u.isActive())
             .map(u -> u.getName())
@@ -61,7 +61,7 @@ fn test_stream_api() {
 
 #[test]
 fn test_try_with_resources() {
-    let block = sigil_quote!(JavaLang {
+    let block = sigil_quote!(Java {
         try (BufferedReader reader = new BufferedReader(new FileReader(path))) {
             String line = reader.readLine();
             System.out.println(line);
@@ -74,7 +74,7 @@ fn test_try_with_resources() {
 #[test]
 fn test_name_keyword_escape_in_macro() {
     let name = "class";
-    let block = sigil_quote!(JavaLang {
+    let block = sigil_quote!(Java {
         $N(name) = 1;
     })
     .unwrap();

--- a/tests/java/quote_imports.rs
+++ b/tests/java/quote_imports.rs
@@ -1,5 +1,5 @@
 use sigil_stitch::code_block::CodeBlock;
-use sigil_stitch::lang::java_lang::JavaLang;
+use sigil_stitch::lang::java::Java;
 use sigil_stitch::prelude::*;
 use sigil_stitch::spec::file_spec::FileSpec;
 use sigil_stitch::type_name::TypeName;
@@ -7,7 +7,7 @@ use sigil_stitch::type_name::TypeName;
 use super::golden;
 
 fn render(block: &CodeBlock) -> String {
-    FileSpec::builder_with("Test.java", JavaLang::new())
+    FileSpec::builder_with("Test.java", Java::new())
         .add_code(block.clone())
         .build()
         .unwrap()
@@ -19,7 +19,7 @@ fn render(block: &CodeBlock) -> String {
 fn test_imports() {
     let list_type = TypeName::importable("java.util", "List");
     let map_type = TypeName::importable("java.util", "Map");
-    let block = sigil_quote!(JavaLang {
+    let block = sigil_quote!(Java {
         $T(list_type) items = new ArrayList<>();
         $T(map_type) lookup = new HashMap<>();
     })

--- a/tests/java/quote_suite.rs
+++ b/tests/java/quote_suite.rs
@@ -1,5 +1,5 @@
 use sigil_stitch::code_block::CodeBlock;
-use sigil_stitch::lang::java_lang::JavaLang;
+use sigil_stitch::lang::java::Java;
 use sigil_stitch::prelude::*;
 use sigil_stitch::spec::file_spec::FileSpec;
 
@@ -9,7 +9,7 @@ pub struct JavaSuite;
 
 impl LanguageTestSuite for JavaSuite {
     fn control_flow_block() -> CodeBlock {
-        sigil_quote!(JavaLang {
+        sigil_quote!(Java {
             if(x > 0) {
                 return $S("positive");
             } else {
@@ -24,7 +24,7 @@ impl LanguageTestSuite for JavaSuite {
     }
 
     fn basic_block() -> CodeBlock {
-        sigil_quote!(JavaLang {
+        sigil_quote!(Java {
             String name = $S("Alice");
             int age = 30;
             System.out.println(name);
@@ -37,7 +37,7 @@ impl LanguageTestSuite for JavaSuite {
     }
 
     fn render(block: CodeBlock) -> String {
-        FileSpec::builder_with("Test.java", JavaLang::new())
+        FileSpec::builder_with("Test.java", Java::new())
             .add_code(block)
             .build()
             .unwrap()

--- a/tests/java/quote_verbatim_string.rs
+++ b/tests/java/quote_verbatim_string.rs
@@ -45,7 +45,7 @@ fn verbatim_at_interpolation_multiple() {
 
 #[test]
 fn attr_annotation_java() {
-    let block = sigil_quote!(JavaLang {
+    let block = sigil_quote!(Java {
         $attr("Override")
 
         public String toString() {

--- a/tests/macro/c_each.rs
+++ b/tests/macro/c_each.rs
@@ -339,20 +339,20 @@ fn test_c_each_in_control_flow_no_blank_lines() {
 
 #[test]
 fn test_c_each_no_trailing_blank_line_in_fun_spec_body() {
-    use sigil_stitch::lang::java_lang::JavaLang;
+    use sigil_stitch::lang::java::Java;
 
     let fields = ["statusCode", "raw", "status200"];
     let assignments: Vec<CodeBlock> = fields
         .iter()
         .map(|f| {
-            sigil_quote!(JavaLang {
+            sigil_quote!(Java {
                 this.$N(*f) = $N(*f);
             })
             .unwrap()
         })
         .collect();
 
-    let ctor_body = sigil_quote!(JavaLang {
+    let ctor_body = sigil_quote!(Java {
         $C_each(assignments);
     })
     .unwrap();
@@ -363,7 +363,7 @@ fn test_c_each_no_trailing_blank_line_in_fun_spec_body() {
     ctor = ctor.body(ctor_body);
     cls = cls.add_method(ctor.build().unwrap());
 
-    let file = FileSpec::builder_with("TestClass.java", JavaLang::new())
+    let file = FileSpec::builder_with("TestClass.java", Java::new())
         .add_type(cls.build().unwrap())
         .build()
         .unwrap();

--- a/tests/macro/comments.rs
+++ b/tests/macro/comments.rs
@@ -253,7 +253,7 @@ fn test_attr_with_dynamic_expression() {
 #[test]
 fn test_attr_with_format_expression() {
     let name = "Debug";
-    let block = sigil_quote!(RustLang {
+    let block = sigil_quote!(Rust {
         $attr(format!("derive({name}, Clone)"));
 
         struct Foo;
@@ -285,7 +285,7 @@ fn test_attr_with_to_string_expression() {
 #[test]
 fn test_attr_with_at_interpolation() {
     let trait_name = "Debug";
-    let block = sigil_quote!(RustLang {
+    let block = sigil_quote!(Rust {
         $attr("derive(@{trait_name}, Clone)");
 
         struct Foo;
@@ -334,7 +334,7 @@ fn test_attr_basic_typescript() {
 
 #[test]
 fn test_attr_basic_rust() {
-    let block = sigil_quote!(RustLang {
+    let block = sigil_quote!(Rust {
         $attr("derive(Debug, Clone)")
 
         struct Foo;
@@ -362,7 +362,7 @@ fn test_attr_multiple() {
 
 #[test]
 fn test_attr_cpp_double_bracket() {
-    let block = sigil_quote!(CppLang {
+    let block = sigil_quote!(Cpp {
         $attr("nodiscard")
 
         int getValue() {
@@ -377,7 +377,7 @@ fn test_attr_cpp_double_bracket() {
 
 #[test]
 fn test_attr_rust_derive() {
-    let block = sigil_quote!(RustLang {
+    let block = sigil_quote!(Rust {
         $attr("derive(Debug, Clone, Serialize, Deserialize)")
 
         pub struct $N("User") {
@@ -396,7 +396,7 @@ fn test_attr_rust_derive() {
 #[test]
 fn test_attr_with_if_conditional() {
     let needs_serde = true;
-    let block = sigil_quote!(RustLang {
+    let block = sigil_quote!(Rust {
         $attr("derive(Debug, Clone)")
 
         $if(needs_serde) {

--- a/tests/macro/cross_lang_spacing.rs
+++ b/tests/macro/cross_lang_spacing.rs
@@ -6,7 +6,7 @@ use super::helpers::*;
 
 #[test]
 fn test_cpp_nested_templates() {
-    let block = sigil_quote!(CppLang {
+    let block = sigil_quote!(Cpp {
         std::vector<std::vector<std::map<std::string, uint64_t>>> nested;
     })
     .unwrap();
@@ -21,7 +21,7 @@ fn test_cpp_nested_templates() {
 
 #[test]
 fn test_cpp_right_shift_operator() {
-    let block = sigil_quote!(CppLang {
+    let block = sigil_quote!(Cpp {
         int result = x >> 2;
     })
     .unwrap();
@@ -35,7 +35,7 @@ fn test_cpp_right_shift_operator() {
 
 #[test]
 fn test_cpp_left_shift_operator() {
-    let block = sigil_quote!(CppLang {
+    let block = sigil_quote!(Cpp {
         int result = x << 2;
     })
     .unwrap();
@@ -49,7 +49,7 @@ fn test_cpp_left_shift_operator() {
 
 #[test]
 fn test_cpp_namespace_path() {
-    let block = sigil_quote!(CppLang {
+    let block = sigil_quote!(Cpp {
         std::unique_ptr<std::vector<int>> ptr = std::make_unique<std::vector<int>>();
     })
     .unwrap();
@@ -63,7 +63,7 @@ fn test_cpp_namespace_path() {
 fn test_cpp_pointer_and_reference() {
     // After an ident, `&`/`*` are treated as binary (ambiguous with bitwise ops).
     // For tight reference/pointer params, use ParameterSpec or TypeName.
-    let block = sigil_quote!(CppLang {
+    let block = sigil_quote!(Cpp {
         void foo(const std::string &name, int *ptr);
     })
     .unwrap();
@@ -79,7 +79,7 @@ fn test_cpp_pointer_and_reference() {
 
 #[test]
 fn test_cpp_template_with_comparison() {
-    let block = sigil_quote!(CppLang {
+    let block = sigil_quote!(Cpp {
         if(x < 5 && y > 10) {
             return;
         }
@@ -99,7 +99,7 @@ fn test_cpp_template_with_comparison() {
 
 #[test]
 fn test_cpp_stream_operators() {
-    let block = sigil_quote!(CppLang {
+    let block = sigil_quote!(Cpp {
         std::cout << "value: " << x << std::endl;
     })
     .unwrap();
@@ -122,7 +122,7 @@ fn test_cpp_stream_operators() {
 
 #[test]
 fn test_java_nested_generics() {
-    let block = sigil_quote!(JavaLang {
+    let block = sigil_quote!(Java {
         Map<String, List<Set<Integer>>> map = new HashMap<>();
     })
     .unwrap();
@@ -140,7 +140,7 @@ fn test_java_nested_generics() {
 
 #[test]
 fn test_java_right_shift() {
-    let block = sigil_quote!(JavaLang {
+    let block = sigil_quote!(Java {
         int x = value >> 3;
     })
     .unwrap();
@@ -154,7 +154,7 @@ fn test_java_right_shift() {
 
 #[test]
 fn test_java_unsigned_right_shift() {
-    let block = sigil_quote!(JavaLang {
+    let block = sigil_quote!(Java {
         int x = value >>> 3;
     })
     .unwrap();
@@ -168,7 +168,7 @@ fn test_java_unsigned_right_shift() {
 
 #[test]
 fn test_java_generic_method_call() {
-    let block = sigil_quote!(JavaLang {
+    let block = sigil_quote!(Java {
         List<String> items = Collections.<String>emptyList();
     })
     .unwrap();
@@ -182,7 +182,7 @@ fn test_java_generic_method_call() {
 
 #[test]
 fn test_java_wildcard_generics() {
-    let block = sigil_quote!(JavaLang {
+    let block = sigil_quote!(Java {
         List<? extends Comparable<? super T>> items;
     })
     .unwrap();
@@ -418,7 +418,7 @@ fn test_swift_right_shift() {
 
 #[test]
 fn test_rust_array_typing() {
-    let block = sigil_quote!(RustLang {
+    let block = sigil_quote!(Rust {
         let matrix: [[i32; N]; M] = [[0; N]; M];
     })
     .unwrap();
@@ -436,7 +436,7 @@ fn test_rust_array_typing() {
 
 #[test]
 fn test_rust_deeply_nested_generics() {
-    let block = sigil_quote!(RustLang {
+    let block = sigil_quote!(Rust {
         let x: Arc<Mutex<HashMap<String, Vec<Option<u32>>>>> = Arc::new(Mutex::new(HashMap::new()));
     })
     .unwrap();
@@ -450,7 +450,7 @@ fn test_rust_deeply_nested_generics() {
 
 #[test]
 fn test_rust_right_shift_operator() {
-    let block = sigil_quote!(RustLang {
+    let block = sigil_quote!(Rust {
         let x = value >> 2;
     })
     .unwrap();
@@ -464,7 +464,7 @@ fn test_rust_right_shift_operator() {
 
 #[test]
 fn test_rust_left_shift_operator() {
-    let block = sigil_quote!(RustLang {
+    let block = sigil_quote!(Rust {
         let x = 1 << 8;
     })
     .unwrap();
@@ -478,7 +478,7 @@ fn test_rust_left_shift_operator() {
 
 #[test]
 fn test_rust_generic_with_trait_bounds_inline() {
-    let block = sigil_quote!(RustLang {
+    let block = sigil_quote!(Rust {
         let x: Box<dyn Iterator<Item = u32>> = todo!();
     })
     .unwrap();
@@ -496,7 +496,7 @@ fn test_rust_generic_with_trait_bounds_inline() {
 
 #[test]
 fn test_rust_multiple_macro_calls() {
-    let block = sigil_quote!(RustLang {
+    let block = sigil_quote!(Rust {
         vec![1, 2, 3];
         println!("done");
         assert!(true);
@@ -519,7 +519,7 @@ fn test_rust_multiple_macro_calls() {
 
 #[test]
 fn test_rust_double_reference() {
-    let block = sigil_quote!(RustLang {
+    let block = sigil_quote!(Rust {
         fn foo(x: &&str) {}
     })
     .unwrap();
@@ -530,7 +530,7 @@ fn test_rust_double_reference() {
 
 #[test]
 fn test_rust_deref_field_access() {
-    let block = sigil_quote!(RustLang {
+    let block = sigil_quote!(Rust {
         let x = (*ptr).field;
     })
     .unwrap();
@@ -564,7 +564,7 @@ fn test_scala_nested_generics() {
 
 #[test]
 fn test_dart_nested_generics() {
-    let block = sigil_quote!(DartLang {
+    let block = sigil_quote!(Dart {
         Map<String, List<Set<int>>> map = {};
     })
     .unwrap();
@@ -578,7 +578,7 @@ fn test_dart_nested_generics() {
 
 #[test]
 fn test_dart_null_aware_access() {
-    let block = sigil_quote!(DartLang {
+    let block = sigil_quote!(Dart {
         var len = obj?.name?.length;
     })
     .unwrap();
@@ -596,7 +596,7 @@ fn test_dart_null_aware_access() {
 
 #[test]
 fn test_go_pointer_and_address() {
-    let block = sigil_quote!(GoLang {
+    let block = sigil_quote!(Go {
         ptr := &x;
         val := *ptr;
     })
@@ -609,7 +609,7 @@ fn test_go_pointer_and_address() {
 
 #[test]
 fn test_go_shift_operators() {
-    let block = sigil_quote!(GoLang {
+    let block = sigil_quote!(Go {
         x := y << 2;
         z := w >> 3;
     })
@@ -628,7 +628,7 @@ fn test_go_shift_operators() {
 
 #[test]
 fn test_go_comparison_operators() {
-    let block = sigil_quote!(GoLang {
+    let block = sigil_quote!(Go {
         if x < 5 && y > 10 {
             return;
         }

--- a/tests/macro/equivalence.rs
+++ b/tests/macro/equivalence.rs
@@ -167,7 +167,7 @@ fn test_equiv_wrap_point() {
 #[test]
 fn test_name_escaping_via_macro_rust() {
     let field_name = "type";
-    let macro_block = sigil_quote!(RustLang {
+    let macro_block = sigil_quote!(Rust {
         let $N(field_name) = value;
     })
     .unwrap();
@@ -182,7 +182,7 @@ fn test_name_escaping_via_macro_rust() {
 #[test]
 fn test_name_escaping_via_macro_go() {
     let var_name = "func";
-    let macro_block = sigil_quote!(GoLang {
+    let macro_block = sigil_quote!(Go {
         var $N(var_name) int
     })
     .unwrap();
@@ -217,7 +217,7 @@ fn test_name_no_escape_via_macro() {
 fn test_name_and_type_combined() {
     let field_name = "type";
     let field_type = TypeName::primitive("String");
-    let macro_block = sigil_quote!(RustLang {
+    let macro_block = sigil_quote!(Rust {
         pub $N(field_name): $T(field_type)
     })
     .unwrap();

--- a/tests/macro/helpers.rs
+++ b/tests/macro/helpers.rs
@@ -1,11 +1,11 @@
 pub use sigil_stitch::code_block::{CodeBlock, NameArg, StringLitArg};
 pub use sigil_stitch::import_collector;
-pub use sigil_stitch::lang::c_lang::CLang;
-pub use sigil_stitch::lang::cpp_lang::CppLang;
+pub use sigil_stitch::lang::c::C;
+pub use sigil_stitch::lang::cpp::Cpp;
 pub use sigil_stitch::lang::csharp::CSharp;
-pub use sigil_stitch::lang::dart::DartLang;
+pub use sigil_stitch::lang::dart::Dart;
 pub use sigil_stitch::lang::haskell::Haskell;
-pub use sigil_stitch::lang::java_lang::JavaLang;
+pub use sigil_stitch::lang::java::Java;
 pub use sigil_stitch::lang::kotlin::Kotlin;
 pub use sigil_stitch::lang::lua::Lua;
 pub use sigil_stitch::lang::ocaml::OCaml;
@@ -33,7 +33,7 @@ pub fn render_ts(block: &CodeBlock) -> String {
 }
 
 pub fn render_c(block: &CodeBlock) -> String {
-    let file = FileSpec::builder_with("test.c", CLang::new())
+    let file = FileSpec::builder_with("test.c", C::new())
         .add_code(block.clone())
         .build()
         .unwrap();
@@ -81,7 +81,7 @@ pub fn render_ml(block: &CodeBlock) -> String {
 }
 
 pub fn render_java(block: &CodeBlock) -> String {
-    let file = FileSpec::builder_with("Test.java", JavaLang::new())
+    let file = FileSpec::builder_with("Test.java", Java::new())
         .add_code(block.clone())
         .build()
         .unwrap();
@@ -97,7 +97,7 @@ pub fn render_kt(block: &CodeBlock) -> String {
 }
 
 pub fn render_cpp(block: &CodeBlock) -> String {
-    let file = FileSpec::builder_with("test.cpp", CppLang::new())
+    let file = FileSpec::builder_with("test.cpp", Cpp::new())
         .add_code(block.clone())
         .build()
         .unwrap();
@@ -129,7 +129,7 @@ pub fn render_swift(block: &CodeBlock) -> String {
 }
 
 pub fn render_dart(block: &CodeBlock) -> String {
-    let file = FileSpec::builder_with("test.dart", DartLang::new())
+    let file = FileSpec::builder_with("test.dart", Dart::new())
         .add_code(block.clone())
         .build()
         .unwrap();

--- a/tests/macro/meta_let.rs
+++ b/tests/macro/meta_let.rs
@@ -172,7 +172,7 @@ fn test_meta_let_with_code_block_interpolation() {
 fn test_meta_let_in_for_with_conditional() {
     let variants = vec![("red", "Red"), ("green_ish", "GreenIsh"), ("blue", "Blue")];
 
-    let block = sigil_quote!(RustLang {
+    let block = sigil_quote!(Rust {
         $for((raw, pascal) in &variants) {
             $let(needs_rename = *raw != pascal.to_lowercase());
             $if(needs_rename) {
@@ -452,7 +452,7 @@ fn test_meta_let_result_question_mark_propagates_err() {
 
 #[test]
 fn test_meta_let_with_rust_lang() {
-    let block = sigil_quote!(RustLang {
+    let block = sigil_quote!(Rust {
         $let(name = "MyStruct");
         $let(field_name = "value");
         pub struct $N(name) {
@@ -486,7 +486,7 @@ fn test_meta_let_with_python() {
 #[test]
 fn test_meta_let_with_go() {
     let constants = vec![("StatusOK", "200"), ("StatusNotFound", "404")];
-    let block = sigil_quote!(GoLang {
+    let block = sigil_quote!(Go {
         $for((name, code) in &constants) {
             $let(full = format!("HTTP{name}"));
             const $N(full) = $L(*code);
@@ -514,7 +514,7 @@ fn test_real_world_rust_string_enum() {
         ("BLUE", Some("BLUE")),
     ];
 
-    let block = sigil_quote!(RustLang {
+    let block = sigil_quote!(Rust {
         $for((raw, json_val) in &values) {
             $let(pascal = raw
                 .split('_')
@@ -557,7 +557,7 @@ fn helper_real_world_fallible_enum() -> Option<String> {
         Value::String("blue".into()),
     ];
 
-    let block = sigil_quote!(RustLang {
+    let block = sigil_quote!(Rust {
         $for(v in &values) {
             $let(s = v.as_str()?);
             $let(variant = s
@@ -598,7 +598,7 @@ fn helper_real_world_fallible_enum_with_non_string() -> Option<String> {
     use serde_json::Value;
     let values: Vec<Value> = vec![Value::String("red".into()), Value::Number(42.into())];
 
-    let block = sigil_quote!(RustLang {
+    let block = sigil_quote!(Rust {
         $for(v in &values) {
             $let(s = v.as_str()?);
             $L(format!("{},", s))

--- a/tests/macro/multi_language.rs
+++ b/tests/macro/multi_language.rs
@@ -2,7 +2,7 @@ use super::helpers::*;
 
 #[test]
 fn test_rust_language() {
-    let block = sigil_quote!(RustLang {
+    let block = sigil_quote!(Rust {
         let x = 42;
     })
     .unwrap();
@@ -37,7 +37,7 @@ fn test_python_control_flow() {
 
 #[test]
 fn test_go_language() {
-    let block = sigil_quote!(GoLang {
+    let block = sigil_quote!(Go {
         x := 42;
     })
     .unwrap();

--- a/tests/macro/rust_spacing.rs
+++ b/tests/macro/rust_spacing.rs
@@ -2,7 +2,7 @@ use super::helpers::*;
 
 #[test]
 fn test_path_separator_no_space() {
-    let block = sigil_quote!(RustLang {
+    let block = sigil_quote!(Rust {
         let x = std::fmt::Display;
     })
     .unwrap();
@@ -15,7 +15,7 @@ fn test_path_separator_no_space() {
 
 #[test]
 fn test_reference_prefix() {
-    let block = sigil_quote!(RustLang {
+    let block = sigil_quote!(Rust {
         fn foo(&self, x: &mut T) {}
     })
     .unwrap();
@@ -32,7 +32,7 @@ fn test_reference_prefix() {
 
 #[test]
 fn test_deref_prefix() {
-    let block = sigil_quote!(RustLang {
+    let block = sigil_quote!(Rust {
         let x = *self;
     })
     .unwrap();
@@ -47,7 +47,7 @@ fn test_deref_prefix() {
 
 #[test]
 fn test_macro_call_no_space() {
-    let block = sigil_quote!(RustLang {
+    let block = sigil_quote!(Rust {
         println!("hello");
     })
     .unwrap();
@@ -62,7 +62,7 @@ fn test_macro_call_no_space() {
 
 #[test]
 fn test_generic_angle_brackets() {
-    let block = sigil_quote!(RustLang {
+    let block = sigil_quote!(Rust {
         let x: Vec<T> = Vec::new();
         let y: Option<String> = None;
     })
@@ -75,7 +75,7 @@ fn test_generic_angle_brackets() {
 
 #[test]
 fn test_turbofish() {
-    let block = sigil_quote!(RustLang {
+    let block = sigil_quote!(Rust {
         let size = std::mem::size_of::<u32>();
     })
     .unwrap();
@@ -86,7 +86,7 @@ fn test_turbofish() {
 
 #[test]
 fn test_nested_generics() {
-    let block = sigil_quote!(RustLang {
+    let block = sigil_quote!(Rust {
         let x: HashMap<K, Vec<V>> = HashMap::new();
     })
     .unwrap();
@@ -97,7 +97,7 @@ fn test_nested_generics() {
 
 #[test]
 fn test_lifetime_in_generic() {
-    let block = sigil_quote!(RustLang {
+    let block = sigil_quote!(Rust {
         fn fmt(&self, f: &mut Formatter<'_>) {}
     })
     .unwrap();
@@ -108,7 +108,7 @@ fn test_lifetime_in_generic() {
 
 #[test]
 fn test_generic_close_then_call() {
-    let block = sigil_quote!(RustLang {
+    let block = sigil_quote!(Rust {
         let v = iter.collect::<Vec<i32>>();
     })
     .unwrap();
@@ -119,7 +119,7 @@ fn test_generic_close_then_call() {
 
 #[test]
 fn test_binary_and_still_spaced() {
-    let block = sigil_quote!(RustLang {
+    let block = sigil_quote!(Rust {
         let x = a & b;
     })
     .unwrap();
@@ -143,7 +143,7 @@ fn test_comparison_still_spaced() {
 
 #[test]
 fn test_arrow_return_type() {
-    let block = sigil_quote!(RustLang {
+    let block = sigil_quote!(Rust {
         let f: fn() -> T = foo;
     })
     .unwrap();

--- a/tests/macro/spacing.rs
+++ b/tests/macro/spacing.rs
@@ -51,7 +51,7 @@ fn test_arrow_function() {
 
 #[test]
 fn test_rust_path_separator() {
-    let block = sigil_quote!(RustLang {
+    let block = sigil_quote!(Rust {
         let x = std::mem::size_of::<u32>();
     })
     .unwrap();
@@ -134,7 +134,7 @@ fn test_array_literal() {
 
 #[test]
 fn test_java_ternary_colon_spacing() {
-    let block = sigil_quote!(JavaLang {
+    let block = sigil_quote!(Java {
         String result = x != null ? x.toString() : "default";
     })
     .unwrap();
@@ -194,7 +194,7 @@ fn test_type_annotation_colon_no_space() {
 
 #[test]
 fn test_go_walrus_spacing() {
-    let block = sigil_quote!(GoLang {
+    let block = sigil_quote!(Go {
         x := 42;
     })
     .unwrap();
@@ -390,7 +390,7 @@ fn test_colon_ternary_resets_at_statement_boundary() {
 
 #[test]
 fn test_colon_ternary_in_java_error_handling() {
-    let block = sigil_quote!(JavaLang {
+    let block = sigil_quote!(Java {
         String msg = error != null ? error.getMessage() : "unknown";
     })
     .unwrap();
@@ -404,7 +404,7 @@ fn test_colon_ternary_in_java_error_handling() {
 
 #[test]
 fn test_colon_path_separator_rust() {
-    let block = sigil_quote!(RustLang {
+    let block = sigil_quote!(Rust {
         let v = std::collections::HashMap::new();
     })
     .unwrap();
@@ -420,12 +420,12 @@ fn test_colon_path_separator_rust() {
 
 #[test]
 fn test_colon_path_separator_cpp() {
-    let block = sigil_quote!(CppLang {
+    let block = sigil_quote!(Cpp {
         auto v = std::make_unique(42);
     })
     .unwrap();
 
-    let file = FileSpec::builder_with("test.cpp", sigil_stitch::lang::cpp_lang::CppLang::new())
+    let file = FileSpec::builder_with("test.cpp", sigil_stitch::lang::cpp::Cpp::new())
         .add_code(block)
         .build()
         .unwrap();
@@ -439,7 +439,7 @@ fn test_colon_path_separator_cpp() {
 
 #[test]
 fn test_colon_path_then_type_annotation() {
-    let block = sigil_quote!(RustLang {
+    let block = sigil_quote!(Rust {
         let x: std::string::String = String::new();
     })
     .unwrap();
@@ -451,7 +451,7 @@ fn test_colon_path_then_type_annotation() {
 
 #[test]
 fn test_colon_walrus_with_expression() {
-    let block = sigil_quote!(GoLang {
+    let block = sigil_quote!(Go {
         result := computeValue(42);
     })
     .unwrap();
@@ -465,7 +465,7 @@ fn test_colon_walrus_with_expression() {
 
 #[test]
 fn test_colon_walrus_multiple_assignments() {
-    let block = sigil_quote!(GoLang {
+    let block = sigil_quote!(Go {
         x := 1;
         y := 2;
         z := x + y;
@@ -480,7 +480,7 @@ fn test_colon_walrus_multiple_assignments() {
 
 #[test]
 fn test_colon_walrus_in_control_flow() {
-    let block = sigil_quote!(GoLang {
+    let block = sigil_quote!(Go {
         if err := doSomething() {
             return err;
         }
@@ -544,7 +544,7 @@ fn test_colon_context_kotlin_full_scenario() {
 
 #[test]
 fn test_colon_switch_case_label() {
-    let block = sigil_quote!(JavaLang {
+    let block = sigil_quote!(Java {
         switch(x) {
             case(1):
             return "one";
@@ -582,7 +582,7 @@ fn test_safe_call_let_no_space() {
 
 #[test]
 fn test_ternary_still_has_space_before_question() {
-    let block = sigil_quote!(JavaLang {
+    let block = sigil_quote!(Java {
         String result = x != null ? x.toString() : "default";
     })
     .unwrap();
@@ -607,7 +607,7 @@ fn test_elvis_no_space_before_question() {
 
 #[test]
 fn test_postfix_star_pointer_type() {
-    let block = sigil_quote!(CppLang {
+    let block = sigil_quote!(Cpp {
         Config* cfg = get_config();
     })
     .unwrap();
@@ -621,7 +621,7 @@ fn test_postfix_star_pointer_type() {
 
 #[test]
 fn test_postfix_star_const_pointer() {
-    let block = sigil_quote!(CppLang {
+    let block = sigil_quote!(Cpp {
         const char* host = get_host();
     })
     .unwrap();
@@ -707,7 +707,7 @@ fn test_binary_minus_still_spaced() {
 
 #[test]
 fn test_binary_star_still_spaced() {
-    let block = sigil_quote!(CLang {
+    let block = sigil_quote!(C {
         int x = a * b;
     })
     .unwrap();

--- a/tests/rust/builder_control_flow.rs
+++ b/tests/rust/builder_control_flow.rs
@@ -1,5 +1,5 @@
 use sigil_stitch::code_block::CodeBlock;
-use sigil_stitch::lang::rust_lang::RustLang;
+use sigil_stitch::lang::rust::Rust;
 use sigil_stitch::spec::file_spec::FileSpec;
 
 use super::golden;
@@ -25,7 +25,7 @@ fn test_control_flow() {
     b.add_line();
     let block = b.build().unwrap();
 
-    let file = FileSpec::builder_with("classify.rs", RustLang::new())
+    let file = FileSpec::builder_with("classify.rs", Rust::new())
         .add_code(block)
         .build()
         .unwrap();

--- a/tests/rust/builder_edge_cases.rs
+++ b/tests/rust/builder_edge_cases.rs
@@ -1,7 +1,7 @@
 use super::golden;
 
 use sigil_stitch::code_block::{CodeBlock, NameArg};
-use sigil_stitch::lang::rust_lang::RustLang;
+use sigil_stitch::lang::rust::Rust;
 use sigil_stitch::spec::annotation_spec::AnnotationSpec;
 use sigil_stitch::spec::field_spec::FieldSpec;
 use sigil_stitch::spec::file_spec::FileSpec;
@@ -11,7 +11,7 @@ use sigil_stitch::type_name::TypeName;
 
 #[test]
 fn test_optional_field() {
-    let output = FileSpec::builder_with("config.rs", RustLang::new())
+    let output = FileSpec::builder_with("config.rs", Rust::new())
         .add_type(
             TypeSpec::builder("Config", TypeKind::Struct)
                 .visibility(Visibility::Public)
@@ -54,7 +54,7 @@ fn test_derive_annotation() {
                 .unwrap(),
         );
 
-    let output = FileSpec::builder_with("point.rs", RustLang::new())
+    let output = FileSpec::builder_with("point.rs", Rust::new())
         .add_type(tb.build().unwrap())
         .build()
         .unwrap()
@@ -73,7 +73,7 @@ fn test_name_escapes_rust_keywords() {
     ];
     for kw in keywords {
         let block = CodeBlock::of("let %N = value", NameArg(kw.into())).unwrap();
-        let file = FileSpec::builder_with("test.rs", RustLang::new())
+        let file = FileSpec::builder_with("test.rs", Rust::new())
             .add_code(block)
             .build()
             .unwrap();
@@ -90,7 +90,7 @@ fn test_name_no_escape_non_keywords() {
     let names = ["user_id", "count", "my_struct", "TypeName", "snake_case"];
     for name in names {
         let block = CodeBlock::of("let %N = value", NameArg(name.into())).unwrap();
-        let file = FileSpec::builder_with("test.rs", RustLang::new())
+        let file = FileSpec::builder_with("test.rs", Rust::new())
             .add_code(block)
             .build()
             .unwrap();
@@ -112,7 +112,7 @@ fn test_name_escape_in_format_string() {
     cb.add_line();
     let block = cb.build().unwrap();
 
-    let file = FileSpec::builder_with("test.rs", RustLang::new())
+    let file = FileSpec::builder_with("test.rs", Rust::new())
         .add_code(block)
         .build()
         .unwrap();
@@ -124,7 +124,7 @@ fn test_name_escape_in_format_string() {
 
 #[test]
 fn test_annotation_args_with_type_spec() {
-    let output = FileSpec::builder_with("config.rs", RustLang::new())
+    let output = FileSpec::builder_with("config.rs", Rust::new())
         .add_type(
             TypeSpec::builder("Config", TypeKind::Struct)
                 .visibility(Visibility::Public)
@@ -148,7 +148,7 @@ fn test_annotation_args_with_type_spec() {
 
 #[test]
 fn test_annotation_args_serde_field() {
-    let output = FileSpec::builder_with("model.rs", RustLang::new())
+    let output = FileSpec::builder_with("model.rs", Rust::new())
         .add_type(
             TypeSpec::builder("User", TypeKind::Struct)
                 .visibility(Visibility::Public)

--- a/tests/rust/builder_functions.rs
+++ b/tests/rust/builder_functions.rs
@@ -1,5 +1,5 @@
 use sigil_stitch::code_block::CodeBlock;
-use sigil_stitch::lang::rust_lang::RustLang;
+use sigil_stitch::lang::rust::Rust;
 use sigil_stitch::spec::file_spec::FileSpec;
 use sigil_stitch::spec::fun_spec::FunSpec;
 use sigil_stitch::spec::modifiers::Visibility;
@@ -20,7 +20,7 @@ fn test_top_level_function() {
         .add_param(ParameterSpec::new("value", TypeName::primitive("&T")).unwrap())
         .body(body);
 
-    let output = FileSpec::builder_with("utils.rs", RustLang::new())
+    let output = FileSpec::builder_with("utils.rs", Rust::new())
         .add_function(fb.build().unwrap())
         .build()
         .unwrap()
@@ -40,7 +40,7 @@ fn test_function_with_doc() {
         .returns(TypeName::primitive("String"))
         .body(body);
 
-    let output = FileSpec::builder_with("greet.rs", RustLang::new())
+    let output = FileSpec::builder_with("greet.rs", Rust::new())
         .add_function(fb.build().unwrap())
         .build()
         .unwrap()

--- a/tests/rust/builder_imports.rs
+++ b/tests/rust/builder_imports.rs
@@ -1,5 +1,5 @@
 use sigil_stitch::code_block::CodeBlock;
-use sigil_stitch::lang::rust_lang::RustLang;
+use sigil_stitch::lang::rust::Rust;
 use sigil_stitch::spec::file_spec::FileSpec;
 use sigil_stitch::type_name::TypeName;
 
@@ -36,7 +36,7 @@ fn test_function_with_imports() {
     b2.add_line();
     let struct_block = b2.build().unwrap();
 
-    let file = FileSpec::builder_with("lib.rs", RustLang::new())
+    let file = FileSpec::builder_with("lib.rs", Rust::new())
         .add_code(func_block)
         .add_code(struct_block)
         .build()
@@ -76,7 +76,7 @@ fn test_import_grouping() {
     b.add_line();
     let block = b.build().unwrap();
 
-    let file = FileSpec::builder_with("main.rs", RustLang::new())
+    let file = FileSpec::builder_with("main.rs", Rust::new())
         .add_code(block)
         .build()
         .unwrap();
@@ -95,7 +95,7 @@ fn test_import_conflict() {
     b.add_statement("let u2: %T = todo!()", (user2,));
     let block = b.build().unwrap();
 
-    let file = FileSpec::builder_with("conflict.rs", RustLang::new())
+    let file = FileSpec::builder_with("conflict.rs", Rust::new())
         .add_code(block)
         .build()
         .unwrap();

--- a/tests/rust/builder_types.rs
+++ b/tests/rust/builder_types.rs
@@ -1,5 +1,5 @@
 use sigil_stitch::code_block::CodeBlock;
-use sigil_stitch::lang::rust_lang::RustLang;
+use sigil_stitch::lang::rust::Rust;
 use sigil_stitch::spec::enum_variant_spec::EnumVariantSpec;
 use sigil_stitch::spec::field_spec::FieldSpec;
 use sigil_stitch::spec::file_spec::FileSpec;
@@ -61,7 +61,7 @@ fn test_struct_with_impl() {
                 .unwrap(),
         );
 
-    let output = FileSpec::builder_with("config.rs", RustLang::new())
+    let output = FileSpec::builder_with("config.rs", Rust::new())
         .add_type(tb.build().unwrap())
         .build()
         .unwrap()
@@ -100,7 +100,7 @@ fn test_generic_struct() {
                 .unwrap(),
         );
 
-    let output = FileSpec::builder_with("container.rs", RustLang::new())
+    let output = FileSpec::builder_with("container.rs", Rust::new())
         .add_type(tb.build().unwrap())
         .build()
         .unwrap()
@@ -120,7 +120,7 @@ fn test_enum() {
         .add_variant(EnumVariantSpec::new("Green").unwrap())
         .add_variant(EnumVariantSpec::new("Blue").unwrap());
 
-    let output = FileSpec::builder_with("color.rs", RustLang::new())
+    let output = FileSpec::builder_with("color.rs", Rust::new())
         .add_type(tb.build().unwrap())
         .build()
         .unwrap()
@@ -157,7 +157,7 @@ fn test_enum_tuple_variants() {
                 .unwrap(),
         );
 
-    let output = FileSpec::builder_with("expr.rs", RustLang::new())
+    let output = FileSpec::builder_with("expr.rs", Rust::new())
         .add_type(tb.build().unwrap())
         .build()
         .unwrap()
@@ -216,7 +216,7 @@ fn test_enum_struct_variants() {
                 .unwrap(),
         );
 
-    let output = FileSpec::builder_with("message.rs", RustLang::new())
+    let output = FileSpec::builder_with("message.rs", Rust::new())
         .add_type(tb.build().unwrap())
         .build()
         .unwrap()

--- a/tests/rust/quote_edge_cases.rs
+++ b/tests/rust/quote_edge_cases.rs
@@ -1,12 +1,12 @@
 use sigil_stitch::code_block::CodeBlock;
-use sigil_stitch::lang::rust_lang::RustLang;
+use sigil_stitch::lang::rust::Rust;
 use sigil_stitch::prelude::*;
 use sigil_stitch::spec::file_spec::FileSpec;
 
 use super::golden;
 
 fn render(block: &CodeBlock) -> String {
-    FileSpec::builder_with("test.rs", RustLang::new())
+    FileSpec::builder_with("test.rs", Rust::new())
         .add_code(block.clone())
         .build()
         .unwrap()
@@ -16,7 +16,7 @@ fn render(block: &CodeBlock) -> String {
 
 #[test]
 fn test_path_separator() {
-    let block = sigil_quote!(RustLang {
+    let block = sigil_quote!(Rust {
         let size = std::mem::size_of::<u32>();
         let x = std::cmp::max(1, 2);
     })
@@ -26,7 +26,7 @@ fn test_path_separator() {
 
 #[test]
 fn test_lifetime() {
-    let block = sigil_quote!(RustLang {
+    let block = sigil_quote!(Rust {
         fn longest<'a>(x: &'a str, y: &'a str) -> &'a str {
             if x.len() > y.len() {
                 x
@@ -41,7 +41,7 @@ fn test_lifetime() {
 
 #[test]
 fn test_trait_bound() {
-    let block = sigil_quote!(RustLang {
+    let block = sigil_quote!(Rust {
         fn process<T: Clone + Send + 'static>(item: T) -> T {
             item.clone()
         }
@@ -52,7 +52,7 @@ fn test_trait_bound() {
 
 #[test]
 fn test_pattern_matching() {
-    let block = sigil_quote!(RustLang {
+    let block = sigil_quote!(Rust {
         match value {
             Some(x) if x > 0 => println!($S("positive: {}"), x),
             Some(0) => println!($S("zero")),
@@ -66,7 +66,7 @@ fn test_pattern_matching() {
 
 #[test]
 fn test_closure() {
-    let block = sigil_quote!(RustLang {
+    let block = sigil_quote!(Rust {
         let add = |a: i32, b: i32| -> i32 { a + b };
         let result: Vec<i32> = items.iter().map(|x| x * 2).collect();
     })
@@ -76,7 +76,7 @@ fn test_closure() {
 
 #[test]
 fn test_impl_block() {
-    let block = sigil_quote!(RustLang {
+    let block = sigil_quote!(Rust {
         impl<T: Display> fmt::Display for Wrapper<T> {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 write!(f, $S("({})"), self.0)
@@ -90,7 +90,7 @@ fn test_impl_block() {
 #[test]
 fn test_name_keyword_escape_in_macro() {
     let name = "type";
-    let block = sigil_quote!(RustLang {
+    let block = sigil_quote!(Rust {
         let $N(name) = 1;
     })
     .unwrap();

--- a/tests/rust/quote_imports.rs
+++ b/tests/rust/quote_imports.rs
@@ -1,5 +1,5 @@
 use sigil_stitch::code_block::CodeBlock;
-use sigil_stitch::lang::rust_lang::RustLang;
+use sigil_stitch::lang::rust::Rust;
 use sigil_stitch::prelude::*;
 use sigil_stitch::spec::file_spec::FileSpec;
 use sigil_stitch::type_name::TypeName;
@@ -7,7 +7,7 @@ use sigil_stitch::type_name::TypeName;
 use super::golden;
 
 fn render(block: &CodeBlock) -> String {
-    FileSpec::builder_with("test.rs", RustLang::new())
+    FileSpec::builder_with("test.rs", Rust::new())
         .add_code(block.clone())
         .build()
         .unwrap()
@@ -25,7 +25,7 @@ fn test_imports() {
         TypeName::importable("std::collections", "VecDeque"),
         vec![TypeName::primitive("String")],
     );
-    let block = sigil_quote!(RustLang {
+    let block = sigil_quote!(Rust {
         fn demo() {
             let map: $T(hashmap) = HashMap::new();
             let deque: $T(vec_deque) = VecDeque::new();

--- a/tests/rust/quote_suite.rs
+++ b/tests/rust/quote_suite.rs
@@ -1,5 +1,5 @@
 use sigil_stitch::code_block::CodeBlock;
-use sigil_stitch::lang::rust_lang::RustLang;
+use sigil_stitch::lang::rust::Rust;
 use sigil_stitch::prelude::*;
 use sigil_stitch::spec::file_spec::FileSpec;
 
@@ -9,7 +9,7 @@ pub struct RustSuite;
 
 impl LanguageTestSuite for RustSuite {
     fn control_flow_block() -> CodeBlock {
-        sigil_quote!(RustLang {
+        sigil_quote!(Rust {
             if x > 0 {
                 return Ok(x);
             } else {
@@ -24,7 +24,7 @@ impl LanguageTestSuite for RustSuite {
     }
 
     fn basic_block() -> CodeBlock {
-        sigil_quote!(RustLang {
+        sigil_quote!(Rust {
             let x: i32 = 42;
             let name = $S("Alice");
             println!($S("{}: {}"), name, x);
@@ -37,7 +37,7 @@ impl LanguageTestSuite for RustSuite {
     }
 
     fn render(block: CodeBlock) -> String {
-        FileSpec::builder_with("test.rs", RustLang::new())
+        FileSpec::builder_with("test.rs", Rust::new())
             .add_code(block)
             .build()
             .unwrap()

--- a/tests/type_spec_tests.rs
+++ b/tests/type_spec_tests.rs
@@ -1,7 +1,7 @@
 use sigil_stitch::code_block::CodeBlock;
 use sigil_stitch::code_renderer::CodeRenderer;
 use sigil_stitch::import::ImportGroup;
-use sigil_stitch::lang::rust_lang::RustLang;
+use sigil_stitch::lang::rust::Rust;
 use sigil_stitch::lang::typescript::TypeScript;
 use sigil_stitch::spec::emittable::Emittable;
 use sigil_stitch::spec::field_spec::FieldSpec;
@@ -27,7 +27,7 @@ fn render_blocks_ts(blocks: &[CodeBlock]) -> String {
 }
 
 fn render_blocks_rs(blocks: &[CodeBlock]) -> String {
-    let lang = RustLang::new();
+    let lang = Rust::new();
     let imports = ImportGroup::new();
     let mut output = String::new();
     for (i, block) in blocks.iter().enumerate() {
@@ -115,7 +115,7 @@ fn test_rust_struct_with_impl() {
         .build()
         .unwrap();
 
-    let blocks = ts.emit(&RustLang::new()).unwrap();
+    let blocks = ts.emit(&Rust::new()).unwrap();
     let output = render_blocks_rs(&blocks);
     assert!(output.contains("pub struct Config {"));
     assert!(output.contains("pub name: String,"));
@@ -200,7 +200,7 @@ fn test_type_alias_rust() {
         .extends(TypeName::primitive("f64"))
         .build()
         .unwrap();
-    let blocks = spec.emit(&RustLang::new()).unwrap();
+    let blocks = spec.emit(&Rust::new()).unwrap();
     let output = render_blocks_rs(&blocks);
     assert_eq!(output.trim(), "type Meters = f64;");
 }
@@ -212,7 +212,7 @@ fn test_type_alias_rust_pub() {
         .extends(TypeName::primitive("f64"))
         .build()
         .unwrap();
-    let blocks = spec.emit(&RustLang::new()).unwrap();
+    let blocks = spec.emit(&Rust::new()).unwrap();
     let output = render_blocks_rs(&blocks);
     assert_eq!(output.trim(), "pub type Meters = f64;");
 }
@@ -231,12 +231,12 @@ fn test_type_alias_ts() {
 
 #[test]
 fn test_type_alias_cpp() {
-    use sigil_stitch::lang::cpp_lang::CppLang;
+    use sigil_stitch::lang::cpp::Cpp;
     let spec = TypeSpec::builder("Meters", TypeKind::TypeAlias)
         .extends(TypeName::primitive("double"))
         .build()
         .unwrap();
-    let lang = CppLang::new();
+    let lang = Cpp::new();
     let imports = ImportGroup::new();
     let blocks = spec.emit(&lang).unwrap();
     let mut renderer = CodeRenderer::new(&lang, &imports, 80);
@@ -246,12 +246,12 @@ fn test_type_alias_cpp() {
 
 #[test]
 fn test_type_alias_c() {
-    use sigil_stitch::lang::c_lang::CLang;
+    use sigil_stitch::lang::c::C;
     let spec = TypeSpec::builder("Meters", TypeKind::TypeAlias)
         .extends(TypeName::primitive("double"))
         .build()
         .unwrap();
-    let lang = CLang::new();
+    let lang = C::new();
     let imports = ImportGroup::new();
     let blocks = spec.emit(&lang).unwrap();
     let mut renderer = CodeRenderer::new(&lang, &imports, 80);
@@ -261,12 +261,12 @@ fn test_type_alias_c() {
 
 #[test]
 fn test_type_alias_go() {
-    use sigil_stitch::lang::go_lang::GoLang;
+    use sigil_stitch::lang::go::Go;
     let spec = TypeSpec::builder("Meters", TypeKind::TypeAlias)
         .extends(TypeName::primitive("float64"))
         .build()
         .unwrap();
-    let lang = GoLang::new();
+    let lang = Go::new();
     let imports = ImportGroup::new();
     let blocks = spec.emit(&lang).unwrap();
     let mut renderer = CodeRenderer::new(&lang, &imports, 80);
@@ -312,19 +312,19 @@ fn test_newtype_rust() {
         .extends(TypeName::primitive("f64"))
         .build()
         .unwrap();
-    let blocks = spec.emit(&RustLang::new()).unwrap();
+    let blocks = spec.emit(&Rust::new()).unwrap();
     let output = render_blocks_rs(&blocks);
     assert_eq!(output.trim(), "pub struct Meters(f64);");
 }
 
 #[test]
 fn test_newtype_go() {
-    use sigil_stitch::lang::go_lang::GoLang;
+    use sigil_stitch::lang::go::Go;
     let spec = TypeSpec::builder("Meters", TypeKind::Newtype)
         .extends(TypeName::primitive("float64"))
         .build()
         .unwrap();
-    let lang = GoLang::new();
+    let lang = Go::new();
     let imports = ImportGroup::new();
     let blocks = spec.emit(&lang).unwrap();
     let mut renderer = CodeRenderer::new(&lang, &imports, 80);
@@ -421,7 +421,7 @@ fn test_where_clause_rust_struct() {
         )
         .build()
         .unwrap();
-    let blocks = type_spec.emit(&RustLang::new()).unwrap();
+    let blocks = type_spec.emit(&Rust::new()).unwrap();
     let output = render_blocks_rs(&blocks);
     assert!(
         output.contains("pub struct Container<T>"),
@@ -454,7 +454,7 @@ fn test_emittable_returns_multiple_blocks_for_rust() {
         .add_method(FunSpec::builder("hello").build().unwrap())
         .build()
         .unwrap();
-    let lang = RustLang::new();
+    let lang = Rust::new();
     let blocks = ts.emit_members(&lang).unwrap();
     assert!(
         blocks.len() >= 2,
@@ -466,8 +466,8 @@ fn test_emittable_returns_multiple_blocks_for_rust() {
 // ── Embedded types ──────────────────────────────────────
 
 fn render_blocks_go(blocks: &[CodeBlock]) -> String {
-    use sigil_stitch::lang::go_lang::GoLang;
-    let lang = GoLang::new();
+    use sigil_stitch::lang::go::Go;
+    let lang = Go::new();
     let imports = ImportGroup::new();
     let mut output = String::new();
     for (i, block) in blocks.iter().enumerate() {
@@ -482,7 +482,7 @@ fn render_blocks_go(blocks: &[CodeBlock]) -> String {
 
 #[test]
 fn test_embedded_go_struct_emit() {
-    use sigil_stitch::lang::go_lang::GoLang;
+    use sigil_stitch::lang::go::Go;
     let spec = TypeSpec::builder("UserAdmin", TypeKind::Struct)
         .add_embedded(TypeName::primitive("User"))
         .add_embedded(TypeName::primitive("Admin"))
@@ -493,7 +493,7 @@ fn test_embedded_go_struct_emit() {
         )
         .build()
         .unwrap();
-    let blocks = spec.emit(&GoLang::new()).unwrap();
+    let blocks = spec.emit(&Go::new()).unwrap();
     let output = render_blocks_go(&blocks);
     assert!(output.contains("User\n"), "embedded User: {output}");
     assert!(output.contains("Admin\n"), "embedded Admin: {output}");
@@ -542,7 +542,7 @@ fn test_embedded_rust_struct_emit() {
         )
         .build()
         .unwrap();
-    let blocks = spec.emit(&RustLang::new()).unwrap();
+    let blocks = spec.emit(&Rust::new()).unwrap();
     let output = render_blocks_rs(&blocks);
     assert!(output.contains("Base,"), "embedded Base: {output}");
     assert!(output.contains("extra: String,"), "field extra: {output}");
@@ -550,13 +550,13 @@ fn test_embedded_rust_struct_emit() {
 
 #[test]
 fn test_embedded_only_no_fields() {
-    use sigil_stitch::lang::go_lang::GoLang;
+    use sigil_stitch::lang::go::Go;
     let spec = TypeSpec::builder("ReadCloser", TypeKind::Interface)
         .add_embedded(TypeName::primitive("Reader"))
         .add_embedded(TypeName::primitive("Closer"))
         .build()
         .unwrap();
-    let blocks = spec.emit(&GoLang::new()).unwrap();
+    let blocks = spec.emit(&Go::new()).unwrap();
     let output = render_blocks_go(&blocks);
     assert!(output.contains("Reader\n"), "Reader embedded: {output}");
     assert!(output.contains("Closer\n"), "Closer embedded: {output}");
@@ -594,14 +594,14 @@ fn test_embedded_with_methods_after() {
 
 #[test]
 fn test_embedded_import_tracking() {
-    use sigil_stitch::lang::go_lang::GoLang;
+    use sigil_stitch::lang::go::Go;
     let io_reader = TypeName::importable("io", "Reader");
     let spec = TypeSpec::builder("MyReader", TypeKind::Struct)
         .add_embedded(io_reader)
         .build()
         .unwrap();
 
-    let file = sigil_stitch::spec::file_spec::FileSpec::builder_with("reader.go", GoLang::new())
+    let file = sigil_stitch::spec::file_spec::FileSpec::builder_with("reader.go", Go::new())
         .header(CodeBlock::of("package main", ()).unwrap())
         .add_type(spec)
         .build()


### PR DESCRIPTION
## Summary

Drop the `Lang` suffix from all language struct names and remove the `_lang` suffix from corresponding source files:

- `GoLang` → `Go`, `JavaLang` → `Java`, `RustLang` → `Rust`
- `CppLang` → `Cpp`, `CLang` → `C`, `DartLang` → `Dart`
- `go_lang.rs` → `go.rs`, `java_lang.rs` → `java.rs`, etc.
- `MacroLang::GoLang` → `MacroLang::Go`

All 20 languages now follow a single naming convention: the plain language name, no suffix.

## Test plan

- [x] `cargo test --workspace` — all pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean