### PR TITLE
docs: add inline control flow, language spacing, and zsh codegen examples

### DIFF
--- a/examples/inline_control_flow.rs
+++ b/examples/inline_control_flow.rs
@@ -1,0 +1,240 @@
+//! Demonstrate inline `$for` and `$if` inside expressions across multiple
+//! languages — array/dict literals, function arguments, object literals.
+//!
+//! Inline meta-directives work anywhere in a template, not just at column 0.
+//! `$for`/`$if` are meta-selection: true/false branches and loop bodies are
+//! evaluated at Rust compile time by the macro, then spliced into place.
+//! Each language gets correct delimiters: TypeScript keeps `{ }` for objects,
+//! Python keeps `{ }` for dicts (no stray `:`).
+//!
+//! Run: `cargo run --example inline_control_flow`
+
+use sigil_stitch::lang::bash::Bash;
+use sigil_stitch::lang::cpp::Cpp;
+use sigil_stitch::lang::ruby::Ruby;
+use sigil_stitch::prelude::*;
+use sigil_stitch::spec::file_spec::FileSpec;
+
+fn main() {
+    typescript_inline_for_array();
+    typescript_inline_if_function_arg();
+    typescript_inline_if_else_chain();
+    typescript_inline_if_in_object_literal();
+    python_inline_for_list();
+    python_inline_if_dict();
+    cpp_inline_for_vector();
+    ruby_inline_if_expression();
+    bash_inline_for_join();
+    inline_for_with_type_imports();
+    empty_for_clean_output();
+}
+
+// ── TypeScript ──
+
+/// `$for` inside a TypeScript array literal — items spliced inline.
+fn typescript_inline_for_array() {
+    println!("--- TS: Inline $for in array ---\n");
+    let items = vec!["hostname", "platform", "arch"];
+
+    let block = sigil_quote!(TypeScript {
+        const defaultKeys = [$for(item in &items) { $S(*item), }];
+    })
+    .unwrap();
+    println!("{}\n", render_ts(&block));
+}
+
+/// `$if`/`$else` inline inside a function call argument.
+fn typescript_inline_if_function_arg() {
+    println!("--- TS: Inline $if/$else in function argument ---\n");
+    let is_admin = true;
+
+    let block = sigil_quote!(TypeScript {
+        setPermissions($if(is_admin) { "read-write" } $else { "read-only" });
+    })
+    .unwrap();
+    println!("{}\n", render_ts(&block));
+}
+
+/// `$if` / `$else_if` / `$else` chain — all inline in one expression.
+fn typescript_inline_if_else_chain() {
+    println!("--- TS: Inline $if/$else_if/$else chain ---\n");
+    let level: u32 = 2;
+
+    let block = sigil_quote!(TypeScript {
+        const label = $if(level == 0) { "trace" } $else_if(level == 1) { "debug" } $else { "info" };
+    })
+    .unwrap();
+    println!("{}\n", render_ts(&block));
+}
+
+/// `$if`/`$else` inside an object literal value position — braces stay literal.
+fn typescript_inline_if_in_object_literal() {
+    println!("--- TS: Inline $if/$else in object literal ---\n");
+    let production = true;
+
+    let block = sigil_quote!(TypeScript {
+        const config = {
+            mode: $if(production) { "production" } $else { "development" },
+            debug: $if(production) { false } $else { true },
+        };
+    })
+    .unwrap();
+    println!("{}\n", render_ts(&block));
+}
+
+// ── Python ──
+
+/// `$for` inside a Python list — no stray `:` from block delimiters.
+fn python_inline_for_list() {
+    println!("--- Python: Inline $for in list ---\n");
+    let fields = vec!["name", "age", "email"];
+
+    let block = sigil_quote!(Python {
+        required_fields = [$for(f in &fields) { $S(*f), }]
+    })
+    .unwrap();
+    println!("{}\n", render_py(&block));
+}
+
+/// `$if`/`$else` inside a Python dict literal — braces stay literal, no stray `:`.
+fn python_inline_if_dict() {
+    println!("--- Python: Inline $if/$else in dict literal ---\n");
+    let is_prod = true;
+
+    let block = sigil_quote!(Python {
+        config = {
+            "mode": $if(is_prod) { $S("production") } $else { $S("development") },
+            "debug": $if(is_prod) { False } $else { True },
+        }
+    })
+    .unwrap();
+    println!("{}\n", render_py(&block));
+}
+
+// ── C++ ──
+
+/// `$for` inside a C++ initializer list — `{}` stays literal.
+fn cpp_inline_for_vector() {
+    println!("--- C++: Inline $for in initializer list ---\n");
+    let values = vec!["1", "2", "3"];
+
+    let block = sigil_quote!(Cpp {
+        std::vector<int> vec = { $for(v in &values) { $L(*v), } };
+    })
+    .unwrap();
+    println!("{}\n", render_with(&block, &Cpp::new()));
+}
+
+// ── Ruby ──
+
+/// `$if`/`$else` as a value expression in Ruby — selects the branch output.
+fn ruby_inline_if_expression() {
+    println!("--- Ruby: Inline $if/$else meta-selection ---\n");
+    let flag = true;
+
+    let block = sigil_quote!(Ruby {
+        result = $if(flag) { "yes" } $else { "no" }
+    })
+    .unwrap();
+    println!("{}\n", render_rb(&block));
+}
+
+// ── Bash ──
+
+/// `$join` in a Bash command — builds a single space-separated argument string.
+fn bash_inline_for_join() {
+    println!("--- Bash: $for with $join for shell args ---\n");
+    let flags = vec!["--verbose", "--no-cache", "--force"];
+
+    // $join produces a single line; $for would produce multiline output.
+    let block = sigil_quote!(Bash {
+        mycommand $join(" ", &flags) target
+    })
+    .unwrap();
+    println!("{}\n", render_bash(&block));
+}
+
+// ── Import tracking inside inline $for ──
+
+/// `$T` inside inline `$for` still tracks and propagates imports.
+fn inline_for_with_type_imports() {
+    println!("--- Inline $for with $T import tracking ---\n");
+    let types = vec![
+        TypeName::importable_type("./models", "User"),
+        TypeName::importable_type("./models", "Admin"),
+    ];
+
+    let block = sigil_quote!(TypeScript {
+        const types = [$for(ty in &types) { $T(ty.clone()), }];
+    })
+    .unwrap();
+    println!("{}\n", render_ts(&block));
+}
+
+// ── Empty / edge cases ──
+
+/// Empty `$for` produces no output — array literal renders as `[]`.
+fn empty_for_clean_output() {
+    println!("--- Empty $for produces clean output ---\n");
+    let items: Vec<&str> = vec![];
+
+    let block = sigil_quote!(TypeScript {
+        const keys: string[] = [$for(item in &items) { $S(*item), }];
+    })
+    .unwrap();
+    println!("  TS:  {}", render_ts(&block));
+
+    let block = sigil_quote!(Python {
+        keys = [$for(item in &items) { $S(*item), }]
+    })
+    .unwrap();
+    println!("  Py:  {}", render_py(&block));
+    println!();
+}
+
+// ── helpers ──
+
+fn render_ts(block: &CodeBlock) -> String {
+    FileSpec::builder("demo.ts")
+        .add_code(block.clone())
+        .build()
+        .unwrap()
+        .render(60)
+        .unwrap()
+}
+
+fn render_py(block: &CodeBlock) -> String {
+    FileSpec::builder("demo.py")
+        .add_code(block.clone())
+        .build()
+        .unwrap()
+        .render(60)
+        .unwrap()
+}
+
+fn render_rb(block: &CodeBlock) -> String {
+    FileSpec::builder_with("demo.rb", Ruby::new())
+        .add_code(block.clone())
+        .build()
+        .unwrap()
+        .render(60)
+        .unwrap()
+}
+
+fn render_bash(block: &CodeBlock) -> String {
+    FileSpec::builder_with("demo.sh", Bash::new())
+        .add_code(block.clone())
+        .build()
+        .unwrap()
+        .render(60)
+        .unwrap()
+}
+
+fn render_with<L: sigil_stitch::lang::CodeLang + Clone>(block: &CodeBlock, lang: &L) -> String {
+    FileSpec::builder_with("demo", lang.clone())
+        .add_code(block.clone())
+        .build()
+        .unwrap()
+        .render(60)
+        .unwrap()
+}

