### PR TITLE
feat: add inline $for and $if support to sigil_quote!

### DIFF
--- a/macros/src/codegen.rs
+++ b/macros/src/codegen.rs
@@ -281,6 +281,19 @@ fn build_args_tuple(args: &[TypedArg]) -> TokenStream {
                             }
                         }
                     }
+                    InterpolationKind::ParsedSplice => {
+                        let body_stmts = arg.parsed_body.as_ref()
+                            .expect("ParsedSplice must have parsed_body");
+                        let body_calls = generate_statements(body_stmts);
+                        quote! {
+                            {
+                                let mut __sigil_builder =
+                                    ::sigil_stitch::code_block::CodeBlock::builder();
+                                #(#body_calls)*
+                                __sigil_builder.build().unwrap()
+                            }
+                        }
+                    }
                 }
             })
             .collect();

--- a/macros/src/parse/brace_classifier.rs
+++ b/macros/src/parse/brace_classifier.rs
@@ -31,6 +31,11 @@ pub(super) enum BraceKind {
 /// handled inline because they depend on outer loop context.
 pub(super) fn classify(prefix_tokens: &[TokenTree], group: &proc_macro2::Group) -> BraceKind {
     if looks_like_control_flow_header(prefix_tokens) {
+        // Don't intercept `$if(cond) { ... }` or `$for(pat in expr) { ... }`
+        // — these are inline meta directives, not target-language control flow.
+        if ends_with_sigil_directive(prefix_tokens) {
+            return BraceKind::Literal;
+        }
         return BraceKind::ControlFlow;
     }
 
@@ -164,8 +169,39 @@ fn is_interpolation_paren(tokens: &[TokenTree], pos: usize) -> bool {
         && matches!(&tokens[pos - 1], TokenTree::Ident(_))
 }
 
+/// Check whether the prefix tokens end with a sigil-stitch inline directive
+/// pattern. Recognizes:
+/// - `$if(expr)` / `$for(expr)` / `$else_if(expr)` → brace is directive body
+/// - `$else` → brace is `$else { ... }` directive body
+fn ends_with_sigil_directive(tokens: &[TokenTree]) -> bool {
+    let n = tokens.len();
+    // Pattern: `$`, `else`, (no paren group needed — $else has no condition)
+    if n >= 2
+        && let TokenTree::Punct(dollar) = &tokens[n - 2]
+        && dollar.as_char() == '$'
+        && let TokenTree::Ident(id) = &tokens[n - 1]
+        && id.to_string().as_str() == "else"
+    {
+        return true;
+    }
+    // Pattern: `$`, `if`/`for`/`else_if`, `(...)`
+    if n >= 3
+        && let TokenTree::Punct(dollar) = &tokens[n - 3]
+        && dollar.as_char() == '$'
+        && let TokenTree::Ident(id) = &tokens[n - 2]
+        && matches!(id.to_string().as_str(), "if" | "for" | "else_if")
+        && let TokenTree::Group(g) = &tokens[n - 1]
+        && g.delimiter() == Delimiter::Parenthesis
+    {
+        return true;
+    }
+    false
+}
+
 /// Check if a brace group contains a statement-level sigil marker
-/// (`$C_each`, `$for`, `$if`, `$let`) that requires a control-flow context.
+/// (`$C_each`, `$let`) that requires a control-flow context.
+/// Note: `$for`/`$if`/`$else_if`/`$else` are now handled inline by
+/// `tokens_to_format_inner` and do NOT need statement-level interception.
 /// Unlike `has_meta_marker`, this skips inline specifiers (`$S`, `$V`, `$L`,
 /// `$N`, `$T`, `$join`) which work fine inside literal brace groups.
 pub(super) fn has_statement_marker(g: &proc_macro2::Group) -> bool {
@@ -178,10 +214,7 @@ pub(super) fn has_statement_marker(g: &proc_macro2::Group) -> bool {
             && let TokenTree::Ident(id) = &stream[i + 1]
         {
             let s = id.to_string();
-            if matches!(
-                s.as_str(),
-                "C_each" | "for" | "if" | "else_if" | "else" | "let"
-            ) {
+            if matches!(s.as_str(), "C_each" | "let") {
                 return true;
             }
         }

--- a/macros/src/parse/directives.rs
+++ b/macros/src/parse/directives.rs
@@ -1,0 +1,237 @@
+use proc_macro2::{Delimiter, TokenStream, TokenTree};
+
+use super::parse_body;
+use super::types::{CompileError, MacroLang, MetaBranch, Statement};
+use super::util::is_ident;
+
+/// Parse `(pat in expr) { body }` at `paren_pos` (after `$for` confirmed).
+///
+/// Returns `(next_pos, pat, iter_expr, body_statements)` where `next_pos`
+/// is the position after the closing `}` group.
+pub(super) fn parse_for_components(
+    tokens: &[TokenTree],
+    paren_pos: usize,
+    lang: MacroLang,
+) -> Result<(usize, TokenStream, TokenStream, Vec<Statement>), CompileError> {
+    // Bounds checks.
+    if paren_pos >= tokens.len() {
+        return Err(CompileError::new(
+            proc_macro2::Span::call_site(),
+            "expected parenthesized pattern after $for",
+        ));
+    }
+    if paren_pos + 1 >= tokens.len() {
+        return Err(CompileError::new(
+            proc_macro2::Span::call_site(),
+            "$for requires a brace body: $for(pat in expr) { ... }",
+        ));
+    }
+
+    let paren_group = match &tokens[paren_pos] {
+        TokenTree::Group(g) if g.delimiter() == Delimiter::Parenthesis => g.clone(),
+        _ => {
+            return Err(CompileError::new(
+                tokens[paren_pos].span(),
+                "$for requires a parenthesized pattern: $for(pat in expr) { ... }",
+            ));
+        }
+    };
+
+    let body_group = match &tokens[paren_pos + 1] {
+        TokenTree::Group(g) if g.delimiter() == Delimiter::Brace => g.clone(),
+        _ => {
+            return Err(CompileError::new(
+                tokens[paren_pos + 1].span(),
+                "$for requires a brace body: $for(pat in expr) { ... }",
+            ));
+        }
+    };
+
+    // Split paren contents on the first `in` keyword.
+    let paren_tokens: Vec<TokenTree> = paren_group.stream().into_iter().collect();
+    let in_pos = paren_tokens.iter().position(|tt| is_ident(tt, "in"));
+    let in_pos = match in_pos {
+        Some(p) => p,
+        None => {
+            return Err(CompileError::new(
+                paren_group.span(),
+                "$for requires `in` keyword: $for(pat in expr) { ... }",
+            ));
+        }
+    };
+
+    if in_pos == 0 {
+        return Err(CompileError::new(
+            paren_group.span(),
+            "$for pattern cannot be empty: $for(pat in expr) { ... }",
+        ));
+    }
+    if in_pos + 1 >= paren_tokens.len() {
+        return Err(CompileError::new(
+            paren_group.span(),
+            "$for iterator expression cannot be empty: $for(pat in expr) { ... }",
+        ));
+    }
+
+    let pat: TokenStream = paren_tokens[..in_pos].iter().cloned().collect();
+    let iter_expr: TokenStream = paren_tokens[in_pos + 1..].iter().cloned().collect();
+
+    let body_tokens: Vec<TokenTree> = body_group.stream().into_iter().collect();
+    let body = parse_body(&body_tokens, lang)?;
+
+    Ok((paren_pos + 2, pat, iter_expr, body))
+}
+
+/// Parse `(cond) { body } [$else_if(cond) { body }]* [$else { body }]`
+/// at `cond_pos` (after `$if` confirmed).
+///
+/// Returns `(next_pos, branches)` where `next_pos` is the position after
+/// the last consumed token.
+pub(super) fn parse_if_components(
+    tokens: &[TokenTree],
+    cond_pos: usize,
+    lang: MacroLang,
+) -> Result<(usize, Vec<MetaBranch>), CompileError> {
+    // Bounds check for first branch.
+    if cond_pos >= tokens.len() {
+        return Err(CompileError::new(
+            proc_macro2::Span::call_site(),
+            "expected parenthesized condition after $if",
+        ));
+    }
+    if cond_pos + 1 >= tokens.len() {
+        return Err(CompileError::new(
+            proc_macro2::Span::call_site(),
+            "$if requires a brace body: $if(condition) { ... }",
+        ));
+    }
+
+    let mut pos = cond_pos;
+    let mut branches = Vec::new();
+
+    // Parse `(cond) { body }` for the $if branch.
+    let cond_group = match &tokens[pos] {
+        TokenTree::Group(g) if g.delimiter() == Delimiter::Parenthesis => g.clone(),
+        _ => {
+            return Err(CompileError::new(
+                tokens[pos].span(),
+                "$if requires a parenthesized condition: $if(condition) { ... }",
+            ));
+        }
+    };
+    if cond_group.stream().is_empty() {
+        return Err(CompileError::new(
+            cond_group.span(),
+            "$if condition cannot be empty",
+        ));
+    }
+    pos += 1;
+
+    let body_group = match &tokens[pos] {
+        TokenTree::Group(g) if g.delimiter() == Delimiter::Brace => g.clone(),
+        _ => {
+            return Err(CompileError::new(
+                tokens[pos].span(),
+                "$if requires a brace body: $if(condition) { ... }",
+            ));
+        }
+    };
+    pos += 1;
+
+    let body_tokens: Vec<TokenTree> = body_group.stream().into_iter().collect();
+    let body = parse_body(&body_tokens, lang)?;
+    branches.push(MetaBranch {
+        condition: Some(cond_group.stream()),
+        body,
+    });
+
+    // Parse optional $else_if / $else continuations.
+    loop {
+        if pos + 1 >= tokens.len() {
+            break;
+        }
+        let is_dollar = matches!(&tokens[pos], TokenTree::Punct(p) if p.as_char() == '$');
+        if !is_dollar {
+            break;
+        }
+
+        if is_ident(&tokens[pos + 1], "else_if") {
+            pos += 2;
+            if pos >= tokens.len() {
+                return Err(CompileError::new(
+                    tokens[pos - 1].span(),
+                    "$else_if requires a parenthesized condition",
+                ));
+            }
+            let cond_group = match &tokens[pos] {
+                TokenTree::Group(g) if g.delimiter() == Delimiter::Parenthesis => g.clone(),
+                _ => {
+                    return Err(CompileError::new(
+                        tokens[pos].span(),
+                        "$else_if requires a parenthesized condition: $else_if(condition) { ... }",
+                    ));
+                }
+            };
+            if cond_group.stream().is_empty() {
+                return Err(CompileError::new(
+                    cond_group.span(),
+                    "$else_if condition cannot be empty",
+                ));
+            }
+            pos += 1;
+            if pos >= tokens.len() {
+                return Err(CompileError::new(
+                    tokens[pos - 1].span(),
+                    "$else_if requires a brace body",
+                ));
+            }
+            let body_group = match &tokens[pos] {
+                TokenTree::Group(g) if g.delimiter() == Delimiter::Brace => g.clone(),
+                _ => {
+                    return Err(CompileError::new(
+                        tokens[pos].span(),
+                        "$else_if requires a brace body: $else_if(condition) { ... }",
+                    ));
+                }
+            };
+            pos += 1;
+
+            let body_tokens: Vec<TokenTree> = body_group.stream().into_iter().collect();
+            let body = parse_body(&body_tokens, lang)?;
+            branches.push(MetaBranch {
+                condition: Some(cond_group.stream()),
+                body,
+            });
+        } else if is_ident(&tokens[pos + 1], "else") {
+            pos += 2;
+            if pos >= tokens.len() {
+                return Err(CompileError::new(
+                    tokens[pos - 1].span(),
+                    "$else requires a brace body",
+                ));
+            }
+            let body_group = match &tokens[pos] {
+                TokenTree::Group(g) if g.delimiter() == Delimiter::Brace => g.clone(),
+                _ => {
+                    return Err(CompileError::new(
+                        tokens[pos].span(),
+                        "$else requires a brace body: $else { ... }",
+                    ));
+                }
+            };
+            pos += 1;
+
+            let body_tokens: Vec<TokenTree> = body_group.stream().into_iter().collect();
+            let body = parse_body(&body_tokens, lang)?;
+            branches.push(MetaBranch {
+                condition: None,
+                body,
+            });
+            break;
+        } else {
+            break;
+        }
+    }
+
+    Ok((pos, branches))
+}

--- a/macros/src/parse/format.rs
+++ b/macros/src/parse/format.rs
@@ -3,8 +3,9 @@ use proc_macro2::{Delimiter, Spacing, TokenStream, TokenTree};
 use super::annotate::{
     CONTROL_FLOW_KEYWORDS, DECLARATION_KEYWORDS, TokenAnnotation, annotate_tokens,
 };
+use super::directives::{parse_for_components, parse_if_components};
 use super::spacing::{ColonContext, PrevTokenKind, SpacingState, maybe_space};
-use super::types::{CompileError, InterpolationKind, MacroLang, TypedArg};
+use super::types::{CompileError, InterpolationKind, MacroLang, Statement, TypedArg};
 use super::util::is_ident;
 
 /// Convert a sequence of tokens into a format string and typed argument list.
@@ -143,16 +144,90 @@ fn tokens_to_format_inner(
                 ));
             }
 
-            // `$if`/`$else_if`/`$else`/`$for`/`$let` should have been caught earlier (statement-level).
-            if is_ident(next, "if")
-                || is_ident(next, "else_if")
-                || is_ident(next, "else")
-                || is_ident(next, "for")
-                || is_ident(next, "let")
-            {
+            // `$for(pat in expr) { body }` — inline meta-for loop.
+            if is_ident(next, "for") {
+                pos += 1;
+                if pos >= tokens.len() {
+                    return Err(CompileError::new(
+                        next.span(),
+                        "$for requires a parenthesized pattern: $for(pat in expr) { ... }",
+                    ));
+                }
+                let (after_for, pat, iter_expr, body) = parse_for_components(tokens, pos, lang)?;
+
+                if !adjacent_to_prev_specifier {
+                    maybe_space(
+                        format,
+                        state,
+                        PrevTokenKind::Specifier,
+                        TokenAnnotation::Normal,
+                    );
+                }
+                format.push_str("%L");
+                state.prev = PrevTokenKind::Specifier;
+                let end = tokens[after_for - 1].span().end();
+                state.prev_specifier_end = Some((end.line, end.column));
+
+                args.push(TypedArg {
+                    kind: InterpolationKind::ParsedSplice,
+                    expr: TokenStream::new(),
+                    parsed_body: Some(vec![Statement::MetaFor {
+                        pat,
+                        iter_expr,
+                        body,
+                    }]),
+                });
+                pos = after_for;
+                continue;
+            }
+
+            // `$if(cond) { body } [$else_if(cond) { body }]* [$else { body }]`
+            // — inline meta-conditional.
+            if is_ident(next, "if") {
+                pos += 1;
+                if pos >= tokens.len() {
+                    return Err(CompileError::new(
+                        next.span(),
+                        "$if requires a parenthesized condition: $if(condition) { ... }",
+                    ));
+                }
+                let (after_if, branches) = parse_if_components(tokens, pos, lang)?;
+
+                if !adjacent_to_prev_specifier {
+                    maybe_space(
+                        format,
+                        state,
+                        PrevTokenKind::Specifier,
+                        TokenAnnotation::Normal,
+                    );
+                }
+                format.push_str("%L");
+                state.prev = PrevTokenKind::Specifier;
+                let end = tokens[after_if - 1].span().end();
+                state.prev_specifier_end = Some((end.line, end.column));
+
+                args.push(TypedArg {
+                    kind: InterpolationKind::ParsedSplice,
+                    expr: TokenStream::new(),
+                    parsed_body: Some(vec![Statement::MetaIf { branches }]),
+                });
+                pos = after_if;
+                continue;
+            }
+
+            // `$else_if` / `$else` only valid as continuation of `$if`.
+            if is_ident(next, "else_if") || is_ident(next, "else") {
                 return Err(CompileError::new(
                     next.span(),
-                    "$if/$else_if/$else/$for/$let must appear at the start of a line",
+                    "$else_if/$else must immediately follow a $if(condition) { ... } branch",
+                ));
+            }
+
+            // `$let` is a Rust-level binding, only meaningful at statement level.
+            if is_ident(next, "let") {
+                return Err(CompileError::new(
+                    next.span(),
+                    "$let must appear at the start of a line",
                 ));
             }
 
@@ -283,7 +358,7 @@ fn tokens_to_format_inner(
                             id.span(),
                             format!(
                                 "unknown interpolation kind `${kind_str}`. \
-                                     Expected $T, $N, $S, $V, $L, $C, $W, $T_join, $join, $comment, or $C_each"
+                                     Expected $T, $N, $S, $V, $L, $C, $W, $T_join, $join, $comment, $for, $if, or $C_each"
                             ),
                         ));
                     }
@@ -319,7 +394,8 @@ fn tokens_to_format_inner(
                     InterpolationKind::Literal
                     | InterpolationKind::Code
                     | InterpolationKind::TypeJoin
-                    | InterpolationKind::ParsedBlock => "%L",
+                    | InterpolationKind::ParsedBlock
+                    | InterpolationKind::ParsedSplice => "%L",
                     InterpolationKind::Comment => "%R",
                 };
 
@@ -348,7 +424,7 @@ fn tokens_to_format_inner(
 
             return Err(CompileError::new(
                 next.span(),
-                "expected interpolation kind after `$`: $T, $N, $S, $V, $L, $C, $W, $T_join, $join, $C_each, $for, or $$",
+                "expected interpolation kind after `$`: $T, $N, $S, $V, $L, $C, $W, $T_join, $join, $for, $if, or $$",
             ));
         }
 

--- a/macros/src/parse/format_tests.rs
+++ b/macros/src/parse/format_tests.rs
@@ -182,3 +182,64 @@ fn ruby_symbol_colon_spacing() {
         "attr_reader :name"
     );
 }
+
+#[test]
+fn inline_for_emits_parsed_splice() {
+    let (format, kinds) = fmt_with_args("($for(x in items) { $N(*x) })");
+    assert_eq!(format, "(%L)");
+    assert_eq!(kinds.len(), 1);
+    assert!(matches!(kinds[0], InterpolationKind::ParsedSplice));
+}
+
+#[test]
+fn inline_for_mixed_with_literals() {
+    let (format, kinds) = fmt_with_args("prefix $for(x in items) { $N(*x) } suffix");
+    assert!(format.starts_with("prefix "));
+    assert!(format.contains(" %L "));
+    assert!(format.ends_with(" suffix"));
+    assert!(matches!(kinds[0], InterpolationKind::ParsedSplice));
+}
+
+#[test]
+fn inline_if_emits_parsed_splice() {
+    let (format, kinds) = fmt_with_args("($if(cond) { a } $else { b })");
+    assert_eq!(format, "(%L)");
+    assert_eq!(kinds.len(), 1);
+    assert!(matches!(kinds[0], InterpolationKind::ParsedSplice));
+}
+
+#[test]
+fn inline_else_if_standalone_rejected() {
+    let ts: TokenStream = "$else_if(cond) { body }".parse().unwrap();
+    let tokens: Vec<TokenTree> = ts.into_iter().collect();
+    let result = tokens_to_format(&tokens, MacroLang::Unaware);
+    assert!(result.is_err());
+}
+
+#[test]
+fn inline_else_standalone_rejected() {
+    let ts: TokenStream = "$else { body }".parse().unwrap();
+    let tokens: Vec<TokenTree> = ts.into_iter().collect();
+    let result = tokens_to_format(&tokens, MacroLang::Unaware);
+    assert!(result.is_err());
+}
+
+#[test]
+fn inline_let_rejected() {
+    let ts: TokenStream = "($let(x = 1))".parse().unwrap();
+    let tokens: Vec<TokenTree> = ts.into_iter().collect();
+    let result = tokens_to_format(&tokens, MacroLang::Unaware);
+    assert!(result.is_err());
+}
+
+#[test]
+fn inline_for_adjacent_to_prev_specifier() {
+    // $T(type)$for(x in items) { $N(*x) } — no space between specifiers
+    let ts: TokenStream = "$T(my_type)$for(x in items) { $N(*x) }".parse().unwrap();
+    let tokens: Vec<TokenTree> = ts.into_iter().collect();
+    let (format, args) = tokens_to_format(&tokens, MacroLang::Unaware).unwrap();
+    assert_eq!(format, "%T%L");
+    assert_eq!(args.len(), 2);
+    assert!(matches!(args[0].kind, InterpolationKind::Type));
+    assert!(matches!(args[1].kind, InterpolationKind::ParsedSplice));
+}

--- a/macros/src/parse/mod.rs
+++ b/macros/src/parse/mod.rs
@@ -5,6 +5,7 @@
 
 mod annotate;
 mod brace_classifier;
+mod directives;
 mod format;
 mod spacing;
 mod statements;

--- a/macros/src/parse/statements.rs
+++ b/macros/src/parse/statements.rs
@@ -1,11 +1,10 @@
 use proc_macro2::{Delimiter, Spacing, TokenStream, TokenTree};
 
 use super::brace_classifier::{self, BraceKind};
+use super::directives::{parse_for_components, parse_if_components};
 use super::format::tokens_to_format;
 use super::parse_body;
-use super::types::{
-    Branch, CompileError, InterpolationKind, MacroLang, MetaBranch, Statement, TypedArg,
-};
+use super::types::{Branch, CompileError, InterpolationKind, MacroLang, Statement, TypedArg};
 use super::util::{is_ident, is_semicolon};
 
 /// Parse a single statement starting at `pos`.
@@ -375,125 +374,9 @@ fn try_parse_meta_if(
         return Ok(None);
     }
 
-    let mut pos = start + 2;
-    let mut branches = Vec::new();
+    let (next_pos, branches) = parse_if_components(tokens, start + 2, lang)?;
 
-    // Parse `(cond) { body }` for the $if branch.
-    let cond_group = match &tokens[pos] {
-        TokenTree::Group(g) if g.delimiter() == Delimiter::Parenthesis => g.clone(),
-        _ => {
-            return Err(CompileError::new(
-                tokens[pos].span(),
-                "$if requires a parenthesized condition: $if(condition) { ... }",
-            ));
-        }
-    };
-    pos += 1;
-
-    let body_group = match &tokens[pos] {
-        TokenTree::Group(g) if g.delimiter() == Delimiter::Brace => g.clone(),
-        _ => {
-            return Err(CompileError::new(
-                tokens[pos].span(),
-                "$if requires a brace body: $if(condition) { ... }",
-            ));
-        }
-    };
-    pos += 1;
-
-    let body_tokens: Vec<TokenTree> = body_group.stream().into_iter().collect();
-    let body = parse_body(&body_tokens, lang)?;
-    branches.push(MetaBranch {
-        condition: Some(cond_group.stream()),
-        body,
-    });
-
-    // Parse optional $else_if / $else continuations.
-    loop {
-        // Look for `$` `else_if` or `$` `else`.
-        if pos + 1 >= tokens.len() {
-            break;
-        }
-        let is_dollar = matches!(&tokens[pos], TokenTree::Punct(p) if p.as_char() == '$');
-        if !is_dollar {
-            break;
-        }
-
-        if is_ident(&tokens[pos + 1], "else_if") {
-            // $else_if(cond) { body }
-            pos += 2;
-            if pos >= tokens.len() {
-                return Err(CompileError::new(
-                    tokens[pos - 1].span(),
-                    "$else_if requires a parenthesized condition",
-                ));
-            }
-            let cond_group = match &tokens[pos] {
-                TokenTree::Group(g) if g.delimiter() == Delimiter::Parenthesis => g.clone(),
-                _ => {
-                    return Err(CompileError::new(
-                        tokens[pos].span(),
-                        "$else_if requires a parenthesized condition: $else_if(condition) { ... }",
-                    ));
-                }
-            };
-            pos += 1;
-            if pos >= tokens.len() {
-                return Err(CompileError::new(
-                    tokens[pos - 1].span(),
-                    "$else_if requires a brace body",
-                ));
-            }
-            let body_group = match &tokens[pos] {
-                TokenTree::Group(g) if g.delimiter() == Delimiter::Brace => g.clone(),
-                _ => {
-                    return Err(CompileError::new(
-                        tokens[pos].span(),
-                        "$else_if requires a brace body: $else_if(condition) { ... }",
-                    ));
-                }
-            };
-            pos += 1;
-
-            let body_tokens: Vec<TokenTree> = body_group.stream().into_iter().collect();
-            let body = parse_body(&body_tokens, lang)?;
-            branches.push(MetaBranch {
-                condition: Some(cond_group.stream()),
-                body,
-            });
-        } else if is_ident(&tokens[pos + 1], "else") {
-            // $else { body }
-            pos += 2;
-            if pos >= tokens.len() {
-                return Err(CompileError::new(
-                    tokens[pos - 1].span(),
-                    "$else requires a brace body",
-                ));
-            }
-            let body_group = match &tokens[pos] {
-                TokenTree::Group(g) if g.delimiter() == Delimiter::Brace => g.clone(),
-                _ => {
-                    return Err(CompileError::new(
-                        tokens[pos].span(),
-                        "$else requires a brace body: $else { ... }",
-                    ));
-                }
-            };
-            pos += 1;
-
-            let body_tokens: Vec<TokenTree> = body_group.stream().into_iter().collect();
-            let body = parse_body(&body_tokens, lang)?;
-            branches.push(MetaBranch {
-                condition: None,
-                body,
-            });
-            break; // $else is always last.
-        } else {
-            break;
-        }
-    }
-
-    Ok(Some((Statement::MetaIf { branches }, pos)))
+    Ok(Some((Statement::MetaIf { branches }, next_pos)))
 }
 
 /// Try to parse `$for(pat in expr) { ... }` at position `start`.
