### PR TITLE
fix: Ruby colon symbol prefix and inheritance angle spacing

### DIFF
--- a/examples/ruby_codegen.rs
+++ b/examples/ruby_codegen.rs
@@ -92,7 +92,7 @@ fn builder_approach() -> String {
 fn macro_approach() -> String {
     let body = sigil_quote!(Ruby {
         class Greeter {
-            attr_reader "name"
+            attr_reader :name
 
             def initialize(name) {
                 @name = name

--- a/macros/src/parse/annotate.rs
+++ b/macros/src/parse/annotate.rs
@@ -15,6 +15,8 @@ pub(super) enum TokenAnnotation {
     GenericOpen,
     /// `>` used as generic closer (matched via stack).
     GenericClose,
+    /// `<` used as Ruby inheritance operator (`class Dog < Animal`).
+    InheritanceAngle,
     /// `&` or `*` used as prefix operator (not binary).
     PrefixOp,
     /// `!` used as macro-call bang (after ident).
@@ -40,6 +42,8 @@ pub(super) enum TokenAnnotation {
     AssignAdjacent,
     /// `:` span-adjacent to both neighbors (Lua method call `obj:method()`).
     MethodCallColon,
+    /// `:` used as Ruby symbol prefix (`:name`, `:foo`).
+    SymbolColon,
     /// `-` that acts as flag prefix (like `-q`, `-f`). Does NOT suppress space
     /// before (so `declare -q` keeps the space). Only suppresses space after via
     /// `PrevTokenKind::PrefixOp`.
@@ -172,6 +176,28 @@ pub(super) fn annotate_tokens(tokens: &[TokenTree], lang: MacroLang) -> Vec<Toke
                                 && colon_end.column == next_start.column
                             {
                                 annotations[i] = TokenAnnotation::MethodCallColon;
+                            }
+                        }
+
+                        // Ruby symbol prefix: `:foo` — space before, no space after.
+                        if lang == MacroLang::Ruby
+                            && p.spacing() == Spacing::Alone
+                            && i + 1 < tokens.len()
+                            && matches!(&tokens[i + 1], TokenTree::Ident(_))
+                        {
+                            let colon_start = p.span().start();
+                            let colon_end = p.span().end();
+                            let next_start = tokens[i + 1].span().start();
+                            let prev_adjacent = i > 0 && {
+                                let prev_end = tokens[i - 1].span().end();
+                                prev_end.line == colon_start.line
+                                    && prev_end.column == colon_start.column
+                            };
+                            if !prev_adjacent
+                                && colon_end.line == next_start.line
+                                && colon_end.column == next_start.column
+                            {
+                                annotations[i] = TokenAnnotation::SymbolColon;
                             }
                         }
                     }
@@ -548,8 +574,12 @@ pub(super) fn annotate_tokens(tokens: &[TokenTree], lang: MacroLang) -> Vec<Toke
                             }
                         };
                         if is_generic {
-                            annotations[i] = TokenAnnotation::GenericOpen;
-                            generic_stack.push(i);
+                            if lang == MacroLang::Ruby {
+                                annotations[i] = TokenAnnotation::InheritanceAngle;
+                            } else {
+                                annotations[i] = TokenAnnotation::GenericOpen;
+                                generic_stack.push(i);
+                            }
                         }
                     }
                     '>' if !generic_stack.is_empty() => {

--- a/macros/src/parse/annotate_tests.rs
+++ b/macros/src/parse/annotate_tests.rs
@@ -168,6 +168,21 @@ fn go_send_not_prefix() {
 }
 
 #[test]
+fn ruby_symbol_colon() {
+    // space before :, NOT after (:name is adjacent)
+    let a = annotate_lang("attr_reader :name", MacroLang::Ruby);
+    assert_eq!(
+        ann_at(&a, 1),
+        TokenAnnotation::SymbolColon,
+        "expected SymbolColon, tokens: {}",
+        a.iter()
+            .map(|(t, a)| format!("{t}({a:?})"))
+            .collect::<Vec<_>>()
+            .join(" ")
+    );
+}
+
+#[test]
 fn normal_tokens_stay_normal() {
     let a = annotate_src("let x = 42");
     for (_, ann) in &a {

--- a/macros/src/parse/format.rs
+++ b/macros/src/parse/format.rs
@@ -411,7 +411,9 @@ fn tokens_to_format_inner(
                 state.prev = match annotation {
                     TokenAnnotation::PathSepComplete => PrevTokenKind::PathSep,
                     TokenAnnotation::GenericOpen => PrevTokenKind::GenericOpen,
-                    TokenAnnotation::PrefixOp => PrevTokenKind::PrefixOp(ch),
+                    TokenAnnotation::PrefixOp | TokenAnnotation::SymbolColon => {
+                        PrevTokenKind::PrefixOp(ch)
+                    }
                     TokenAnnotation::NullablePrefix => PrevTokenKind::PrefixOp('?'),
                     TokenAnnotation::DashFlag => PrevTokenKind::PrefixOp(ch),
                     TokenAnnotation::ArrowOp

--- a/macros/src/parse/format_tests.rs
+++ b/macros/src/parse/format_tests.rs
@@ -173,3 +173,12 @@ fn go_slice_type() {
 fn go_map_type() {
     assert_eq!(fmt_lang("map[string]int", MacroLang::Go), "map[string]int");
 }
+
+#[test]
+fn ruby_symbol_colon_spacing() {
+    // space before :, none after
+    assert_eq!(
+        fmt_lang("attr_reader :name", MacroLang::Ruby),
+        "attr_reader :name"
+    );
+}

--- a/macros/src/parse/spacing.rs
+++ b/macros/src/parse/spacing.rs
@@ -110,12 +110,17 @@ pub(super) fn maybe_space(
         match ch {
             ',' | ';' | ')' | ']' => return,
             '.' if annotation != TokenAnnotation::DotArg => return,
-            ':' if annotation != TokenAnnotation::DoubleColonOp => match state.colon_ctx {
-                ColonContext::Ternary | ColonContext::WalrusAssign | ColonContext::ForRange => {}
-                ColonContext::TypeAnnotation
-                | ColonContext::MapEntry
-                | ColonContext::PathSeparator => return,
-            },
+            ':' if annotation != TokenAnnotation::DoubleColonOp
+                && annotation != TokenAnnotation::SymbolColon =>
+            {
+                match state.colon_ctx {
+                    ColonContext::Ternary | ColonContext::WalrusAssign | ColonContext::ForRange => {
+                    }
+                    ColonContext::TypeAnnotation
+                    | ColonContext::MapEntry
+                    | ColonContext::PathSeparator => return,
+                }
+            }
             _ => {}
         }
     }

--- a/test-goldens/ruby/quote_inheritance.rb
+++ b/test-goldens/ruby/quote_inheritance.rb
@@ -1,4 +1,4 @@
-class Dog<Animal
+class Dog < Animal
   def speak
     "woof"
   end


### PR DESCRIPTION
## Summary

Fixes the two Ruby spacing limitations noted in #135:

- `attr_reader :name` no longer renders as `attr_reader:name` — colon keeps its leading space
- `class Dog < Animal` no longer renders as `class Dog<Animal` — `<` gets spaces on both sides

## Approach

Two new language-aware `TokenAnnotation` variants, both gated on `lang == MacroLang::Ruby`:

- **`SymbolColon`** — detected when `:` is adjacent to a following ident but not adjacent to the previous token. Maps to `PrevTokenKind::PrefixOp(':')` (suppresses space after) and exempted from `colon_ctx`-based suppression (allows space before)
- **`InheritanceAngle`** — used instead of `GenericOpen` for `<` in Ruby context. Falls through to default `Punct` spacing (spaces on both sides)

## Files changed

| File | Change |
|---|---|
| `macros/src/parse/annotate.rs` | Two new variants + detection logic |
| `macros/src/parse/format.rs` | `SymbolColon` → `PrefixOp` mapping |
| `macros/src/parse/spacing.rs` | `SymbolColon` exemption from `colon_ctx` |
| `macros/src/parse/annotate_tests.rs` | Unit test for `SymbolColon` annotation |
| `macros/src/parse/format_tests.rs` | Unit test for `SymbolColon` spacing |
| `examples/ruby_codegen.rs` | Remove `attr_reader "name"` workaround |
| `test-goldens/ruby/quote_inheritance.rb` | Golden updated: `class Dog < Animal` |

## Verification

- All workspace tests pass (zero failures)
- Clippy clean, rustfmt clean
