### PR TITLE
test: expand CodeFragment coverage and docs

### DIFF
--- a/docs/src/format_specifiers.md
+++ b/docs/src/format_specifiers.md
@@ -11,7 +11,7 @@
 | `%S` | String | `StringLitArg` | Emit escaped string literal |
 | `%V` | Verbatim | `VerbatimStrArg` | Emit string with interpolation preserved |
 | `%R` | Remark | `CommentArg` | Emit inline comment |
-| `%L` | Literal | `&str`, `String`, `CodeBlock` | Emit raw value or nested block |
+| `%L` | Literal | `&str`, `String`, `CodeBlock`, `CodeFragment` | Emit raw value or nested block/fragment |
 | `%W` | Wrap | (none) | Soft line break point |
 | `%>` | Indent | (none) | Increase indent level |
 | `%<` | Dedent | (none) | Decrease indent level |
@@ -274,15 +274,17 @@ let block = sigil_quote!(Bash {
 
 If the expression is not a string literal (e.g. `$V(my_var)` or `$L(format!(...))`), `@{...}` processing is skipped and the expression is used as-is.
 
-## `%L` -- Literal
+## `%L` -- Literal and Nested Code
 
-Emits a raw value with no transformation. This is the default for bare `&str` and `String` arguments, so no wrapper is needed. Also accepts `CodeBlock` for embedding nested blocks. Supports `@{expr}` interpolation inside string literals (see above).
-
-Emits a raw value with no transformation. This is the default for bare `&str` and `String` arguments, so no wrapper is needed. Also accepts `CodeBlock` for embedding nested blocks.
+Emits raw literal text or structured nested code. Bare `&str` and `String`
+arguments map to raw `Arg::Literal`, so no wrapper is needed for ordinary
+language text. `%L` also accepts `CodeBlock` and `CodeFragment` for nested code
+that should keep imports, indentation, and other structure. Supports `@{expr}`
+interpolation inside string literals in `sigil_quote!` (see above).
 
 ```rust
 # extern crate sigil_stitch;
-# use sigil_stitch::code_block::CodeBlock;
+# use sigil_stitch::code_block::{CodeBlock, CodeFragment};
 # use sigil_stitch::prelude::*;
 # fn main() {
 let mut cb = CodeBlock::builder();
@@ -294,11 +296,29 @@ cb.add_statement("const count = %L", "42");
 let inner = CodeBlock::of("getValue()", ()).unwrap();
 cb.add_statement("const x = %L", inner);
 
+// Parsed CodeFragment -> Arg::Code -> structural markers compose
+let branch = CodeFragment::of("if (ready) {\n%>return true;%<\n}", ()).unwrap();
+cb.add("%L", branch);
+
 let block = cb.build().unwrap();
 // const count = 42;
 // const x = getValue();
+// if (ready) {
+//   return true;
+// }
 # }
 ```
+
+Raw literal strings are intentionally not reparsed as format strings. If a raw
+`&str` / `String` passed through `%L` contains `%>` or `%<`, `build()` returns an
+`UnresolvedIndentMarker` error instead of rendering those markers literally. Use
+`CodeFragment::of(...)` for snippets that contain structural markers.
+
+`CodeFragment` snippets must balance their own `%>` / `%<` markers. A fragment
+with `%>` and no matching `%<` is rejected because it would leak indentation into
+whatever code is rendered after it. If you need indentation to span multiple
+builder calls, use `CodeBlock::builder()` and balance the markers before
+`build()`.
 
 ## `%W` -- Soft Line Break
 
@@ -389,7 +409,7 @@ let block = CodeBlock::of("progress: 100%%", ()).unwrap();
 
 ## Arguments and the `IntoArgs` Trait
 
-Every method that accepts a format string (`add`, `add_statement`, `begin_control_flow`, `next_control_flow`, `CodeBlock::of`) takes `args: impl IntoArgs`. This trait converts Rust values into `Vec<Arg>` for the format engine.
+Every method that accepts a format string (`add`, `add_statement`, `begin_control_flow`, `next_control_flow`, `CodeBlock::of`, `CodeFragment::of`) takes `args: impl IntoArgs`. This trait converts Rust values into `Vec<Arg>` for the format engine.
 
 The critical rule: **bare strings map to `Arg::Literal`** (consumed by `%L`), not to `Arg::Name` or `Arg::StringLit`. To target `%N` or `%S`, use the `NameArg` and `StringLitArg` wrappers from `sigil_stitch::code_block`.
 
@@ -402,6 +422,7 @@ The critical rule: **bare strings map to `Arg::Literal`** (consumed by `%L`), no
 | `&str` | `Arg::Literal` | `%L` |
 | `String` | `Arg::Literal` | `%L` |
 | `CodeBlock` | `Arg::Code` | `%L` |
+| `CodeFragment` | `Arg::Code` | `%L` |
 | `NameArg(String)` | `Arg::Name` | `%N` |
 | `StringLitArg(String)` | `Arg::StringLit` | `%S` |
 | `VerbatimStrArg(String)` | `Arg::VerbatimStr` | `%V` |

--- a/docs/src/sigil_quote.md
+++ b/docs/src/sigil_quote.md
@@ -38,7 +38,7 @@ It returns `Result<CodeBlock, SigilStitchError>`.
 | `$N(expr)` | `%N` | `impl ToString` | Name identifier |
 | `$S(expr)` | `%S` | `impl ToString` | String literal (quoted in output) |
 | `$V(expr)` | `%V` | `impl ToString` | Verbatim string (interpolation preserved) |
-| `$L(expr)` | `%L` | `impl Into<Arg>` | Literal value or nested code |
+| `$L(expr)` | `%L` | `impl Into<Arg>` | Literal value, nested code, or parsed fragment |
 | `$C(expr)` | `%L` | `CodeBlock` | Nested code block |
 | `$W` | `%W` | (none) | Soft line-break point |
 | `$>` | `%>` | (none) | Increase indent level |
@@ -176,6 +176,43 @@ let block = sigil_quote!(TypeScript {
 // Output: const count = 0;
 # }
 ```
+
+`$L` can also splice structured code via `CodeBlock` or `CodeFragment`. Use
+`CodeFragment` when the snippet contains format markers such as `%>` / `%<` and
+must carry indentation state instead of rendering those markers as text:
+
+```rust
+# extern crate sigil_stitch;
+# use sigil_stitch::prelude::*;
+# use sigil_stitch::lang::python::Python;
+# use sigil_stitch::spec::file_spec::FileSpec;
+# fn main() {
+let early_return = CodeFragment::of("if enabled:\n%>return value%<", ()).unwrap();
+
+let block = sigil_quote!(Python {
+    def choose(enabled: bool, value: str) -> str: {
+        $L(early_return)
+        return "fallback"
+    }
+}).unwrap();
+
+let output = FileSpec::builder_with("demo.py", Python::new())
+    .add_code(block)
+    .build()
+    .unwrap()
+    .render(80)
+    .unwrap();
+
+assert!(output.contains("if enabled:\n        return value"));
+# }
+```
+
+Raw strings passed through `$L` are not reparsed. A raw string containing `%>` or
+`%<` fails with `UnresolvedIndentMarker`; wrap that snippet in `CodeFragment::of`
+when the markers are intended to control indentation.
+
+`CodeFragment` must have balanced indentation markers. Write `%>...%<` inside the
+fragment, not `%>...` with the expectation that the caller will dedent later.
 
 ### Nested Code Blocks (`$C`)
 

--- a/examples/code_fragments.rs
+++ b/examples/code_fragments.rs
@@ -1,0 +1,27 @@
+//! Compose parsed fragments without losing indentation state.
+//!
+//! Run: `cargo run --example code_fragments`
+
+use sigil_stitch::lang::python::Python;
+use sigil_stitch::prelude::*;
+
+fn main() {
+    let early_return = CodeFragment::of("if enabled:\n%>return value%<", ()).unwrap();
+
+    let block = sigil_quote!(Python {
+        def choose(enabled: bool, value: str) -> str: {
+            $L(early_return)
+            return "fallback"
+        }
+    })
+    .unwrap();
+
+    let output = FileSpec::builder_with("demo.py", Python::new())
+        .add_code(block)
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap();
+
+    println!("{output}");
+}

--- a/src/code_block.rs
+++ b/src/code_block.rs
@@ -175,10 +175,10 @@ pub struct CodeFragment {
 impl CodeFragment {
     /// Parse a format string and arguments into a composable fragment.
     pub fn of(format: &str, args: impl IntoArgs) -> Result<Self, crate::error::SigilStitchError> {
+        let nodes = format_to_nodes(format, args.into_args())?;
+        validate_balanced_indent_markers(&nodes)?;
         Ok(Self {
-            block: CodeBlock {
-                nodes: format_to_nodes(format, args.into_args())?,
-            },
+            block: CodeBlock { nodes },
         })
     }
 
@@ -461,6 +461,7 @@ impl CodeBlockBuilder {
                 depth: self.indent_depth,
             });
         }
+        validate_balanced_indent_markers(&self.nodes)?;
         validate_no_unresolved_indent_markers(&self.nodes)?;
         Ok(CodeBlock { nodes: self.nodes })
     }
@@ -506,6 +507,30 @@ fn format_to_nodes(
     let nodes = parts_args_to_nodes(&parsed, &args);
     validate_no_unresolved_indent_markers(&nodes)?;
     Ok(nodes)
+}
+
+pub(crate) fn validate_balanced_indent_markers(
+    nodes: &[CodeNode],
+) -> Result<(), crate::error::SigilStitchError> {
+    fn walk(nodes: &[CodeNode], depth: &mut i32) -> Result<(), crate::error::SigilStitchError> {
+        for node in nodes {
+            match node {
+                CodeNode::Indent => *depth += 1,
+                CodeNode::Dedent => *depth -= 1,
+                CodeNode::Nested(block) => walk(&block.nodes, depth)?,
+                CodeNode::Sequence(children) => walk(children, depth)?,
+                _ => {}
+            }
+        }
+        Ok(())
+    }
+
+    let mut depth = 0;
+    walk(nodes, &mut depth)?;
+    if depth != 0 {
+        return Err(crate::error::SigilStitchError::UnbalancedIndent { depth });
+    }
+    Ok(())
 }
 
 pub(crate) fn validate_no_unresolved_indent_markers(
@@ -985,12 +1010,80 @@ mod tests {
     }
 
     #[test]
+    fn test_fragment_rejects_unbalanced_indent_marker() {
+        let result = CodeFragment::of("%>nested", ());
+
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(err_msg.contains("unbalanced control flow"));
+        assert!(err_msg.contains("indent depth is 1"));
+    }
+
+    #[test]
+    fn test_fragment_rejects_unmatched_dedent_marker() {
+        let result = CodeFragment::of("%<nested", ());
+
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(err_msg.contains("unbalanced control flow"));
+        assert!(err_msg.contains("indent depth is -1"));
+    }
+
+    #[test]
+    fn test_builder_allows_incremental_balanced_indent_markers() {
+        let mut b = CodeBlock::builder();
+        b.add("outer\n", ());
+        b.add("%>", ());
+        b.add("nested", ());
+        b.add("%<", ());
+        let block = b.build().unwrap();
+
+        let output = block.render_standalone(&TypeScript::new(), 80).unwrap();
+        assert_eq!(output, "outer\n  nested");
+    }
+
+    #[test]
+    fn test_builder_rejects_unbalanced_parsed_indent_marker_at_build() {
+        let mut b = CodeBlock::builder();
+        b.add("%>", ());
+        let result = b.build();
+
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(err_msg.contains("unbalanced control flow"));
+        assert!(err_msg.contains("indent depth is 1"));
+    }
+
+    #[test]
     fn test_fragment_can_be_passed_to_percent_l() {
         let fragment = CodeFragment::of("%>nested%<", ()).unwrap();
         let block = CodeBlock::of("outer\n%L", fragment).unwrap();
 
         let output = block.render_standalone(&TypeScript::new(), 80).unwrap();
         assert_eq!(output, "outer\n  nested");
+    }
+
+    #[test]
+    fn test_fragment_preserves_imports_when_passed_to_percent_l() {
+        let user = TypeName::importable_type("./models", "User");
+        let fragment = CodeFragment::of("const user: %T = loadUser()", (user,)).unwrap();
+        let block = CodeBlock::of("%L", fragment).unwrap();
+
+        let imports = crate::import_collector::collect_imports(&block);
+        assert_eq!(imports.len(), 1);
+        assert_eq!(imports[0].module, "./models");
+        assert_eq!(imports[0].name, "User");
+        assert!(imports[0].is_type_only);
+    }
+
+    #[test]
+    fn test_fragment_accepts_nested_codeblock_arguments() {
+        let inner = CodeBlock::of("compute()", ()).unwrap();
+        let fragment = CodeFragment::of("return %L", inner).unwrap();
+        let block = CodeBlock::of("%L", fragment).unwrap();
+
+        let output = block.render_standalone(&TypeScript::new(), 80).unwrap();
+        assert_eq!(output, "return compute()");
     }
 
     #[test]

--- a/tests/template_tests.rs
+++ b/tests/template_tests.rs
@@ -1,4 +1,4 @@
-use sigil_stitch::code_block::{CodeBlock, NameArg};
+use sigil_stitch::code_block::{CodeBlock, CodeFragment, NameArg};
 use sigil_stitch::code_template::CodeTemplate;
 use sigil_stitch::spec::file_spec::FileSpec;
 use sigil_stitch::type_name::TypeName;
@@ -87,6 +87,30 @@ fn test_template_composition_via_literal() {
 
     assert!(output.contains("function getAnswer()"));
     assert!(output.contains("return 42"));
+}
+
+#[test]
+fn test_template_composition_via_code_fragment() {
+    let body = CodeFragment::of("%>return 42;%<", ()).unwrap();
+    let tmpl = CodeTemplate::new("function #{name:N}() {\n#{body:L}\n}").unwrap();
+
+    let block = tmpl
+        .apply()
+        .set("name", NameArg("getAnswer".into()))
+        .set("body", body)
+        .build()
+        .unwrap();
+
+    let output = FileSpec::builder("answer.ts")
+        .add_code(block)
+        .build()
+        .unwrap()
+        .render(80)
+        .unwrap();
+
+    assert!(output.contains("function getAnswer() {\n  return 42;\n}"));
+    assert!(!output.contains("%>"));
+    assert!(!output.contains("%<"));
 }
 
 // ── RawContentWithImports integration ───────────────────


### PR DESCRIPTION
## Summary
- Add broader `CodeFragment` coverage for imports, nested code block args, template composition, and unbalanced indentation marker validation.
- Add a runnable `code_fragments` example showing Python indentation composition through `(CodeFragment)`.
- Document raw `%L` vs structured `CodeFragment` behavior, including `UnresolvedIndentMarker` and balanced `%>` / `%<` requirements.

## Tests
- `cargo test -p sigil-stitch fragment -- --nocapture`
- `cargo test --test cpp`
- `cargo test`
- `cargo run --example code_fragments`
- `git diff --check`