### PR TITLE
chore: prepare 0.6.8 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## 0.6.8
+
+### Added
+
+- `$for` separator options: `separator = expr` inserts text between emitted
+  iterations, and `trailing = true` reuses that separator after the final item.
+- Inline `$for` / `$if` continuations after source lines ending in `=` or `|`,
+  so multiline assignments and union-style declarations can keep their shape.
+
+### Fixed
+
+- Inline `$if` chains now preserve multiline fragments and keep `$else_if` /
+  `$else` attached when chains span source lines.
+- Plain statement-level meta remains statement-level after Python `:`, nullable
+  type `?`, and comma-separated declarations.
+- `$for` option diagnostics now name the invalid option and expected syntax.
+
+### Changed
+
+- Repository metadata, README badge, and mdBook edit links now point at
+  `rust-codegen-group/sigil-stitch` and the `main` branch.
+
 ## 0.6.7
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,7 +100,7 @@ dependencies = [
 
 [[package]]
 name = "sigil-stitch"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "pretty",
  "serde",
@@ -111,7 +111,7 @@ dependencies = [
 
 [[package]]
 name = "sigil-stitch-macros"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,13 +3,13 @@ members = ["macros"]
 resolver = "3"
 
 [workspace.package]
-version = "0.6.7"
+version = "0.6.8"
 edition = "2024"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"
 authors = ["Adam Cavendish"]
-repository = "https://github.com/adamcavendish/sigil-stitch"
-homepage = "https://github.com/adamcavendish/sigil-stitch"
+repository = "https://github.com/rust-codegen-group/sigil-stitch"
+homepage = "https://github.com/rust-codegen-group/sigil-stitch"
 
 [package]
 name = "sigil-stitch"
@@ -35,7 +35,7 @@ exclude = [
 [dependencies]
 pretty = "0.12"
 snafu = "0.9"
-sigil-stitch-macros = { path = "macros", version = "0.6.6" }
+sigil-stitch-macros = { path = "macros", version = "0.6.8" }
 serde = { version = "1", features = ["derive"] }
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Type-safe, import-aware, width-aware code generation for multiple languages.
 
 [![Crates.io](https://img.shields.io/crates/v/sigil-stitch.svg)](https://crates.io/crates/sigil-stitch)
 [![docs.rs](https://docs.rs/sigil-stitch/badge.svg)](https://docs.rs/sigil-stitch)
-[![CI](https://github.com/adamcavendish/sigil-stitch/actions/workflows/ci.yml/badge.svg)](https://github.com/adamcavendish/sigil-stitch/actions/workflows/ci.yml)
+[![CI](https://github.com/rust-codegen-group/sigil-stitch/actions/workflows/ci.yml/badge.svg)](https://github.com/rust-codegen-group/sigil-stitch/actions/workflows/ci.yml)
 
 sigil-stitch combines [JavaPoet](https://github.com/square/javapoet)'s builder + CodeBlock
 model with [Wadler-Lindig pretty printing](https://homepages.inf.ed.ac.uk/wadler/papers/prettier/prettier.pdf)

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -9,8 +9,8 @@ src = "src"
 build-dir = "book"
 
 [output.html]
-git-repository-url = "https://github.com/adamcavendish/sigil-stitch"
-edit-url-template = "https://github.com/adamcavendish/sigil-stitch/edit/master/docs/{path}"
+git-repository-url = "https://github.com/rust-codegen-group/sigil-stitch"
+edit-url-template = "https://github.com/rust-codegen-group/sigil-stitch/edit/main/docs/{path}"
 
 [output.html.search]
 enable = true


### PR DESCRIPTION
## Summary

- bump workspace crates and lockfile to 0.6.8
- add 0.6.8 changelog entries for inline meta continuations and `$for` separator options
- update repository metadata, CI badge, and mdBook links for `rust-codegen-group/sigil-stitch` and `main`

## Tests

- `cargo test && just lint && cargo fmt --check && git diff --check && mdbook build docs`