### PR TITLE
feat: add language-aware gates to TokenAnnotation variants

### DIFF
--- a/macros/src/parse/annotate.rs
+++ b/macros/src/parse/annotate.rs
@@ -27,6 +27,8 @@ pub(super) enum TokenAnnotation {
     PostfixIncDec,
     /// `*` used as postfix pointer marker (e.g. `Config*`) — suppress space before.
     PostfixStar,
+    /// `&` used as postfix reference marker (e.g. `auto&`, `int&`) — suppress space before.
+    PostfixAmpersand,
     /// `?` used as postfix type marker (e.g. `Int?`, `String?`) — suppress space before.
     PostfixQuestion,
     /// `?` used as nullable prefix (e.g. `?User`, `?string`) — suppress space around.
@@ -325,7 +327,12 @@ pub(super) fn annotate_tokens(tokens: &[TokenTree], lang: MacroLang) -> Vec<Toke
                         }
 
                         // PostfixStar: `*` span-adjacent to preceding ident (pointer type like `Config*`).
-                        if ch == '*' && i > 0 && matches!(&tokens[i - 1], TokenTree::Ident(_)) {
+                        // Only for languages with postfix pointer syntax (C, C++, C#).
+                        if ch == '*'
+                            && lang.has_postfix_star()
+                            && i > 0
+                            && matches!(&tokens[i - 1], TokenTree::Ident(_))
+                        {
                             let prev_end = tokens[i - 1].span().end();
                             let star_start = p.span().start();
                             if prev_end.line == star_start.line
@@ -338,14 +345,18 @@ pub(super) fn annotate_tokens(tokens: &[TokenTree], lang: MacroLang) -> Vec<Toke
                         }
 
                         // PostfixAmpersand: `&` span-adjacent to preceding ident/keyword
-                        // (reference type like `auto&`, `int&`).
-                        if ch == '&' && i > 0 && matches!(&tokens[i - 1], TokenTree::Ident(_)) {
+                        // (reference type like `auto&`, `int&`). C++ only.
+                        if ch == '&'
+                            && lang.has_postfix_ampersand()
+                            && i > 0
+                            && matches!(&tokens[i - 1], TokenTree::Ident(_))
+                        {
                             let prev_end = tokens[i - 1].span().end();
                             let amp_start = p.span().start();
                             if prev_end.line == amp_start.line
                                 && prev_end.column == amp_start.column
                             {
-                                annotations[i] = TokenAnnotation::PostfixStar;
+                                annotations[i] = TokenAnnotation::PostfixAmpersand;
                                 i += 1;
                                 continue;
                             }
@@ -503,7 +514,9 @@ pub(super) fn annotate_tokens(tokens: &[TokenTree], lang: MacroLang) -> Vec<Toke
                         }
                         // PostfixQuestion: `?` span-adjacent to preceding ident or group-close
                         // (e.g. `Int?`, `String?`, `(Int)?`)
-                        else if i > 0 {
+                        // Only for languages with postfix nullable type syntax
+                        // (C#, TS, Swift, Kotlin, Dart).
+                        else if lang.has_postfix_question_type() && i > 0 {
                             let prev_end = tokens[i - 1].span().end();
                             let q_start = p.span().start();
                             let is_adjacent =
@@ -594,7 +607,7 @@ pub(super) fn annotate_tokens(tokens: &[TokenTree], lang: MacroLang) -> Vec<Toke
                         // Reset generic stack at statement boundaries
                         generic_stack.clear();
                     }
-                    '=' if i > 0 => {
+                    '=' if lang.is_shell() && i > 0 => {
                         let prev_is_assignable = matches!(
                             &tokens[i - 1],
                             TokenTree::Ident(_) | TokenTree::Literal(_) | TokenTree::Group(_)

--- a/macros/src/parse/annotate_tests.rs
+++ b/macros/src/parse/annotate_tests.rs
@@ -113,22 +113,22 @@ fn prefix_op_ampersand() {
 
 #[test]
 fn postfix_question_adjacent() {
-    let a = annotate_src("Int?");
-    // "Int" "?" — adjacent → PostfixQuestion
+    let a = annotate_lang("Int?", MacroLang::CSharp);
+    // "Int" "?" — adjacent → PostfixQuestion (C# nullable)
     assert_eq!(ann_at(&a, 1), TokenAnnotation::PostfixQuestion);
 }
 
 #[test]
 fn postfix_star_adjacent() {
-    let a = annotate_src("Config*");
-    // "Config" "*" — adjacent → PostfixStar
+    let a = annotate_lang("Config*", MacroLang::C);
+    // "Config" "*" — adjacent → PostfixStar (C pointer)
     assert_eq!(ann_at(&a, 1), TokenAnnotation::PostfixStar);
 }
 
 #[test]
 fn assign_adjacent() {
-    let a = annotate_src("NAME=val");
-    // "NAME" "=" "val"
+    let a = annotate_lang("NAME=val", MacroLang::Bash);
+    // "NAME" "=" "val" — shell adjacent assign
     assert_eq!(ann_at(&a, 1), TokenAnnotation::AssignAdjacent);
 }
 
@@ -188,4 +188,128 @@ fn normal_tokens_stay_normal() {
     for (_, ann) in &a {
         assert_eq!(*ann, TokenAnnotation::Normal);
     }
+}
+
+// --- Language-gated annotation tests ---
+
+#[test]
+fn postfix_star_c_languages() {
+    // C, C++, C# use postfix * for pointer types
+    assert_eq!(
+        ann_at(&annotate_lang("Config*", MacroLang::C), 1),
+        TokenAnnotation::PostfixStar
+    );
+    assert_eq!(
+        ann_at(&annotate_lang("Config*", MacroLang::Cpp), 1),
+        TokenAnnotation::PostfixStar
+    );
+    assert_eq!(
+        ann_at(&annotate_lang("int*", MacroLang::CSharp), 1),
+        TokenAnnotation::PostfixStar
+    );
+}
+
+#[test]
+fn postfix_star_not_in_other_languages() {
+    assert_eq!(
+        ann_at(&annotate_lang("Config*", MacroLang::Go), 1),
+        TokenAnnotation::Normal
+    );
+    assert_eq!(
+        ann_at(&annotate_lang("Config*", MacroLang::Ruby), 1),
+        TokenAnnotation::Normal
+    );
+    assert_eq!(
+        ann_at(&annotate_lang("Config*", MacroLang::Bash), 1),
+        TokenAnnotation::Normal
+    );
+}
+
+#[test]
+fn postfix_ampersand_cpp_only() {
+    assert_eq!(
+        ann_at(&annotate_lang("auto&", MacroLang::Cpp), 1),
+        TokenAnnotation::PostfixAmpersand
+    );
+}
+
+#[test]
+fn postfix_ampersand_not_in_other_languages() {
+    // C has no references, & is address-of (prefix)
+    assert_eq!(
+        ann_at(&annotate_lang("auto&", MacroLang::C), 1),
+        TokenAnnotation::Normal
+    );
+    assert_eq!(
+        ann_at(&annotate_lang("auto&", MacroLang::Go), 1),
+        TokenAnnotation::Normal
+    );
+}
+
+#[test]
+fn postfix_question_nullable_languages() {
+    assert_eq!(
+        ann_at(&annotate_lang("Int?", MacroLang::CSharp), 1),
+        TokenAnnotation::PostfixQuestion
+    );
+    assert_eq!(
+        ann_at(&annotate_lang("string?", MacroLang::TypeScript), 1),
+        TokenAnnotation::PostfixQuestion
+    );
+    assert_eq!(
+        ann_at(&annotate_lang("Int?", MacroLang::Swift), 1),
+        TokenAnnotation::PostfixQuestion
+    );
+    assert_eq!(
+        ann_at(&annotate_lang("Int?", MacroLang::Kotlin), 1),
+        TokenAnnotation::PostfixQuestion
+    );
+    assert_eq!(
+        ann_at(&annotate_lang("int?", MacroLang::Dart), 1),
+        TokenAnnotation::PostfixQuestion
+    );
+}
+
+#[test]
+fn postfix_question_not_in_other_languages() {
+    assert_eq!(
+        ann_at(&annotate_lang("foo?", MacroLang::Ruby), 1),
+        TokenAnnotation::Normal
+    );
+    assert_eq!(
+        ann_at(&annotate_lang("x?", MacroLang::Php), 1),
+        TokenAnnotation::Normal
+    );
+}
+
+#[test]
+fn assign_adjacent_shell_only() {
+    assert_eq!(
+        ann_at(&annotate_lang("NAME=val", MacroLang::Bash), 1),
+        TokenAnnotation::AssignAdjacent
+    );
+    assert_eq!(
+        ann_at(&annotate_lang("NAME=val", MacroLang::Zsh), 1),
+        TokenAnnotation::AssignAdjacent
+    );
+}
+
+#[test]
+fn assign_adjacent_not_in_non_shell() {
+    assert_eq!(
+        ann_at(&annotate_lang("x=5", MacroLang::Go), 1),
+        TokenAnnotation::Normal
+    );
+    assert_eq!(
+        ann_at(&annotate_lang("x=5", MacroLang::C), 1),
+        TokenAnnotation::Normal
+    );
+    assert_eq!(
+        ann_at(&annotate_lang("x=5", MacroLang::Cpp), 1),
+        TokenAnnotation::Normal
+    );
+    assert_eq!(
+        ann_at(&annotate_lang("x=5", MacroLang::Unaware), 1),
+        TokenAnnotation::Normal
+    );
 }

--- a/macros/src/parse/mod.rs
+++ b/macros/src/parse/mod.rs
@@ -25,12 +25,18 @@ fn parse_macro_lang(ts: &TokenStream) -> MacroLang {
     if let Some(TokenTree::Ident(id)) = first {
         match id.to_string().as_str() {
             "Bash" => MacroLang::Bash,
+            "C" => MacroLang::C,
             "CSharp" => MacroLang::CSharp,
+            "Cpp" => MacroLang::Cpp,
+            "Dart" => MacroLang::Dart,
             "Go" => MacroLang::Go,
             "Haskell" => MacroLang::Haskell,
+            "Kotlin" => MacroLang::Kotlin,
             "OCaml" => MacroLang::OCaml,
             "Php" => MacroLang::Php,
             "Ruby" => MacroLang::Ruby,
+            "Swift" => MacroLang::Swift,
+            "TypeScript" => MacroLang::TypeScript,
             "Zsh" => MacroLang::Zsh,
             _ => MacroLang::Unaware,
         }

--- a/macros/src/parse/spacing.rs
+++ b/macros/src/parse/spacing.rs
@@ -91,6 +91,7 @@ pub(super) fn maybe_space(
         | TokenAnnotation::SafeCallQ
         | TokenAnnotation::PostfixIncDec
         | TokenAnnotation::PostfixStar
+        | TokenAnnotation::PostfixAmpersand
         | TokenAnnotation::PostfixQuestion
         | TokenAnnotation::NullablePrefix
         | TokenAnnotation::ArrowOp

--- a/macros/src/parse/types.rs
+++ b/macros/src/parse/types.rs
@@ -8,12 +8,18 @@ use proc_macro2::{Span, TokenStream};
 pub(crate) enum MacroLang {
     Unaware,
     Bash,
+    C,
+    Cpp,
     CSharp,
+    Dart,
     Go,
     Haskell,
+    Kotlin,
     OCaml,
     Php,
     Ruby,
+    Swift,
+    TypeScript,
     Zsh,
 }
 
@@ -38,6 +44,7 @@ impl MacroLang {
             self,
             Self::Ruby
                 | Self::Bash
+                | Self::C
                 | Self::Zsh
                 | Self::OCaml
                 | Self::Php
@@ -49,6 +56,27 @@ impl MacroLang {
     /// Whether `?Ident` (nullable prefix like `?User`, `?string`) is valid syntax.
     pub fn nullable_prefix_is_valid(self) -> bool {
         matches!(self, Self::Php | Self::OCaml)
+    }
+
+    /// Whether `*` adjacent to a preceding ident means a postfix pointer type
+    /// (C/C++ `Config*`, C# `int*` in unsafe context).
+    pub fn has_postfix_star(self) -> bool {
+        matches!(self, Self::C | Self::Cpp | Self::CSharp)
+    }
+
+    /// Whether `&` adjacent to a preceding ident means a postfix reference type
+    /// (C++ `auto&`, `int&`).
+    pub fn has_postfix_ampersand(self) -> bool {
+        matches!(self, Self::Cpp)
+    }
+
+    /// Whether `?` adjacent to a preceding ident means a postfix nullable type
+    /// (C# `int?`, TS `string?`, Swift `Int?`, Kotlin `Int?`, Dart `int?`).
+    pub fn has_postfix_question_type(self) -> bool {
+        matches!(
+            self,
+            Self::CSharp | Self::Dart | Self::Kotlin | Self::Swift | Self::TypeScript
+        )
     }
 }
 


### PR DESCRIPTION
## Summary
Add language-aware gates to four `TokenAnnotation` variants that previously fired unconditionally for ALL languages. Also fix a bug where `&` was incorrectly assigned `PostfixStar` instead of a new `PostfixAmpersand` variant.

## Changes
- **`types.rs`** — +6 `MacroLang` variants (C, Cpp, Dart, Kotlin, Swift, TypeScript), +3 methods (`has_postfix_star`, `has_postfix_ampersand`, `has_postfix_question_type`), exclude C from `has_angle_generics()`
- **`mod.rs`** — +6 string mappings
- **`annotate.rs`** — +`PostfixAmpersand` variant, fix `&`→PostfixStar bug, 4 language gates:
  - `PostfixStar`: C, Cpp, CSharp (pointer types `Config*`)
  - `PostfixAmpersand`: Cpp only (references `auto&`)
  - `PostfixQuestion`: CSharp, Dart, Kotlin, Swift, TypeScript (nullable `Int?`)
  - `AssignAdjacent`: Bash, Zsh only (shell `NAME=val`)
- **`spacing.rs`** — `PostfixAmpersand` in space-suppression list
- **`annotate_tests.rs`** — 3 existing tests updated for explicit languages, +8 new gating tests

## Test plan
- [x] `cargo test --workspace` — 0 failures
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean