### PR TITLE
fix: trim inline meta splice newlines

### DIFF
--- a/macros/src/codegen.rs
+++ b/macros/src/codegen.rs
@@ -290,7 +290,7 @@ fn build_args_tuple(args: &[TypedArg]) -> TokenStream {
                                 let mut __sigil_builder =
                                     ::sigil_stitch::code_block::CodeBlock::builder();
                                 #(#body_calls)*
-                                __sigil_builder.build().unwrap()
+                                __sigil_builder.build().unwrap().__sigil_trim_trailing_newline()
                             }
                         }
                     }

--- a/macros/src/parse/format.rs
+++ b/macros/src/parse/format.rs
@@ -176,7 +176,7 @@ fn tokens_to_format_inner(
                     );
                 }
                 format.push_str("%L");
-                state.prev = PrevTokenKind::Specifier;
+                state.prev = PrevTokenKind::ParsedSplice;
                 let end = tokens[after_for - 1].span().end();
                 state.prev_specifier_end = Some((end.line, end.column));
 
@@ -214,7 +214,7 @@ fn tokens_to_format_inner(
                     );
                 }
                 format.push_str("%L");
-                state.prev = PrevTokenKind::Specifier;
+                state.prev = PrevTokenKind::ParsedSplice;
                 let end = tokens[after_if - 1].span().end();
                 state.prev_specifier_end = Some((end.line, end.column));
 
@@ -602,6 +602,20 @@ fn tokens_to_format_inner(
                 }
                 let inner_annotations = annotate_tokens(&inner, lang);
                 tokens_to_format_inner(&inner, &inner_annotations, format, args, state, lang)?;
+
+                if g.delimiter() == Delimiter::Parenthesis
+                    && let Some(last) = inner.last()
+                {
+                    let last_line = last.span().end().line;
+                    let close_line = g.span().end().line;
+                    if close_line > last_line
+                        && state.prev == PrevTokenKind::ParsedSplice
+                        && !format.ends_with('\n')
+                    {
+                        format.push('\n');
+                        state.prev = PrevTokenKind::None;
+                    }
+                }
 
                 state.colon_ctx = saved_ctx;
                 if add_bracket_spaces {

--- a/macros/src/parse/format_tests.rs
+++ b/macros/src/parse/format_tests.rs
@@ -24,6 +24,15 @@ fn fmt_with_args(src: &str) -> (String, Vec<InterpolationKind>) {
     (format, kinds)
 }
 
+fn fmt_err(src: &str) -> String {
+    let ts: TokenStream = src.parse().unwrap();
+    let tokens: Vec<TokenTree> = ts.into_iter().collect();
+    match tokens_to_format(&tokens, MacroLang::Unaware) {
+        Ok(_) => panic!("expected error for {src}"),
+        Err(err) => err.message().to_string(),
+    }
+}
+
 #[test]
 fn simple_assignment() {
     assert_eq!(fmt("const x = 42"), "const x = 42");
@@ -230,6 +239,33 @@ fn inline_let_rejected() {
     let tokens: Vec<TokenTree> = ts.into_iter().collect();
     let result = tokens_to_format(&tokens, MacroLang::Unaware);
     assert!(result.is_err());
+}
+
+#[test]
+fn inline_c_each_rejected() {
+    let message = fmt_err("($C_each(blocks))");
+    assert!(
+        message.contains("$C_each() must appear at the start of a line"),
+        "got: {message}"
+    );
+}
+
+#[test]
+fn inline_for_missing_body_rejected() {
+    let message = fmt_err("($for(x in items))");
+    assert!(
+        message.contains("$for requires a brace body"),
+        "got: {message}"
+    );
+}
+
+#[test]
+fn inline_if_empty_condition_rejected() {
+    let message = fmt_err("($if() { body })");
+    assert!(
+        message.contains("$if condition cannot be empty"),
+        "got: {message}"
+    );
 }
 
 #[test]

--- a/macros/src/parse/spacing.rs
+++ b/macros/src/parse/spacing.rs
@@ -19,6 +19,8 @@ pub(super) enum PrevTokenKind {
     Specifier,
     /// `%W` soft-break — already provides a space, so suppress `maybe_space`.
     SoftBreak,
+    /// Inline `$for`/`$if` parsed splice emitted as `%L`.
+    ParsedSplice,
     /// `$$` literal dollar — suppress space after it so `$$1` renders as `$1`.
     DollarLiteral,
 }
@@ -155,7 +157,7 @@ pub(super) fn maybe_space(
     // No space before a group when preceded by a specifier ($T, $N, etc.)
     // — handles `$T(x){}` struct literals and `$T(x)()` calls.
     if let PrevTokenKind::GroupOpen = current
-        && prev == PrevTokenKind::Specifier
+        && matches!(prev, PrevTokenKind::Specifier | PrevTokenKind::ParsedSplice)
     {
         return;
     }

--- a/macros/src/parse/types.rs
+++ b/macros/src/parse/types.rs
@@ -220,6 +220,11 @@ impl CompileError {
         }
     }
 
+    #[cfg(test)]
+    pub(crate) fn message(&self) -> &str {
+        &self.message
+    }
+
     /// Convert to a `compile_error!()` token stream.
     pub fn into_compile_error(self) -> TokenStream {
         let msg = &self.message;

--- a/src/code_block.rs
+++ b/src/code_block.rs
@@ -197,6 +197,30 @@ impl CodeBlock {
         check_last(&self.nodes)
     }
 
+    /// Remove one trailing newline from this block.
+    ///
+    /// This is used by `sigil_quote!` for inline meta-splices (`$for`/`$if`
+    /// inside expressions). Statement bodies naturally emit a final newline,
+    /// but expression splices must not leak that newline before `]`, `)`, `}`,
+    /// or `;` in the surrounding expression.
+    #[doc(hidden)]
+    pub fn __sigil_trim_trailing_newline(mut self) -> Self {
+        fn trim(nodes: &mut Vec<CodeNode>) -> bool {
+            match nodes.last_mut() {
+                Some(CodeNode::Newline) => {
+                    nodes.pop();
+                    true
+                }
+                Some(CodeNode::Sequence(children)) => trim(children),
+                Some(CodeNode::Nested(inner)) => trim(&mut inner.nodes),
+                _ => false,
+            }
+        }
+
+        trim(&mut self.nodes);
+        self
+    }
+
     /// Collect all import references from this code block.
     pub fn collect_imports(&self, out: &mut Vec<ImportRef>) {
         crate::import_collector::walk_nodes(&self.nodes, out);

--- a/tests/macro/helpers.rs
+++ b/tests/macro/helpers.rs
@@ -1,23 +1,35 @@
 pub use sigil_stitch::code_block::{CodeBlock, NameArg, StringLitArg};
 pub use sigil_stitch::import_collector;
+pub use sigil_stitch::lang::bash::Bash;
 pub use sigil_stitch::lang::c::C;
 pub use sigil_stitch::lang::cpp::Cpp;
 pub use sigil_stitch::lang::csharp::CSharp;
 pub use sigil_stitch::lang::dart::Dart;
 pub use sigil_stitch::lang::haskell::Haskell;
 pub use sigil_stitch::lang::java::Java;
+pub use sigil_stitch::lang::javascript::JavaScript;
 pub use sigil_stitch::lang::kotlin::Kotlin;
 pub use sigil_stitch::lang::lua::Lua;
 pub use sigil_stitch::lang::ocaml::OCaml;
+pub use sigil_stitch::lang::php::Php;
+pub use sigil_stitch::lang::ruby::Ruby;
 pub use sigil_stitch::lang::scala::Scala;
 pub use sigil_stitch::lang::swift::Swift;
+pub use sigil_stitch::lang::zsh::Zsh;
 pub use sigil_stitch::prelude::*;
 pub use sigil_stitch::spec::file_spec::FileSpec;
 pub use sigil_stitch::type_name::TypeName;
 
 pub fn render_js(block: &CodeBlock) -> String {
-    use sigil_stitch::lang::javascript::JavaScript;
     let file = FileSpec::builder_with("test.js", JavaScript::new())
+        .add_code(block.clone())
+        .build()
+        .unwrap();
+    file.render(80).unwrap()
+}
+
+pub fn render_bash(block: &CodeBlock) -> String {
+    let file = FileSpec::builder_with("test.sh", Bash::new())
         .add_code(block.clone())
         .build()
         .unwrap();
@@ -120,6 +132,22 @@ pub fn render_lua(block: &CodeBlock) -> String {
     file.render(80).unwrap()
 }
 
+pub fn render_php(block: &CodeBlock) -> String {
+    let file = FileSpec::builder_with("test.php", Php::new())
+        .add_code(block.clone())
+        .build()
+        .unwrap();
+    file.render(80).unwrap()
+}
+
+pub fn render_rb(block: &CodeBlock) -> String {
+    let file = FileSpec::builder_with("test.rb", Ruby::new())
+        .add_code(block.clone())
+        .build()
+        .unwrap();
+    file.render(80).unwrap()
+}
+
 pub fn render_swift(block: &CodeBlock) -> String {
     let file = FileSpec::builder_with("test.swift", Swift::new())
         .add_code(block.clone())
@@ -138,6 +166,14 @@ pub fn render_dart(block: &CodeBlock) -> String {
 
 pub fn render_scala(block: &CodeBlock) -> String {
     let file = FileSpec::builder_with("test.scala", Scala::new())
+        .add_code(block.clone())
+        .build()
+        .unwrap();
+    file.render(80).unwrap()
+}
+
+pub fn render_zsh(block: &CodeBlock) -> String {
+    let file = FileSpec::builder_with("test.zsh", Zsh::new())
         .add_code(block.clone())
         .build()
         .unwrap();

--- a/tests/macro/meta_inline.rs
+++ b/tests/macro/meta_inline.rs
@@ -254,12 +254,7 @@ fn test_inline_for_ts_array_exact() {
     })
     .unwrap();
     let output = render_ts(&block);
-    assert!(output.contains("const x = ["), "got: {output}");
-    assert!(output.contains("'a'"), "got: {output}");
-    assert!(output.contains("];"), "got: {output}");
-    // No stray block braces
-    assert!(!output.contains('{'), "got: {output}");
-    assert!(!output.contains('}'), "got: {output}");
+    assert_eq!(output, "const x = ['a'];\n");
 }
 
 #[test]
@@ -270,9 +265,182 @@ fn test_inline_if_function_call_exact() {
     })
     .unwrap();
     let output = render_ts(&block);
-    assert!(output.contains("foo("), "got: {output}");
-    assert!(output.contains("\"active\""), "got: {output}");
-    assert!(output.contains(");"), "got: {output}");
-    // No stray block braces
-    assert!(!output.contains('{'), "got: {output}");
+    assert_eq!(output, "foo(\"active\");\n");
 }
+
+#[test]
+fn test_inline_for_python_multiline_list_exact() {
+    let items = vec!["a", "b"];
+    let block = sigil_quote!(Python {
+        x = [
+            $for(item in &items) { $S(*item), }
+        ]
+    })
+    .unwrap();
+    let output = render_py(&block);
+    assert_eq!(output, "x = ['a',\n'b',]\n");
+}
+
+#[test]
+fn test_inline_if_ts_object_literal_exact() {
+    let enabled = true;
+    let block = sigil_quote!(TypeScript {
+        const obj = { enabled: $if(enabled) { true } $else { false } };
+    })
+    .unwrap();
+    let output = render_ts(&block);
+    assert_eq!(output, "const obj = {enabled: true};\n");
+}
+
+#[test]
+fn test_inline_if_ruby_hash_literal_preserves_braces() {
+    let enabled = false;
+    let block = sigil_quote!(Ruby {
+        config = { enabled: $if(enabled) { true } $else { false } }
+    })
+    .unwrap();
+    let output = render_rb(&block);
+    assert_eq!(output, "config = {enabled: false}\n");
+}
+
+#[test]
+fn test_inline_if_php_array_literal_preserves_brackets() {
+    let enabled = true;
+    let block = sigil_quote!(Php {
+        $$config = ["enabled" => $if(enabled) { true } $else { false }];
+    })
+    .unwrap();
+    let output = render_php(&block);
+    assert_eq!(output, "$config = [\"enabled\" => true];\n");
+}
+
+#[test]
+fn test_inline_if_lua_table_literal_preserves_braces() {
+    let enabled = true;
+    let block = sigil_quote!(Lua {
+        config = { enabled = $if(enabled) { true } $else { false } }
+    })
+    .unwrap();
+    let output = render_lua(&block);
+    assert_eq!(output, "config = {enabled = true}\n");
+}
+
+macro_rules! assert_multiline_paren_close_not_restored_for_plain_specifier {
+    ($test_name:ident, $lang:ident, $render:ident) => {
+        #[test]
+        fn $test_name() {
+            let block = sigil_quote!($lang {
+                call(
+                    $S("x")
+                )
+            })
+            .unwrap();
+            let output = $render(&block);
+            assert!(
+                !output.contains("\n)"),
+                "plain specifier should not restore a newline before `)`, got:\n{output}"
+            );
+        }
+    };
+}
+
+assert_multiline_paren_close_not_restored_for_plain_specifier!(
+    test_plain_specifier_multiline_paren_bash,
+    Bash,
+    render_bash
+);
+assert_multiline_paren_close_not_restored_for_plain_specifier!(
+    test_plain_specifier_multiline_paren_c,
+    C,
+    render_c
+);
+assert_multiline_paren_close_not_restored_for_plain_specifier!(
+    test_plain_specifier_multiline_paren_cpp,
+    Cpp,
+    render_cpp
+);
+assert_multiline_paren_close_not_restored_for_plain_specifier!(
+    test_plain_specifier_multiline_paren_csharp,
+    CSharp,
+    render_cs
+);
+assert_multiline_paren_close_not_restored_for_plain_specifier!(
+    test_plain_specifier_multiline_paren_dart,
+    Dart,
+    render_dart
+);
+assert_multiline_paren_close_not_restored_for_plain_specifier!(
+    test_plain_specifier_multiline_paren_go,
+    Go,
+    render_go
+);
+assert_multiline_paren_close_not_restored_for_plain_specifier!(
+    test_plain_specifier_multiline_paren_haskell,
+    Haskell,
+    render_hs
+);
+assert_multiline_paren_close_not_restored_for_plain_specifier!(
+    test_plain_specifier_multiline_paren_java,
+    Java,
+    render_java
+);
+assert_multiline_paren_close_not_restored_for_plain_specifier!(
+    test_plain_specifier_multiline_paren_javascript,
+    JavaScript,
+    render_js
+);
+assert_multiline_paren_close_not_restored_for_plain_specifier!(
+    test_plain_specifier_multiline_paren_kotlin,
+    Kotlin,
+    render_kt
+);
+assert_multiline_paren_close_not_restored_for_plain_specifier!(
+    test_plain_specifier_multiline_paren_lua,
+    Lua,
+    render_lua
+);
+assert_multiline_paren_close_not_restored_for_plain_specifier!(
+    test_plain_specifier_multiline_paren_ocaml,
+    OCaml,
+    render_ml
+);
+assert_multiline_paren_close_not_restored_for_plain_specifier!(
+    test_plain_specifier_multiline_paren_php,
+    Php,
+    render_php
+);
+assert_multiline_paren_close_not_restored_for_plain_specifier!(
+    test_plain_specifier_multiline_paren_python,
+    Python,
+    render_py
+);
+assert_multiline_paren_close_not_restored_for_plain_specifier!(
+    test_plain_specifier_multiline_paren_ruby,
+    Ruby,
+    render_rb
+);
+assert_multiline_paren_close_not_restored_for_plain_specifier!(
+    test_plain_specifier_multiline_paren_rust,
+    Rust,
+    render_rs
+);
+assert_multiline_paren_close_not_restored_for_plain_specifier!(
+    test_plain_specifier_multiline_paren_scala,
+    Scala,
+    render_scala
+);
+assert_multiline_paren_close_not_restored_for_plain_specifier!(
+    test_plain_specifier_multiline_paren_swift,
+    Swift,
+    render_swift
+);
+assert_multiline_paren_close_not_restored_for_plain_specifier!(
+    test_plain_specifier_multiline_paren_typescript,
+    TypeScript,
+    render_ts
+);
+assert_multiline_paren_close_not_restored_for_plain_specifier!(
+    test_plain_specifier_multiline_paren_zsh,
+    Zsh,
+    render_zsh
+);


### PR DESCRIPTION
## Summary
- Trim trailing newlines from inline `` / `` meta splices so expression contexts render without stray newlines before closers.
- Track parsed splices separately from ordinary specifiers so multiline paren close preservation only applies to inline meta splices.
- Add exact regression coverage for inline splices and all-language plain-specifier multiline paren cases.

## Tests
- `cargo test --test macro plain_specifier_multiline_paren -- --nocapture`
- `cargo test -p sigil-stitch-macros`
- `cargo test --test macro`
- `cargo test --test python --test php`
- `cargo test`