### PR TITLE
chore: bump version to 0.6.7, update changelog and docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,55 @@
 # Changelog
 
-## 0.6.6
+## 0.6.7
+
+### Added
+
+- **PHP language support** — `sigil_quote!(Php { ... })` for generating PHP code.
+- **Ruby language support** — `sigil_quote!(Ruby { ... })` with language-aware
+  annotations: `attr_reader :name` (space before `:`, none after) and
+  `class Dog < Animal` (space before `<` for inheritance).
+- **Inline `$for` and `$if`** — meta-directives now work anywhere in a template,
+  not just at column 0. Inside array/dict literals, function arguments, object
+  literals, and indented blocks. Uses `ParsedSplice` (no synthetic block
+  delimiters) so output splices cleanly without stray `{}` or `:`.
+- **Language-aware spacing** — the macro tokenizer now adapts spacing to the
+  target language:
+  - C/C++/C# `Config*` (postfix pointer) — tight, no space before `*`
+  - C++ `auto&` (postfix reference) — tight, no space before `&`
+  - C#/TS/Swift/Kotlin/Dart `int?` (postfix nullable) — tight, no space before `?`
+  - Bash/Zsh `NAME=val` — tight around `=`
+  - Ruby `attr_reader :name` — space before `:`, none after
+  - Ruby `class Dog < Animal` — space before `<` (inheritance, not generics)
+  - C no longer treats `<` as a generic opener
+- **New `MacroLang` variants** — C, Cpp, CSharp, Dart, Kotlin, Swift, TypeScript, Zsh
+  added to the enum for explicit language-aware behavior. No longer fall through
+  to `Unaware`.
+- **New examples** — `inline_control_flow` (inline `$for`/`$if` across 5 languages),
+  `language_spacing` (per-language spacing comparison across 9 features),
+  `zsh_codegen` (Zsh script generation).
+
+### Fixed
+
+- Compound operator `&&` / `**` second char no longer suppresses trailing space.
+  `a && b` correctly has space before `b` (infix). `&&str` / `**ptr` correctly
+  stay tight (prefix compound). `1 - -2` correctly keeps unary operator tight
+  before operand.
+- `PostfixQuestion` no longer false-positives on compact ternaries. `x?1:2`,
+  `x?y:z`, and `x?(a):b` are correctly detected as ternaries. TS optional
+  property `name?: string` is preserved as PostfixQuestion.
+- `$T(...)`-triggered `GenericOpen` marking now respects `has_angle_generics()` —
+  languages without `<>` generics no longer get spurious `GenericOpen`.
+- `?` `NullablePrefix` annotation now respects `nullable_prefix_is_valid()` —
+  only PHP and OCaml mark `?` as nullable prefix.
+- `:` post-emission reset now preserves group-level contexts (`MapEntry`,
+  `ForRange`) instead of unconditionally overwriting them.
+
+### Changed
+
+- `$for` / `$if` no longer require column-0 position in templates.
+- `has_statement_marker` now checks only `C_each` and `let` — `$for`/`$if` are
+  handled inline.
+- `MacroLang` enum expanded to 14 variants.
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,7 +100,7 @@ dependencies = [
 
 [[package]]
 name = "sigil-stitch"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "pretty",
  "serde",
@@ -111,7 +111,7 @@ dependencies = [
 
 [[package]]
 name = "sigil-stitch-macros"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["macros"]
 resolver = "3"
 
 [workspace.package]
-version = "0.6.6"
+version = "0.6.7"
 edition = "2024"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -23,6 +23,8 @@
   - [C](cookbook_c.md)
   - [C#](cookbook_csharp.md)
   - [Lua](cookbook_lua.md)
+  - [Ruby](cookbook_ruby.md)
+  - [PHP](cookbook_php.md)
   - [Scala](cookbook_scala.md)
   - [Haskell](cookbook_haskell.md)
   - [OCaml](cookbook_ocaml.md)

--- a/docs/src/cookbook_php.md
+++ b/docs/src/cookbook_php.md
@@ -1,0 +1,24 @@
+# PHP Cookbook
+
+## Classes and Methods
+
+```rust
+# extern crate sigil_stitch;
+# use sigil_stitch::prelude::*;
+# fn main() -> Result<(), Box<dyn std::error::Error>> {
+sigil_quote!(Php {
+    class Calculator {
+        public function add(int $$a, int $$b): int {
+            return $$a + $$b;
+        }
+    }
+})?;
+# Ok(())
+# }
+```
+
+**Key points:**
+
+- PHP uses `?Type` for nullable type declarations (`?string`, `?User`).
+- PHP does not use `<>` for generics — the tokenizer correctly treats `<` as comparison.
+- `$` in PHP variable names must be escaped as `$$` in templates: `$$a` produces `$a`.

--- a/docs/src/cookbook_ruby.md
+++ b/docs/src/cookbook_ruby.md
@@ -1,0 +1,31 @@
+# Ruby Cookbook
+
+## Classes and Modules
+
+```rust
+# extern crate sigil_stitch;
+# use sigil_stitch::prelude::*;
+# fn main() -> Result<(), Box<dyn std::error::Error>> {
+sigil_quote!(Ruby {
+    class Greeter {
+        attr_reader :name
+
+        def initialize(name) {
+            @name = name
+        }
+
+        def greet {
+            $V("Hello, #{@name}!")
+        }
+    }
+})?;
+# Ok(())
+# }
+```
+
+**Key points:**
+
+- Ruby uses `{ }` blocks in `sigil_quote!` — the Ruby backend translates them to `do`/`end` or indent/dedent as appropriate.
+- Symbol literals like `:name` get correct spacing (space before `:`, none after).
+- Inheritance uses `<` with space before it: `class Dog < Animal`.
+- `$V` passes strings through for Ruby interpolation (`#{...}`).

--- a/docs/src/macrolang.md
+++ b/docs/src/macrolang.md
@@ -37,9 +37,32 @@ Languages not in the enum get `MacroLang::Unaware`, which applies only universal
 |---------|-----------------|-------------------|
 | `Unaware` | All other languages | Universal heuristics only |
 | `Bash` | `sigil_quote!(Bash { ... })` | Shell-specific (see below) |
-| `Zsh` | `sigil_quote!(Zsh { ... })` | Shell-specific (same as Bash) |
-| `Go` | `sigil_quote!(Go { ... })` | `<-` prefix receive |
+| `C` | `sigil_quote!(C { ... })` | No angle generics, postfix `*` pointer |
+| `Cpp` | `sigil_quote!(Cpp { ... })` | Postfix `*` pointer, postfix `&` reference |
+| `CSharp` | `sigil_quote!(CSharp { ... })` | Postfix `*` pointer, postfix `?` nullable |
+| `Dart` | `sigil_quote!(Dart { ... })` | Postfix `?` nullable |
+| `Go` | `sigil_quote!(Go { ... })` | `<-` prefix receive, paren blocks |
 | `Haskell` | `sigil_quote!(Haskell { ... })` | `$$` dollar operator spacing |
+| `Kotlin` | `sigil_quote!(Kotlin { ... })` | Postfix `?` nullable |
+| `OCaml` | `sigil_quote!(OCaml { ... })` | Space before `:`, prefix `?` nullable |
+| `Php` | `sigil_quote!(Php { ... })` | Prefix `?` nullable |
+| `Ruby` | `sigil_quote!(Ruby { ... })` | Symbol colon, inheritance angle |
+| `Swift` | `sigil_quote!(Swift { ... })` | Postfix `?` nullable |
+| `TypeScript` | `sigil_quote!(TypeScript { ... })` | Postfix `?` nullable |
+| `Zsh` | `sigil_quote!(Zsh { ... })` | Shell-specific (same as Bash) |
+
+### Gated annotations (language-aware)
+
+These annotations used to fire for ALL languages but are now restricted to languages where the syntax is valid:
+
+| Annotation | Gates | Languages | Effect |
+|---|---|---|---|
+| `PostfixStar` | `has_postfix_star()` | C, Cpp, CSharp | `Config*` — no space before `*` |
+| `PostfixAmpersand` | `has_postfix_ampersand()` | Cpp only | `auto&` — no space before `&` |
+| `PostfixQuestion` | `has_postfix_question_type()` | CSharp, Dart, Kotlin, Swift, TypeScript | `int?` — no space before `?` |
+| `AssignAdjacent` | `is_shell()` | Bash, Zsh | `NAME=val` — no space around `=` |
+| `GenericOpen` (ordinary) | `has_angle_generics()` | Excludes C, Go, Haskell, OCaml, Php, Bash, Zsh, Ruby | `<` as generic opener |
+| `NullablePrefix` | `nullable_prefix_is_valid()` | Php, OCaml | `?User` — no space before `?` |
 
 ### Shell Languages (Bash, Zsh)
 
@@ -72,6 +95,39 @@ These share a common `is_shell()` check and enable:
   suppresses space after `$` (designed for shell `$VAR`). For Haskell, it sets
   `PrevTokenKind::Punct('$', Alone)` instead, allowing the normal spacing rule to insert a
   space — producing `putStrLn $ show 42`.
+
+### Ruby
+
+- **Symbol colon (`:name`)**: `:` span-adjacent to the next ident but NOT span-adjacent to the
+  previous token gets `SymbolColon` annotation — space before `:` but none after:
+  `attr_reader :name, :age`.
+- **Inheritance angle (`<`)**: `<` following an ident is marked `InheritanceAngle` instead of
+  `GenericOpen` — space before `<` is preserved: `class Dog < Animal`.
+- **No angle generics**: Ruby is excluded from `has_angle_generics()`, so `$T(...)<...>` does
+  not trigger `GenericOpen`.
+
+### PHP / OCaml
+
+- **Nullable prefix (`?User`)**: `?` span-adjacent to the following ident gets `NullablePrefix`
+  annotation — suppressing space on both sides: `?string`, `?User`.
+- **No angle generics**: Both are excluded from `has_angle_generics()`.
+
+### C / C++ / C#
+
+- **Postfix pointer (`Config*`)**: `*` span-adjacent to the preceding ident gets `PostfixStar`
+  — no space before: `Config* p`.
+- **Postfix reference (`auto&`)**: C++ only — `&` span-adjacent to the preceding ident gets
+  `PostfixAmpersand` — no space before: `auto& x`.
+- **Postfix nullable (`int?`)**: C# only — `?` span-adjacent to the preceding ident gets
+  `PostfixQuestion` — no space before: `int? count`.
+- **No angle generics** (C only): C is excluded from `has_angle_generics()`.
+
+### Inline `$for` / `$if` Meta-Directives
+
+`$for` and `$if` (with `$else_if`/`$else` chaining) now work inline — inside parenthesized
+groups, array/dict literals, function arguments, and indented blocks. They no longer require
+column-0 position. The parser produces `ParsedSplice` (no synthetic block delimiters) so inline
+output splices cleanly without stray `{}` or `:`.
 
 ## Universal Heuristics (all languages)
 

--- a/docs/src/sigil_quote.md
+++ b/docs/src/sigil_quote.md
@@ -865,6 +865,60 @@ sigil_quote!(TypeScript {
 # }
 ```
 
+### Inline Expressions
+
+`$for` and `$if` also work **inline** — inside parenthesized groups, array
+literals, object literals, and function arguments. They no longer need to be
+at column 0:
+
+```rust
+# extern crate sigil_stitch;
+# use sigil_stitch::prelude::*;
+# fn main() -> Result<(), Box<dyn std::error::Error>> {
+let items = vec!["hostname", "platform", "arch"];
+
+sigil_quote!(TypeScript {
+    const defaultKeys = [$for(item in &items) { $S(*item), }];
+})?;
+// Output: const defaultKeys = ['hostname', 'platform', 'arch'];
+# Ok(())
+# }
+```
+
+```rust
+# extern crate sigil_stitch;
+# use sigil_stitch::prelude::*;
+# fn main() -> Result<(), Box<dyn std::error::Error>> {
+let is_admin = true;
+
+sigil_quote!(TypeScript {
+    setPermissions($if(is_admin) { "read-write" } $else { "read-only" });
+})?;
+// Output: setPermissions("read-write");
+# Ok(())
+# }
+```
+
+The `$if` / `$else_if` / `$else` chain also works inline:
+
+```rust
+# extern crate sigil_stitch;
+# use sigil_stitch::prelude::*;
+# fn main() -> Result<(), Box<dyn std::error::Error>> {
+let level: u32 = 2;
+
+sigil_quote!(TypeScript {
+    const label = $if(level == 0) { "trace" } $else_if(level == 1) { "debug" } $else { "info" };
+})?;
+// Output: const label = "info";
+# Ok(())
+# }
+```
+
+Inline meta-directives produce `ParsedSplice` output — the body is spliced
+directly into place without synthetic block delimiters. This means no stray
+`{}` in C-like languages and no stray `:` in Python.
+
 ## Meta-Bindings (`$let`)
 
 `$let` introduces a Rust-level `let` binding inside the macro body. It emits a

--- a/docs/src/type_presentation.md
+++ b/docs/src/type_presentation.md
@@ -52,9 +52,6 @@ This separates three concerns that were previously tangled:
 `TypePresentation` is an enum of syntactic patterns. Each variant describes a structural template for assembling already-rendered inner type docs:
 
 ```rust
-# extern crate sigil_stitch;
-# use sigil_stitch::prelude::*;
-# fn main() {
 pub enum TypePresentation<'a> {
     /// `name<P1, P2>` — delimiters from generic_syntax().open/.close.
     /// Vec<T>, Option<T>, HashMap<K,V>, List<T>.
@@ -79,7 +76,6 @@ pub enum TypePresentation<'a> {
     /// `P1 sep P2 sep ... Pn` — A | B, A & B, A + B.
     Infix { sep: &'a str },
 }
-# }
 ```
 
 Six patterns cover every type rendering need across all supported languages. A language implementation never builds `BoxDoc` — it returns one of these variants with the appropriate strings filled in.
@@ -89,9 +85,6 @@ Six patterns cover every type rendering need across all supported languages. A l
 Function types are too complex for a single `TypePresentation` variant — they have parameter lists, return types, arrows, optional keywords, and wrappers that combine in language-specific ways. They get their own struct:
 
 ```rust
-# extern crate sigil_stitch;
-# use sigil_stitch::prelude::*;
-# fn main() {
 pub struct FunctionPresentation<'a> {
     pub keyword: &'a str,        // "fn", "func", ""
     pub params_open: &'a str,    // "(", "Callable[["
@@ -103,7 +96,6 @@ pub struct FunctionPresentation<'a> {
     pub wrapper_open: &'a str,   // C++: "std::function<"
     pub wrapper_close: &'a str,  // C++: ">"
 }
-# }
 ```
 
 This declaratively covers TypeScript `(A, B) => R`, Rust `fn(A, B) -> R`, Python `Callable[[A, B], R]`, C++ `std::function<R(A, B)>`, Dart `R Function(A, B)`, and Haskell `A -> B -> R` — all from a single rendering engine interpreting the data.


### PR DESCRIPTION
## Summary
Release preparation for 0.6.7.

## Changes
- Bump version to 0.6.7 in `Cargo.toml`
- Full changelog entry for 0.6.7
- Update macrolang.md with all 14 MacroLang variants, gated annotations table, language-specific sections
- Update sigil_quote.md with inline `\$for`/`\$if` section
- Add Ruby and PHP cookbook entries to SUMMARY

## Test plan
- [x] `cargo check --workspace`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`