### PR TITLE
feat: add Ruby language support

### DIFF
--- a/examples/ruby_codegen.rs
+++ b/examples/ruby_codegen.rs
@@ -1,0 +1,122 @@
+//! Generate a Ruby file — builder API vs `sigil_quote!` comparison.
+//!
+//! Demonstrates: class with `initialize`, module with class methods,
+//! `if`/`else` control flow, doc comments, `attr_reader` for properties,
+//! and `require` imports via `TypeName::importable`.
+//!
+//! Note: The builder API uses raw CodeBlock construction (typical for
+//! dynamic languages like Ruby/Lua). The `sigil_quote!` macro uses
+//! brace-style `{ }` blocks which are automatically translated to
+//! indent/dedent + `end`. Both produce identical output.
+//!
+//! Run: `cargo run --example ruby_codegen`
+
+use sigil_stitch::code_block::CodeBlock;
+use sigil_stitch::lang::CodeLang;
+use sigil_stitch::lang::ruby::Ruby;
+use sigil_stitch::prelude::*;
+
+fn main() {
+    println!("=== Builder API ===\n");
+    let builder_output = builder_approach();
+    println!("{builder_output}");
+
+    println!("=== sigil_quote! Macro ===\n");
+    let macro_output = macro_approach();
+    println!("{macro_output}");
+}
+
+fn builder_approach() -> String {
+    let ruby = Ruby::new();
+    let doc = ruby.render_doc_comment(&["Greeter says hello to a person."]);
+
+    let mut b = CodeBlock::builder();
+    b.add("%L", doc);
+    b.add_line();
+    b.add("class Greeter", ());
+    b.add_line();
+
+    b.add("%>", ());
+    b.add_statement("attr_reader :name", ());
+    b.add_line();
+
+    b.add("def initialize(name)", ());
+    b.add_line();
+    b.add("%>", ());
+    b.add_statement("@name = name", ());
+    b.add("%<", ());
+    b.add("end", ());
+    b.add_line();
+    b.add_line();
+
+    b.add("def greet", ());
+    b.add_line();
+    b.add("%>", ());
+    b.add_statement(r##""Hello, #{@name}!""##, ());
+    b.add("%<", ());
+    b.add("end", ());
+    b.add_line();
+    b.add_line();
+
+    b.add("def describe(x)", ());
+    b.add_line();
+    b.add("%>", ());
+    b.add("if x > 0", ());
+    b.add_line();
+    b.add("%>", ());
+    b.add_statement("\"positive\"", ());
+    b.add("%<", ());
+    b.add("else", ());
+    b.add_line();
+    b.add("%>", ());
+    b.add_statement("\"not positive\"", ());
+    b.add("%<", ());
+    b.add("end", ());
+    b.add_line();
+    b.add("%<", ());
+    b.add("end", ());
+    b.add_line();
+
+    b.add("%<", ());
+    b.add("end", ());
+    b.add_line();
+
+    FileSpec::builder_with("greeter.rb", Ruby::new())
+        .add_code(b.build().unwrap())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap()
+}
+
+fn macro_approach() -> String {
+    let body = sigil_quote!(Ruby {
+        class Greeter {
+            attr_reader "name"
+
+            def initialize(name) {
+                @name = name
+            }
+
+            def greet {
+                "Hello, #{@name}!"
+            }
+
+            def describe(x) {
+                if x > 0 {
+                    $S("positive")
+                } else {
+                    $S("not positive")
+                }
+            }
+        }
+    })
+    .unwrap();
+
+    FileSpec::builder_with("greeter.rb", Ruby::new())
+        .add_code(body)
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap()
+}

--- a/macros/src/parse/mod.rs
+++ b/macros/src/parse/mod.rs
@@ -29,6 +29,7 @@ fn parse_macro_lang(ts: &TokenStream) -> MacroLang {
             "Haskell" => MacroLang::Haskell,
             "OCaml" => MacroLang::OCaml,
             "Php" => MacroLang::Php,
+            "Ruby" => MacroLang::Ruby,
             _ => MacroLang::Unaware,
         }
     } else {

--- a/macros/src/parse/types.rs
+++ b/macros/src/parse/types.rs
@@ -13,6 +13,7 @@ pub(crate) enum MacroLang {
     Haskell,
     OCaml,
     Php,
+    Ruby,
 }
 
 impl MacroLang {

--- a/src/lang/mod.rs
+++ b/src/lang/mod.rs
@@ -28,6 +28,8 @@ pub mod ocaml;
 pub mod php;
 /// Python language support.
 pub mod python;
+/// Ruby language support.
+pub mod ruby;
 /// Rust language support.
 pub mod rust;
 /// Scala language support.
@@ -424,6 +426,7 @@ pub fn lang_from_extension(ext: &str) -> Option<Box<dyn CodeLang>> {
         "sh" | "bash" => Some(Box::new(bash::Bash::default())),
         "zsh" => Some(Box::new(zsh::Zsh::default())),
         "php" => Some(Box::new(php::Php::default())),
+        "rb" => Some(Box::new(ruby::Ruby::default())),
         _ => None,
     }
 }

--- a/src/lang/ruby.rs
+++ b/src/lang/ruby.rs
@@ -1,0 +1,394 @@
+//! Ruby language implementation.
+//!
+//! Ruby characteristics:
+//! - Dynamically typed (no type annotations)
+//! - `def` keyword, `end` for block close
+//! - `#` line comments
+//! - `class` and `module` type keywords
+//! - `public`/`private`/`protected` visibility (method-call style)
+//! - `require "module"` imports
+//! - `@` instance variables, `@@` class variables
+//! - `attr_reader`/`attr_writer`/`attr_accessor` for properties
+//! - 2-space indent by convention
+//! - `nil` absent literal
+//! - `self.` prefix for class methods
+//!
+//! # Interpolation
+//!
+//! Ruby uses `#{expr}` for string interpolation. Since `$` is sigil_quote's
+//! interpolation marker, every `$` in Ruby code (for global vars like `$stdout`)
+//! must be written as `$$` inside `sigil_quote!(Ruby { ... })`.
+//!
+//! # Blocks
+//!
+//! Ruby uses `end` to close blocks, same as Lua. Braces `{ }` in
+//! `sigil_quote!` map to indent/dedent + `end` in the output.
+
+use crate::import::ImportGroup;
+use crate::lang::config::{
+    BlockSyntaxConfig, EnumAndAnnotationConfig, FunctionSyntaxConfig, TypeDeclSyntaxConfig,
+    TypePresentationConfig,
+};
+use crate::lang::{CodeLang, RendererLang};
+use crate::spec::modifiers::{DeclarationContext, TypeKind, Visibility};
+
+/// Ruby language implementation.
+///
+/// Configurable indent (default: 2 spaces by convention) and file extension
+/// (default: `"rb"`).
+#[derive(Debug, Clone)]
+pub struct Ruby {
+    /// Indent with this string (default: `"  "` — 2 spaces by convention).
+    pub indent: String,
+    /// File extension (default: `"rb"`).
+    pub extension: String,
+}
+
+impl Default for Ruby {
+    fn default() -> Self {
+        Self {
+            indent: "  ".to_string(),
+            extension: "rb".to_string(),
+        }
+    }
+}
+
+impl Ruby {
+    /// Create a new Ruby language instance with default settings.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set the indent string (e.g., `"  "` for 2-space, `"    "` for 4-space).
+    pub fn with_indent(mut self, s: &str) -> Self {
+        self.indent = s.to_string();
+        self
+    }
+
+    /// Set the file extension (default: `"rb"`).
+    pub fn with_extension(mut self, s: &str) -> Self {
+        self.extension = s.to_string();
+        self
+    }
+}
+
+#[rustfmt::skip]
+const RUBY_RESERVED: &[&str] = &[
+    "__ENCODING__", "__LINE__", "__FILE__", "BEGIN", "END",
+    "alias", "and", "begin", "break", "case", "class", "def",
+    "defined?", "do", "else", "elsif", "end", "ensure", "false",
+    "for", "if", "in", "module", "next", "nil", "not", "or",
+    "redo", "rescue", "retry", "return", "self", "super", "then",
+    "true", "undef", "unless", "until", "when", "while", "yield",
+];
+
+impl RendererLang for Ruby {
+    fn file_extension(&self) -> &str {
+        &self.extension
+    }
+
+    fn line_comment_prefix(&self) -> &str {
+        "#"
+    }
+
+    fn render_string_literal(&self, s: &str) -> String {
+        let escaped = s
+            .replace('\\', "\\\\")
+            .replace('"', "\\\"")
+            .replace('#', "\\#")
+            .replace('\n', "\\n")
+            .replace('\t', "\\t")
+            .replace('\r', "\\r");
+        format!("\"{escaped}\"")
+    }
+
+    fn render_verbatim_string(&self, s: &str) -> String {
+        // Use single quotes for verbatim strings — no interpolation risk.
+        let escaped = s.replace('\\', "\\\\").replace('\'', "\\'");
+        format!("'{escaped}'")
+    }
+
+    fn reserved_words(&self) -> &[&str] {
+        RUBY_RESERVED
+    }
+
+    fn module_separator(&self) -> Option<&str> {
+        Some("::")
+    }
+
+    fn block_syntax(&self) -> BlockSyntaxConfig<'_> {
+        BlockSyntaxConfig {
+            block_open: "",
+            block_close: "end",
+            close_on_transition: false,
+            indent_unit: &self.indent,
+            uses_semicolons: false,
+            field_terminator: "",
+            ..Default::default()
+        }
+    }
+
+    fn type_presentation(&self) -> TypePresentationConfig<'_> {
+        TypePresentationConfig {
+            optional_absent_literal: "nil",
+            ..Default::default()
+        }
+    }
+}
+
+impl CodeLang for Ruby {
+    fn render_visibility(&self, vis: Visibility, ctx: DeclarationContext) -> &str {
+        match ctx {
+            DeclarationContext::TopLevel => "",
+            DeclarationContext::Member => match vis {
+                Visibility::Public => "public\n",
+                Visibility::Private => "private\n",
+                Visibility::Protected => "protected\n",
+                _ => "public\n",
+            },
+            DeclarationContext::InterfaceMember => "",
+        }
+    }
+
+    fn function_keyword(&self, _ctx: DeclarationContext) -> &str {
+        "def"
+    }
+
+    fn type_keyword(&self, kind: TypeKind) -> &str {
+        match kind {
+            TypeKind::Class | TypeKind::Struct => "class",
+            TypeKind::Trait | TypeKind::Interface => "module",
+            TypeKind::Enum => "class",
+            TypeKind::TypeAlias | TypeKind::Newtype => "class",
+        }
+    }
+
+    fn methods_inside_type_body(&self, _kind: TypeKind) -> bool {
+        true
+    }
+
+    fn render_imports(&self, imports: &ImportGroup) -> String {
+        let mut lines = Vec::new();
+        for entry in imports.entries() {
+            if entry.is_side_effect || entry.name.is_empty() || entry.is_wildcard {
+                lines.push(format!("require '{}'", entry.module));
+            } else {
+                let module_path = entry.module.replace("::", "/");
+                let name = entry.resolved_name();
+                if entry.module.is_empty() {
+                    lines.push(format!("require '{}'", name));
+                } else {
+                    lines.push(format!("require '{module_path}'",));
+                }
+            }
+        }
+        lines.sort();
+        lines.dedup();
+        lines.join("\n")
+    }
+
+    fn render_doc_comment(&self, lines: &[&str]) -> String {
+        let mut out = String::new();
+        for line in lines {
+            if line.is_empty() {
+                out.push_str("#\n");
+            } else {
+                out.push_str(&format!("# {line}\n"));
+            }
+        }
+        out
+    }
+
+    fn fun_block_open(&self) -> &str {
+        "" // Method bodies start on next line after `def`
+    }
+
+    fn type_header_block_open(&self, _kind: TypeKind) -> &str {
+        "" // Class/module bodies start on next line
+    }
+
+    fn property_style(&self) -> crate::spec::modifiers::PropertyStyle {
+        crate::spec::modifiers::PropertyStyle::Field
+    }
+
+    fn property_getter_keyword(&self) -> &str {
+        "attr_reader"
+    }
+
+    fn type_decl_syntax(&self) -> TypeDeclSyntaxConfig<'_> {
+        TypeDeclSyntaxConfig {
+            type_before_name: false,
+            return_type_is_prefix: false,
+            type_annotation_separator: "", // Ruby has no type annotations
+            super_type_keyword: " < ",
+            ..Default::default()
+        }
+    }
+
+    fn function_syntax(&self) -> FunctionSyntaxConfig<'_> {
+        FunctionSyntaxConfig {
+            return_type_separator: "", // No return type syntax in Ruby
+            empty_body: "",
+            static_keyword: "self.",
+            ..Default::default()
+        }
+    }
+
+    fn enum_and_annotation(&self) -> EnumAndAnnotationConfig<'_> {
+        EnumAndAnnotationConfig {
+            readonly_keyword: "",
+            annotation_prefix: "# ",
+            annotation_suffix: "",
+            ..Default::default()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::import::ImportEntry;
+
+    use super::*;
+
+    #[test]
+    fn test_file_extension() {
+        let ruby = Ruby::new();
+        assert_eq!(ruby.file_extension(), "rb");
+    }
+
+    #[test]
+    fn test_line_comment() {
+        let ruby = Ruby::new();
+        assert_eq!(ruby.line_comment_prefix(), "#");
+    }
+
+    #[test]
+    fn test_render_string_literal() {
+        let ruby = Ruby::new();
+        assert_eq!(ruby.render_string_literal("hello"), "\"hello\"");
+        assert_eq!(
+            ruby.render_string_literal("say \"hi\""),
+            "\"say \\\"hi\\\"\""
+        );
+        assert_eq!(
+            ruby.render_string_literal("interp #{x}"),
+            "\"interp \\#{x}\""
+        );
+        assert_eq!(
+            ruby.render_string_literal("line1\nline2"),
+            "\"line1\\nline2\""
+        );
+    }
+
+    #[test]
+    fn test_render_verbatim_string() {
+        let ruby = Ruby::new();
+        let out = ruby.render_verbatim_string("Hello #{name}");
+        assert_eq!(out, "'Hello #{name}'");
+    }
+
+    #[test]
+    fn test_escape_reserved() {
+        let ruby = Ruby::new();
+        assert_eq!(ruby.escape_reserved("foo"), "foo");
+        assert_eq!(ruby.escape_reserved("class"), "class_");
+        assert_eq!(ruby.escape_reserved("end"), "end_");
+        assert_eq!(ruby.escape_reserved("def"), "def_");
+    }
+
+    #[test]
+    fn test_render_imports() {
+        let ruby = Ruby::new();
+        let entries = vec![
+            ImportEntry {
+                module: "json".to_string(),
+                name: "JSON".to_string(),
+                alias: None,
+                is_type_only: false,
+                is_side_effect: false,
+                is_wildcard: false,
+            },
+            ImportEntry {
+                module: "net/http".to_string(),
+                name: String::new(),
+                alias: None,
+                is_type_only: false,
+                is_side_effect: true,
+                is_wildcard: false,
+            },
+        ];
+        let group = ImportGroup::from(entries);
+        let out = ruby.render_imports(&group);
+        assert!(out.contains("require 'json'"));
+        assert!(out.contains("require 'net/http'"));
+    }
+
+    #[test]
+    fn test_render_doc_comment() {
+        let ruby = Ruby::new();
+        let out = ruby.render_doc_comment(&["Says hello.", "", "@param name [String]"]);
+        assert!(out.contains("# Says hello.\n"));
+        assert!(out.contains("#\n"));
+        assert!(out.contains("# @param name [String]\n"));
+    }
+
+    #[test]
+    fn test_block_syntax() {
+        let ruby = Ruby::new();
+        let bs = ruby.block_syntax();
+        assert_eq!(bs.block_open, "");
+        assert_eq!(bs.block_close, "end");
+        assert!(!bs.uses_semicolons);
+        assert!(!bs.close_on_transition);
+    }
+
+    #[test]
+    fn test_visibility() {
+        let ruby = Ruby::new();
+        assert_eq!(
+            ruby.render_visibility(Visibility::Public, DeclarationContext::Member),
+            "public\n"
+        );
+        assert_eq!(
+            ruby.render_visibility(Visibility::Private, DeclarationContext::Member),
+            "private\n"
+        );
+        assert_eq!(
+            ruby.render_visibility(Visibility::Public, DeclarationContext::TopLevel),
+            ""
+        );
+    }
+
+    #[test]
+    fn test_function_keyword() {
+        let ruby = Ruby::new();
+        assert_eq!(ruby.function_keyword(DeclarationContext::TopLevel), "def");
+    }
+
+    #[test]
+    fn test_type_keyword() {
+        let ruby = Ruby::new();
+        assert_eq!(ruby.type_keyword(TypeKind::Class), "class");
+        assert_eq!(ruby.type_keyword(TypeKind::Interface), "module");
+        assert_eq!(ruby.type_keyword(TypeKind::Trait), "module");
+    }
+
+    #[test]
+    fn test_module_separator() {
+        let ruby = Ruby::new();
+        assert_eq!(ruby.module_separator(), Some("::"));
+    }
+
+    #[test]
+    fn test_static_keyword() {
+        let ruby = Ruby::new();
+        assert_eq!(ruby.function_syntax().static_keyword, "self.");
+    }
+
+    #[test]
+    fn test_builder_fluent() {
+        let ruby = Ruby::new().with_indent("\t").with_extension("rb");
+        assert_eq!(ruby.file_extension(), "rb");
+        assert_eq!(ruby.block_syntax().indent_unit, "\t");
+    }
+}

--- a/test-goldens/ruby/builder_array.rb
+++ b/test-goldens/ruby/builder_array.rb
@@ -1,0 +1,2 @@
+items = [1, 2, 3]
+names = ['alice', 'bob', 'carol']

--- a/test-goldens/ruby/builder_begin_rescue.rb
+++ b/test-goldens/ruby/builder_begin_rescue.rb
@@ -1,0 +1,7 @@
+begin
+  do_something
+rescue => e
+  handle_error(e)
+ensure
+  cleanup
+end

--- a/test-goldens/ruby/builder_block.rb
+++ b/test-goldens/ruby/builder_block.rb
@@ -1,0 +1,3 @@
+items.each do |item|
+  puts item
+end

--- a/test-goldens/ruby/builder_case.rb
+++ b/test-goldens/ruby/builder_case.rb
@@ -1,0 +1,9 @@
+case x
+  when 0
+    'zero'
+  when 1
+    'one'
+  else
+    'many'
+  end
+end

--- a/test-goldens/ruby/builder_control_flow.rb
+++ b/test-goldens/ruby/builder_control_flow.rb
@@ -1,0 +1,7 @@
+def describe(x)
+  if x > 0
+    "positive"
+  else
+    "not positive"
+  end
+end

--- a/test-goldens/ruby/builder_hash.rb
+++ b/test-goldens/ruby/builder_hash.rb
@@ -1,0 +1,5 @@
+config = {
+  host: 'localhost'
+  port: 8080
+  debug: true
+}

--- a/test-goldens/ruby/builder_if_else.rb
+++ b/test-goldens/ruby/builder_if_else.rb
@@ -1,0 +1,7 @@
+if x > 0
+  'positive'
+elsif x < 0
+  'negative'
+else
+  'zero'
+end

--- a/test-goldens/ruby/builder_import.rb
+++ b/test-goldens/ruby/builder_import.rb
@@ -1,0 +1,4 @@
+require 'json'
+require 'net/http'
+
+# JSON Net

--- a/test-goldens/ruby/builder_require.rb
+++ b/test-goldens/ruby/builder_require.rb
@@ -1,0 +1,3 @@
+require 'json'
+require 'net/http'
+require_relative 'lib/helpers'

--- a/test-goldens/ruby/builder_unless.rb
+++ b/test-goldens/ruby/builder_unless.rb
@@ -1,0 +1,5 @@
+unless x > 0
+  'not positive'
+else
+  'positive'
+end

--- a/test-goldens/ruby/builder_while.rb
+++ b/test-goldens/ruby/builder_while.rb
@@ -1,0 +1,3 @@
+while x > 0
+  x -= 1
+end

--- a/test-goldens/ruby/class.rb
+++ b/test-goldens/ruby/class.rb
@@ -1,0 +1,11 @@
+# Greeter says hello.
+
+class Greeter
+  def initialize(name)
+    @name = name
+  end
+
+  def greet
+    "Hello, #{@name}"
+  end
+end

--- a/test-goldens/ruby/class_method.rb
+++ b/test-goldens/ruby/class_method.rb
@@ -1,0 +1,5 @@
+# Create returns a new instance.
+
+def self.create(name)
+  new(name: name)
+end

--- a/test-goldens/ruby/macro_basic.rb
+++ b/test-goldens/ruby/macro_basic.rb
@@ -1,0 +1,3 @@
+x = 42
+name = "Alice"
+puts name, x

--- a/test-goldens/ruby/macro_control_flow.rb
+++ b/test-goldens/ruby/macro_control_flow.rb
@@ -1,0 +1,5 @@
+if x > 0
+  return "positive"
+else
+  return "negative"
+end

--- a/test-goldens/ruby/method.rb
+++ b/test-goldens/ruby/method.rb
@@ -1,0 +1,5 @@
+# Add returns the sum of two integers.
+
+def add(a, b)
+  a + b
+end

--- a/test-goldens/ruby/module.rb
+++ b/test-goldens/ruby/module.rb
@@ -1,0 +1,5 @@
+module StringHelpers
+  def self.pluralize(word)
+    "#{word}s"
+  end
+end

--- a/test-goldens/ruby/quote_for_in.rb
+++ b/test-goldens/ruby/quote_for_in.rb
@@ -1,0 +1,3 @@
+for i in 0..5
+  puts i
+end

--- a/test-goldens/ruby/quote_imports.rb
+++ b/test-goldens/ruby/quote_imports.rb
@@ -1,0 +1,5 @@
+require 'json'
+require 'net/http'
+
+data = JSON.parse(input)
+Net.start

--- a/test-goldens/ruby/quote_inheritance.rb
+++ b/test-goldens/ruby/quote_inheritance.rb
@@ -1,0 +1,5 @@
+class Dog<Animal
+  def speak
+    "woof"
+  end
+end

--- a/test-goldens/ruby/quote_instance_vars.rb
+++ b/test-goldens/ruby/quote_instance_vars.rb
@@ -1,0 +1,3 @@
+@name = "Alice"
+@age = 30
+@@count = 1

--- a/test-goldens/ruby/quote_method.rb
+++ b/test-goldens/ruby/quote_method.rb
@@ -1,0 +1,3 @@
+def greet(name)
+  "Hello, " + name + "!"
+end

--- a/test-goldens/ruby/quote_string_interpolation.rb
+++ b/test-goldens/ruby/quote_string_interpolation.rb
@@ -1,0 +1,2 @@
+greeting = "Hello, #{name}!"
+path = "/users/#{id}/posts"

--- a/test-goldens/ruby/quote_unless.rb
+++ b/test-goldens/ruby/quote_unless.rb
@@ -1,0 +1,5 @@
+unless x > 0
+  "not positive"
+else
+  "positive"
+end

--- a/test-goldens/ruby/quote_while.rb
+++ b/test-goldens/ruby/quote_while.rb
@@ -1,0 +1,3 @@
+while x > 0
+  x -= 1
+end

--- a/tests/ruby/builder_control_flow.rs
+++ b/tests/ruby/builder_control_flow.rs
@@ -1,0 +1,79 @@
+use sigil_stitch::code_block::CodeBlock;
+use sigil_stitch::lang::ruby::Ruby;
+use sigil_stitch::spec::file_spec::FileSpec;
+
+use super::golden;
+
+#[test]
+fn test_if_else() {
+    let mut cb = CodeBlock::builder();
+    cb.begin_control_flow("if x > 0", ());
+    cb.add_statement("'positive'", ());
+    cb.next_control_flow("elsif x < 0", ());
+    cb.add_statement("'negative'", ());
+    cb.next_control_flow("else", ());
+    cb.add_statement("'zero'", ());
+    cb.end_control_flow();
+
+    let file = FileSpec::builder_with("test.rb", Ruby::new())
+        .add_code(cb.build().unwrap())
+        .build()
+        .unwrap();
+    let output = file.render(80).unwrap();
+
+    golden::assert_golden("ruby/builder_if_else.rb", &output);
+}
+
+#[test]
+fn test_unless() {
+    let mut cb = CodeBlock::builder();
+    cb.begin_control_flow("unless x > 0", ());
+    cb.add_statement("'not positive'", ());
+    cb.next_control_flow("else", ());
+    cb.add_statement("'positive'", ());
+    cb.end_control_flow();
+
+    let file = FileSpec::builder_with("test.rb", Ruby::new())
+        .add_code(cb.build().unwrap())
+        .build()
+        .unwrap();
+    let output = file.render(80).unwrap();
+
+    golden::assert_golden("ruby/builder_unless.rb", &output);
+}
+
+#[test]
+fn test_while_loop() {
+    let mut cb = CodeBlock::builder();
+    cb.begin_control_flow("while x > 0", ());
+    cb.add_statement("x -= 1", ());
+    cb.end_control_flow();
+
+    let file = FileSpec::builder_with("test.rb", Ruby::new())
+        .add_code(cb.build().unwrap())
+        .build()
+        .unwrap();
+    let output = file.render(80).unwrap();
+
+    golden::assert_golden("ruby/builder_while.rb", &output);
+}
+
+#[test]
+fn test_begin_rescue() {
+    let mut cb = CodeBlock::builder();
+    cb.begin_control_flow("begin", ());
+    cb.add_statement("do_something", ());
+    cb.next_control_flow("rescue => e", ());
+    cb.add_statement("handle_error(e)", ());
+    cb.next_control_flow("ensure", ());
+    cb.add_statement("cleanup", ());
+    cb.end_control_flow();
+
+    let file = FileSpec::builder_with("test.rb", Ruby::new())
+        .add_code(cb.build().unwrap())
+        .build()
+        .unwrap();
+    let output = file.render(80).unwrap();
+
+    golden::assert_golden("ruby/builder_begin_rescue.rb", &output);
+}

--- a/tests/ruby/builder_edge_cases.rs
+++ b/tests/ruby/builder_edge_cases.rs
@@ -1,0 +1,98 @@
+use sigil_stitch::code_block::CodeBlock;
+use sigil_stitch::lang::ruby::Ruby;
+use sigil_stitch::spec::file_spec::FileSpec;
+
+use super::golden;
+
+#[test]
+fn test_hash_constructor() {
+    let mut b = CodeBlock::builder();
+    b.add("config = {", ());
+    b.add_line();
+    b.add("%>", ());
+    b.add_statement("host: 'localhost'", ());
+    b.add_statement("port: 8080", ());
+    b.add_statement("debug: true", ());
+    b.add("%<", ());
+    b.add("}", ());
+    b.add_line();
+
+    let file = FileSpec::builder_with("test.rb", Ruby::new())
+        .add_code(b.build().unwrap())
+        .build()
+        .unwrap();
+    let output = file.render(80).unwrap();
+
+    golden::assert_golden("ruby/builder_hash.rb", &output);
+}
+
+#[test]
+fn test_array_literal() {
+    let mut b = CodeBlock::builder();
+    b.add_statement("items = [1, 2, 3]", ());
+    b.add_statement("names = ['alice', 'bob', 'carol']", ());
+
+    let file = FileSpec::builder_with("test.rb", Ruby::new())
+        .add_code(b.build().unwrap())
+        .build()
+        .unwrap();
+    let output = file.render(80).unwrap();
+
+    golden::assert_golden("ruby/builder_array.rb", &output);
+}
+
+#[test]
+fn test_block_with_do() {
+    let mut b = CodeBlock::builder();
+    b.add("items.each do |item|", ());
+    b.add_line();
+    b.add("%>", ());
+    b.add_statement("puts item", ());
+    b.add("%<", ());
+    b.add("end", ());
+    b.add_line();
+
+    let file = FileSpec::builder_with("test.rb", Ruby::new())
+        .add_code(b.build().unwrap())
+        .build()
+        .unwrap();
+    let output = file.render(80).unwrap();
+
+    golden::assert_golden("ruby/builder_block.rb", &output);
+}
+
+#[test]
+fn test_case_when() {
+    let mut b = CodeBlock::builder();
+    b.add("case x", ());
+    b.add_line();
+    b.add("%>", ());
+    b.add("when 0", ());
+    b.add_line();
+    b.add("%>", ());
+    b.add_statement("'zero'", ());
+    b.add("%<", ());
+    b.add("when 1", ());
+    b.add_line();
+    b.add("%>", ());
+    b.add_statement("'one'", ());
+    b.add("%<", ());
+    b.add("else", ());
+    b.add_line();
+    b.add("%>", ());
+    b.add_statement("'many'", ());
+    b.add("%<", ());
+    b.add("end", ());
+    b.add_line();
+    b.add("%<", ());
+    b.add("end", ());
+    b.add_line();
+
+    let file = FileSpec::builder_with("test.rb", Ruby::new())
+        .add_code(b.build().unwrap())
+        .build()
+        .unwrap();
+    let output = file.render(80).unwrap();
+
+    golden::assert_golden("ruby/builder_case.rb", &output);
+}

--- a/tests/ruby/builder_functions.rs
+++ b/tests/ruby/builder_functions.rs
@@ -1,0 +1,87 @@
+use sigil_stitch::code_block::CodeBlock;
+use sigil_stitch::lang::CodeLang;
+use sigil_stitch::lang::ruby::Ruby;
+use sigil_stitch::spec::file_spec::FileSpec;
+
+use super::golden;
+
+#[test]
+fn test_method() {
+    let ruby = Ruby::new();
+    let doc = ruby.render_doc_comment(&["Add returns the sum of two integers."]);
+
+    let mut b = CodeBlock::builder();
+    b.add("%L", doc);
+    b.add_line();
+    b.add("def add(a, b)", ());
+    b.add_line();
+    b.add("%>", ());
+    b.add_statement("a + b", ());
+    b.add("%<", ());
+    b.add("end", ());
+    b.add_line();
+
+    let file = FileSpec::builder_with("math.rb", Ruby::new())
+        .add_code(b.build().unwrap())
+        .build()
+        .unwrap();
+    let output = file.render(80).unwrap();
+
+    golden::assert_golden("ruby/method.rb", &output);
+}
+
+#[test]
+fn test_class_method() {
+    let ruby = Ruby::new();
+    let doc = ruby.render_doc_comment(&["Create returns a new instance."]);
+
+    let mut b = CodeBlock::builder();
+    b.add("%L", doc);
+    b.add_line();
+    b.add("def self.create(name)", ());
+    b.add_line();
+    b.add("%>", ());
+    b.add_statement("new(name: name)", ());
+    b.add("%<", ());
+    b.add("end", ());
+    b.add_line();
+
+    let file = FileSpec::builder_with("factory.rb", Ruby::new())
+        .add_code(b.build().unwrap())
+        .build()
+        .unwrap();
+    let output = file.render(80).unwrap();
+
+    golden::assert_golden("ruby/class_method.rb", &output);
+}
+
+#[test]
+fn test_control_flow_method() {
+    let mut b = CodeBlock::builder();
+    b.add("def describe(x)", ());
+    b.add_line();
+    b.add("%>", ());
+    b.add("if x > 0", ());
+    b.add_line();
+    b.add("%>", ());
+    b.add_statement("\"positive\"", ());
+    b.add("%<", ());
+    b.add("else", ());
+    b.add_line();
+    b.add("%>", ());
+    b.add_statement("\"not positive\"", ());
+    b.add("%<", ());
+    b.add("end", ());
+    b.add_line();
+    b.add("%<", ());
+    b.add("end", ());
+    b.add_line();
+
+    let file = FileSpec::builder_with("describe.rb", Ruby::new())
+        .add_code(b.build().unwrap())
+        .build()
+        .unwrap();
+    let output = file.render(80).unwrap();
+
+    golden::assert_golden("ruby/builder_control_flow.rb", &output);
+}

--- a/tests/ruby/builder_imports.rs
+++ b/tests/ruby/builder_imports.rs
@@ -1,0 +1,40 @@
+use sigil_stitch::code_block::CodeBlock;
+use sigil_stitch::lang::ruby::Ruby;
+use sigil_stitch::spec::file_spec::FileSpec;
+use sigil_stitch::type_name::TypeName;
+
+use super::golden;
+
+#[test]
+fn test_import() {
+    let json = TypeName::importable("json", "JSON");
+    let net = TypeName::importable("net/http", "Net");
+
+    let mut b = CodeBlock::builder();
+    b.add_statement("# %T %T", (json, net));
+    let block = b.build().unwrap();
+
+    let file = FileSpec::builder_with("test.rb", Ruby::new())
+        .add_code(block)
+        .build()
+        .unwrap();
+    let output = file.render(80).unwrap();
+
+    golden::assert_golden("ruby/builder_import.rb", &output);
+}
+
+#[test]
+fn test_require_gem() {
+    let mut b = CodeBlock::builder();
+    b.add_statement("require 'json'", ());
+    b.add_statement("require 'net/http'", ());
+    b.add_statement("require_relative 'lib/helpers'", ());
+
+    let file = FileSpec::builder_with("test.rb", Ruby::new())
+        .add_code(b.build().unwrap())
+        .build()
+        .unwrap();
+    let output = file.render(80).unwrap();
+
+    golden::assert_golden("ruby/builder_require.rb", &output);
+}

--- a/tests/ruby/builder_types.rs
+++ b/tests/ruby/builder_types.rs
@@ -1,0 +1,71 @@
+use sigil_stitch::code_block::CodeBlock;
+use sigil_stitch::lang::CodeLang;
+use sigil_stitch::lang::ruby::Ruby;
+use sigil_stitch::spec::file_spec::FileSpec;
+
+use super::golden;
+
+#[test]
+fn test_class() {
+    let ruby = Ruby::new();
+    let doc = ruby.render_doc_comment(&["Greeter says hello."]);
+
+    let mut b = CodeBlock::builder();
+    b.add("%L", doc);
+    b.add_line();
+    b.add("class Greeter", ());
+    b.add_line();
+    b.add("%>", ());
+    b.add("def initialize(name)", ());
+    b.add_line();
+    b.add("%>", ());
+    b.add_statement("@name = name", ());
+    b.add("%<", ());
+    b.add("end", ());
+    b.add_line();
+    b.add_line();
+    b.add("def greet", ());
+    b.add_line();
+    b.add("%>", ());
+    b.add_statement(r##""Hello, #{@name}""##, ());
+    b.add("%<", ());
+    b.add("end", ());
+    b.add_line();
+    b.add("%<", ());
+    b.add("end", ());
+    b.add_line();
+
+    let file = FileSpec::builder_with("greeter.rb", Ruby::new())
+        .add_code(b.build().unwrap())
+        .build()
+        .unwrap();
+    let output = file.render(80).unwrap();
+
+    golden::assert_golden("ruby/class.rb", &output);
+}
+
+#[test]
+fn test_module() {
+    let mut b = CodeBlock::builder();
+    b.add("module StringHelpers", ());
+    b.add_line();
+    b.add("%>", ());
+    b.add("def self.pluralize(word)", ());
+    b.add_line();
+    b.add("%>", ());
+    b.add_statement(r##""#{word}s""##, ());
+    b.add("%<", ());
+    b.add("end", ());
+    b.add_line();
+    b.add("%<", ());
+    b.add("end", ());
+    b.add_line();
+
+    let file = FileSpec::builder_with("helpers.rb", Ruby::new())
+        .add_code(b.build().unwrap())
+        .build()
+        .unwrap();
+    let output = file.render(80).unwrap();
+
+    golden::assert_golden("ruby/module.rb", &output);
+}

--- a/tests/ruby/main.rs
+++ b/tests/ruby/main.rs
@@ -1,0 +1,15 @@
+#[path = "../golden.rs"]
+mod golden;
+
+mod builder_control_flow;
+mod builder_edge_cases;
+mod builder_functions;
+mod builder_imports;
+mod builder_types;
+mod quote_basic;
+mod quote_control_flow;
+mod quote_edge_cases;
+mod quote_imports;
+mod quote_suite;
+#[path = "../shared/mod.rs"]
+mod shared;

--- a/tests/ruby/quote_basic.rs
+++ b/tests/ruby/quote_basic.rs
@@ -1,0 +1,4 @@
+#[test]
+fn test_basic() {
+    crate::shared::run_basic_test::<super::quote_suite::RubySuite>();
+}

--- a/tests/ruby/quote_control_flow.rs
+++ b/tests/ruby/quote_control_flow.rs
@@ -1,0 +1,4 @@
+#[test]
+fn test_control_flow() {
+    crate::shared::run_control_flow_test::<super::quote_suite::RubySuite>();
+}

--- a/tests/ruby/quote_edge_cases.rs
+++ b/tests/ruby/quote_edge_cases.rs
@@ -1,0 +1,107 @@
+use sigil_stitch::code_block::CodeBlock;
+use sigil_stitch::lang::ruby::Ruby;
+use sigil_stitch::prelude::*;
+use sigil_stitch::spec::file_spec::FileSpec;
+
+use super::golden;
+
+fn render(block: &CodeBlock) -> String {
+    FileSpec::builder_with("test.rb", Ruby::new())
+        .add_code(block.clone())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap()
+}
+
+#[test]
+fn test_string_interpolation() {
+    let block = sigil_quote!(Ruby {
+        greeting = "Hello, #{name}!"
+        path = "/users/#{id}/posts"
+    })
+    .unwrap();
+    golden::assert_golden("ruby/quote_string_interpolation.rb", &render(&block));
+}
+
+#[test]
+fn test_instance_variables() {
+    let block = sigil_quote!(Ruby {
+        @name = $S("Alice")
+        @age = 30
+        @@count = 1
+    })
+    .unwrap();
+    golden::assert_golden("ruby/quote_instance_vars.rb", &render(&block));
+}
+
+#[test]
+fn test_method_with_body() {
+    let block = sigil_quote!(Ruby {
+        def greet(name) {
+            $S("Hello, ") + name + $S("!")
+        }
+    })
+    .unwrap();
+    golden::assert_golden("ruby/quote_method.rb", &render(&block));
+}
+
+#[test]
+fn test_unless_control_flow() {
+    let block = sigil_quote!(Ruby {
+        unless x > 0 {
+            $S("not positive")
+        } else {
+            $S("positive")
+        }
+    })
+    .unwrap();
+    golden::assert_golden("ruby/quote_unless.rb", &render(&block));
+}
+
+#[test]
+fn test_while_loop() {
+    let block = sigil_quote!(Ruby {
+        while x > 0 {
+            x -= 1
+        }
+    })
+    .unwrap();
+    golden::assert_golden("ruby/quote_while.rb", &render(&block));
+}
+
+#[test]
+fn test_for_in_loop() {
+    let block = sigil_quote!(Ruby {
+        for i in 0..5 {
+            puts i
+        }
+    })
+    .unwrap();
+    golden::assert_golden("ruby/quote_for_in.rb", &render(&block));
+}
+
+#[test]
+fn test_name_keyword_escape() {
+    let name = "class";
+    let block = sigil_quote!(Ruby {
+        $N(name) = 1
+    })
+    .unwrap();
+
+    let output = render(&block);
+    assert!(output.contains("class_ = 1"), "got: {output}");
+}
+
+#[test]
+fn test_class_inheritance() {
+    let block = sigil_quote!(Ruby {
+        class Dog < Animal {
+            def speak {
+                $S("woof")
+            }
+        }
+    })
+    .unwrap();
+    golden::assert_golden("ruby/quote_inheritance.rb", &render(&block));
+}

--- a/tests/ruby/quote_imports.rs
+++ b/tests/ruby/quote_imports.rs
@@ -1,0 +1,28 @@
+use sigil_stitch::code_block::CodeBlock;
+use sigil_stitch::lang::ruby::Ruby;
+use sigil_stitch::prelude::*;
+use sigil_stitch::spec::file_spec::FileSpec;
+use sigil_stitch::type_name::TypeName;
+
+use super::golden;
+
+fn render(block: &CodeBlock) -> String {
+    FileSpec::builder_with("test.rb", Ruby::new())
+        .add_code(block.clone())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap()
+}
+
+#[test]
+fn test_imports() {
+    let json = TypeName::importable("json", "JSON");
+    let net = TypeName::importable("net/http", "Net");
+    let block = sigil_quote!(Ruby {
+        data = $T(json).parse(input)
+        $T(net).start
+    })
+    .unwrap();
+    golden::assert_golden("ruby/quote_imports.rb", &render(&block));
+}

--- a/tests/ruby/quote_suite.rs
+++ b/tests/ruby/quote_suite.rs
@@ -1,0 +1,51 @@
+use sigil_stitch::code_block::CodeBlock;
+use sigil_stitch::lang::ruby::Ruby;
+use sigil_stitch::prelude::*;
+use sigil_stitch::spec::file_spec::FileSpec;
+
+use crate::shared::LanguageTestSuite;
+
+pub struct RubySuite;
+
+impl LanguageTestSuite for RubySuite {
+    fn control_flow_block() -> CodeBlock {
+        sigil_quote!(Ruby {
+            if x > 0 {
+                return $S("positive")
+            } else {
+                return $S("negative")
+            }
+        })
+        .unwrap()
+    }
+
+    fn control_flow_golden_path() -> &'static str {
+        "ruby/macro_control_flow.rb"
+    }
+
+    fn basic_block() -> CodeBlock {
+        sigil_quote!(Ruby {
+            x = 42
+            name = $S("Alice")
+            puts name, x
+        })
+        .unwrap()
+    }
+
+    fn basic_golden_path() -> &'static str {
+        "ruby/macro_basic.rb"
+    }
+
+    fn render(block: CodeBlock) -> String {
+        FileSpec::builder_with("test.rb", Ruby::new())
+            .add_code(block)
+            .build()
+            .unwrap()
+            .render(80)
+            .unwrap()
+    }
+
+    fn file_spec_name() -> &'static str {
+        "test.rb"
+    }
+}


### PR DESCRIPTION
## Summary

- Full `RendererLang` + `CodeLang` implementation for Ruby
- `end`-delimited blocks with `close_on_transition: false` (same as Lua)
- `def`/`class`/`module` keywords, `#` line comments, 2-space indent
- `require` imports, `::` module separator
- `public`/`private`/`protected` visibility
- 26 golden tests (builder + sigil_quote! macro), 7 builder tests, example file

## Known limitations

- sigil_quote! Ruby symbol spacing: `attr_reader :name` renders as `attr_reader: name` due to colon-context treating `:` as type annotation
- sigil_quote! inheritance spacing: `class Dog < Animal` renders as `class Dog<Animal` due to `<` treated as GenericOpen

## Test plan

- [x] `cargo test --workspace` — all 520+ tests pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo run --example ruby_codegen` — valid Ruby output