### PR TITLE
Preserve multiline inline if chains

### DIFF
--- a/examples/inline_control_flow.rs
+++ b/examples/inline_control_flow.rs
@@ -3,7 +3,7 @@
 //!
 //! Inline meta-directives work anywhere in a template, not just at column 0.
 //! `$for`/`$if` are meta-selection: true/false branches and loop bodies are
-//! evaluated at Rust compile time by the macro, then spliced into place.
+//! evaluated by the generated Rust builder code, then spliced into place.
 //! Each language gets correct delimiters: TypeScript keeps `{ }` for objects,
 //! Python keeps `{ }` for dicts (no stray `:`).
 //!

--- a/macros/src/parse/format.rs
+++ b/macros/src/parse/format.rs
@@ -62,7 +62,8 @@ fn tokens_to_format_inner(
                 format.push('\n');
                 state.prev = PrevTokenKind::None;
             }
-            if gap == 0 && tt_line > prev_line && starts_inline_for_at(tokens, pos) {
+            if gap == 0 && tt_line > prev_line && preserves_newline_before_inline_meta(tokens, pos)
+            {
                 format.push('\n');
                 for _ in 0..tt_start.column.saturating_sub(base_column) {
                     format.push(' ');
@@ -663,10 +664,24 @@ fn tokens_to_format_inner(
     Ok(())
 }
 
-fn starts_inline_for_at(tokens: &[TokenTree], pos: usize) -> bool {
-    pos + 1 < tokens.len()
-        && matches!(&tokens[pos], TokenTree::Punct(p) if p.as_char() == '$')
-        && is_ident(&tokens[pos + 1], "for")
+fn preserves_newline_before_inline_meta(tokens: &[TokenTree], pos: usize) -> bool {
+    if pos + 1 >= tokens.len() || !matches!(&tokens[pos], TokenTree::Punct(p) if p.as_char() == '$')
+    {
+        return false;
+    }
+
+    if is_ident(&tokens[pos + 1], "for") {
+        return true;
+    }
+
+    if is_ident(&tokens[pos + 1], "if") {
+        return !matches!(
+            pos.checked_sub(1).and_then(|prev| tokens.get(prev)),
+            Some(TokenTree::Punct(p)) if p.as_char() == '='
+        );
+    }
+
+    false
 }
 
 /// Split `$join(sep, iter)` arguments on the first top-level comma.

--- a/macros/src/parse/format_tests.rs
+++ b/macros/src/parse/format_tests.rs
@@ -218,6 +218,23 @@ fn inline_if_emits_parsed_splice() {
 }
 
 #[test]
+fn inline_if_preserves_source_newline_before_next_inline_if() {
+    let (format, kinds) = fmt_with_args("($if(a) { a }\n$if(b) { b })");
+    assert_eq!(format, "(%L\n%L)");
+    assert_eq!(kinds.len(), 2);
+    assert!(matches!(kinds[0], InterpolationKind::ParsedSplice));
+    assert!(matches!(kinds[1], InterpolationKind::ParsedSplice));
+}
+
+#[test]
+fn inline_if_after_assignment_continuation_collapses_newline() {
+    let (format, kinds) = fmt_with_args("value =\n  $if(flag) { enabled } $else { disabled }");
+    assert_eq!(format, "value = %L");
+    assert_eq!(kinds.len(), 1);
+    assert!(matches!(kinds[0], InterpolationKind::ParsedSplice));
+}
+
+#[test]
 fn inline_else_if_standalone_rejected() {
     let ts: TokenStream = "$else_if(cond) { body }".parse().unwrap();
     let tokens: Vec<TokenTree> = ts.into_iter().collect();

--- a/macros/src/parse/statements.rs
+++ b/macros/src/parse/statements.rs
@@ -193,8 +193,9 @@ pub(super) fn parse_one_statement(
                 // Don't split if next line starts with `.` (method chaining),
                 // or if an incomplete statement continues with inline `$for`/`$if`.
                 let starts_with_dot = matches!(tt, TokenTree::Punct(p) if p.as_char() == '.');
-                let continues_with_inline_meta = starts_with_inline_meta(tokens, pos)
-                    && can_continue_before_inline_meta(&collected);
+                let continues_with_inline_meta = (starts_with_inline_meta(tokens, pos)
+                    && can_continue_before_inline_meta(&collected))
+                    || (starts_with_inline_if_tail(tokens, pos) && contains_inline_if(&collected));
                 if !starts_with_dot && !continues_with_inline_meta {
                     let (format, args) = tokens_to_format(&collected, lang)?;
                     return Ok((Statement::Line { format, args }, pos));
@@ -223,6 +224,18 @@ fn starts_with_inline_meta(tokens: &[TokenTree], pos: usize) -> bool {
     pos + 1 < tokens.len()
         && matches!(&tokens[pos], TokenTree::Punct(p) if p.as_char() == '$')
         && (is_ident(&tokens[pos + 1], "for") || is_ident(&tokens[pos + 1], "if"))
+}
+
+fn starts_with_inline_if_tail(tokens: &[TokenTree], pos: usize) -> bool {
+    pos + 1 < tokens.len()
+        && matches!(&tokens[pos], TokenTree::Punct(p) if p.as_char() == '$')
+        && (is_ident(&tokens[pos + 1], "else_if") || is_ident(&tokens[pos + 1], "else"))
+}
+
+fn contains_inline_if(tokens: &[TokenTree]) -> bool {
+    tokens.windows(2).any(|pair| {
+        matches!(&pair[0], TokenTree::Punct(p) if p.as_char() == '$') && is_ident(&pair[1], "if")
+    })
 }
 
 fn can_continue_before_inline_meta(tokens: &[TokenTree]) -> bool {

--- a/tests/macro/meta_inline.rs
+++ b/tests/macro/meta_inline.rs
@@ -300,6 +300,57 @@ fn test_inline_if_after_assignment_continuation() {
 }
 
 #[test]
+fn test_inline_if_after_pipe_continuation() {
+    let include_dog = true;
+
+    assert_quote!(TypeScript, {
+        export type Pet = Cat |
+          $if(include_dog) { Dog } $else { Fish };
+    }, r#"export type Pet = Cat |
+  Dog;
+"#);
+}
+
+#[test]
+fn test_inline_if_multiline_siblings_preserve_newline() {
+    let first = true;
+    let second = true;
+
+    assert_quote!(TypeScript, {
+        const values = (
+          $if(first) { first }
+          $if(second) { second }
+        );
+    }, r#"const values = (
+first
+second
+);
+"#);
+}
+
+#[test]
+fn test_inline_if_else_on_next_line_stays_in_chain() {
+    let prod = false;
+
+    assert_quote!(TypeScript, {
+        const mode = $if(prod) { "prod" }
+          $else { "dev" };
+    }, "const mode = \"dev\";\n");
+}
+
+#[test]
+fn test_inline_if_else_if_on_next_line_stays_in_chain() {
+    let trace = false;
+    let debug = true;
+
+    assert_quote!(TypeScript, {
+        const label = $if(trace) { "trace" }
+          $else_if(debug) { "debug" }
+          $else { "info" };
+    }, "const label = \"debug\";\n");
+}
+
+#[test]
 fn test_meta_if_after_python_colon_header_stays_statement_level() {
     let flag = true;
 
@@ -339,6 +390,35 @@ fn test_metafor_after_comma_stays_statement_level() {
   Dog,
   Fish,
 }
+"#);
+}
+
+#[test]
+fn test_meta_if_after_comma_stays_statement_level() {
+    let include_dog = true;
+
+    assert_quote!(TypeScript, {
+        enum Pet {
+            Cat,
+            $if(include_dog) { Dog, }
+        }
+    }, r#"enum Pet {
+  Cat,
+  Dog,
+}
+"#);
+}
+
+#[test]
+fn test_inline_if_tracks_imports() {
+    let include_user = true;
+    let user = TypeName::importable_type("./models", "User");
+
+    assert_quote!(TypeScript, {
+        export type MaybeUser = $if(include_user) { $T(user.clone()) } $else { null };
+    }, r#"import type { User } from './models';
+
+export type MaybeUser = User;
 "#);
 }
 


### PR DESCRIPTION
## Summary
- preserve source newlines before inline `$if` where they represent multiline inline fragments
- keep inline `$else_if` / `$else` attached when chains span source lines
- retain assignment-continuation collapse for value expressions like `const mode =\n  $if(...)`
- add exact coverage for pipe continuations, multiline siblings, split chains, comma guards, and import tracking
- fix inline-control-flow example wording about evaluation timing

## Verification
- `cargo test`
- `just lint`
- `cargo fmt --check`
- `git diff --check`
- `cargo run --example inline_control_flow`