### PR TITLE
fix: compound operator spacing, PostfixQuestion ternaries, GenericOpen gate

### DIFF
--- a/macros/src/parse/annotate.rs
+++ b/macros/src/parse/annotate.rs
@@ -362,6 +362,24 @@ pub(super) fn annotate_tokens(tokens: &[TokenTree], lang: MacroLang) -> Vec<Toke
                             }
                         }
 
+                        // Compound-operator second char (&&, **):
+                        // When preceded by same-char Joint punct and current
+                        // is Alone, normalize for infix/separator/postfix.
+                        // Note: `--` is NOT included — the shell downgrade
+                        // below already handles the separator case, and prefix
+                        // `--x` in C-like languages needs PrefixOp preserved.
+                        if matches!(ch, '&' | '*')
+                            && i > 0
+                            && let TokenTree::Punct(prev_p) = &tokens[i - 1]
+                            && prev_p.as_char() == ch
+                            && prev_p.spacing() == Spacing::Joint
+                            && annotations[i - 1] != TokenAnnotation::PrefixOp
+                            && p.spacing() != Spacing::Joint
+                        {
+                            i += 1;
+                            continue;
+                        }
+
                         // PrefixOp: NOT preceded by non-keyword ident, literal, `)`, or `]`
                         // After keywords like `return`, `-` is prefix (unary minus)
                         let is_prefix = if i == 0 {
@@ -531,7 +549,47 @@ pub(super) fn annotate_tokens(tokens: &[TokenTree], lang: MacroLang) -> Vec<Toke
                                     _ => false,
                                 };
                                 if is_type_context {
-                                    annotations[i] = TokenAnnotation::PostfixQuestion;
+                                    // If `:` appears after an expression consequent
+                                    // (not immediately), this is a compact ternary
+                                    // (x?y:z, x?1:2, x?(a):b), not a nullable type.
+                                    // `?:` (TS optional property, Kotlin Elvis) is
+                                    // NOT a ternary — `:` immediately follows `?`.
+                                    let is_ternary = i + 1 < tokens.len()
+                                        && !matches!(
+                                            &tokens[i + 1],
+                                            TokenTree::Punct(p2) if p2.as_char() == ':'
+                                        )
+                                        && {
+                                            let mut j = i + 1;
+                                            let mut found = false;
+                                            while j < tokens.len() {
+                                                match &tokens[j] {
+                                                    TokenTree::Punct(p2) if p2.as_char() == ':' => {
+                                                        found = true;
+                                                        break;
+                                                    }
+                                                    TokenTree::Punct(p2) if p2.as_char() == ';' => {
+                                                        break;
+                                                    }
+                                                    TokenTree::Group(_) => {
+                                                        // skip — could be (a) in x?(a):b
+                                                    }
+                                                    _ => {}
+                                                }
+                                                if j > 0 {
+                                                    let prev_end = tokens[j - 1].span().end();
+                                                    let curr_start = tokens[j].span().start();
+                                                    if curr_start.line > prev_end.line {
+                                                        break;
+                                                    }
+                                                }
+                                                j += 1;
+                                            }
+                                            found
+                                        };
+                                    if !is_ternary {
+                                        annotations[i] = TokenAnnotation::PostfixQuestion;
+                                    }
                                 }
                             }
                         }
@@ -593,7 +651,7 @@ pub(super) fn annotate_tokens(tokens: &[TokenTree], lang: MacroLang) -> Vec<Toke
                         if is_generic {
                             if lang == MacroLang::Ruby {
                                 annotations[i] = TokenAnnotation::InheritanceAngle;
-                            } else {
+                            } else if lang.has_angle_generics() {
                                 annotations[i] = TokenAnnotation::GenericOpen;
                                 generic_stack.push(i);
                             }

--- a/macros/src/parse/annotate_tests.rs
+++ b/macros/src/parse/annotate_tests.rs
@@ -313,3 +313,125 @@ fn assign_adjacent_not_in_non_shell() {
         TokenAnnotation::Normal
     );
 }
+
+// --- Compound operator tests ---
+
+#[test]
+fn compound_and_infix() {
+    // a && b: second & should be Normal (infix)
+    assert_eq!(
+        ann_at(&annotate_lang("a && b", MacroLang::Cpp), 2),
+        TokenAnnotation::Normal
+    );
+}
+
+#[test]
+fn compound_and_prefix() {
+    // &&str: second & should be PrefixOp (prefix compound)
+    assert_eq!(
+        ann_at(&annotate_lang("&&str", MacroLang::Unaware), 1),
+        TokenAnnotation::PrefixOp
+    );
+}
+
+#[test]
+fn compound_and_postfix() {
+    // auto&& item: second & should be Normal (postfix)
+    assert_eq!(
+        ann_at(&annotate_lang("auto&& item", MacroLang::Cpp), 2),
+        TokenAnnotation::Normal
+    );
+}
+
+#[test]
+fn compound_star_infix() {
+    // a ** b: second * should be Normal (infix)
+    assert_eq!(
+        ann_at(&annotate_lang("a ** b", MacroLang::Unaware), 2),
+        TokenAnnotation::Normal
+    );
+}
+
+#[test]
+fn compound_star_prefix() {
+    // **ptr: second * should be PrefixOp (prefix compound)
+    assert_eq!(
+        ann_at(&annotate_lang("**ptr", MacroLang::Unaware), 1),
+        TokenAnnotation::PrefixOp
+    );
+}
+
+// --- PostfixQuestion ternary tests ---
+
+#[test]
+fn postfix_question_ternary_literal() {
+    // x?1:2: ? should be Normal (compact ternary with literal)
+    assert_eq!(
+        ann_at(&annotate_lang("x?1:2", MacroLang::CSharp), 1),
+        TokenAnnotation::Normal
+    );
+}
+
+#[test]
+fn postfix_question_ternary_ident() {
+    // x?y:z: ? should be Normal (compact ternary with ident)
+    assert_eq!(
+        ann_at(&annotate_lang("x?y:z", MacroLang::CSharp), 1),
+        TokenAnnotation::Normal
+    );
+}
+
+#[test]
+fn postfix_question_nullable_with_space() {
+    // Int? name: ? followed by space then ident → nullable, not ternary
+    assert_eq!(
+        ann_at(&annotate_lang("Int? name", MacroLang::CSharp), 1),
+        TokenAnnotation::PostfixQuestion
+    );
+}
+
+#[test]
+fn postfix_question_nullable_comma() {
+    // Int?,: ? followed by comma → nullable
+    assert_eq!(
+        ann_at(&annotate_lang("Int?, x", MacroLang::CSharp), 1),
+        TokenAnnotation::PostfixQuestion
+    );
+}
+
+#[test]
+fn postfix_question_optional_property() {
+    // name?: string: ? followed by : is TS optional property, not ternary
+    assert_eq!(
+        ann_at(&annotate_lang("name?: string", MacroLang::TypeScript), 1),
+        TokenAnnotation::PostfixQuestion
+    );
+}
+
+// --- GenericOpen gate tests ---
+
+#[test]
+fn generic_open_gated_for_c() {
+    // C has no angle generics — < should be Normal
+    assert_eq!(
+        ann_at(&annotate_lang("Array<T>", MacroLang::C), 1),
+        TokenAnnotation::Normal
+    );
+}
+
+#[test]
+fn generic_open_allowed_for_generic_lang() {
+    // Unaware (C-like) — < should be GenericOpen
+    assert_eq!(
+        ann_at(&annotate_lang("Vec<T>", MacroLang::Unaware), 1),
+        TokenAnnotation::GenericOpen
+    );
+}
+
+#[test]
+fn ruby_inheritance_angle_preserved() {
+    assert_eq!(
+        ann_at(&annotate_lang("class Dog < Animal", MacroLang::Ruby), 2),
+        TokenAnnotation::InheritanceAngle
+    );
+}


### PR DESCRIPTION
## Summary
Three pre-existing annotation bug fixes identified during the language-aware spacing audit, all in `annotate.rs`.

## Changes

### 1. Fix `&&` / `**` compound operator spacing
The second char of `&&` and `**` was incorrectly classified as `PrefixOp`, suppressing trailing space (`a &&b`, `auto&&item`, `a **b`). Now the second char inherits PrefixOp only when the predecessor is PrefixOp (prefix compounds like `&&str`, `**ptr`). Otherwise Normal for infix/postfix contexts.

### 2. Fix PostfixQuestion false positive on compact ternaries
In nullable-type languages (C#, TS, Swift, Kotlin, Dart), compact ternaries like `x?1:2`, `x?y:z`, `x?(a):b` matched PostfixQuestion because `?` is span-adjacent to the preceding ident. Now forward-scans for `:` before a statement boundary to detect ternary context.

### 3. Gate ordinary `<` GenericOpen heuristic
The non-`\$T` path for marking `<` as `GenericOpen` now respects `has_angle_generics()`. C, Go, Haskell, OCaml, PHP, Bash, Zsh no longer get spurious `GenericOpen`. Ruby `InheritanceAngle` preserved.

## Test plan
- [x] 12 new annotate tests
- [x] `cargo test --workspace` — 0 failures
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean