### PR TITLE
feat: add $for loop separator options

### DIFF
--- a/docs/src/sigil_quote.md
+++ b/docs/src/sigil_quote.md
@@ -89,6 +89,7 @@ final newlines are significant.
 | `$T_join(sep, iter)` | `%T` | separator + `impl IntoIterator<Item: TypeName>` | Type name join with per-item import tracking |
 | `$if(cond) { ... }` | — | Rust expression | Meta-conditional (runtime codegen control) |
 | `$for(pat in expr) { ... }` | — | Rust pattern + iterable | Meta-loop (emit body per iteration) |
+| `$for(pat in expr; separator = expr, trailing = bool) { ... }` | — | Rust pattern + iterable + options | Meta-loop with separator control |
 | `$let(binding);` | — | Rust `let` binding | Rust-level variable binding inside macro body |
 | `$join(sep, iter)` | `%L` | separator + `impl IntoIterator<Item: ToString>` | Separator-joined list |
 | `$+` | — | (none) | Line continuation (suppress line-break split) |
@@ -877,6 +878,100 @@ sigil_quote!(TypeScript {
 # }
 ```
 
+### Loop Separators
+
+`$for` can insert a separator between emitted iterations. This is useful when
+each iteration emits a complete chunk and the spacing between chunks should be
+owned by the loop, not repeated inside each body:
+
+```rust
+# extern crate sigil_stitch;
+# use sigil_stitch::prelude::*;
+# fn main() -> Result<(), Box<dyn std::error::Error>> {
+let handlers = vec!["createUser", "updateUser"];
+
+sigil_quote!(TypeScript {
+    $for(handler in &handlers; separator = "\n") {
+        export function $N(*handler)() {
+            return runHandler($S(*handler));
+        }
+    }
+})?;
+// Output:
+// export function createUser() {
+//     return runHandler('createUser');
+// }
+//
+// export function updateUser() {
+//     return runHandler('updateUser');
+// }
+# Ok(())
+# }
+```
+
+Inline `$for` acts like a join expression: the surrounding statement layout is
+preserved, and the separator is inserted between inline fragments. This is useful
+when later items need a continuation prefix:
+
+```rust
+# extern crate sigil_stitch;
+# use sigil_stitch::prelude::*;
+# fn main() -> Result<(), Box<dyn std::error::Error>> {
+let name = "Pet";
+let members = vec![
+    TypeName::primitive("Cat"),
+    TypeName::primitive("Dog"),
+    TypeName::primitive("null"),
+];
+
+sigil_quote!(TypeScript {
+    export type $N(name) =
+      $for(member in &members; separator = "\n| ") { $T((*member).clone()) };
+})?;
+// Output:
+// export type Pet =
+//   Cat
+// | Dog
+// | null;
+# Ok(())
+# }
+```
+
+Use `trailing = true` only when you really want the same separator after the
+last emitted iteration. Empty loops emit neither separators nor trailing
+separators.
+
+Use `$join(sep, iter)` when each item is just a value that can be converted to
+text. Use inline `$for(...; separator = ...)` when each item is a fragment that
+needs interpolation markers like `$T` / `$N` / `$S`. Use statement `$for` when
+each iteration emits structured code: multiple statements, comments, attributes,
+or nested `$if`.
+
+The separator is a Rust expression. It is converted to a string and inserted via
+`%L`, so `format!(...)` works too. Statement `$for` bodies already emit their
+normal trailing newline, so start a statement-loop separator with text unless you
+intentionally want a blank line:
+
+```rust
+# extern crate sigil_stitch;
+# use sigil_stitch::prelude::*;
+# fn main() -> Result<(), Box<dyn std::error::Error>> {
+let rows = vec![("a", "1"), ("b", "2")];
+let sep = "// next row\n";
+
+sigil_quote!(TypeScript {
+    $for((name, value) in &rows; separator = sep) {
+        export const $N(*name) = $L(*value);
+    }
+})?;
+// Output:
+// export const a = 1;
+// // next row
+// export const b = 2;
+# Ok(())
+# }
+```
+
 ### Destructuring Patterns
 
 Any Rust `for` pattern works:
@@ -956,6 +1051,23 @@ let items = vec!["hostname", "platform", "arch"];
 
 sigil_quote!(TypeScript {
     const defaultKeys = [$for(item in &items) { $S(*item), }];
+})?;
+// Output: const defaultKeys = ['hostname', 'platform', 'arch'];
+# Ok(())
+# }
+```
+
+Inline `$for` supports the same separator options, which is useful when the loop
+body is still structured but the result belongs inside a larger expression:
+
+```rust
+# extern crate sigil_stitch;
+# use sigil_stitch::prelude::*;
+# fn main() -> Result<(), Box<dyn std::error::Error>> {
+let items = vec!["hostname", "platform", "arch"];
+
+sigil_quote!(TypeScript {
+    const defaultKeys = [$for(item in &items; separator = ", ") { $S(*item) }];
 })?;
 // Output: const defaultKeys = ['hostname', 'platform', 'arch'];
 # Ok(())

--- a/examples/macro_features.rs
+++ b/examples/macro_features.rs
@@ -23,6 +23,7 @@ fn main() {
     nested_code_block();
     soft_line_break();
     join_separator();
+    meta_for_separator();
     dollar_escape();
     comment_directive();
     indent_dedent();
@@ -143,6 +144,39 @@ fn join_separator() {
         const keys = [$join(", ", fields)];
     })
     .unwrap();
+    println!("{}", render_ts(&block));
+}
+
+/// `$for(...; separator = ...)` — emit structured bodies with separators.
+fn meta_for_separator() {
+    println!("--- $for: Structured Separator Loop ---\n");
+
+    let handlers = vec!["createUser", "updateUser", "deleteUser"];
+
+    let block = sigil_quote!(TypeScript {
+        $for(handler in &handlers; separator = "\n") {
+            export function $N(*handler)() {
+                return runHandler($S(*handler));
+            }
+        }
+    })
+    .unwrap();
+
+    println!("Blank-line separated generated functions:");
+    println!("{}", render_ts(&block));
+
+    let members = vec![
+        TypeName::primitive("Cat"),
+        TypeName::primitive("Dog"),
+        TypeName::primitive("null"),
+    ];
+    let block = sigil_quote!(TypeScript {
+        export type Pet =
+          $for(member in &members; separator = "\n| ") { $T((*member).clone()) };
+    })
+    .unwrap();
+
+    println!("Inline union members with continuation separators:");
     println!("{}", render_ts(&block));
 }
 

--- a/macros/src/codegen.rs
+++ b/macros/src/codegen.rs
@@ -118,14 +118,69 @@ fn generate_statements(statements: &[Statement]) -> Vec<TokenStream> {
             Statement::MetaFor {
                 pat,
                 iter_expr,
+                separator,
+                trailing,
                 body,
             } => {
                 let body_calls = generate_statements(body);
-                calls.push(quote! {
-                    for #pat in #iter_expr {
-                        #(#body_calls)*
-                    }
-                });
+                if let Some(separator) = separator {
+                    let trailing = trailing
+                        .as_ref()
+                        .map_or_else(|| quote! { false }, |expr| quote! { #expr });
+                    calls.push(quote! {
+                        let mut __sigil_for_emitted = false;
+                        for #pat in #iter_expr {
+                            if __sigil_for_emitted {
+                                __sigil_builder.add("%L", ::std::string::ToString::to_string(&(#separator)));
+                            }
+                            __sigil_for_emitted = true;
+                            #(#body_calls)*
+                        }
+                        if __sigil_for_emitted && (#trailing) {
+                            __sigil_builder.add("%L", ::std::string::ToString::to_string(&(#separator)));
+                        }
+                    });
+                } else {
+                    calls.push(quote! {
+                        for #pat in #iter_expr {
+                            #(#body_calls)*
+                        }
+                    });
+                }
+            }
+            Statement::InlineFor {
+                pat,
+                iter_expr,
+                separator,
+                trailing,
+                body_format,
+                body_args,
+            } => {
+                let body_args_tuple = build_args_tuple(body_args);
+                if let Some(separator) = separator {
+                    let trailing = trailing
+                        .as_ref()
+                        .map_or_else(|| quote! { false }, |expr| quote! { #expr });
+                    calls.push(quote! {
+                        let mut __sigil_for_emitted = false;
+                        for #pat in #iter_expr {
+                            if __sigil_for_emitted {
+                                __sigil_builder.add("%L", ::std::string::ToString::to_string(&(#separator)));
+                            }
+                            __sigil_for_emitted = true;
+                            __sigil_builder.add(#body_format, #body_args_tuple);
+                        }
+                        if __sigil_for_emitted && (#trailing) {
+                            __sigil_builder.add("%L", ::std::string::ToString::to_string(&(#separator)));
+                        }
+                    });
+                } else {
+                    calls.push(quote! {
+                        for #pat in #iter_expr {
+                            __sigil_builder.add(#body_format, #body_args_tuple);
+                        }
+                    });
+                }
             }
             Statement::MetaLet { binding } => {
                 calls.push(quote! {

--- a/macros/src/parse/annotate.rs
+++ b/macros/src/parse/annotate.rs
@@ -344,6 +344,41 @@ pub(super) fn annotate_tokens(tokens: &[TokenTree], lang: MacroLang) -> Vec<Toke
                             }
                         }
 
+                        // Go pointer types use prefix `*T`. Treat `*` as prefix
+                        // when it is span-adjacent to the following type token,
+                        // while preserving binary multiplication (`a*b`, `a * b`).
+                        if ch == '*'
+                            && lang == MacroLang::Go
+                            && i + 1 < tokens.len()
+                            && matches!(&tokens[i + 1], TokenTree::Ident(_) | TokenTree::Group(_))
+                        {
+                            let has_adjacent_expr_left = i > 0 && {
+                                let prev_end = tokens[i - 1].span().end();
+                                let star_start = p.span().start();
+                                prev_end.line == star_start.line
+                                    && prev_end.column == star_start.column
+                                    && match &tokens[i - 1] {
+                                        TokenTree::Ident(id) => {
+                                            let s = id.to_string();
+                                            !CONTROL_FLOW_KEYWORDS.contains(&s.as_str())
+                                                && !DECLARATION_KEYWORDS.contains(&s.as_str())
+                                        }
+                                        TokenTree::Literal(_) => true,
+                                        _ => false,
+                                    }
+                            };
+                            let star_end = p.span().end();
+                            let next_start = tokens[i + 1].span().start();
+                            if star_end.line == next_start.line
+                                && star_end.column == next_start.column
+                                && !has_adjacent_expr_left
+                            {
+                                annotations[i] = TokenAnnotation::PrefixOp;
+                                i += 1;
+                                continue;
+                            }
+                        }
+
                         // PostfixAmpersand: `&` span-adjacent to preceding ident/keyword
                         // (reference type like `auto&`, `int&`). C++ only.
                         if ch == '&'

--- a/macros/src/parse/annotate_tests.rs
+++ b/macros/src/parse/annotate_tests.rs
@@ -168,6 +168,28 @@ fn go_send_not_prefix() {
 }
 
 #[test]
+fn go_pointer_star_after_field_name() {
+    let a = annotate_lang("Raw *http.Response", MacroLang::Go);
+    assert_eq!(ann_at(&a, 1), TokenAnnotation::PrefixOp);
+}
+
+#[test]
+fn go_compact_star_multiplication_not_prefix() {
+    assert_eq!(
+        ann_at(&annotate_lang("a*b", MacroLang::Go), 1),
+        TokenAnnotation::Normal
+    );
+    assert_eq!(
+        ann_at(&annotate_lang("a*(b+c)", MacroLang::Go), 1),
+        TokenAnnotation::Normal
+    );
+    assert_eq!(
+        ann_at(&annotate_lang("1*2", MacroLang::Go), 1),
+        TokenAnnotation::Normal
+    );
+}
+
+#[test]
 fn ruby_symbol_colon() {
     // space before :, NOT after (:name is adjacent)
     let a = annotate_lang("attr_reader :name", MacroLang::Ruby);

--- a/macros/src/parse/directives.rs
+++ b/macros/src/parse/directives.rs
@@ -4,15 +4,48 @@ use super::parse_body;
 use super::types::{CompileError, MacroLang, MetaBranch, Statement};
 use super::util::is_ident;
 
-/// Parse `(pat in expr) { body }` at `paren_pos` (after `$for` confirmed).
+type ForComponents = (
+    usize,
+    TokenStream,
+    TokenStream,
+    Option<TokenStream>,
+    Option<TokenStream>,
+    Vec<Statement>,
+);
+
+type ForRawComponents = (
+    usize,
+    TokenStream,
+    TokenStream,
+    Option<TokenStream>,
+    Option<TokenStream>,
+    Vec<TokenTree>,
+);
+
+/// Parse `(pat in expr[; separator = expr[, trailing = bool]]) { body }` at
+/// `paren_pos` (after `$for` confirmed).
 ///
-/// Returns `(next_pos, pat, iter_expr, body_statements)` where `next_pos`
-/// is the position after the closing `}` group.
+/// Returns `(next_pos, pat, iter_expr, separator, trailing, body_statements)`
+/// where `next_pos` is the position after the closing `}` group.
 pub(super) fn parse_for_components(
     tokens: &[TokenTree],
     paren_pos: usize,
     lang: MacroLang,
-) -> Result<(usize, TokenStream, TokenStream, Vec<Statement>), CompileError> {
+) -> Result<ForComponents, CompileError> {
+    let (next_pos, pat, iter_expr, separator, trailing, body_tokens) =
+        parse_for_raw_components(tokens, paren_pos)?;
+    let body = parse_body(&body_tokens, lang)?;
+
+    Ok((next_pos, pat, iter_expr, separator, trailing, body))
+}
+
+/// Parse `(pat in expr[; separator = expr[, trailing = bool]]) { body }` and
+/// return raw body tokens. Statement-level callers parse the body as statements;
+/// inline callers parse it as a format fragment.
+pub(super) fn parse_for_raw_components(
+    tokens: &[TokenTree],
+    paren_pos: usize,
+) -> Result<ForRawComponents, CompileError> {
     // Bounds checks.
     if paren_pos >= tokens.len() {
         return Err(CompileError::new(
@@ -47,7 +80,8 @@ pub(super) fn parse_for_components(
         }
     };
 
-    // Split paren contents on the first `in` keyword.
+    // Split paren contents on the first `in` keyword, then split loop options
+    // after a top-level `;` so iterator expressions can still contain commas.
     let paren_tokens: Vec<TokenTree> = paren_group.stream().into_iter().collect();
     let in_pos = paren_tokens.iter().position(|tt| is_ident(tt, "in"));
     let in_pos = match in_pos {
@@ -74,12 +108,153 @@ pub(super) fn parse_for_components(
     }
 
     let pat: TokenStream = paren_tokens[..in_pos].iter().cloned().collect();
-    let iter_expr: TokenStream = paren_tokens[in_pos + 1..].iter().cloned().collect();
+    let after_in = &paren_tokens[in_pos + 1..];
+    let options_pos = after_in
+        .iter()
+        .position(|tt| matches!(tt, TokenTree::Punct(p) if p.as_char() == ';'));
+    let (iter_tokens, option_tokens) = match options_pos {
+        Some(pos) => (&after_in[..pos], Some(&after_in[pos + 1..])),
+        None => (after_in, None),
+    };
+
+    let iter_expr: TokenStream = iter_tokens.iter().cloned().collect();
+    if iter_expr.is_empty() {
+        return Err(CompileError::new(
+            paren_group.span(),
+            "$for iterator expression cannot be empty: $for(pat in expr) { ... }",
+        ));
+    }
+
+    let (separator, trailing) = match option_tokens {
+        Some(tokens) => parse_for_options(tokens, paren_group.span())?,
+        None => (None, None),
+    };
 
     let body_tokens: Vec<TokenTree> = body_group.stream().into_iter().collect();
-    let body = parse_body(&body_tokens, lang)?;
 
-    Ok((paren_pos + 2, pat, iter_expr, body))
+    Ok((
+        paren_pos + 2,
+        pat,
+        iter_expr,
+        separator,
+        trailing,
+        body_tokens,
+    ))
+}
+
+fn parse_for_options(
+    tokens: &[TokenTree],
+    span: proc_macro2::Span,
+) -> Result<(Option<TokenStream>, Option<TokenStream>), CompileError> {
+    if tokens.is_empty() {
+        return Err(CompileError::new(
+            span,
+            "$for options cannot be empty after `;`",
+        ));
+    }
+
+    let mut separator = None;
+    let mut trailing = None;
+
+    for option in split_for_options(tokens) {
+        if option.is_empty() {
+            return Err(CompileError::new(span, "$for option cannot be empty"));
+        }
+
+        let name = match option.first() {
+            Some(TokenTree::Ident(id)) => id.to_string(),
+            Some(tt) => {
+                return Err(CompileError::new(
+                    tt.span(),
+                    "$for options must be named: separator = expr, trailing = bool",
+                ));
+            }
+            None => unreachable!(),
+        };
+
+        let equals_pos = option
+            .iter()
+            .position(|tt| matches!(tt, TokenTree::Punct(p) if p.as_char() == '='));
+        let equals_pos = match equals_pos {
+            Some(pos) => pos,
+            None => {
+                return Err(CompileError::new(
+                    option[0].span(),
+                    "$for options require `=`: separator = expr, trailing = bool",
+                ));
+            }
+        };
+
+        if equals_pos != 1 {
+            return Err(CompileError::new(
+                option[0].span(),
+                "$for option names must be followed by `=`",
+            ));
+        }
+
+        let value: TokenStream = option[equals_pos + 1..].iter().cloned().collect();
+        if value.is_empty() {
+            return Err(CompileError::new(
+                option[0].span(),
+                "$for option value cannot be empty",
+            ));
+        }
+
+        match name.as_str() {
+            "separator" => {
+                if separator.is_some() {
+                    return Err(CompileError::new(
+                        option[0].span(),
+                        "duplicate $for separator option",
+                    ));
+                }
+                separator = Some(value);
+            }
+            "trailing" => {
+                if trailing.is_some() {
+                    return Err(CompileError::new(
+                        option[0].span(),
+                        "duplicate $for trailing option",
+                    ));
+                }
+                trailing = Some(value);
+            }
+            _ => {
+                return Err(CompileError::new(
+                    option[0].span(),
+                    format!("unknown $for option `{name}`. Expected separator or trailing"),
+                ));
+            }
+        }
+    }
+
+    if trailing.is_some() && separator.is_none() {
+        return Err(CompileError::new(
+            span,
+            "$for trailing option requires separator = expr",
+        ));
+    }
+
+    Ok((separator, trailing))
+}
+
+fn split_for_options(tokens: &[TokenTree]) -> Vec<&[TokenTree]> {
+    let mut parts = Vec::new();
+    let mut start = 0;
+    for (i, tt) in tokens.iter().enumerate() {
+        if matches!(tt, TokenTree::Punct(p) if p.as_char() == ',')
+            && starts_for_option(&tokens[i + 1..])
+        {
+            parts.push(&tokens[start..i]);
+            start = i + 1;
+        }
+    }
+    parts.push(&tokens[start..]);
+    parts
+}
+
+fn starts_for_option(tokens: &[TokenTree]) -> bool {
+    matches!(tokens, [TokenTree::Ident(_), TokenTree::Punct(eq), ..] if eq.as_char() == '=')
 }
 
 /// Parse `(cond) { body } [$else_if(cond) { body }]* [$else { body }]`

--- a/macros/src/parse/format.rs
+++ b/macros/src/parse/format.rs
@@ -3,7 +3,7 @@ use proc_macro2::{Delimiter, Spacing, TokenStream, TokenTree};
 use super::annotate::{
     CONTROL_FLOW_KEYWORDS, DECLARATION_KEYWORDS, TokenAnnotation, annotate_tokens,
 };
-use super::directives::{parse_for_components, parse_if_components};
+use super::directives::{parse_for_raw_components, parse_if_components};
 use super::spacing::{ColonContext, PrevTokenKind, SpacingState, maybe_space};
 use super::types::{CompileError, InterpolationKind, MacroLang, Statement, TypedArg};
 use super::util::is_ident;
@@ -43,6 +43,10 @@ fn tokens_to_format_inner(
 ) -> Result<(), CompileError> {
     let mut pos = 0;
     let mut prev_end_line: Option<usize> = None;
+    let base_column = tokens
+        .first()
+        .map(|tt| tt.span().start().column)
+        .unwrap_or(0);
 
     while pos < tokens.len() {
         let tt = &tokens[pos];
@@ -50,11 +54,19 @@ fn tokens_to_format_inner(
         // Detect blank lines via span-location gaps between tokens.
         // Only emit for blank lines (gap >= 2), not consecutive lines.
         // Consecutive line breaks are handled by the statement parser.
-        let tt_line = tt.span().start().line;
-        if let Some(pl) = prev_end_line {
-            let gap = tt_line.saturating_sub(pl).saturating_sub(1);
+        let tt_start = tt.span().start();
+        let tt_line = tt_start.line;
+        if let Some(prev_line) = prev_end_line {
+            let gap = tt_line.saturating_sub(prev_line).saturating_sub(1);
             for _ in 0..gap {
                 format.push('\n');
+                state.prev = PrevTokenKind::None;
+            }
+            if gap == 0 && tt_line > prev_line && starts_inline_for_at(tokens, pos) {
+                format.push('\n');
+                for _ in 0..tt_start.column.saturating_sub(base_column) {
+                    format.push(' ');
+                }
                 state.prev = PrevTokenKind::None;
             }
         }
@@ -165,7 +177,9 @@ fn tokens_to_format_inner(
                         "$for requires a parenthesized pattern: $for(pat in expr) { ... }",
                     ));
                 }
-                let (after_for, pat, iter_expr, body) = parse_for_components(tokens, pos, lang)?;
+                let (after_for, pat, iter_expr, separator, trailing, body_tokens) =
+                    parse_for_raw_components(tokens, pos)?;
+                let (body_format, body_args) = tokens_to_format(&body_tokens, lang)?;
 
                 if !adjacent_to_prev_specifier {
                     maybe_space(
@@ -183,10 +197,13 @@ fn tokens_to_format_inner(
                 args.push(TypedArg {
                     kind: InterpolationKind::ParsedSplice,
                     expr: TokenStream::new(),
-                    parsed_body: Some(vec![Statement::MetaFor {
+                    parsed_body: Some(vec![Statement::InlineFor {
                         pat,
                         iter_expr,
-                        body,
+                        separator,
+                        trailing,
+                        body_format,
+                        body_args,
                     }]),
                 });
                 pos = after_for;
@@ -644,6 +661,12 @@ fn tokens_to_format_inner(
     }
 
     Ok(())
+}
+
+fn starts_inline_for_at(tokens: &[TokenTree], pos: usize) -> bool {
+    pos + 1 < tokens.len()
+        && matches!(&tokens[pos], TokenTree::Punct(p) if p.as_char() == '$')
+        && is_ident(&tokens[pos + 1], "for")
 }
 
 /// Split `$join(sep, iter)` arguments on the first top-level comma.

--- a/macros/src/parse/statements.rs
+++ b/macros/src/parse/statements.rs
@@ -190,9 +190,12 @@ pub(super) fn parse_one_statement(
                 collected.pop();
                 collected.pop();
             } else {
-                // Don't split if next line starts with `.` (method chaining)
+                // Don't split if next line starts with `.` (method chaining),
+                // or if an incomplete statement continues with an inline `$for`.
                 let starts_with_dot = matches!(tt, TokenTree::Punct(p) if p.as_char() == '.');
-                if !starts_with_dot {
+                let continues_with_inline_for = starts_with_inline_for(tokens, pos)
+                    && collected_ends_with_assignment(&collected);
+                if !starts_with_dot && !continues_with_inline_for {
                     let (format, args) = tokens_to_format(&collected, lang)?;
                     return Ok((Statement::Line { format, args }, pos));
                 }
@@ -214,6 +217,16 @@ pub(super) fn parse_one_statement(
         let (format, args) = tokens_to_format(&collected, lang)?;
         Ok((Statement::Line { format, args }, pos))
     }
+}
+
+fn starts_with_inline_for(tokens: &[TokenTree], pos: usize) -> bool {
+    pos + 1 < tokens.len()
+        && matches!(&tokens[pos], TokenTree::Punct(p) if p.as_char() == '$')
+        && is_ident(&tokens[pos + 1], "for")
+}
+
+fn collected_ends_with_assignment(tokens: &[TokenTree]) -> bool {
+    matches!(tokens.last(), Some(TokenTree::Punct(p)) if p.as_char() == '=')
 }
 
 /// Parse a control flow chain starting from tokens that lead into a brace group.
@@ -400,12 +413,15 @@ fn try_parse_meta_for(
         return Ok(None);
     }
 
-    let (next_pos, pat, iter_expr, body) = parse_for_components(tokens, start + 2, lang)?;
+    let (next_pos, pat, iter_expr, separator, trailing, body) =
+        parse_for_components(tokens, start + 2, lang)?;
 
     Ok(Some((
         Statement::MetaFor {
             pat,
             iter_expr,
+            separator,
+            trailing,
             body,
         },
         next_pos, // helper returns paren_pos + 2 = start + 4

--- a/macros/src/parse/statements_tests.rs
+++ b/macros/src/parse/statements_tests.rs
@@ -248,6 +248,7 @@ fn stmt_kind(s: &Statement) -> &'static str {
         Statement::SpliceEach { .. } => "SpliceEach",
         Statement::MetaIf { .. } => "MetaIf",
         Statement::MetaFor { .. } => "MetaFor",
+        Statement::InlineFor { .. } => "InlineFor",
         Statement::MetaLet { .. } => "MetaLet",
         Statement::ParenBlock { .. } => "ParenBlock",
     }

--- a/macros/src/parse/types.rs
+++ b/macros/src/parse/types.rs
@@ -126,11 +126,24 @@ pub(crate) enum Statement {
     SpliceEach { expr: TokenStream },
     /// `$if(cond) { ... } $else_if(cond) { ... } $else { ... }` — meta-conditional.
     MetaIf { branches: Vec<MetaBranch> },
-    /// `$for(pat in expr) { ... }` — meta-loop that emits body once per iteration.
+    /// `$for(pat in expr[; separator = expr[, trailing = bool]]) { ... }` —
+    /// meta-loop that emits body once per iteration.
     MetaFor {
         pat: TokenStream,
         iter_expr: TokenStream,
+        separator: Option<TokenStream>,
+        trailing: Option<TokenStream>,
         body: Vec<Statement>,
+    },
+    /// Inline `$for(...) { ... }` splice that emits fragment bodies without
+    /// statement newlines.
+    InlineFor {
+        pat: TokenStream,
+        iter_expr: TokenStream,
+        separator: Option<TokenStream>,
+        trailing: Option<TokenStream>,
+        body_format: String,
+        body_args: Vec<TypedArg>,
     },
     /// `$let(binding);` — Rust-level `let` binding inside macro body.
     MetaLet { binding: TokenStream },

--- a/tests/go/quote_edge_cases.rs
+++ b/tests/go/quote_edge_cases.rs
@@ -155,3 +155,41 @@ fn test_channel_receive_standalone() {
         "standalone receive should be tight, got: {output}"
     );
 }
+
+#[test]
+fn test_prefix_pointer_type_spacing() {
+    let response_type = "FetchResponse";
+
+    let block = sigil_quote!(Go {
+        type $N(response_type) struct {
+            Raw *http.Response
+        }
+    })
+    .unwrap();
+
+    assert_eq!(
+        render(&block),
+        r#"type FetchResponse struct {
+	Raw *http.Response
+}
+"#,
+    );
+}
+
+#[test]
+fn test_compact_multiplication_spacing() {
+    let block = sigil_quote!(Go {
+        result := a*b;
+        nested := a*(b+c);
+        literal := 1*2;
+    })
+    .unwrap();
+
+    assert_eq!(
+        render(&block),
+        r#"result := a * b
+nested := a * (b + c)
+literal := 1 * 2
+"#,
+    );
+}

--- a/tests/macro/helpers.rs
+++ b/tests/macro/helpers.rs
@@ -1,3 +1,4 @@
+pub use sigil_stitch::assert_quote;
 pub use sigil_stitch::code_block::{CodeBlock, NameArg, StringLitArg};
 pub use sigil_stitch::import_collector;
 pub use sigil_stitch::lang::bash::Bash;
@@ -15,6 +16,7 @@ pub use sigil_stitch::lang::php::Php;
 pub use sigil_stitch::lang::ruby::Ruby;
 pub use sigil_stitch::lang::scala::Scala;
 pub use sigil_stitch::lang::swift::Swift;
+pub use sigil_stitch::lang::typescript::TypeScript;
 pub use sigil_stitch::lang::zsh::Zsh;
 pub use sigil_stitch::prelude::*;
 pub use sigil_stitch::spec::file_spec::FileSpec;

--- a/tests/macro/meta_for.rs
+++ b/tests/macro/meta_for.rs
@@ -429,6 +429,75 @@ fn test_meta_for_empty_iter() {
     assert!(!output.contains("null"), "got: {output}");
 }
 
+#[test]
+fn test_meta_for_separator_newline() {
+    let names = vec!["alpha", "beta", "gamma"];
+
+    assert_quote!(TypeScript, {
+        $for(name in &names; separator = "\n") {
+            export const $N(*name) = true;
+        }
+    }, "export const alpha = true;\n\nexport const beta = true;\n\nexport const gamma = true;\n");
+}
+
+#[test]
+fn test_meta_for_separator_trailing() {
+    let names = vec!["alpha", "beta"];
+
+    assert_quote!(TypeScript, {
+        const before = 1;
+        $for(name in &names; separator = "\n", trailing = true) {
+            export const $N(*name) = true;
+        }
+        const after = 2;
+    }, "const before = 1;\nexport const alpha = true;\n\nexport const beta = true;\n\nconst after = 2;\n");
+}
+
+#[test]
+fn test_meta_for_separator_compound_expression() {
+    let names = vec!["alpha", "beta"];
+    let prefix = "// next".to_owned();
+    let suffix = "\n";
+
+    let block = sigil_quote!(TypeScript {
+        $for(name in &names; separator = prefix.clone() + suffix) {
+            export const $N(*name) = true;
+        }
+    })
+    .unwrap();
+
+    sigil_stitch::assert_rendered!(
+        TypeScript::new(),
+        block,
+        "export const alpha = true;\n// next\nexport const beta = true;\n",
+    );
+}
+
+#[test]
+fn test_meta_for_separator_comment_between_rows() {
+    let rows = vec![("a", "1"), ("b", "2")];
+    let sep = "// next row\n";
+
+    assert_quote!(TypeScript, {
+        $for((name, value) in &rows; separator = sep) {
+            export const $N(*name) = $L(*value);
+        }
+    }, "export const a = 1;\n// next row\nexport const b = 2;\n");
+}
+
+#[test]
+fn test_meta_for_empty_iter_ignores_trailing_separator() {
+    let names: Vec<&str> = vec![];
+
+    assert_quote!(TypeScript, {
+        const before = 1;
+        $for(name in &names; separator = "\n", trailing = true) {
+            export const $N(*name) = true;
+        }
+        const after = 2;
+    }, "const before = 1;\nconst after = 2;\n");
+}
+
 // --- Real-world pattern: enum variant generation ---
 
 #[test]

--- a/tests/macro/meta_inline.rs
+++ b/tests/macro/meta_inline.rs
@@ -258,6 +258,75 @@ fn test_inline_for_ts_array_exact() {
 }
 
 #[test]
+fn test_inline_for_typescript_union_separator_exact() {
+    let name = "Pet";
+    let members = vec![
+        TypeName::primitive("Cat"),
+        TypeName::primitive("Dog"),
+        TypeName::primitive("null"),
+    ];
+
+    assert_quote!(TypeScript, {
+        export type $N(name) =
+          $for(member in &members; separator = "\n| ", trailing = false) { $T((*member).clone()) };
+    }, r#"export type Pet =
+  Cat
+| Dog
+| null;
+"#);
+}
+
+#[test]
+fn test_inline_for_typescript_union_tracks_imports() {
+    let members = vec![
+        TypeName::importable_type("./pets", "Cat"),
+        TypeName::importable_type("./pets", "Dog"),
+    ];
+
+    assert_quote!(TypeScript, {
+        export type Pet =
+          $for(member in &members; separator = "\n| ") { $T((*member).clone()) };
+    }, r#"import type { Cat, Dog } from './pets';
+
+export type Pet =
+  Cat
+| Dog;
+"#);
+}
+
+#[test]
+fn test_inline_for_empty_with_separator_emits_no_items() {
+    let members: Vec<&str> = vec![];
+
+    assert_quote!(TypeScript, {
+        const pets = [$for(member in &members; separator = ", ") { $S(*member) }];
+    }, "const pets = [];\n");
+}
+
+#[test]
+fn test_inline_for_trailing_reuses_separator() {
+    let values = vec!["1", "2"];
+
+    assert_quote!(TypeScript, {
+        const values = [$for(value in &values; separator = ", ", trailing = true) { $L(*value) }];
+    }, "const values = [1, 2, ];\n");
+}
+
+#[test]
+fn test_inline_for_haskell_constructor_separator_exact() {
+    let variants = vec!["Cat", "Dog", "Fish"];
+
+    assert_quote!(Haskell, {
+        data Pet =
+          $for(variant in &variants; separator = "\n  | ") { $N(*variant) }
+    }, r#"data Pet =
+  Cat
+  | Dog
+  | Fish
+"#);
+}
+
+#[test]
 fn test_inline_if_function_call_exact() {
     let flag = true;
     let block = sigil_quote!(TypeScript {
@@ -269,7 +338,7 @@ fn test_inline_if_function_call_exact() {
 }
 
 #[test]
-fn test_inline_for_python_multiline_list_exact() {
+fn test_inline_for_python_list_exact() {
     let items = vec!["a", "b"];
     let block = sigil_quote!(Python {
         x = [
@@ -278,7 +347,7 @@ fn test_inline_for_python_multiline_list_exact() {
     })
     .unwrap();
     let output = render_py(&block);
-    assert_eq!(output, "x = ['a',\n'b',]\n");
+    assert_eq!(output, "x = ['a','b',]\n");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add `separator = expr` and `trailing = bool` options to `$for`
- keep statement `$for` separators literal while adding true inline `$for` fragment joins
- support multiline inline separators for union-style continuations, such as TypeScript `|` members
- document the inline-vs-statement mental model and refresh macro feature examples
- add coverage for inline unions, import tracking, trailing separators, statement separators, compound separators, and Go pointer spacing

## Semantics
- statement `$for` emits statement or block chunks and preserves their rendered newlines
- inline `$for` acts like a join expression inside the surrounding statement
- `trailing = true` repeats the same separator after the final non-empty iteration
- empty loops emit no separator or trailing separator

## Verification
- `cargo test`
- `just lint`
- `cargo run --example macro_features`
- `mdbook build docs`
- `mdbook test` with an isolated `CARGO_TARGET_DIR`
- `git diff --check`