@@ -517,57 +400,7 @@ fn try_parse_meta_for(
         return Ok(None);
     }
 
-    let paren_group = match &tokens[start + 2] {
-        TokenTree::Group(g) if g.delimiter() == Delimiter::Parenthesis => g.clone(),
-        _ => {
-            return Err(CompileError::new(
-                tokens[start + 2].span(),
-                "$for requires a parenthesized pattern: $for(pat in expr) { ... }",
-            ));
-        }
-    };
-
-    let body_group = match &tokens[start + 3] {
-        TokenTree::Group(g) if g.delimiter() == Delimiter::Brace => g.clone(),
-        _ => {
-            return Err(CompileError::new(
-                tokens[start + 3].span(),
-                "$for requires a brace body: $for(pat in expr) { ... }",
-            ));
-        }
-    };
-
-    // Split paren contents on the first `in` keyword.
-    let paren_tokens: Vec<TokenTree> = paren_group.stream().into_iter().collect();
-    let in_pos = paren_tokens.iter().position(|tt| is_ident(tt, "in"));
-    let in_pos = match in_pos {
-        Some(p) => p,
-        None => {
-            return Err(CompileError::new(
-                paren_group.span(),
-                "$for requires `in` keyword: $for(pat in expr) { ... }",
-            ));
-        }
-    };
-
-    if in_pos == 0 {
-        return Err(CompileError::new(
-            paren_group.span(),
-            "$for pattern cannot be empty: $for(pat in expr) { ... }",
-        ));
-    }
-    if in_pos + 1 >= paren_tokens.len() {
-        return Err(CompileError::new(
-            paren_group.span(),
-            "$for iterator expression cannot be empty: $for(pat in expr) { ... }",
-        ));
-    }
-
-    let pat: proc_macro2::TokenStream = paren_tokens[..in_pos].iter().cloned().collect();
-    let iter_expr: proc_macro2::TokenStream = paren_tokens[in_pos + 1..].iter().cloned().collect();
-
-    let body_tokens: Vec<TokenTree> = body_group.stream().into_iter().collect();
-    let body = parse_body(&body_tokens, lang)?;
+    let (next_pos, pat, iter_expr, body) = parse_for_components(tokens, start + 2, lang)?;
 
     Ok(Some((
         Statement::MetaFor {
@@ -575,7 +408,7 @@ fn try_parse_meta_for(
             iter_expr,
             body,
         },
-        start + 4,
+        next_pos, // helper returns paren_pos + 2 = start + 4
     )))
 }
 

--- a/macros/src/parse/types.rs
+++ b/macros/src/parse/types.rs
@@ -166,6 +166,10 @@ pub(crate) enum InterpolationKind {
     /// (`$C_each`, `$for`, `$if`, `$let`). Emitted as a nested
     /// `CodeBlock` via `%L`.
     ParsedBlock,
+    /// Parsed inline splice (`$for`/`$if` inside expressions).
+    /// Emitted as `%L` + nested CodeBlock WITHOUT synthetic block delimiters
+    /// (no `begin_control_flow` / `end_control_flow_no_newline` wrapping).
+    ParsedSplice,
 }
 
 /// A compile error with span information.

--- a/tests/macro/main.rs
+++ b/tests/macro/main.rs
@@ -22,6 +22,7 @@ mod keyword_spacing;
 mod line_splitting;
 mod meta_for;
 mod meta_if;
+mod meta_inline;
 mod meta_let;
 mod multi_language;
 mod non_brace_langs;

--- a/tests/macro/meta_inline.rs
+++ b/tests/macro/meta_inline.rs
@@ -1,0 +1,278 @@
+use super::helpers::*;
+
+// --- Inline $for inside expressions ---
+
+#[test]
+fn test_inline_for_inside_parens_ts() {
+    let items = vec!["a", "b"];
+    let block = sigil_quote!(TypeScript {
+        const x = [$for(item in &items) { $S(*item), }];
+    })
+    .unwrap();
+    let output = render_ts(&block);
+    assert!(output.contains("const x = ["), "got: {output}");
+    assert!(output.contains("'a'"), "got: {output}");
+    assert!(output.contains("'b'"), "got: {output}");
+    // No stray braces from block delimiters
+    assert!(!output.contains('{'), "unexpected brace in: {output}");
+    assert!(!output.contains('}'), "unexpected brace in: {output}");
+}
+
+#[test]
+fn test_inline_for_zero_items() {
+    let items: Vec<&str> = vec![];
+    let block = sigil_quote!(TypeScript {
+        const x = [$for(item in &items) { $S(*item), }];
+    })
+    .unwrap();
+    let output = render_ts(&block);
+    // Empty iteration produces nothing inside the array
+    assert!(
+        output.contains("const x = []") || output.contains("const x = [ ]"),
+        "got: {output}"
+    );
+}
+
+#[test]
+fn test_inline_for_inside_parens_py() {
+    let items = vec!["a", "b"];
+    let block = sigil_quote!(Python {
+        x = [$for(item in &items) { $S(*item), }]
+    })
+    .unwrap();
+    let output = render_py(&block);
+    assert!(output.contains("x = ["), "got: {output}");
+    assert!(output.contains("'a'"), "got: {output}");
+    assert!(output.contains("'b'"), "got: {output}");
+    // No stray colon from block delimiters
+    assert!(
+        !output.contains(": ["),
+        "unexpected colon before bracket in: {output}"
+    );
+}
+
+#[test]
+fn test_inline_for_empty_py() {
+    let items: Vec<&str> = vec![];
+    let block = sigil_quote!(Python {
+        x = [$for(item in &items) { $S(*item), }]
+    })
+    .unwrap();
+    let output = render_py(&block);
+    assert!(
+        output.contains("x = []") || output.contains("x = [ ]"),
+        "got: {output}"
+    );
+}
+
+// --- Inline $if/$else inside expressions ---
+
+#[test]
+fn test_inline_if_true_branch_ts() {
+    let flag = true;
+    let block = sigil_quote!(TypeScript {
+        const msg = $if(flag) { "yes" } $else { "no" };
+    })
+    .unwrap();
+    let output = render_ts(&block);
+    assert!(output.contains("yes"), "got: {output}");
+    assert!(!output.contains("no"), "got: {output}");
+    // No stray braces
+    assert!(!output.contains('{'), "unexpected brace in: {output}");
+    assert!(!output.contains('}'), "unexpected brace in: {output}");
+}
+
+#[test]
+fn test_inline_if_false_branch_ts() {
+    let flag = false;
+    let block = sigil_quote!(TypeScript {
+        const msg = $if(flag) { "yes" } $else { "no" };
+    })
+    .unwrap();
+    let output = render_ts(&block);
+    assert!(output.contains("no"), "got: {output}");
+    assert!(!output.contains("yes"), "got: {output}");
+}
+
+#[test]
+fn test_inline_if_false_without_else_ts() {
+    let flag = false;
+    let block = sigil_quote!(TypeScript {
+        const prefix = "x";
+        $if(flag) { const dead = true; }
+        const suffix = "y";
+    })
+    .unwrap();
+    let output = render_ts(&block);
+    assert!(output.contains("prefix"), "got: {output}");
+    assert!(output.contains("suffix"), "got: {output}");
+    assert!(!output.contains("dead"), "got: {output}");
+}
+
+#[test]
+fn test_inline_if_inside_function_call() {
+    let flag = true;
+    let block = sigil_quote!(TypeScript {
+        foo($if(flag) { "active" } $else { "inactive" })
+    })
+    .unwrap();
+    let output = render_ts(&block);
+    assert!(output.contains("foo("), "got: {output}");
+    assert!(output.contains("active"), "got: {output}");
+    assert!(!output.contains("inactive"), "got: {output}");
+    assert!(!output.contains('{'), "unexpected brace in: {output}");
+}
+
+// --- $T import tracking inside inline $for ---
+
+#[test]
+fn test_inline_for_with_type_imports() {
+    let types = vec![
+        TypeName::importable_type("./models", "User"),
+        TypeName::importable_type("./models", "Admin"),
+    ];
+    let block = sigil_quote!(TypeScript {
+        const types = [$for(ty in &types) { $T(ty.clone()), }];
+    })
+    .unwrap();
+    let output = render_ts(&block);
+    assert!(
+        output.contains("import type { Admin, User } from './models'"),
+        "imports should be tracked, got:\n{output}"
+    );
+    assert!(output.contains("User"), "got: {output}");
+    assert!(output.contains("Admin"), "got: {output}");
+}
+
+// --- Mixed inline and statement-level ---
+
+#[test]
+fn test_inline_for_nested_in_stmt_if() {
+    let items = vec!["a", "b"];
+    let flag = true;
+    let block = sigil_quote!(TypeScript {
+        $if(flag) {
+            const arr = [$for(item in &items) { $S(*item), }];
+        }
+    })
+    .unwrap();
+    let output = render_ts(&block);
+    assert!(output.contains("const arr = ["), "got: {output}");
+    assert!(output.contains("'a'"), "got: {output}");
+    assert!(output.contains("'b'"), "got: {output}");
+}
+
+#[test]
+fn test_stmt_for_with_inline_if() {
+    let pairs: Vec<(&str, bool)> = vec![("x", true), ("y", false)];
+    let block = sigil_quote!(TypeScript {
+        $for((name, flag) in &pairs) {
+            $if(*flag) { required: $S(*name) } $else { optional: $S(*name) }
+        }
+    })
+    .unwrap();
+    let output = render_ts(&block);
+    assert!(output.contains("required: 'x'"), "got: {output}");
+    assert!(output.contains("optional: 'y'"), "got: {output}");
+}
+
+// --- Inline $if with $else_if chain ---
+
+#[test]
+fn test_inline_if_else_if_chain_ts() {
+    let a = false;
+    let b = true;
+    let block = sigil_quote!(TypeScript {
+        const msg = $if(a) { "a" } $else_if(b) { "b" } $else { "c" };
+    })
+    .unwrap();
+    let output = render_ts(&block);
+    assert!(output.contains("\"b\""), "got: {output}");
+    assert!(!output.contains("\"a\""), "got: {output}");
+    assert!(!output.contains("\"c\""), "got: {output}");
+}
+
+#[test]
+fn test_inline_if_else_in_object_literal() {
+    let flag = true;
+    let block = sigil_quote!(TypeScript {
+        const obj = { key: $if(flag) { 1 } $else { 2 } };
+    })
+    .unwrap();
+    let output = render_ts(&block);
+    assert!(output.contains("key: 1"), "got: {output}");
+    assert!(!output.contains("key: 2"), "got: {output}");
+    // Object literal delimiters preserved, content correct
+    assert!(output.contains("const obj = {"), "got: {output}");
+    assert!(output.contains("key: 1"), "got: {output}");
+    assert!(output.contains("};"), "got: {output}");
+    // Not block `:` delimiter
+    assert!(!output.contains("= :"), "got: {output}");
+}
+
+// --- Literal braces must stay literal (not become block delimiters) ---
+
+#[test]
+fn test_inline_if_python_dict_preserves_literal_braces() {
+    let flag = true;
+    let block = sigil_quote!(Python {
+        x = { "k": $if(flag) { 1 } $else { 2 } }
+    })
+    .unwrap();
+    let output = render_py(&block);
+    assert!(output.contains("x = {"), "got: {output}");
+    assert!(output.contains("}"), "got: {output}");
+    assert!(output.contains("\"k\": 1"), "got: {output}");
+    // Must NOT have stray colon from block_open
+    assert!(!output.contains(": {"), "got: {output}");
+}
+
+#[test]
+fn test_inline_if_python_dict_literal_ruby_hash() {
+    // Ruby hash literal with inline $if — braces must stay literal
+    // Simulation: Python with inline conditional inside dict
+    let flag = false;
+    let block = sigil_quote!(Python {
+        x = { "a": $if(flag) { true } $else { false } }
+    })
+    .unwrap();
+    let output = render_py(&block);
+    assert!(output.contains("x = {"), "got: {output}");
+    assert!(output.contains("false"), "got: {output}");
+    assert!(!output.contains("true"), "got: {output}");
+    // No stray `: {` pattern
+    assert!(!output.contains(": {"), "got: {output}");
+}
+
+// --- Stricter exact-output tests ---
+
+#[test]
+fn test_inline_for_ts_array_exact() {
+    let items = vec!["a"];
+    let block = sigil_quote!(TypeScript {
+        const x = [$for(item in &items) { $S(*item) }];
+    })
+    .unwrap();
+    let output = render_ts(&block);
+    assert!(output.contains("const x = ["), "got: {output}");
+    assert!(output.contains("'a'"), "got: {output}");
+    assert!(output.contains("];"), "got: {output}");
+    // No stray block braces
+    assert!(!output.contains('{'), "got: {output}");
+    assert!(!output.contains('}'), "got: {output}");
+}
+
+#[test]
+fn test_inline_if_function_call_exact() {
+    let flag = true;
+    let block = sigil_quote!(TypeScript {
+        foo($if(flag) { "active" } $else { "inactive" });
+    })
+    .unwrap();
+    let output = render_ts(&block);
+    assert!(output.contains("foo("), "got: {output}");
+    assert!(output.contains("\"active\""), "got: {output}");
+    assert!(output.contains(");"), "got: {output}");
+    // No stray block braces
+    assert!(!output.contains('{'), "got: {output}");
+}