--- a/examples/language_spacing.rs
+++ b/examples/language_spacing.rs
@@ -1,0 +1,270 @@
+//! Demonstrate language-aware spacing — the same `sigil_quote!` template
+//! renders with different spacing rules depending on the target language.
+//!
+//! The macro tokenizer knows that:
+//! - C/C++/C# use `Config*` (postfix pointer) — no space before `*`
+//! - C++ uses `auto&` (postfix reference) — no space before `&`
+//! - C#/TS/Swift/Kotlin/Dart use `int?` (postfix nullable) — no space before `?`
+//! - TS uses `name?: string` (optional property) — `?:` stays tight
+//! - Ruby uses `attr_reader :name` (symbol colon) — space before, none after `:`
+//! - Ruby uses `class Dog < Animal` — space before `<` (inheritance, not generics)
+//! - Bash/Zsh use `NAME=val` — no space around `=` in assignments
+//! - Bash/Zsh use `--flag` — tight compound flags
+//! - C doesn't treat `<` as generic open (no angle generics)
+//!
+//! Run: `cargo run --example language_spacing`
+
+use sigil_stitch::lang::bash::Bash;
+use sigil_stitch::lang::c::C;
+use sigil_stitch::lang::cpp::Cpp;
+use sigil_stitch::lang::csharp::CSharp;
+use sigil_stitch::lang::ruby::Ruby;
+use sigil_stitch::lang::zsh::Zsh;
+use sigil_stitch::prelude::*;
+use sigil_stitch::spec::file_spec::FileSpec;
+
+fn main() {
+    postfix_star_pointers();
+    postfix_ampersand_references();
+    postfix_question_nullable();
+    ts_optional_property();
+    shell_assign_adjacent();
+    shell_double_dash_flags();
+    ruby_symbol_colon();
+    ruby_inheritance_angle();
+    c_no_angle_generics();
+}
+
+/// C/C++/C#: `Config*` keeps `*` tight (postfix pointer).
+/// Ruby: `*` is binary multiplication — space before `*` is normal.
+fn postfix_star_pointers() {
+    println!("=== PostfixStar: pointer types ===\n");
+    println!("  Template: `Config* p` (no space before *)");
+    println!();
+
+    let block = sigil_quote!(C { Config* p; }).unwrap();
+    println!("  C:   {}", render_with(&block, &C::new()));
+
+    let block = sigil_quote!(Cpp { Config* p; }).unwrap();
+    println!("  C++: {}", render_with(&block, &Cpp::new()));
+
+    let block = sigil_quote!(CSharp { Config* p; }).unwrap();
+    println!("  C#:  {}", render_cs(&block));
+
+    // Ruby: * is binary multiplication, not a postfix pointer
+    let block = sigil_quote!(Ruby { Config* x }).unwrap();
+    println!(
+        "  Ruby: {}  (space before *, not a postfix pointer)",
+        render_rb(&block)
+    );
+    println!();
+}
+
+/// C++: `auto&` keeps `&` tight (postfix reference type).
+/// C: `&` is address-of — space before `&` is normal.
+fn postfix_ampersand_references() {
+    println!("=== PostfixAmpersand: C++ references ===\n");
+    println!("  Template: `auto& x` (no space before &)");
+    println!();
+
+    let block = sigil_quote!(Cpp { auto& x = value; }).unwrap();
+    println!("  C++: {}", render_with(&block, &Cpp::new()));
+
+    let block = sigil_quote!(C { auto& x; }).unwrap();
+    println!(
+        "  C:   {}  (space before &, no postfix refs in C)",
+        render_with(&block, &C::new())
+    );
+    println!();
+}
+
+/// C#/TS/Swift/Kotlin/Dart: `int?` keeps `?` tight (postfix nullable).
+/// Ruby/Go/PHP: `?` is NOT a nullable type suffix.
+fn postfix_question_nullable() {
+    println!("=== PostfixQuestion: nullable types ===\n");
+    println!("  Template: `int? count` (no space before ?)");
+    println!();
+
+    let block = sigil_quote!(CSharp { int? count; }).unwrap();
+    println!("  C#:     {}", render_cs(&block));
+
+    let block = sigil_quote!(Swift { var count: Int? = nil }).unwrap();
+    println!("  Swift:  {}", render_swift(&block));
+
+    let block = sigil_quote!(Kotlin { var count: Int? = null }).unwrap();
+    println!("  Kotlin: {}", render_kotlin(&block));
+
+    let block = sigil_quote!(Dart { int? count; }).unwrap();
+    println!("  Dart:   {}", render_dart(&block));
+
+    // Ruby: ? is method suffix/ternary, not nullable
+    println!("  Ruby/PHP/Go: ? is NOT a nullable type suffix — space is normal");
+    println!();
+}
+
+/// TypeScript: `name?: string` keeps `?:` tight (optional property).
+/// My fix for compact ternaries correctly excludes `?:`.
+fn ts_optional_property() {
+    println!("=== TS optional property (`?:`) ===\n");
+    println!("  Template: `name?: string`");
+    println!();
+
+    let block = sigil_quote!(TypeScript {
+        interface Config {
+            name?: string;
+            debug?: boolean;
+        }
+    })
+    .unwrap();
+    println!("  TS: {}", render_ts(&block));
+    println!();
+}
+
+/// Bash/Zsh: `NAME=val` keeps `=` tight (shell assignment).
+fn shell_assign_adjacent() {
+    println!("=== AssignAdjacent: shell assignments ===\n");
+    println!("  Template: `NAME=value` (no space around =)");
+    println!();
+
+    let block = sigil_quote!(Bash { export NAME=value }).unwrap();
+    println!("  Bash: {}", render_bash(&block));
+
+    let block = sigil_quote!(Zsh { export NAME=value }).unwrap();
+    println!("  Zsh:  {}", render_zsh(&block));
+    println!("       (NAME=value tight — shell style)\n");
+}
+
+/// Bash/Zsh: `--flag` keeps dashes tight (compound flag).
+fn shell_double_dash_flags() {
+    println!("=== Double-dash flags: shell ===\n");
+    println!("  Template: `git commit --amend --no-edit`");
+    println!();
+
+    let block = sigil_quote!(Bash { git commit --amend --no-edit }).unwrap();
+    println!("  Bash: {}", render_bash(&block));
+
+    let block = sigil_quote!(Zsh { git commit --amend --no-edit }).unwrap();
+    println!("  Zsh:  {}", render_zsh(&block));
+    println!("       (--amend --no-edit stay tight)\n");
+}
+
+/// Ruby: `attr_reader :name` has space before `:`, none after.
+fn ruby_symbol_colon() {
+    println!("=== Ruby symbol colon ===\n");
+    println!("  Template: `attr_reader :name, :age`");
+    println!();
+
+    let block = sigil_quote!(Ruby { attr_reader :name, :age }).unwrap();
+    println!("  Ruby: {}", render_rb(&block));
+    println!("       (space before :, none after — :name :age)\n");
+}
+
+/// Ruby: `class Dog < Animal` has space before `<` (inheritance, not generics).
+fn ruby_inheritance_angle() {
+    println!("=== Ruby inheritance angle ===\n");
+
+    let block = sigil_quote!(Ruby {
+        class Dog < Animal {
+        }
+    })
+    .unwrap();
+    println!("  Ruby: {}", render_rb(&block));
+    println!("       (class Dog < Animal — space before < preserved)\n");
+}
+
+/// C: `<` is a comparison operator, never a generic open.
+fn c_no_angle_generics() {
+    println!("=== C: no angle generics ===\n");
+
+    let block = sigil_quote!(C {
+        if (size < MAX_SIZE) {
+            printf("ok");
+        }
+    })
+    .unwrap();
+    println!("  C: {}", render_with(&block, &C::new()));
+    println!("      (< is always less-than in C, never generic)\n");
+}
+
+// ── helpers ──
+
+fn render_with<L: sigil_stitch::lang::CodeLang + Clone>(block: &CodeBlock, lang: &L) -> String {
+    FileSpec::builder_with("demo", lang.clone())
+        .add_code(block.clone())
+        .build()
+        .unwrap()
+        .render(70)
+        .unwrap()
+}
+
+fn render_ts(block: &CodeBlock) -> String {
+    FileSpec::builder("demo.ts")
+        .add_code(block.clone())
+        .build()
+        .unwrap()
+        .render(70)
+        .unwrap()
+}
+
+fn render_cs(block: &CodeBlock) -> String {
+    FileSpec::builder_with("demo.cs", CSharp::new())
+        .add_code(block.clone())
+        .build()
+        .unwrap()
+        .render(70)
+        .unwrap()
+}
+
+fn render_rb(block: &CodeBlock) -> String {
+    FileSpec::builder_with("demo.rb", Ruby::new())
+        .add_code(block.clone())
+        .build()
+        .unwrap()
+        .render(70)
+        .unwrap()
+}
+
+fn render_bash(block: &CodeBlock) -> String {
+    FileSpec::builder_with("demo.sh", Bash::new())
+        .add_code(block.clone())
+        .build()
+        .unwrap()
+        .render(70)
+        .unwrap()
+}
+
+fn render_zsh(block: &CodeBlock) -> String {
+    FileSpec::builder_with("demo.zsh", Zsh::new())
+        .add_code(block.clone())
+        .build()
+        .unwrap()
+        .render(70)
+        .unwrap()
+}
+
+fn render_swift(block: &CodeBlock) -> String {
+    FileSpec::builder("demo.swift")
+        .add_code(block.clone())
+        .build()
+        .unwrap()
+        .render(70)
+        .unwrap()
+}
+
+fn render_kotlin(block: &CodeBlock) -> String {
+    FileSpec::builder("demo.kt")
+        .add_code(block.clone())
+        .build()
+        .unwrap()
+        .render(70)
+        .unwrap()
+}
+
+fn render_dart(block: &CodeBlock) -> String {
+    FileSpec::builder("demo.dart")
+        .add_code(block.clone())
+        .build()
+        .unwrap()
+        .render(70)
+        .unwrap()
+}

--- a/examples/zsh_codegen.rs
+++ b/examples/zsh_codegen.rs
@@ -1,0 +1,141 @@
+//! Generate a Zsh script — builder API vs `sigil_quote!` comparison.
+//!
+//! Demonstrates: Zsh-specific features (arrays, parameter expansion,
+//! `[[ ... ]]`, `autoload -Uz`), shell spacing (tight `NAME=value`,
+//! `--flag`), and `$V` verbatim strings.
+//!
+//! Run: `cargo run --example zsh_codegen`
+
+use sigil_stitch::lang::zsh::Zsh;
+use sigil_stitch::prelude::*;
+
+fn main() {
+    println!("=== Builder API ===\n");
+    let builder_output = builder_approach();
+    println!("{builder_output}");
+
+    println!("=== sigil_quote! Macro ===\n");
+    let macro_output = macro_approach();
+    println!("{macro_output}");
+}
+
+fn builder_approach() -> String {
+    let mut b = CodeBlock::builder();
+
+    // Shebang
+    b.add("#!/usr/bin/env zsh", ());
+    b.add_line();
+    b.add_line();
+
+    // Emulate standard Zsh behavior
+    b.add("emulate -L zsh", ());
+    b.add_line();
+    b.add("set -euo pipefail", ());
+    b.add_line();
+    b.add_line();
+
+    // Autoload — Zsh function loading system
+    b.add("autoload -Uz add-zsh-hook compinit zmv", ());
+    b.add_line();
+    b.add_line();
+
+    // Array with parameter expansion
+    b.add("typeset -a TARGETS=(api worker scheduler)", ());
+    b.add_line();
+    b.add("typeset -A CONFIG", ());
+    b.add_line();
+    b.add("CONFIG=(", ());
+    b.add_line();
+    b.add("%>", ());
+    b.add("NAME=myapp", ());
+    b.add_line();
+    b.add("VERSION=1.0.0", ());
+    b.add_line();
+    b.add("ENV=production", ());
+    b.add_line();
+    b.add("%<", ());
+    b.add(")", ());
+    b.add_line();
+    b.add_line();
+
+    // Check with [[ ... ]] conditional
+    b.add("%<", ());
+    b.add("if [[ -z \"$ENV\" ]]; then", ());
+    b.add_line();
+    b.add("%>", ());
+    b.add("print -u2 \"Error: ENV not set\"", ());
+    b.add_line();
+    b.add("return 1", ());
+    b.add_line();
+    b.add("%<", ());
+    b.add("fi", ());
+    b.add_line();
+    b.add("%>", ());
+    b.add_line();
+
+    // Loop over array
+    b.add("for target in $TARGETS; do", ());
+    b.add_line();
+    b.add("%>", ());
+    b.add("print \"Deploying $target to $ENV...\"", ());
+    b.add_line();
+    b.add("%<", ());
+    b.add("done", ());
+    b.add_line();
+    b.add("%>", ());
+    b.add_line();
+
+    // Parameter expansion with defaults
+    b.add("local name=${1:?Usage: $0 <name>}", ());
+    b.add_line();
+    b.add("local count=${2:-1}", ());
+    b.add_line();
+    b.add("print \"Running $name x${count}\"", ());
+
+    FileSpec::builder_with("deploy.zsh", Zsh::new())
+        .add_code(b.build().unwrap())
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap()
+}
+
+fn macro_approach() -> String {
+    let block = sigil_quote!(Zsh {
+        #!/usr/bin/env zsh
+
+        emulate -L zsh
+        set -euo pipefail
+
+        autoload -Uz add-zsh-hook compinit zmv
+
+        typeset -a TARGETS=(api worker scheduler)
+        typeset -A CONFIG
+        CONFIG=(
+            NAME=myapp
+            VERSION=1.0.0
+            ENV=production
+        )
+
+        if [[ -z $$ENV ]]; {
+            print -u2 $V("\"Error: ENV not set\"")
+            return 1
+        }
+
+        for target in $$TARGETS; {
+            print $V("\"Deploying $target to ${ENV}...\"")
+        }
+
+        local name=$${1:?Usage: $$0 <name>}
+        local count=$${2:-1}
+        print $V("\"Running ${name} x${count}\"")
+    })
+    .unwrap();
+
+    FileSpec::builder_with("deploy.zsh", Zsh::new())
+        .add_code(block)
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap()
+}


### PR DESCRIPTION
## Summary
Three new examples demonstrating recently-added features and filling documentation gaps.

## New examples

### `inline_control_flow.rs`
Demonstrates inline `\$for` and `\$if` inside expressions across TypeScript, Python, C++, Ruby, and Bash — array/dict literals, function arguments, object literals, initializer lists, import tracking, and empty iteration.

### `language_spacing.rs`
Demonstrates language-aware spacing — the same template renders differently per language:
- PostfixStar (C/C++/C# pointer `Config*`)
- PostfixAmpersand (C++ reference `auto&`)
- PostfixQuestion (C#/Swift/Kotlin/Dart nullable `int?`)
- TS optional property (`name?: string`)
- AssignAdjacent (Bash/Zsh `NAME=value`)
- Double-dash flags (Bash/Zsh `--flag`)
- Ruby symbol colon (`:name`)
- Ruby inheritance angle (`class Dog < Animal`)
- C no-angle-generics

### `zsh_codegen.rs`
First Zsh example — arrays, parameter expansion, `[[ ... ]]`, `autoload -Uz`, and inherited shell spacing.

## Test plan
- [x] `cargo check --examples` — clean
- [x] `cargo run --example inline_control_flow`
- [x] `cargo run --example language_spacing`
- [x] `cargo run --example zsh_codegen`