### PR TITLE
feat: add language-aware spacing via MacroLang methods

### DIFF
--- a/macros/src/parse/annotate.rs
+++ b/macros/src/parse/annotate.rs
@@ -117,8 +117,10 @@ pub(super) fn annotate_tokens(tokens: &[TokenTree], lang: MacroLang) -> Vec<Toke
                     i += 1;
                 }
                 // $T(...) always produces a type — mark following `<` as generic
-                // but NOT if it's `<<` (shift operator)
+                // but NOT if it's `<<` (shift operator), and only for
+                // languages that actually use `<>` angle-bracket generics.
                 if is_type_interp
+                    && lang.has_angle_generics()
                     && i < tokens.len()
                     && let TokenTree::Punct(p) = &tokens[i]
                     && p.as_char() == '<'
@@ -522,7 +524,9 @@ pub(super) fn annotate_tokens(tokens: &[TokenTree], lang: MacroLang) -> Vec<Toke
                         }
                         // NullablePrefix: `?` span-adjacent to a following ident —
                         // nullable type prefix like `?User` or `?string`.
-                        if annotations[i] == TokenAnnotation::Normal
+                        // Only valid in languages that use `?` as nullable prefix.
+                        if lang.nullable_prefix_is_valid()
+                            && annotations[i] == TokenAnnotation::Normal
                             && i + 1 < tokens.len()
                             && matches!(&tokens[i + 1], TokenTree::Ident(_))
                         {

--- a/macros/src/parse/format.rs
+++ b/macros/src/parse/format.rs
@@ -17,7 +17,7 @@ pub(crate) fn tokens_to_format(
 ) -> Result<(String, Vec<TypedArg>), CompileError> {
     let mut format = String::new();
     let mut args: Vec<TypedArg> = Vec::new();
-    let mut state = SpacingState::new();
+    let mut state = SpacingState::new(lang);
     let annotations = annotate_tokens(tokens, lang);
 
     tokens_to_format_inner(
@@ -403,8 +403,27 @@ fn tokens_to_format_inner(
                 // Context transitions after emitting the token.
                 match (ch, p.spacing()) {
                     ('?', Spacing::Alone) => state.colon_ctx = ColonContext::Ternary,
-                    (':', _) => state.colon_ctx = ColonContext::TypeAnnotation,
-                    (';', _) => state.colon_ctx = ColonContext::TypeAnnotation,
+                    (':', _)
+                        if !matches!(
+                            state.colon_ctx,
+                            ColonContext::MapEntry | ColonContext::ForRange
+                        ) =>
+                    {
+                        state.colon_ctx = if lang.default_colon_is_space_before() {
+                            ColonContext::SpaceBefore
+                        } else {
+                            ColonContext::TypeAnnotation
+                        };
+                    }
+                    // MapEntry (inside braces) or ForRange — preserve group-level context.
+                    (':', _) => {}
+                    (';', _) => {
+                        state.colon_ctx = if lang.default_colon_is_space_before() {
+                            ColonContext::SpaceBefore
+                        } else {
+                            ColonContext::TypeAnnotation
+                        };
+                    }
                     _ => {}
                 }
                 // Set prev based on annotation.

--- a/macros/src/parse/mod.rs
+++ b/macros/src/parse/mod.rs
@@ -24,12 +24,13 @@ fn parse_macro_lang(ts: &TokenStream) -> MacroLang {
     if let Some(TokenTree::Ident(id)) = first {
         match id.to_string().as_str() {
             "Bash" => MacroLang::Bash,
-            "Zsh" => MacroLang::Zsh,
+            "CSharp" => MacroLang::CSharp,
             "Go" => MacroLang::Go,
             "Haskell" => MacroLang::Haskell,
             "OCaml" => MacroLang::OCaml,
             "Php" => MacroLang::Php,
             "Ruby" => MacroLang::Ruby,
+            "Zsh" => MacroLang::Zsh,
             _ => MacroLang::Unaware,
         }
     } else {

--- a/macros/src/parse/spacing.rs
+++ b/macros/src/parse/spacing.rs
@@ -1,6 +1,7 @@
 use proc_macro2::Spacing;
 
 use super::annotate::TokenAnnotation;
+use super::types::MacroLang;
 
 /// What kind of token was just emitted (for spacing decisions).
 #[derive(Clone, Copy, PartialEq)]
@@ -37,6 +38,9 @@ pub(super) enum ColonContext {
     WalrusAssign,
     /// `for (item : collection)` — space before `:`.
     ForRange,
+    /// Explicit space-before-colon for languages where `:` is not a type annotation
+    /// (OCaml, Shell). Behaves like `Ternary`/`ForRange` — allows space before `:`.
+    SpaceBefore,
 }
 
 /// Accumulated state threaded through the format-string builder.
@@ -49,10 +53,14 @@ pub(super) struct SpacingState {
 }
 
 impl SpacingState {
-    pub fn new() -> Self {
+    pub fn new(lang: MacroLang) -> Self {
         Self {
             prev: PrevTokenKind::None,
-            colon_ctx: ColonContext::TypeAnnotation,
+            colon_ctx: if lang.default_colon_is_space_before() {
+                ColonContext::SpaceBefore
+            } else {
+                ColonContext::TypeAnnotation
+            },
             prev_specifier_end: None,
         }
     }
@@ -114,8 +122,10 @@ pub(super) fn maybe_space(
                 && annotation != TokenAnnotation::SymbolColon =>
             {
                 match state.colon_ctx {
-                    ColonContext::Ternary | ColonContext::WalrusAssign | ColonContext::ForRange => {
-                    }
+                    ColonContext::Ternary
+                    | ColonContext::WalrusAssign
+                    | ColonContext::ForRange
+                    | ColonContext::SpaceBefore => {}
                     ColonContext::TypeAnnotation
                     | ColonContext::MapEntry
                     | ColonContext::PathSeparator => return,

--- a/macros/src/parse/types.rs
+++ b/macros/src/parse/types.rs
@@ -8,17 +8,47 @@ use proc_macro2::{Span, TokenStream};
 pub(crate) enum MacroLang {
     Unaware,
     Bash,
-    Zsh,
+    CSharp,
     Go,
     Haskell,
     OCaml,
     Php,
     Ruby,
+    Zsh,
 }
 
 impl MacroLang {
     pub fn is_shell(self) -> bool {
         matches!(self, Self::Bash | Self::Zsh)
+    }
+
+    /// Whether `:` defaults to space-before in type position.
+    /// C-like languages use `name: Type` (no space before `:`);
+    /// OCaml and Shell conventionally use `(x : int)` / `echo :` with space.
+    pub fn default_colon_is_space_before(self) -> bool {
+        matches!(self, Self::OCaml | Self::Bash | Self::Zsh)
+    }
+
+    /// Whether the language uses `<>` angle brackets for generics,
+    /// so that `$T(Type)<params>` should mark `<` as GenericOpen.
+    /// True for `Unaware` because most unrecognized languages (C#, Java,
+    /// TypeScript, C++, etc.) use C-style angle-bracket generics.
+    pub fn has_angle_generics(self) -> bool {
+        !matches!(
+            self,
+            Self::Ruby
+                | Self::Bash
+                | Self::Zsh
+                | Self::OCaml
+                | Self::Php
+                | Self::Go
+                | Self::Haskell
+        )
+    }
+
+    /// Whether `?Ident` (nullable prefix like `?User`, `?string`) is valid syntax.
+    pub fn nullable_prefix_is_valid(self) -> bool {
+        matches!(self, Self::Php | Self::OCaml)
     }
 }
 


### PR DESCRIPTION
## Summary
- Add `default_colon_is_space_before()`, `has_angle_generics()`, `nullable_prefix_is_valid()` methods to `MacroLang`
- Add `ColonContext::SpaceBefore` for languages where `:` is not a type annotation (OCaml, Shell)
- Gate `$T(...)` GenericOpen marking and `?` NullablePrefix annotation on language features
- Preserve `MapEntry`/`ForRange` group contexts through `:` emission in format.rs
- Add `CSharp` to `MacroLang` enum

## Test plan
- [x] `cargo test --workspace` — 0 failures
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean