### PR TITLE
Extend inline meta continuations

### DIFF
--- a/docs/src/macrolang.md
+++ b/docs/src/macrolang.md
@@ -129,6 +129,10 @@ groups, array/dict literals, function arguments, and indented blocks. They no lo
 column-0 position. The parser produces `ParsedSplice` (no synthetic block delimiters) so inline
 output splices cleanly without stray `{}` or `:`.
 
+When a source line ends with continuation punctuation such as `=` or `|`, an inline
+`$for`/`$if` on the next line remains part of the same statement. A plain newline before `$for`
+still starts a statement-level meta-loop.
+
 ## Universal Heuristics (all languages)
 
 These annotations fire regardless of `MacroLang`:

--- a/docs/src/sigil_quote.md
+++ b/docs/src/sigil_quote.md
@@ -937,6 +937,28 @@ sigil_quote!(TypeScript {
 # }
 ```
 
+The same pattern works for constructor-style continuations in non-brace
+languages:
+
+```rust
+# extern crate sigil_stitch;
+# use sigil_stitch::prelude::*;
+# fn main() -> Result<(), Box<dyn std::error::Error>> {
+let variants = vec!["Cat", "Dog", "Fish"];
+
+sigil_quote!(Haskell {
+    data Pet =
+      $for(variant in &variants; separator = "\n  | ") { $N(*variant) }
+})?;
+// Output:
+// data Pet =
+//   Cat
+//   | Dog
+//   | Fish
+# Ok(())
+# }
+```
+
 Use `trailing = true` only when you really want the same separator after the
 last emitted iteration. Empty loops emit neither separators nor trailing
 separators.
@@ -1070,6 +1092,39 @@ sigil_quote!(TypeScript {
     const defaultKeys = [$for(item in &items; separator = ", ") { $S(*item) }];
 })?;
 // Output: const defaultKeys = ['hostname', 'platform', 'arch'];
+# Ok(())
+# }
+```
+
+Separators are often clearer than writing punctuation inside the loop body when
+the fragments are function arguments:
+
+```rust
+# extern crate sigil_stitch;
+# use sigil_stitch::prelude::*;
+# fn main() -> Result<(), Box<dyn std::error::Error>> {
+let handlers = vec!["createUser", "updateUser", "deleteUser"];
+
+sigil_quote!(TypeScript {
+    registerHandlers($for(handler in &handlers; separator = ", ") { $N(*handler) });
+})?;
+// Output: registerHandlers(createUser, updateUser, deleteUser);
+# Ok(())
+# }
+```
+
+If the iterable is empty, inline `$for` emits no body and no separators:
+
+```rust
+# extern crate sigil_stitch;
+# use sigil_stitch::prelude::*;
+# fn main() -> Result<(), Box<dyn std::error::Error>> {
+let items: Vec<&str> = vec![];
+
+sigil_quote!(TypeScript {
+    const defaultKeys = [$for(item in &items; separator = ", ") { $S(*item) }];
+})?;
+// Output: const defaultKeys = [];
 # Ok(())
 # }
 ```

--- a/examples/inline_control_flow.rs
+++ b/examples/inline_control_flow.rs
@@ -11,18 +11,22 @@
 
 use sigil_stitch::lang::bash::Bash;
 use sigil_stitch::lang::cpp::Cpp;
+use sigil_stitch::lang::haskell::Haskell;
 use sigil_stitch::lang::ruby::Ruby;
 use sigil_stitch::prelude::*;
 use sigil_stitch::spec::file_spec::FileSpec;
 
 fn main() {
     typescript_inline_for_array();
+    typescript_inline_for_function_args();
+    typescript_inline_for_union_separator();
     typescript_inline_if_function_arg();
     typescript_inline_if_else_chain();
     typescript_inline_if_in_object_literal();
     python_inline_for_list();
     python_inline_if_dict();
     cpp_inline_for_vector();
+    haskell_inline_for_constructors();
     ruby_inline_if_expression();
     bash_inline_for_join();
     inline_for_with_type_imports();
@@ -38,6 +42,35 @@ fn typescript_inline_for_array() {
 
     let block = sigil_quote!(TypeScript {
         const defaultKeys = [$for(item in &items) { $S(*item), }];
+    })
+    .unwrap();
+    println!("{}\n", render_ts(&block));
+}
+
+/// Inline `$for` with an explicit separator for function arguments.
+fn typescript_inline_for_function_args() {
+    println!("--- TS: Inline $for with argument separators ---\n");
+    let handlers = vec!["createUser", "updateUser", "deleteUser"];
+
+    let block = sigil_quote!(TypeScript {
+        registerHandlers($for(handler in &handlers; separator = ", ") { $N(*handler) });
+    })
+    .unwrap();
+    println!("{}\n", render_ts(&block));
+}
+
+/// Inline `$for` with a multiline separator for TypeScript union continuations.
+fn typescript_inline_for_union_separator() {
+    println!("--- TS: Inline $for union continuation separators ---\n");
+    let members = vec![
+        TypeName::primitive("Cat"),
+        TypeName::primitive("Dog"),
+        TypeName::primitive("null"),
+    ];
+
+    let block = sigil_quote!(TypeScript {
+        export type Pet =
+          $for(member in &members; separator = "\n| ") { $T((*member).clone()) };
     })
     .unwrap();
     println!("{}\n", render_ts(&block));
@@ -125,6 +158,21 @@ fn cpp_inline_for_vector() {
     println!("{}\n", render_with(&block, &Cpp::new()));
 }
 
+// ── Haskell ──
+
+/// Inline `$for` with constructor separators in a Haskell data declaration.
+fn haskell_inline_for_constructors() {
+    println!("--- Haskell: Inline $for constructor separators ---\n");
+    let variants = vec!["Cat", "Dog", "Fish"];
+
+    let block = sigil_quote!(Haskell {
+        data Pet =
+          $for(variant in &variants; separator = "\n  | ") { $N(*variant) }
+    })
+    .unwrap();
+    println!("{}\n", render_with(&block, &Haskell::new()));
+}
+
 // ── Ruby ──
 
 /// `$if`/`$else` as a value expression in Ruby — selects the branch output.
@@ -173,13 +221,13 @@ fn inline_for_with_type_imports() {
 
 // ── Empty / edge cases ──
 
-/// Empty `$for` produces no output — array literal renders as `[]`.
+/// Empty `$for` produces no output — separators are not emitted either.
 fn empty_for_clean_output() {
     println!("--- Empty $for produces clean output ---\n");
     let items: Vec<&str> = vec![];
 
     let block = sigil_quote!(TypeScript {
-        const keys: string[] = [$for(item in &items) { $S(*item), }];
+        const keys: string[] = [$for(item in &items; separator = ", ") { $S(*item) }];
     })
     .unwrap();
     println!("  TS:  {}", render_ts(&block));

--- a/macros/src/parse/directives.rs
+++ b/macros/src/parse/directives.rs
@@ -149,7 +149,7 @@ fn parse_for_options(
     if tokens.is_empty() {
         return Err(CompileError::new(
             span,
-            "$for options cannot be empty after `;`",
+            "$for options cannot be empty after ';'; expected separator = expr or trailing = bool",
         ));
     }
 
@@ -158,7 +158,10 @@ fn parse_for_options(
 
     for option in split_for_options(tokens) {
         if option.is_empty() {
-            return Err(CompileError::new(span, "$for option cannot be empty"));
+            return Err(CompileError::new(
+                span,
+                "$for option cannot be empty; expected separator = expr or trailing = bool",
+            ));
         }
 
         let name = match option.first() {
@@ -180,7 +183,7 @@ fn parse_for_options(
             None => {
                 return Err(CompileError::new(
                     option[0].span(),
-                    "$for options require `=`: separator = expr, trailing = bool",
+                    format!("$for option '{name}' requires '='"),
                 ));
             }
         };
@@ -188,7 +191,7 @@ fn parse_for_options(
         if equals_pos != 1 {
             return Err(CompileError::new(
                 option[0].span(),
-                "$for option names must be followed by `=`",
+                format!("$for option '{name}' requires '=' immediately after the name"),
             ));
         }
 
@@ -196,7 +199,7 @@ fn parse_for_options(
         if value.is_empty() {
             return Err(CompileError::new(
                 option[0].span(),
-                "$for option value cannot be empty",
+                format!("$for option '{name}' requires a value"),
             ));
         }
 
@@ -205,7 +208,7 @@ fn parse_for_options(
                 if separator.is_some() {
                     return Err(CompileError::new(
                         option[0].span(),
-                        "duplicate $for separator option",
+                        "duplicate $for option 'separator'",
                     ));
                 }
                 separator = Some(value);
@@ -214,7 +217,7 @@ fn parse_for_options(
                 if trailing.is_some() {
                     return Err(CompileError::new(
                         option[0].span(),
-                        "duplicate $for trailing option",
+                        "duplicate $for option 'trailing'",
                     ));
                 }
                 trailing = Some(value);
@@ -222,7 +225,7 @@ fn parse_for_options(
             _ => {
                 return Err(CompileError::new(
                     option[0].span(),
-                    format!("unknown $for option `{name}`. Expected separator or trailing"),
+                    format!("unknown $for option '{name}'; expected 'separator' or 'trailing'"),
                 ));
             }
         }
@@ -231,7 +234,7 @@ fn parse_for_options(
     if trailing.is_some() && separator.is_none() {
         return Err(CompileError::new(
             span,
-            "$for trailing option requires separator = expr",
+            "$for option 'trailing' requires separator = expr",
         ));
     }
 
@@ -409,4 +412,82 @@ pub(super) fn parse_if_components(
     }
 
     Ok((pos, branches))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn for_error(src: &str) -> String {
+        let ts: TokenStream = src.parse().unwrap();
+        let tokens: Vec<TokenTree> = ts.into_iter().collect();
+        parse_for_raw_components(&tokens, 0)
+            .unwrap_err()
+            .message()
+            .to_owned()
+    }
+
+    fn assert_for_error_contains(src: &str, expected: &str) {
+        let actual = for_error(src);
+        assert!(
+            actual.contains(expected),
+            "expected error to contain {expected:?}, got {actual:?}"
+        );
+    }
+
+    #[test]
+    fn for_options_reject_empty_after_semicolon() {
+        assert_for_error_contains(
+            "(item in items;) { item }",
+            "$for options cannot be empty after ';'; expected separator = expr or trailing = bool",
+        );
+    }
+
+    #[test]
+    fn for_options_reject_unknown_name() {
+        assert_for_error_contains(
+            r#"(item in items; sep = ",") { item }"#,
+            "unknown $for option 'sep'; expected 'separator' or 'trailing'",
+        );
+    }
+
+    #[test]
+    fn for_options_reject_missing_equals() {
+        assert_for_error_contains(
+            r#"(item in items; separator ",") { item }"#,
+            "$for option 'separator' requires '='",
+        );
+    }
+
+    #[test]
+    fn for_options_reject_empty_value() {
+        assert_for_error_contains(
+            "(item in items; separator =) { item }",
+            "$for option 'separator' requires a value",
+        );
+    }
+
+    #[test]
+    fn for_options_reject_duplicate_separator() {
+        assert_for_error_contains(
+            r#"(item in items; separator = ",", separator = ";") { item }"#,
+            "duplicate $for option 'separator'",
+        );
+    }
+
+    #[test]
+    fn for_options_reject_duplicate_trailing() {
+        assert_for_error_contains(
+            r#"(item in items; separator = ",", trailing = true, trailing = false) { item }"#,
+            "duplicate $for option 'trailing'",
+        );
+    }
+
+    #[test]
+    fn for_options_reject_trailing_without_separator() {
+        assert_for_error_contains(
+            "(item in items; trailing = true) { item }",
+            "$for option 'trailing' requires separator = expr",
+        );
+    }
 }

--- a/macros/src/parse/statements.rs
+++ b/macros/src/parse/statements.rs
@@ -191,11 +191,11 @@ pub(super) fn parse_one_statement(
                 collected.pop();
             } else {
                 // Don't split if next line starts with `.` (method chaining),
-                // or if an incomplete statement continues with an inline `$for`.
+                // or if an incomplete statement continues with inline `$for`/`$if`.
                 let starts_with_dot = matches!(tt, TokenTree::Punct(p) if p.as_char() == '.');
-                let continues_with_inline_for = starts_with_inline_for(tokens, pos)
-                    && collected_ends_with_assignment(&collected);
-                if !starts_with_dot && !continues_with_inline_for {
+                let continues_with_inline_meta = starts_with_inline_meta(tokens, pos)
+                    && can_continue_before_inline_meta(&collected);
+                if !starts_with_dot && !continues_with_inline_meta {
                     let (format, args) = tokens_to_format(&collected, lang)?;
                     return Ok((Statement::Line { format, args }, pos));
                 }
@@ -219,14 +219,18 @@ pub(super) fn parse_one_statement(
     }
 }
 
-fn starts_with_inline_for(tokens: &[TokenTree], pos: usize) -> bool {
+fn starts_with_inline_meta(tokens: &[TokenTree], pos: usize) -> bool {
     pos + 1 < tokens.len()
         && matches!(&tokens[pos], TokenTree::Punct(p) if p.as_char() == '$')
-        && is_ident(&tokens[pos + 1], "for")
+        && (is_ident(&tokens[pos + 1], "for") || is_ident(&tokens[pos + 1], "if"))
 }
 
-fn collected_ends_with_assignment(tokens: &[TokenTree]) -> bool {
-    matches!(tokens.last(), Some(TokenTree::Punct(p)) if p.as_char() == '=')
+fn can_continue_before_inline_meta(tokens: &[TokenTree]) -> bool {
+    matches!(
+        tokens.last(),
+        Some(TokenTree::Punct(p))
+            if matches!(p.as_char(), '=' | '|')
+    )
 }
 
 /// Parse a control flow chain starting from tokens that lead into a brace group.

--- a/macros/src/parse/statements_tests.rs
+++ b/macros/src/parse/statements_tests.rs
@@ -148,6 +148,14 @@ fn statement_with_interpolation() {
 }
 
 #[test]
+fn newline_before_metafor_without_continuation_still_splits() {
+    let stmts = parse_all_stmts("const before = 1\n$for(item in items) { const x = $N(item); }");
+    assert_eq!(stmts.len(), 2);
+    assert!(matches!(stmts[0], Statement::Line { .. }));
+    assert!(matches!(stmts[1], Statement::MetaFor { .. }));
+}
+
+#[test]
 fn go_for_with_embedded_semicolons() {
     let stmt = parse_stmt_lang("for i := 0; i < n; i++ { body(); }", MacroLang::Go);
     match stmt {

--- a/tests/macro/helpers.rs
+++ b/tests/macro/helpers.rs
@@ -13,6 +13,7 @@ pub use sigil_stitch::lang::kotlin::Kotlin;
 pub use sigil_stitch::lang::lua::Lua;
 pub use sigil_stitch::lang::ocaml::OCaml;
 pub use sigil_stitch::lang::php::Php;
+pub use sigil_stitch::lang::python::Python;
 pub use sigil_stitch::lang::ruby::Ruby;
 pub use sigil_stitch::lang::scala::Scala;
 pub use sigil_stitch::lang::swift::Swift;

--- a/tests/macro/meta_inline.rs
+++ b/tests/macro/meta_inline.rs
@@ -277,6 +277,72 @@ fn test_inline_for_typescript_union_separator_exact() {
 }
 
 #[test]
+fn test_inline_for_typescript_union_after_pipe_continuation() {
+    let members = vec![TypeName::primitive("Dog"), TypeName::primitive("Fish")];
+
+    assert_quote!(TypeScript, {
+        export type Pet = Cat |
+          $for(member in &members; separator = "\n| ") { $T((*member).clone()) };
+    }, r#"export type Pet = Cat |
+  Dog
+| Fish;
+"#);
+}
+
+#[test]
+fn test_inline_if_after_assignment_continuation() {
+    let flag = true;
+
+    assert_quote!(TypeScript, {
+        const mode =
+          $if(flag) { "enabled" } $else { "disabled" };
+    }, "const mode = \"enabled\";\n");
+}
+
+#[test]
+fn test_meta_if_after_python_colon_header_stays_statement_level() {
+    let flag = true;
+
+    assert_quote!(Python, {
+        if x > 0:
+            $if(flag) { return True }
+            return False
+    }, r#"if x > 0:
+return True
+return False
+"#);
+}
+
+#[test]
+fn test_meta_if_after_swift_nullable_type_stays_statement_level() {
+    let flag = true;
+
+    assert_quote!(Swift, {
+        let value: String?
+        $if(flag) { let next = 1 }
+    }, r#"let value: String?
+let next = 1
+"#);
+}
+
+#[test]
+fn test_metafor_after_comma_stays_statement_level() {
+    let names = vec!["Dog", "Fish"];
+
+    assert_quote!(TypeScript, {
+        enum Pet {
+            Cat,
+            $for(name in &names) { $N(*name), }
+        }
+    }, r#"enum Pet {
+  Cat,
+  Dog,
+  Fish,
+}
+"#);
+}
+
+#[test]
 fn test_inline_for_typescript_union_tracks_imports() {
     let members = vec![
         TypeName::importable_type("./pets", "Cat"),


### PR DESCRIPTION
## Summary
- allow inline `$for` and `$if` to continue after safe newline punctuation: `=` and `|`
- keep plain newline `$for`/`$if` statement-level after Python colons, nullable `?`, and comma-separated declarations
- improve `$for` option diagnostics and document inline separator examples

## Verification
- `cargo test`
- `just lint`
- `cargo fmt --check`
- `git diff --check`
- `cargo run --example inline_control_flow`
- `cargo run --example macro_features`
- `mdbook build docs`
- isolated `mdbook test docs -L <isolated>/debug/deps`
- Codex review gate: PASS, no `[P1]` findings