### PR DESCRIPTION
## Summary

`$for` and `$if` (with `$else_if`/`$else` chaining) now work inline inside expressions — parenthesized groups, array/dict literals, function arguments — not just at column-0 statement level.

## Changes
- **`directives.rs`** (NEW) — `parse_for_components` and `parse_if_components` shared parsing helpers with bounds checks and empty-condition validation
- **`types.rs`** — `InterpolationKind::ParsedSplice` for inline splices without synthetic block delimiters
- **`format.rs`** — inline `$for`/`$if` handlers in `tokens_to_format_inner` producing `%L` + `ParsedSplice`
- **`brace_classifier.rs`** — `ends_with_sigil_directive` prevents the statement parser from intercepting inline directive bodies; `has_statement_marker` limited to `$C_each` and `$let`
- **`codegen.rs`** — `ParsedSplice` arm builds nested `CodeBlock` without `begin_control_flow` / `end_control_flow_no_newline` (no stray `{}` or `:`)
- **`statements.rs`** — refactored `try_parse_meta_for`/`try_parse_meta_if` to use directive helpers

## Test plan
- [x] 7 unit tests in `format_tests.rs`
- [x] 17 integration tests in `meta_inline.rs` (TS, Python, import tracking, dict/array literals, else_if chains)
- [x] `cargo test --workspace` — 0 failures
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean